### PR TITLE
[RFC-003/ADR-004/ADR-005] Phase 3D: async + LanceDB + fastembed architecture

### DIFF
--- a/.agents/skills/coding-guidelines/SKILL.md
+++ b/.agents/skills/coding-guidelines/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: coding-guidelines
+description: "Use when asking about Rust code style or best practices. Keywords: naming, formatting, comment, clippy, rustfmt, lint, code style, best practice, P.NAM, G.FMT, code review, naming convention, variable naming, function naming, type naming, 命名规范, 代码风格, 格式化, 最佳实践, 代码审查, 怎么命名"
+source: https://rust-coding-guidelines.github.io/rust-coding-guidelines-zh/
+user-invocable: false
+---
+
+# Rust Coding Guidelines (50 Core Rules)
+
+## Naming (Rust-Specific)
+
+| Rule | Guideline |
+|------|-----------|
+| No `get_` prefix | `fn name()` not `fn get_name()` |
+| Iterator convention | `iter()` / `iter_mut()` / `into_iter()` |
+| Conversion naming | `as_` (cheap &), `to_` (expensive), `into_` (ownership) |
+| Static var prefix | `G_CONFIG` for `static`, no prefix for `const` |
+
+## Data Types
+
+| Rule | Guideline |
+|------|-----------|
+| Use newtypes | `struct Email(String)` for domain semantics |
+| Prefer slice patterns | `if let [first, .., last] = slice` |
+| Pre-allocate | `Vec::with_capacity()`, `String::with_capacity()` |
+| Avoid Vec abuse | Use arrays for fixed sizes |
+
+## Strings
+
+| Rule | Guideline |
+|------|-----------|
+| Prefer bytes | `s.bytes()` over `s.chars()` when ASCII |
+| Use `Cow<str>` | When might modify borrowed data |
+| Use `format!` | Over string concatenation with `+` |
+| Avoid nested iteration | `contains()` on string is O(n*m) |
+
+## Error Handling
+
+| Rule | Guideline |
+|------|-----------|
+| Use `?` propagation | Not `try!()` macro |
+| `expect()` over `unwrap()` | When value guaranteed |
+| Assertions for invariants | `assert!` at function entry |
+
+## Memory
+
+| Rule | Guideline |
+|------|-----------|
+| Meaningful lifetimes | `'src`, `'ctx` not just `'a` |
+| `try_borrow()` for RefCell | Avoid panic |
+| Shadowing for transformation | `let x = x.parse()?` |
+
+## Concurrency
+
+| Rule | Guideline |
+|------|-----------|
+| Identify lock ordering | Prevent deadlocks |
+| Atomics for primitives | Not Mutex for bool/usize |
+| Choose memory order carefully | Relaxed/Acquire/Release/SeqCst |
+
+## Async
+
+| Rule | Guideline |
+|------|-----------|
+| Sync for CPU-bound | Async is for I/O |
+| Don't hold locks across await | Use scoped guards |
+
+## Macros
+
+| Rule | Guideline |
+|------|-----------|
+| Avoid unless necessary | Prefer functions/generics |
+| Follow Rust syntax | Macro input should look like Rust |
+
+## Deprecated → Better
+
+| Deprecated | Better | Since |
+|------------|--------|-------|
+| `lazy_static!` | `std::sync::OnceLock` | 1.70 |
+| `once_cell::Lazy` | `std::sync::LazyLock` | 1.80 |
+| `std::sync::mpsc` | `crossbeam::channel` | - |
+| `std::sync::Mutex` | `parking_lot::Mutex` | - |
+| `failure`/`error-chain` | `thiserror`/`anyhow` | - |
+| `try!()` | `?` operator | 2018 |
+
+## Quick Reference
+
+```
+Naming: snake_case (fn/var), CamelCase (type), SCREAMING_CASE (const)
+Format: rustfmt (just use it)
+Docs: /// for public items, //! for module docs
+Lint: #![warn(clippy::all)]
+```
+
+Claude knows Rust conventions well. These are the non-obvious Rust-specific rules.

--- a/.agents/skills/coding-guidelines/clippy-lints/_index.md
+++ b/.agents/skills/coding-guidelines/clippy-lints/_index.md
@@ -1,0 +1,16 @@
+# Clippy Lint → Rule Mapping
+
+| Clippy Lint | Category | Fix |
+|-------------|----------|-----|
+| `unwrap_used` | Error | Use `?` or `expect()` |
+| `needless_clone` | Perf | Use reference |
+| `await_holding_lock` | Async | Scope guard before await |
+| `linkedlist` | Perf | Use Vec/VecDeque |
+| `wildcard_imports` | Style | Explicit imports |
+| `missing_safety_doc` | Safety | Add `# Safety` doc |
+| `undocumented_unsafe_blocks` | Safety | Add `// SAFETY:` |
+| `transmute_ptr_to_ptr` | Safety | Use `pointer::cast()` |
+| `large_stack_arrays` | Mem | Use Vec or Box |
+| `too_many_arguments` | Design | Use struct params |
+
+For unsafe-related lints → see `unsafe-checker` skill.

--- a/.agents/skills/coding-guidelines/index/rules-index.md
+++ b/.agents/skills/coding-guidelines/index/rules-index.md
@@ -1,0 +1,6 @@
+# Complete Rules Reference
+
+For the full 500+ rules, see:
+- Source: https://rust-coding-guidelines.github.io/rust-coding-guidelines-zh/
+
+Core rules are in `../SKILL.md`.

--- a/.agents/skills/domain-cli/SKILL.md
+++ b/.agents/skills/domain-cli/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: domain-cli
+description: "Use when building CLI tools. Keywords: CLI, command line, terminal, clap, structopt, argument parsing, subcommand, interactive, TUI, ratatui, crossterm, indicatif, progress bar, colored output, shell completion, config file, environment variable, 命令行, 终端应用, 参数解析"
+globs: ["**/Cargo.toml"]
+user-invocable: false
+---
+
+# CLI Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| User ergonomics | Clear help, errors | clap derive macros |
+| Config precedence | CLI > env > file | Layered config loading |
+| Exit codes | Non-zero on error | Proper Result handling |
+| Stdout/stderr | Data vs errors | eprintln! for errors |
+| Interruptible | Handle Ctrl+C | Signal handling |
+
+---
+
+## Critical Constraints
+
+### User Communication
+
+```
+RULE: Errors to stderr, data to stdout
+WHY: Pipeable output, scriptability
+RUST: eprintln! for errors, println! for data
+```
+
+### Configuration Priority
+
+```
+RULE: CLI args > env vars > config file > defaults
+WHY: User expectation, override capability
+RUST: Layered config with clap + figment/config
+```
+
+### Exit Codes
+
+```
+RULE: Return non-zero on any error
+WHY: Script integration, automation
+RUST: main() -> Result<(), Error> or explicit exit()
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need argument parsing"
+    ↓ m05-type-driven: Derive structs for args
+    ↓ clap: #[derive(Parser)]
+
+"Need config layering"
+    ↓ m09-domain: Config as domain object
+    ↓ figment/config: Layer sources
+
+"Need progress display"
+    ↓ m12-lifecycle: Progress bar as RAII
+    ↓ indicatif: ProgressBar
+```
+
+---
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Argument parsing | clap |
+| Interactive prompts | dialoguer |
+| Progress bars | indicatif |
+| Colored output | colored |
+| Terminal UI | ratatui |
+| Terminal control | crossterm |
+| Console utilities | console |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Args struct | Type-safe args | `#[derive(Parser)]` |
+| Subcommands | Command hierarchy | `#[derive(Subcommand)]` |
+| Config layers | Override precedence | CLI > env > file |
+| Progress | User feedback | `ProgressBar::new(len)` |
+
+## Code Pattern: CLI Structure
+
+```rust
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "myapp", about = "My CLI tool")]
+struct Cli {
+    /// Enable verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new project
+    Init { name: String },
+    /// Run the application
+    Run {
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Init { name } => init_project(&name)?,
+        Commands::Run { port } => run_server(port.unwrap_or(8080))?,
+    }
+    Ok(())
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Errors to stdout | Breaks piping | eprintln! |
+| No help text | Poor UX | #[arg(help = "...")] |
+| Panic on error | Bad exit code | Result + proper handling |
+| No progress for long ops | User uncertainty | indicatif |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Type-safe args | Derive macros | clap Parser |
+| Error handling | Result propagation | anyhow + exit codes |
+| User feedback | Progress RAII | indicatif ProgressBar |
+| Config precedence | Builder pattern | Layered sources |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Error handling | m06-error-handling |
+| Type-driven args | m05-type-driven |
+| Progress lifecycle | m12-lifecycle |
+| Async CLI | m07-concurrency |

--- a/.agents/skills/domain-cloud-native/SKILL.md
+++ b/.agents/skills/domain-cloud-native/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: domain-cloud-native
+description: "Use when building cloud-native apps. Keywords: kubernetes, k8s, docker, container, grpc, tonic, microservice, service mesh, observability, tracing, metrics, health check, cloud, deployment, 云原生, 微服务, 容器"
+user-invocable: false
+---
+
+# Cloud-Native Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| 12-Factor | Config from env | Environment-based config |
+| Observability | Metrics + traces | tracing + opentelemetry |
+| Health checks | Liveness/readiness | Dedicated endpoints |
+| Graceful shutdown | Clean termination | Signal handling |
+| Horizontal scale | Stateless design | No local state |
+| Container-friendly | Small binaries | Release optimization |
+
+---
+
+## Critical Constraints
+
+### Stateless Design
+
+```
+RULE: No local persistent state
+WHY: Pods can be killed/rescheduled anytime
+RUST: External state (Redis, DB), no static mut
+```
+
+### Graceful Shutdown
+
+```
+RULE: Handle SIGTERM, drain connections
+WHY: Zero-downtime deployments
+RUST: tokio::signal + graceful shutdown
+```
+
+### Observability
+
+```
+RULE: Every request must be traceable
+WHY: Debugging distributed systems
+RUST: tracing spans, opentelemetry export
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need distributed tracing"
+    ↓ m12-lifecycle: Span lifecycle
+    ↓ tracing + opentelemetry
+
+"Need graceful shutdown"
+    ↓ m07-concurrency: Signal handling
+    ↓ m12-lifecycle: Connection draining
+
+"Need health checks"
+    ↓ domain-web: HTTP endpoints
+    ↓ m06-error-handling: Health status
+```
+
+---
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| gRPC | tonic |
+| Kubernetes | kube, kube-runtime |
+| Docker | bollard |
+| Tracing | tracing, opentelemetry |
+| Metrics | prometheus, metrics |
+| Config | config, figment |
+| Health | HTTP endpoints |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| gRPC services | Service mesh | tonic + tower |
+| K8s operators | Custom resources | kube-runtime Controller |
+| Observability | Debugging | tracing + OTEL |
+| Health checks | Orchestration | `/health`, `/ready` |
+| Config | 12-factor | Env vars + secrets |
+
+## Code Pattern: Graceful Shutdown
+
+```rust
+use tokio::signal;
+
+async fn run_server() -> anyhow::Result<()> {
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready));
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    signal::ctrl_c().await.expect("failed to listen for ctrl+c");
+    tracing::info!("shutdown signal received");
+}
+```
+
+## Health Check Pattern
+
+```rust
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn ready(State(db): State<Arc<DbPool>>) -> StatusCode {
+    match db.ping().await {
+        Ok(_) => StatusCode::OK,
+        Err(_) => StatusCode::SERVICE_UNAVAILABLE,
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Local file state | Not stateless | External storage |
+| No SIGTERM handling | Hard kills | Graceful shutdown |
+| No tracing | Can't debug | tracing spans |
+| Static config | Not 12-factor | Env vars |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Stateless | External state | Arc<Client> for external |
+| Graceful shutdown | Signal handling | tokio::signal |
+| Tracing | Span lifecycle | tracing + OTEL |
+| Health checks | HTTP endpoints | Dedicated routes |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Async patterns | m07-concurrency |
+| HTTP endpoints | domain-web |
+| Error handling | m13-domain-error |
+| Resource lifecycle | m12-lifecycle |

--- a/.agents/skills/domain-embedded/SKILL.md
+++ b/.agents/skills/domain-embedded/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: domain-embedded
+description: "Use when developing embedded/no_std Rust. Keywords: embedded, no_std, microcontroller, MCU, ARM, RISC-V, bare metal, firmware, HAL, PAC, RTIC, embassy, interrupt, DMA, peripheral, GPIO, SPI, I2C, UART, embedded-hal, cortex-m, esp32, stm32, nrf, 嵌入式, 单片机, 固件, 裸机"
+globs: ["**/Cargo.toml", "**/.cargo/config.toml"]
+user-invocable: false
+---
+
+## Project Context (Auto-Injected)
+
+**Target configuration:**
+!`cat .cargo/config.toml 2>/dev/null || echo "No .cargo/config.toml found"`
+
+---
+
+# Embedded Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| No heap | Stack allocation | heapless, no Box/Vec |
+| No std | Core only | #![no_std] |
+| Real-time | Predictable timing | No dynamic alloc |
+| Resource limited | Minimal memory | Static buffers |
+| Hardware safety | Safe peripheral access | HAL + ownership |
+| Interrupt safe | No blocking in ISR | Atomic, critical sections |
+
+---
+
+## Critical Constraints
+
+### No Dynamic Allocation
+
+```
+RULE: Cannot use heap (no allocator)
+WHY: Deterministic memory, no OOM
+RUST: heapless::Vec<T, N>, arrays
+```
+
+### Interrupt Safety
+
+```
+RULE: Shared state must be interrupt-safe
+WHY: ISR can preempt at any time
+RUST: Mutex<RefCell<T>> + critical section
+```
+
+### Hardware Ownership
+
+```
+RULE: Peripherals must have clear ownership
+WHY: Prevent conflicting access
+RUST: HAL takes ownership, singletons
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need no_std compatible data structures"
+    ↓ m02-resource: heapless collections
+    ↓ Static sizing: heapless::Vec<T, N>
+
+"Need interrupt-safe state"
+    ↓ m03-mutability: Mutex<RefCell<Option<T>>>
+    ↓ m07-concurrency: Critical sections
+
+"Need peripheral ownership"
+    ↓ m01-ownership: Singleton pattern
+    ↓ m12-lifecycle: RAII for hardware
+```
+
+---
+
+## Layer Stack
+
+| Layer | Examples | Purpose |
+|-------|----------|---------|
+| PAC | stm32f4, esp32c3 | Register access |
+| HAL | stm32f4xx-hal | Hardware abstraction |
+| Framework | RTIC, Embassy | Concurrency |
+| Traits | embedded-hal | Portable drivers |
+
+## Framework Comparison
+
+| Framework | Style | Best For |
+|-----------|-------|----------|
+| RTIC | Priority-based | Interrupt-driven apps |
+| Embassy | Async | Complex state machines |
+| Bare metal | Manual | Simple apps |
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Runtime (ARM) | cortex-m-rt |
+| Panic handler | panic-halt, panic-probe |
+| Collections | heapless |
+| HAL traits | embedded-hal |
+| Logging | defmt |
+| Flash/debug | probe-run |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| no_std setup | Bare metal | `#![no_std]` + `#![no_main]` |
+| Entry point | Startup | `#[entry]` or embassy |
+| Static state | ISR access | `Mutex<RefCell<Option<T>>>` |
+| Fixed buffers | No heap | `heapless::Vec<T, N>` |
+
+## Code Pattern: Static Peripheral
+
+```rust
+#![no_std]
+#![no_main]
+
+use cortex_m::interrupt::{self, Mutex};
+use core::cell::RefCell;
+
+static LED: Mutex<RefCell<Option<Led>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+    let led = Led::new(dp.GPIOA);
+
+    interrupt::free(|cs| {
+        LED.borrow(cs).replace(Some(led));
+    });
+
+    loop {
+        interrupt::free(|cs| {
+            if let Some(led) = LED.borrow(cs).borrow_mut().as_mut() {
+                led.toggle();
+            }
+        });
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Using Vec | Heap allocation | heapless::Vec |
+| No critical section | Race with ISR | Mutex + interrupt::free |
+| Blocking in ISR | Missed interrupts | Defer to main loop |
+| Unsafe peripheral | Hardware conflict | HAL ownership |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| No heap | Static collections | heapless::Vec<T, N> |
+| ISR safety | Critical sections | Mutex<RefCell<T>> |
+| Hardware ownership | Singleton | take().unwrap() |
+| no_std | Core-only | #![no_std], #![no_main] |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Static memory | m02-resource |
+| Interior mutability | m03-mutability |
+| Interrupt patterns | m07-concurrency |
+| Unsafe for hardware | unsafe-checker |

--- a/.agents/skills/domain-fintech/SKILL.md
+++ b/.agents/skills/domain-fintech/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: domain-fintech
+description: "Use when building fintech apps. Keywords: fintech, trading, decimal, currency, financial, money, transaction, ledger, payment, exchange rate, precision, rounding, accounting, 金融, 交易系统, 货币, 支付"
+user-invocable: false
+---
+
+# FinTech Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| Audit trail | Immutable records | Arc<T>, no mutation |
+| Precision | No floating point | rust_decimal |
+| Consistency | Transaction boundaries | Clear ownership |
+| Compliance | Complete logging | Structured tracing |
+| Reproducibility | Deterministic execution | No race conditions |
+
+---
+
+## Critical Constraints
+
+### Financial Precision
+
+```
+RULE: Never use f64 for money
+WHY: Floating point loses precision
+RUST: Use rust_decimal::Decimal
+```
+
+### Audit Requirements
+
+```
+RULE: All transactions must be immutable and traceable
+WHY: Regulatory compliance, dispute resolution
+RUST: Arc<T> for sharing, event sourcing pattern
+```
+
+### Consistency
+
+```
+RULE: Money can't disappear or appear
+WHY: Double-entry accounting principles
+RUST: Transaction types with validated totals
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need immutable transaction records"
+    ↓ m09-domain: Model as Value Objects
+    ↓ m01-ownership: Use Arc for shared immutable data
+
+"Need precise decimal math"
+    ↓ m05-type-driven: Newtype for Currency/Amount
+    ↓ rust_decimal: Use Decimal type
+
+"Need transaction boundaries"
+    ↓ m12-lifecycle: RAII for transaction scope
+    ↓ m09-domain: Aggregate boundaries
+```
+
+---
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Decimal math | rust_decimal |
+| Date/time | chrono, time |
+| UUID | uuid |
+| Serialization | serde |
+| Validation | validator |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Currency newtype | Type safety | `struct Amount(Decimal);` |
+| Transaction | Atomic operations | Event sourcing |
+| Audit log | Traceability | Structured logging with trace IDs |
+| Ledger | Double-entry | Debit/credit balance |
+
+## Code Pattern: Currency Type
+
+```rust
+use rust_decimal::Decimal;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Amount {
+    value: Decimal,
+    currency: Currency,
+}
+
+impl Amount {
+    pub fn new(value: Decimal, currency: Currency) -> Self {
+        Self { value, currency }
+    }
+
+    pub fn add(&self, other: &Amount) -> Result<Amount, CurrencyMismatch> {
+        if self.currency != other.currency {
+            return Err(CurrencyMismatch);
+        }
+        Ok(Amount::new(self.value + other.value, self.currency))
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Using f64 | Precision loss | rust_decimal |
+| Mutable transaction | Audit trail broken | Immutable + events |
+| String for amount | No validation | Validated newtype |
+| Silent overflow | Money disappears | Checked arithmetic |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Immutable records | Event sourcing | Arc<T>, Clone |
+| Transaction scope | Aggregate | Owned children |
+| Precision | Value Object | rust_decimal newtype |
+| Thread-safe sharing | Shared immutable | Arc (not Rc) |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Value Object design | m09-domain |
+| Ownership for immutable | m01-ownership |
+| Arc for sharing | m02-resource |
+| Error handling | m13-domain-error |

--- a/.agents/skills/domain-iot/SKILL.md
+++ b/.agents/skills/domain-iot/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: domain-iot
+description: "Use when building IoT apps. Keywords: IoT, Internet of Things, sensor, MQTT, device, edge computing, telemetry, actuator, smart home, gateway, protocol, 物联网, 传感器, 边缘计算, 智能家居"
+user-invocable: false
+---
+
+# IoT Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| Unreliable network | Offline-first | Local buffering |
+| Power constraints | Efficient code | Sleep modes, minimal alloc |
+| Resource limits | Small footprint | no_std where needed |
+| Security | Encrypted comms | TLS, signed firmware |
+| Reliability | Self-recovery | Watchdog, error handling |
+| OTA updates | Safe upgrades | Rollback capability |
+
+---
+
+## Critical Constraints
+
+### Network Unreliability
+
+```
+RULE: Network can fail at any time
+WHY: Wireless, remote locations
+RUST: Local queue, retry with backoff
+```
+
+### Power Management
+
+```
+RULE: Minimize power consumption
+WHY: Battery life, energy costs
+RUST: Sleep modes, efficient algorithms
+```
+
+### Device Security
+
+```
+RULE: All communication encrypted
+WHY: Physical access possible
+RUST: TLS, signed messages
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need offline-first design"
+    ↓ m12-lifecycle: Local buffer with persistence
+    ↓ m13-domain-error: Retry with backoff
+
+"Need power efficiency"
+    ↓ domain-embedded: no_std patterns
+    ↓ m10-performance: Minimal allocations
+
+"Need reliable messaging"
+    ↓ m07-concurrency: Async with timeout
+    ↓ MQTT: QoS levels
+```
+
+---
+
+## Environment Comparison
+
+| Environment | Stack | Crates |
+|-------------|-------|--------|
+| Linux gateway | tokio + std | rumqttc, reqwest |
+| MCU device | embassy + no_std | embedded-hal |
+| Hybrid | Split workloads | Both |
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| MQTT (std) | rumqttc, paho-mqtt |
+| Embedded | embedded-hal, embassy |
+| Async (std) | tokio |
+| Async (no_std) | embassy |
+| Logging (no_std) | defmt |
+| Logging (std) | tracing |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Pub/Sub | Device comms | MQTT topics |
+| Edge compute | Local processing | Filter before upload |
+| OTA updates | Firmware upgrade | Signed + rollback |
+| Power mgmt | Battery life | Sleep + wake events |
+| Store & forward | Network reliability | Local queue |
+
+## Code Pattern: MQTT Client
+
+```rust
+use rumqttc::{AsyncClient, MqttOptions, QoS};
+
+async fn run_mqtt() -> anyhow::Result<()> {
+    let mut options = MqttOptions::new("device-1", "broker.example.com", 1883);
+    options.set_keep_alive(Duration::from_secs(30));
+
+    let (client, mut eventloop) = AsyncClient::new(options, 10);
+
+    // Subscribe to commands
+    client.subscribe("devices/device-1/commands", QoS::AtLeastOnce).await?;
+
+    // Publish telemetry
+    tokio::spawn(async move {
+        loop {
+            let data = read_sensor().await;
+            client.publish("devices/device-1/telemetry", QoS::AtLeastOnce, false, data).await.ok();
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        }
+    });
+
+    // Process events
+    loop {
+        match eventloop.poll().await {
+            Ok(event) => handle_event(event).await,
+            Err(e) => {
+                tracing::error!("MQTT error: {}", e);
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
+        }
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| No retry logic | Lost data | Exponential backoff |
+| Always-on radio | Battery drain | Sleep between sends |
+| Unencrypted MQTT | Security risk | TLS |
+| No local buffer | Network outage = data loss | Persist locally |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Offline-first | Store & forward | Local queue + flush |
+| Power efficiency | Sleep patterns | Timer-based wake |
+| Network reliability | Retry | tokio-retry, backoff |
+| Security | TLS | rustls, native-tls |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Embedded patterns | domain-embedded |
+| Async patterns | m07-concurrency |
+| Error recovery | m13-domain-error |
+| Performance | m10-performance |

--- a/.agents/skills/domain-ml/SKILL.md
+++ b/.agents/skills/domain-ml/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: domain-ml
+description: "Use when building ML/AI apps in Rust. Keywords: machine learning, ML, AI, tensor, model, inference, neural network, deep learning, training, prediction, ndarray, tch-rs, burn, candle, 机器学习, 人工智能, 模型推理"
+user-invocable: false
+---
+
+# Machine Learning Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| Large data | Efficient memory | Zero-copy, streaming |
+| GPU acceleration | CUDA/Metal support | candle, tch-rs |
+| Model portability | Standard formats | ONNX |
+| Batch processing | Throughput over latency | Batched inference |
+| Numerical precision | Float handling | ndarray, careful f32/f64 |
+| Reproducibility | Deterministic | Seeded random, versioning |
+
+---
+
+## Critical Constraints
+
+### Memory Efficiency
+
+```
+RULE: Avoid copying large tensors
+WHY: Memory bandwidth is bottleneck
+RUST: References, views, in-place ops
+```
+
+### GPU Utilization
+
+```
+RULE: Batch operations for GPU efficiency
+WHY: GPU overhead per kernel launch
+RUST: Batch sizes, async data loading
+```
+
+### Model Portability
+
+```
+RULE: Use standard model formats
+WHY: Train in Python, deploy in Rust
+RUST: ONNX via tract or candle
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need efficient data pipelines"
+    ↓ m10-performance: Streaming, batching
+    ↓ polars: Lazy evaluation
+
+"Need GPU inference"
+    ↓ m07-concurrency: Async data loading
+    ↓ candle/tch-rs: CUDA backend
+
+"Need model loading"
+    ↓ m12-lifecycle: Lazy init, caching
+    ↓ tract: ONNX runtime
+```
+
+---
+
+## Use Case → Framework
+
+| Use Case | Recommended | Why |
+|----------|-------------|-----|
+| Inference only | tract (ONNX) | Lightweight, portable |
+| Training + inference | candle, burn | Pure Rust, GPU |
+| PyTorch models | tch-rs | Direct bindings |
+| Data pipelines | polars | Fast, lazy eval |
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Tensors | ndarray |
+| ONNX inference | tract |
+| ML framework | candle, burn |
+| PyTorch bindings | tch-rs |
+| Data processing | polars |
+| Embeddings | fastembed |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Model loading | Once, reuse | `OnceLock<Model>` |
+| Batching | Throughput | Collect then process |
+| Streaming | Large data | Iterator-based |
+| GPU async | Parallelism | Data loading parallel to compute |
+
+## Code Pattern: Inference Server
+
+```rust
+use std::sync::OnceLock;
+use tract_onnx::prelude::*;
+
+static MODEL: OnceLock<SimplePlan<TypedFact, Box<dyn TypedOp>, Graph<TypedFact, Box<dyn TypedOp>>>> = OnceLock::new();
+
+fn get_model() -> &'static SimplePlan<...> {
+    MODEL.get_or_init(|| {
+        tract_onnx::onnx()
+            .model_for_path("model.onnx")
+            .unwrap()
+            .into_optimized()
+            .unwrap()
+            .into_runnable()
+            .unwrap()
+    })
+}
+
+async fn predict(input: Vec<f32>) -> anyhow::Result<Vec<f32>> {
+    let model = get_model();
+    let input = tract_ndarray::arr1(&input).into_shape((1, input.len()))?;
+    let result = model.run(tvec!(input.into()))?;
+    Ok(result[0].to_array_view::<f32>()?.iter().copied().collect())
+}
+```
+
+## Code Pattern: Batched Inference
+
+```rust
+async fn batch_predict(inputs: Vec<Vec<f32>>, batch_size: usize) -> Vec<Vec<f32>> {
+    let mut results = Vec::with_capacity(inputs.len());
+
+    for batch in inputs.chunks(batch_size) {
+        // Stack inputs into batch tensor
+        let batch_tensor = stack_inputs(batch);
+
+        // Run inference on batch
+        let batch_output = model.run(batch_tensor).await;
+
+        // Unstack results
+        results.extend(unstack_outputs(batch_output));
+    }
+
+    results
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Clone tensors | Memory waste | Use views |
+| Single inference | GPU underutilized | Batch processing |
+| Load model per request | Slow | Singleton pattern |
+| Sync data loading | GPU idle | Async pipeline |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Memory efficiency | Zero-copy | ndarray views |
+| Model singleton | Lazy init | OnceLock<Model> |
+| Batch processing | Chunked iteration | chunks() + parallel |
+| GPU async | Concurrent loading | tokio::spawn + GPU |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Performance | m10-performance |
+| Lazy initialization | m12-lifecycle |
+| Async patterns | m07-concurrency |
+| Memory efficiency | m01-ownership |

--- a/.agents/skills/domain-web/SKILL.md
+++ b/.agents/skills/domain-web/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: domain-web
+description: "Use when building web services. Keywords: web server, HTTP, REST API, GraphQL, WebSocket, axum, actix, warp, rocket, tower, hyper, reqwest, middleware, router, handler, extractor, state management, authentication, authorization, JWT, session, cookie, CORS, rate limiting, web 开发, HTTP 服务, API 设计, 中间件, 路由"
+globs: ["**/Cargo.toml"]
+user-invocable: false
+---
+
+# Web Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| Stateless HTTP | No request-local globals | State in extractors |
+| Concurrency | Handle many connections | Async, Send + Sync |
+| Latency SLA | Fast response | Efficient ownership |
+| Security | Input validation | Type-safe extractors |
+| Observability | Request tracing | tracing + tower layers |
+
+---
+
+## Critical Constraints
+
+### Async by Default
+
+```
+RULE: Web handlers must not block
+WHY: Block one task = block many requests
+RUST: async/await, spawn_blocking for CPU work
+```
+
+### State Management
+
+```
+RULE: Shared state must be thread-safe
+WHY: Handlers run on any thread
+RUST: Arc<T>, Arc<RwLock<T>> for mutable
+```
+
+### Request Lifecycle
+
+```
+RULE: Resources live only for request duration
+WHY: Memory management, no leaks
+RUST: Extractors, proper ownership
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need shared application state"
+    ↓ m07-concurrency: Use Arc for thread-safe sharing
+    ↓ m02-resource: Arc<RwLock<T>> for mutable state
+
+"Need request validation"
+    ↓ m05-type-driven: Validated extractors
+    ↓ m06-error-handling: IntoResponse for errors
+
+"Need middleware stack"
+    ↓ m12-lifecycle: Tower layers
+    ↓ m04-zero-cost: Trait-based composition
+```
+
+---
+
+## Framework Comparison
+
+| Framework | Style | Best For |
+|-----------|-------|----------|
+| axum | Functional, tower | Modern APIs |
+| actix-web | Actor-based | High performance |
+| warp | Filter composition | Composable APIs |
+| rocket | Macro-driven | Rapid development |
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| HTTP server | axum, actix-web |
+| HTTP client | reqwest |
+| JSON | serde_json |
+| Auth/JWT | jsonwebtoken |
+| Session | tower-sessions |
+| Database | sqlx, diesel |
+| Middleware | tower |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Extractors | Request parsing | `State(db)`, `Json(payload)` |
+| Error response | Unified errors | `impl IntoResponse` |
+| Middleware | Cross-cutting | Tower layers |
+| Shared state | App config | `Arc<AppState>` |
+
+## Code Pattern: Axum Handler
+
+```rust
+async fn handler(
+    State(db): State<Arc<DbPool>>,
+    Json(payload): Json<CreateUser>,
+) -> Result<Json<User>, AppError> {
+    let user = db.create_user(&payload).await?;
+    Ok(Json(user))
+}
+
+// Error handling
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            Self::NotFound => (StatusCode::NOT_FOUND, "Not found"),
+            Self::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal error"),
+        };
+        (status, Json(json!({"error": message}))).into_response()
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Blocking in handler | Latency spike | spawn_blocking |
+| Rc in state | Not Send + Sync | Use Arc |
+| No validation | Security risk | Type-safe extractors |
+| No error response | Bad UX | IntoResponse impl |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Async handlers | Async/await | tokio runtime |
+| Thread-safe state | Shared state | Arc<T>, Arc<RwLock<T>> |
+| Request lifecycle | Extractors | Ownership via From<Request> |
+| Middleware | Tower layers | Trait-based composition |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Async patterns | m07-concurrency |
+| State management | m02-resource |
+| Error handling | m06-error-handling |
+| Middleware design | m12-lifecycle |

--- a/.agents/skills/m01-ownership/SKILL.md
+++ b/.agents/skills/m01-ownership/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: m01-ownership
+description: "CRITICAL: Use for ownership/borrow/lifetime issues. Triggers: E0382, E0597, E0506, E0507, E0515, E0716, E0106, value moved, borrowed value does not live long enough, cannot move out of, use of moved value, ownership, borrow, lifetime, 'a, 'static, move, clone, Copy, 所有权, 借用, 生命周期"
+user-invocable: false
+---
+
+# Ownership & Lifetimes
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Who should own this data, and for how long?**
+
+Before fixing ownership errors, understand the data's role:
+- Is it shared or exclusive?
+- Is it short-lived or long-lived?
+- Is it transformed or just read?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0382 | "Clone it" | Who should own this data? |
+| E0597 | "Extend lifetime" | Is the scope boundary correct? |
+| E0506 | "End borrow first" | Should mutation happen elsewhere? |
+| E0507 | "Clone before move" | Why are we moving from a reference? |
+| E0515 | "Return owned" | Should caller own the data? |
+| E0716 | "Bind to variable" | Why is this temporary? |
+| E0106 | "Add 'a" | What is the actual lifetime relationship? |
+
+---
+
+## Thinking Prompt
+
+Before fixing an ownership error, ask:
+
+1. **What is this data's domain role?**
+   - Entity (unique identity) → owned
+   - Value Object (interchangeable) → clone/copy OK
+   - Temporary (computation result) → maybe restructure
+
+2. **Is the ownership design intentional?**
+   - By design → work within constraints
+   - Accidental → consider redesign
+
+3. **Fix symptom or redesign?**
+   - If Strike 3 (3rd attempt) → escalate to Layer 2
+
+---
+
+## Trace Up ↑
+
+When errors persist, trace to design layer:
+
+```
+E0382 (moved value)
+    ↑ Ask: What design choice led to this ownership pattern?
+    ↑ Check: m09-domain (is this Entity or Value Object?)
+    ↑ Check: domain-* (what constraints apply?)
+```
+
+| Persistent Error | Trace To | Question |
+|-----------------|----------|----------|
+| E0382 repeated | m02-resource | Should use Arc/Rc for sharing? |
+| E0597 repeated | m09-domain | Is scope boundary at right place? |
+| E0506/E0507 | m03-mutability | Should use interior mutability? |
+
+---
+
+## Trace Down ↓
+
+From design decisions to implementation:
+
+```
+"Data needs to be shared immutably"
+    ↓ Use: Arc<T> (multi-thread) or Rc<T> (single-thread)
+
+"Data needs exclusive ownership"
+    ↓ Use: move semantics, take ownership
+
+"Data is read-only view"
+    ↓ Use: &T (immutable borrow)
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Ownership | Cost | Use When |
+|---------|-----------|------|----------|
+| Move | Transfer | Zero | Caller doesn't need data |
+| `&T` | Borrow | Zero | Read-only access |
+| `&mut T` | Exclusive borrow | Zero | Need to modify |
+| `clone()` | Duplicate | Alloc + copy | Actually need a copy |
+| `Rc<T>` | Shared (single) | Ref count | Single-thread sharing |
+| `Arc<T>` | Shared (multi) | Atomic ref count | Multi-thread sharing |
+| `Cow<T>` | Clone-on-write | Alloc if mutated | Might modify |
+
+## Error Code Reference
+
+| Error | Cause | Quick Fix |
+|-------|-------|-----------|
+| E0382 | Value moved | Clone, reference, or redesign ownership |
+| E0597 | Reference outlives owner | Extend owner scope or restructure |
+| E0506 | Assign while borrowed | End borrow before mutation |
+| E0507 | Move out of borrowed | Clone or use reference |
+| E0515 | Return local reference | Return owned value |
+| E0716 | Temporary dropped | Bind to variable |
+| E0106 | Missing lifetime | Add `'a` annotation |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.clone()` everywhere | Hides design issues | Design ownership properly |
+| Fight borrow checker | Increases complexity | Work with the compiler |
+| `'static` for everything | Restricts flexibility | Use appropriate lifetimes |
+| Leak with `Box::leak` | Memory leak | Proper lifetime design |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Need smart pointers | m02-resource |
+| Need interior mutability | m03-mutability |
+| Data is domain entity | m09-domain |
+| Learning ownership concepts | m14-mental-model |

--- a/.agents/skills/m01-ownership/comparison.md
+++ b/.agents/skills/m01-ownership/comparison.md
@@ -1,0 +1,222 @@
+# Ownership: Comparison with Other Languages
+
+## Rust vs C++
+
+### Memory Management
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Default | Move semantics | Copy semantics (pre-C++11) |
+| Move | `let b = a;` (a invalidated) | `auto b = std::move(a);` (a valid but unspecified) |
+| Copy | `let b = a.clone();` | `auto b = a;` |
+| Safety | Compile-time enforcement | Runtime responsibility |
+
+### Rust Move vs C++ Move
+
+```rust
+// Rust: after move, 'a' is INVALID
+let a = String::from("hello");
+let b = a;  // a moved
+// println!("{}", a);  // COMPILE ERROR
+
+// Equivalent in C++:
+// std::string a = "hello";
+// std::string b = std::move(a);
+// std::cout << a;  // UNDEFINED (compiles but buggy)
+```
+
+### Smart Pointers
+
+| Rust | C++ | Purpose |
+|------|-----|---------|
+| `Box<T>` | `std::unique_ptr<T>` | Unique ownership |
+| `Rc<T>` | `std::shared_ptr<T>` | Shared ownership |
+| `Arc<T>` | `std::shared_ptr<T>` + atomic | Thread-safe shared |
+| `RefCell<T>` | (manual runtime checks) | Interior mutability |
+
+---
+
+## Rust vs Go
+
+### Memory Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Memory | Stack + heap, explicit | GC manages all |
+| Ownership | Enforced at compile-time | None (GC handles) |
+| Null | `Option<T>` | `nil` for pointers |
+| Concurrency | `Send`/`Sync` traits | Channels (less strict) |
+
+### Sharing Data
+
+```rust
+// Rust: explicit about sharing
+use std::sync::Arc;
+let data = Arc::new(vec![1, 2, 3]);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{:?}", data_clone);
+});
+
+// Go: implicit sharing
+// data := []int{1, 2, 3}
+// go func() {
+//     fmt.Println(data)  // potential race condition
+// }()
+```
+
+### Why No GC in Rust
+
+1. **Deterministic destruction**: Resources freed exactly when scope ends
+2. **Zero-cost**: No GC pauses or overhead
+3. **Embeddable**: Works in OS kernels, embedded systems
+4. **Predictable latency**: Critical for real-time systems
+
+---
+
+## Rust vs Java/C#
+
+### Reference Semantics
+
+| Aspect | Rust | Java/C# |
+|--------|------|---------|
+| Objects | Owned by default | Reference by default |
+| Null | `Option<T>` | `null` (nullable) |
+| Immutability | Default | Must use `final`/`readonly` |
+| Copy | Explicit `.clone()` | Reference copy (shallow) |
+
+### Comparison
+
+```rust
+// Rust: clear ownership
+fn process(data: Vec<i32>) {  // takes ownership
+    // data is ours, will be freed at end
+}
+
+let numbers = vec![1, 2, 3];
+process(numbers);
+// numbers is invalid here
+
+// Java: ambiguous ownership
+// void process(List<Integer> data) {
+//     // Who owns data? Caller? Callee? Both?
+//     // Can caller still use it?
+// }
+```
+
+---
+
+## Rust vs Python
+
+### Memory Model
+
+| Aspect | Rust | Python |
+|--------|------|--------|
+| Typing | Static, compile-time | Dynamic, runtime |
+| Memory | Ownership-based | Reference counting + GC |
+| Mutability | Default immutable | Default mutable |
+| Performance | Native, zero-cost | Interpreted, higher overhead |
+
+### Common Pattern Translation
+
+```rust
+// Rust: borrowing iteration
+let items = vec!["a", "b", "c"];
+for item in &items {
+    println!("{}", item);
+}
+// items still usable
+
+// Python: iteration doesn't consume
+// items = ["a", "b", "c"]
+// for item in items:
+//     print(item)
+// items still usable (different reason - ref counting)
+```
+
+---
+
+## Unique Rust Concepts
+
+### Concepts Other Languages Lack
+
+1. **Borrow Checker**: No other mainstream language has compile-time borrow checking
+2. **Lifetimes**: Explicit annotation of reference validity
+3. **Move by Default**: Values move, not copy
+4. **No Null**: `Option<T>` instead of null pointers
+5. **Affine Types**: Values can be used at most once
+
+### Learning Curve Areas
+
+| Concept | Coming From | Key Insight |
+|---------|-------------|-------------|
+| Ownership | GC languages | Think about who "owns" data |
+| Borrowing | C/C++ | Like references but checked |
+| Lifetimes | Any | Explicit scope of validity |
+| Move | C++ | Move is default, not copy |
+
+---
+
+## Mental Model Shifts
+
+### From GC Languages (Java, Go, Python)
+
+```
+Before: "Memory just works, GC handles it"
+After:  "I explicitly decide who owns data and when it's freed"
+```
+
+Key shifts:
+- Think about ownership at design time
+- Returning references requires lifetime thinking
+- No more `null` - use `Option<T>`
+
+### From C/C++
+
+```
+Before: "I manually manage memory and hope I get it right"
+After:  "Compiler enforces correctness, I fight the borrow checker"
+```
+
+Key shifts:
+- Trust the compiler's errors
+- Move is the default (unlike C++ copy)
+- Smart pointers are idiomatic, not overhead
+
+### From Functional Languages (Haskell, ML)
+
+```
+Before: "Everything is immutable, copying is fine"
+After:  "Mutability is explicit, ownership prevents aliasing"
+```
+
+Key shifts:
+- Mutability is safe because of ownership rules
+- No persistent data structures needed (usually)
+- Performance characteristics are explicit
+
+---
+
+## Performance Trade-offs
+
+| Language | Memory Overhead | Latency | Throughput |
+|----------|-----------------|---------|------------|
+| Rust | Minimal (no GC) | Predictable | Excellent |
+| C++ | Minimal | Predictable | Excellent |
+| Go | GC overhead | GC pauses | Good |
+| Java | GC overhead | GC pauses | Good |
+| Python | High (ref counting + GC) | Variable | Lower |
+
+### When Rust Ownership Wins
+
+1. **Real-time systems**: No GC pauses
+2. **Embedded**: No runtime overhead
+3. **High-performance**: Zero-cost abstractions
+4. **Concurrent**: Data races prevented at compile time
+
+### When GC Might Be Preferable
+
+1. **Rapid prototyping**: Less mental overhead
+2. **Complex object graphs**: Cycles are tricky in Rust
+3. **GUI applications**: Object lifetimes are dynamic
+4. **Small programs**: Overhead doesn't matter

--- a/.agents/skills/m01-ownership/examples/best-practices.md
+++ b/.agents/skills/m01-ownership/examples/best-practices.md
@@ -1,0 +1,339 @@
+# Ownership Best Practices
+
+## API Design Patterns
+
+### 1. Prefer Borrowing Over Ownership
+
+```rust
+// BAD: takes ownership unnecessarily
+fn print_name(name: String) {
+    println!("Name: {}", name);
+}
+
+// GOOD: borrows instead
+fn print_name(name: &str) {
+    println!("Name: {}", name);
+}
+
+// Caller benefits:
+let name = String::from("Alice");
+print_name(&name);  // can reuse name
+print_name(&name);  // still valid
+```
+
+### 2. Return Owned Values from Constructors
+
+```rust
+// GOOD: return owned value
+impl User {
+    fn new(name: &str) -> Self {
+        User {
+            name: name.to_string(),
+        }
+    }
+}
+
+// GOOD: accept Into<String> for flexibility
+impl User {
+    fn new(name: impl Into<String>) -> Self {
+        User {
+            name: name.into(),
+        }
+    }
+}
+
+// Usage:
+let u1 = User::new("Alice");        // &str
+let u2 = User::new(String::from("Bob"));  // String
+```
+
+### 3. Use AsRef for Generic Borrowing
+
+```rust
+// GOOD: accepts both &str and String
+fn process<S: AsRef<str>>(input: S) {
+    let s = input.as_ref();
+    println!("{}", s);
+}
+
+process("literal");           // &str
+process(String::from("owned")); // String
+process(&String::from("ref")); // &String
+```
+
+### 4. Cow for Clone-on-Write
+
+```rust
+use std::borrow::Cow;
+
+// Return borrowed when possible, owned when needed
+fn maybe_modify(s: &str, uppercase: bool) -> Cow<'_, str> {
+    if uppercase {
+        Cow::Owned(s.to_uppercase())  // allocates
+    } else {
+        Cow::Borrowed(s)  // zero-cost
+    }
+}
+
+let input = "hello";
+let result = maybe_modify(input, false);
+// result is borrowed, no allocation
+```
+
+---
+
+## Struct Design Patterns
+
+### 1. Owned Fields vs References
+
+```rust
+// Use owned fields for most cases
+struct User {
+    name: String,
+    email: String,
+}
+
+// Use references only when lifetime is clear
+struct UserView<'a> {
+    name: &'a str,
+    email: &'a str,
+}
+
+// Pattern: owned data + view for efficiency
+impl User {
+    fn view(&self) -> UserView<'_> {
+        UserView {
+            name: &self.name,
+            email: &self.email,
+        }
+    }
+}
+```
+
+### 2. Builder Pattern with Ownership
+
+```rust
+#[derive(Default)]
+struct RequestBuilder {
+    url: Option<String>,
+    method: Option<String>,
+    body: Option<Vec<u8>>,
+}
+
+impl RequestBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    // Take self by value for chaining
+    fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    fn method(mut self, method: impl Into<String>) -> Self {
+        self.method = Some(method.into());
+        self
+    }
+
+    fn build(self) -> Result<Request, Error> {
+        Ok(Request {
+            url: self.url.ok_or(Error::MissingUrl)?,
+            method: self.method.unwrap_or_else(|| "GET".to_string()),
+            body: self.body.unwrap_or_default(),
+        })
+    }
+}
+
+// Usage:
+let req = RequestBuilder::new()
+    .url("https://example.com")
+    .method("POST")
+    .build()?;
+```
+
+### 3. Interior Mutability When Needed
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Shared mutable state in single-threaded context
+struct Counter {
+    value: Rc<RefCell<u32>>,
+}
+
+impl Counter {
+    fn new() -> Self {
+        Counter {
+            value: Rc::new(RefCell::new(0)),
+        }
+    }
+
+    fn increment(&self) {
+        *self.value.borrow_mut() += 1;
+    }
+
+    fn get(&self) -> u32 {
+        *self.value.borrow()
+    }
+
+    fn clone_handle(&self) -> Self {
+        Counter {
+            value: Rc::clone(&self.value),
+        }
+    }
+}
+```
+
+---
+
+## Collection Patterns
+
+### 1. Efficient Iteration
+
+```rust
+let items = vec![1, 2, 3, 4, 5];
+
+// Iterate by reference (no move)
+for item in &items {
+    println!("{}", item);
+}
+
+// Iterate by mutable reference
+for item in &mut items.clone() {
+    *item *= 2;
+}
+
+// Consume with into_iter when done
+let sum: i32 = items.into_iter().sum();
+```
+
+### 2. Collecting Results
+
+```rust
+// Collect into owned collection
+let strings: Vec<String> = (0..5)
+    .map(|i| format!("item_{}", i))
+    .collect();
+
+// Collect references
+let refs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
+
+// Collect with transformation
+let result: Result<Vec<i32>, _> = ["1", "2", "3"]
+    .iter()
+    .map(|s| s.parse::<i32>())
+    .collect();
+```
+
+### 3. Entry API for Maps
+
+```rust
+use std::collections::HashMap;
+
+let mut map: HashMap<String, Vec<i32>> = HashMap::new();
+
+// Efficient: don't search twice
+map.entry("key".to_string())
+   .or_insert_with(Vec::new)
+   .push(42);
+
+// With entry modification
+map.entry("key".to_string())
+   .and_modify(|v| v.push(43))
+   .or_insert_with(|| vec![43]);
+```
+
+---
+
+## Error Handling with Ownership
+
+### 1. Preserve Context in Errors
+
+```rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct ParseError {
+    input: String,  // owns the problematic input
+    message: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to parse '{}': {}", self.input, self.message)
+    }
+}
+
+fn parse(input: &str) -> Result<i32, ParseError> {
+    input.parse().map_err(|_| ParseError {
+        input: input.to_string(),  // clone for error context
+        message: "not a valid integer".to_string(),
+    })
+}
+```
+
+### 2. Ownership in Result Chains
+
+```rust
+fn process_data(path: &str) -> Result<ProcessedData, Error> {
+    let content = std::fs::read_to_string(path)?;  // owned String
+    let parsed = parse_content(&content)?;          // borrow
+    let processed = transform(parsed)?;             // ownership moves
+    Ok(processed)                                   // return owned
+}
+```
+
+---
+
+## Performance Considerations
+
+### 1. Avoid Unnecessary Clones
+
+```rust
+// BAD: cloning just to compare
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s.clone() == target)  // unnecessary clone
+}
+
+// GOOD: compare references
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s == target)  // String implements PartialEq<str>
+}
+```
+
+### 2. Use Slices for Flexibility
+
+```rust
+// BAD: requires Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// GOOD: accepts any slice
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// Now works with:
+sum(&vec![1, 2, 3]);     // Vec
+sum(&[1, 2, 3]);         // array
+sum(&array[1..3]);       // slice
+```
+
+### 3. In-Place Mutation
+
+```rust
+// BAD: allocates new String
+fn make_uppercase(s: &str) -> String {
+    s.to_uppercase()
+}
+
+// GOOD when you own the data: mutate in place
+fn make_uppercase(mut s: String) -> String {
+    s.make_ascii_uppercase();  // in-place for ASCII
+    s
+}
+```

--- a/.agents/skills/m01-ownership/patterns/common-errors.md
+++ b/.agents/skills/m01-ownership/patterns/common-errors.md
@@ -1,0 +1,265 @@
+# Common Ownership Errors & Fixes
+
+## E0382: Use of Moved Value
+
+### Error Pattern
+```rust
+let s = String::from("hello");
+let s2 = s;          // s moved here
+println!("{}", s);   // ERROR: value borrowed after move
+```
+
+### Fix Options
+
+**Option 1: Clone (if ownership not needed)**
+```rust
+let s = String::from("hello");
+let s2 = s.clone();  // s is cloned
+println!("{}", s);   // OK: s still valid
+```
+
+**Option 2: Borrow (if modification not needed)**
+```rust
+let s = String::from("hello");
+let s2 = &s;         // borrow, not move
+println!("{}", s);   // OK
+println!("{}", s2);  // OK
+```
+
+**Option 3: Use Rc/Arc (for shared ownership)**
+```rust
+use std::rc::Rc;
+let s = Rc::new(String::from("hello"));
+let s2 = Rc::clone(&s);  // shared ownership
+println!("{}", s);       // OK
+println!("{}", s2);      // OK
+```
+
+---
+
+## E0597: Borrowed Value Does Not Live Long Enough
+
+### Error Pattern
+```rust
+fn get_str() -> &str {
+    let s = String::from("hello");
+    &s  // ERROR: s dropped here, but reference returned
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn get_str() -> String {
+    String::from("hello")  // return owned value
+}
+```
+
+**Option 2: Use 'static lifetime**
+```rust
+fn get_str() -> &'static str {
+    "hello"  // string literal has 'static lifetime
+}
+```
+
+**Option 3: Accept reference parameter**
+```rust
+fn get_str<'a>(s: &'a str) -> &'a str {
+    s  // return reference with same lifetime as input
+}
+```
+
+---
+
+## E0499: Cannot Borrow as Mutable More Than Once
+
+### Error Pattern
+```rust
+let mut s = String::from("hello");
+let r1 = &mut s;
+let r2 = &mut s;  // ERROR: second mutable borrow
+println!("{}, {}", r1, r2);
+```
+
+### Fix Options
+
+**Option 1: Sequential borrows**
+```rust
+let mut s = String::from("hello");
+{
+    let r1 = &mut s;
+    r1.push_str(" world");
+}  // r1 goes out of scope
+let r2 = &mut s;  // OK: r1 no longer exists
+```
+
+**Option 2: Use RefCell for interior mutability**
+```rust
+use std::cell::RefCell;
+let s = RefCell::new(String::from("hello"));
+let mut r1 = s.borrow_mut();
+// drop r1 before borrowing again
+drop(r1);
+let mut r2 = s.borrow_mut();
+```
+
+---
+
+## E0502: Cannot Borrow as Mutable While Immutable Borrow Exists
+
+### Error Pattern
+```rust
+let mut v = vec![1, 2, 3];
+let first = &v[0];      // immutable borrow
+v.push(4);              // ERROR: mutable borrow while immutable exists
+println!("{}", first);
+```
+
+### Fix Options
+
+**Option 1: Finish using immutable borrow first**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0];       // copy value, not borrow
+v.push(4);              // OK
+println!("{}", first);  // OK: using copied value
+```
+
+**Option 2: Clone before mutating**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0].clone();  // if T: Clone
+v.push(4);
+println!("{}", first);
+```
+
+---
+
+## E0507: Cannot Move Out of Borrowed Content
+
+### Error Pattern
+```rust
+fn take_string(s: &String) {
+    let moved = *s;  // ERROR: cannot move out of borrowed content
+}
+```
+
+### Fix Options
+
+**Option 1: Clone**
+```rust
+fn take_string(s: &String) {
+    let cloned = s.clone();
+}
+```
+
+**Option 2: Take ownership in function signature**
+```rust
+fn take_string(s: String) {  // take ownership
+    let moved = s;
+}
+```
+
+**Option 3: Use mem::take for Option/Default types**
+```rust
+fn take_from_option(opt: &mut Option<String>) -> Option<String> {
+    std::mem::take(opt)  // replaces with None, returns owned value
+}
+```
+
+---
+
+## E0515: Return Local Reference
+
+### Error Pattern
+```rust
+fn create_string() -> &String {
+    let s = String::from("hello");
+    &s  // ERROR: cannot return reference to local variable
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn create_string() -> String {
+    String::from("hello")
+}
+```
+
+**Option 2: Use static/const**
+```rust
+fn get_static_str() -> &'static str {
+    "hello"
+}
+```
+
+---
+
+## E0716: Temporary Value Dropped While Borrowed
+
+### Error Pattern
+```rust
+let r: &str = &String::from("hello");  // ERROR: temporary dropped
+println!("{}", r);
+```
+
+### Fix Options
+
+**Option 1: Bind to variable first**
+```rust
+let s = String::from("hello");
+let r: &str = &s;
+println!("{}", r);
+```
+
+**Option 2: Use let binding with reference**
+```rust
+let r: &str = {
+    let s = String::from("hello");
+    // s.as_str()  // ERROR: still temporary
+    Box::leak(s.into_boxed_str())  // extreme: leak for 'static
+};
+```
+
+---
+
+## Pattern: Loop Ownership Issues
+
+### Error Pattern
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in strings {
+    println!("{}", s);
+}
+// ERROR: strings moved into loop
+println!("{:?}", strings);
+```
+
+### Fix Options
+
+**Option 1: Iterate by reference**
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in &strings {
+    println!("{}", s);
+}
+println!("{:?}", strings);  // OK
+```
+
+**Option 2: Use iter()**
+```rust
+for s in strings.iter() {
+    println!("{}", s);
+}
+```
+
+**Option 3: Clone if needed**
+```rust
+for s in strings.clone() {
+    // consumes cloned vec
+}
+println!("{:?}", strings);  // original still available
+```

--- a/.agents/skills/m01-ownership/patterns/lifetime-patterns.md
+++ b/.agents/skills/m01-ownership/patterns/lifetime-patterns.md
@@ -1,0 +1,229 @@
+# Lifetime Patterns
+
+## Basic Lifetime Annotation
+
+### When Required
+```rust
+// ERROR: missing lifetime specifier
+fn longest(x: &str, y: &str) -> &str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// FIX: explicit lifetime
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+```
+
+### Lifetime Elision Rules
+1. Each input reference gets its own lifetime
+2. If one input lifetime, output uses same
+3. If `&self` or `&mut self`, output uses self's lifetime
+
+```rust
+// These are equivalent (elision applies):
+fn first_word(s: &str) -> &str { ... }
+fn first_word<'a>(s: &'a str) -> &'a str { ... }
+
+// Method with self (elision applies):
+impl MyStruct {
+    fn get_ref(&self) -> &str { ... }
+    // Equivalent to:
+    fn get_ref<'a>(&'a self) -> &'a str { ... }
+}
+```
+
+---
+
+## Struct Lifetimes
+
+### Struct Holding References
+```rust
+// Struct must declare lifetime for references
+struct Excerpt<'a> {
+    part: &'a str,
+}
+
+impl<'a> Excerpt<'a> {
+    fn level(&self) -> i32 { 3 }
+
+    // Return reference tied to self's lifetime
+    fn get_part(&self) -> &str {
+        self.part
+    }
+}
+```
+
+### Multiple Lifetimes in Struct
+```rust
+struct Multi<'a, 'b> {
+    x: &'a str,
+    y: &'b str,
+}
+
+// Use when references may have different lifetimes
+fn make_multi<'a, 'b>(x: &'a str, y: &'b str) -> Multi<'a, 'b> {
+    Multi { x, y }
+}
+```
+
+---
+
+## 'static Lifetime
+
+### When to Use
+```rust
+// String literals are 'static
+let s: &'static str = "hello";
+
+// Owned data can be leaked to 'static
+let leaked: &'static str = Box::leak(String::from("hello").into_boxed_str());
+
+// Thread spawn requires 'static or move
+std::thread::spawn(move || {
+    // closure owns data, satisfies 'static
+});
+```
+
+### Avoid Overusing 'static
+```rust
+// BAD: requires 'static unnecessarily
+fn process(s: &'static str) { ... }
+
+// GOOD: use generic lifetime
+fn process<'a>(s: &'a str) { ... }
+// or
+fn process(s: &str) { ... }  // lifetime elision
+```
+
+---
+
+## Higher-Ranked Trait Bounds (HRTB)
+
+### for<'a> Syntax
+```rust
+// Function that works with any lifetime
+fn apply_to_ref<F>(f: F)
+where
+    F: for<'a> Fn(&'a str) -> &'a str,
+{
+    let s = String::from("hello");
+    let result = f(&s);
+    println!("{}", result);
+}
+```
+
+### Common Use: Closure Bounds
+```rust
+// Closure that borrows any lifetime
+fn filter_refs<F>(items: &[&str], pred: F) -> Vec<&str>
+where
+    F: for<'a> Fn(&'a str) -> bool,
+{
+    items.iter().copied().filter(|s| pred(s)).collect()
+}
+```
+
+---
+
+## Lifetime Bounds
+
+### 'a: 'b (Outlives)
+```rust
+// 'a must live at least as long as 'b
+fn coerce<'a, 'b>(x: &'a str) -> &'b str
+where
+    'a: 'b,
+{
+    x
+}
+```
+
+### T: 'a (Type Outlives Lifetime)
+```rust
+// T must live at least as long as 'a
+struct Wrapper<'a, T: 'a> {
+    value: &'a T,
+}
+
+// Common pattern with trait objects
+fn use_trait<'a, T: MyTrait + 'a>(t: &'a T) { ... }
+```
+
+---
+
+## Common Lifetime Mistakes
+
+### Mistake 1: Returning Reference to Local
+```rust
+// WRONG
+fn dangle() -> &String {
+    let s = String::from("hello");
+    &s  // s dropped, reference invalid
+}
+
+// RIGHT
+fn no_dangle() -> String {
+    String::from("hello")
+}
+```
+
+### Mistake 2: Conflicting Lifetimes
+```rust
+// WRONG: might return reference to y which has shorter lifetime
+fn wrong<'a, 'b>(x: &'a str, y: &'b str) -> &'a str {
+    y  // ERROR: 'b might not live as long as 'a
+}
+
+// RIGHT: use same lifetime or add bound
+fn right<'a>(x: &'a str, y: &'a str) -> &'a str {
+    y  // OK: both have lifetime 'a
+}
+```
+
+### Mistake 3: Struct Outlives Reference
+```rust
+// WRONG: s might outlive the string it references
+let r;
+{
+    let s = String::from("hello");
+    r = Excerpt { part: &s };  // ERROR
+}
+println!("{}", r.part);  // s already dropped
+
+// RIGHT: ensure source outlives struct
+let s = String::from("hello");
+let r = Excerpt { part: &s };
+println!("{}", r.part);  // OK: s still in scope
+```
+
+---
+
+## Subtyping and Variance
+
+### Covariance
+```rust
+// &'a T is covariant in 'a
+// Can use &'long where &'short expected
+fn example<'short, 'long: 'short>(long_ref: &'long str) {
+    let short_ref: &'short str = long_ref;  // OK: covariance
+}
+```
+
+### Invariance
+```rust
+// &'a mut T is invariant in 'a
+fn example<'a, 'b>(x: &'a mut &'b str, y: &'b str) {
+    *x = y;  // ERROR if 'a and 'b are different
+}
+```
+
+### Practical Impact
+```rust
+// This works due to covariance
+fn accept_any<'a>(s: &'a str) { ... }
+
+let s = String::from("hello");
+let long_lived: &str = &s;
+accept_any(long_lived);  // 'long coerces to 'short
+```

--- a/.agents/skills/m02-resource/SKILL.md
+++ b/.agents/skills/m02-resource/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: m02-resource
+description: "CRITICAL: Use for smart pointers and resource management. Triggers: Box, Rc, Arc, Weak, RefCell, Cell, smart pointer, heap allocation, reference counting, RAII, Drop, should I use Box or Rc, when to use Arc vs Rc, 智能指针, 引用计数, 堆分配"
+user-invocable: false
+---
+
+# Resource Management
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**What ownership pattern does this resource need?**
+
+Before choosing a smart pointer, understand:
+- Is ownership single or shared?
+- Is access single-threaded or multi-threaded?
+- Are there potential cycles?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| "Need heap allocation" | "Use Box" | Why can't this be on stack? |
+| Rc memory leak | "Use Weak" | Is the cycle necessary in design? |
+| RefCell panic | "Use try_borrow" | Is runtime check the right approach? |
+| Arc overhead complaint | "Accept it" | Is multi-thread access actually needed? |
+
+---
+
+## Thinking Prompt
+
+Before choosing a smart pointer:
+
+1. **What's the ownership model?**
+   - Single owner → Box or owned value
+   - Shared ownership → Rc/Arc
+   - Weak reference → Weak
+
+2. **What's the thread context?**
+   - Single-thread → Rc, Cell, RefCell
+   - Multi-thread → Arc, Mutex, RwLock
+
+3. **Are there cycles?**
+   - Yes → One direction must be Weak
+   - No → Regular Rc/Arc is fine
+
+---
+
+## Trace Up ↑
+
+When pointer choice is unclear, trace to design:
+
+```
+"Should I use Arc or Rc?"
+    ↑ Ask: Is this data shared across threads?
+    ↑ Check: m07-concurrency (thread model)
+    ↑ Check: domain-* (performance constraints)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Rc vs Arc confusion | m07-concurrency | What's the concurrency model? |
+| RefCell panics | m03-mutability | Is interior mutability right here? |
+| Memory leaks | m12-lifecycle | Where should cleanup happen? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need single-owner heap data"
+    ↓ Use: Box<T>
+
+"Need shared immutable data (single-thread)"
+    ↓ Use: Rc<T>
+
+"Need shared immutable data (multi-thread)"
+    ↓ Use: Arc<T>
+
+"Need to break reference cycle"
+    ↓ Use: Weak<T>
+
+"Need shared mutable data"
+    ↓ Single-thread: Rc<RefCell<T>>
+    ↓ Multi-thread: Arc<Mutex<T>> or Arc<RwLock<T>>
+```
+
+---
+
+## Quick Reference
+
+| Type | Ownership | Thread-Safe | Use When |
+|------|-----------|-------------|----------|
+| `Box<T>` | Single | Yes | Heap allocation, recursive types |
+| `Rc<T>` | Shared | No | Single-thread shared ownership |
+| `Arc<T>` | Shared | Yes | Multi-thread shared ownership |
+| `Weak<T>` | Weak ref | Same as Rc/Arc | Break reference cycles |
+| `Cell<T>` | Single | No | Interior mutability (Copy types) |
+| `RefCell<T>` | Single | No | Interior mutability (runtime check) |
+
+## Decision Flowchart
+
+```
+Need heap allocation?
+├─ Yes → Single owner?
+│        ├─ Yes → Box<T>
+│        └─ No → Multi-thread?
+│                ├─ Yes → Arc<T>
+│                └─ No → Rc<T>
+└─ No → Stack allocation (default)
+
+Have reference cycles?
+├─ Yes → Use Weak for one direction
+└─ No → Regular Rc/Arc
+
+Need interior mutability?
+├─ Yes → Thread-safe needed?
+│        ├─ Yes → Mutex<T> or RwLock<T>
+│        └─ No → T: Copy? → Cell<T> : RefCell<T>
+└─ No → Use &mut T
+```
+
+---
+
+## Common Errors
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Rc cycle leak | Mutual strong refs | Use Weak for one direction |
+| RefCell panic | Borrow conflict at runtime | Use try_borrow or restructure |
+| Arc overhead | Atomic ops in hot path | Consider Rc if single-threaded |
+| Box unnecessary | Data fits on stack | Remove Box |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Arc everywhere | Unnecessary atomic overhead | Use Rc for single-thread |
+| RefCell everywhere | Runtime panics | Design clear ownership |
+| Box for small types | Unnecessary allocation | Stack allocation |
+| Ignore Weak for cycles | Memory leaks | Design parent-child with Weak |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Ownership errors | m01-ownership |
+| Interior mutability details | m03-mutability |
+| Multi-thread context | m07-concurrency |
+| Resource lifecycle | m12-lifecycle |

--- a/.agents/skills/m03-mutability/SKILL.md
+++ b/.agents/skills/m03-mutability/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: m03-mutability
+description: "CRITICAL: Use for mutability issues. Triggers: E0596, E0499, E0502, cannot borrow as mutable, already borrowed as immutable, mut, &mut, interior mutability, Cell, RefCell, Mutex, RwLock, 可变性, 内部可变性, 借用冲突"
+user-invocable: false
+---
+
+# Mutability
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Why does this data need to change, and who can change it?**
+
+Before adding interior mutability, understand:
+- Is mutation essential or accidental complexity?
+- Who should control mutation?
+- Is the mutation pattern safe?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0596 | "Add mut" | Should this really be mutable? |
+| E0499 | "Split borrows" | Is the data structure right? |
+| E0502 | "Separate scopes" | Why do we need both borrows? |
+| RefCell panic | "Use try_borrow" | Is runtime check appropriate? |
+
+---
+
+## Thinking Prompt
+
+Before adding mutability:
+
+1. **Is mutation necessary?**
+   - Maybe transform → return new value
+   - Maybe builder → construct immutably
+
+2. **Who controls mutation?**
+   - External caller → `&mut T`
+   - Internal logic → interior mutability
+   - Concurrent access → synchronized mutability
+
+3. **What's the thread context?**
+   - Single-thread → Cell/RefCell
+   - Multi-thread → Mutex/RwLock/Atomic
+
+---
+
+## Trace Up ↑
+
+When mutability conflicts persist:
+
+```
+E0499/E0502 (borrow conflicts)
+    ↑ Ask: Is the data structure designed correctly?
+    ↑ Check: m09-domain (should data be split?)
+    ↑ Check: m07-concurrency (is async involved?)
+```
+
+| Persistent Error | Trace To | Question |
+|-----------------|----------|----------|
+| Repeated borrow conflicts | m09-domain | Should data be restructured? |
+| RefCell in async | m07-concurrency | Is Send/Sync needed? |
+| Mutex deadlocks | m07-concurrency | Is the lock design right? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need mutable access from &self"
+    ↓ T: Copy → Cell<T>
+    ↓ T: !Copy → RefCell<T>
+
+"Need thread-safe mutation"
+    ↓ Simple counters → AtomicXxx
+    ↓ Complex data → Mutex<T> or RwLock<T>
+
+"Need shared mutable state"
+    ↓ Single-thread: Rc<RefCell<T>>
+    ↓ Multi-thread: Arc<Mutex<T>>
+```
+
+---
+
+## Borrow Rules
+
+```
+At any time, you can have EITHER:
+├─ Multiple &T (immutable borrows)
+└─ OR one &mut T (mutable borrow)
+
+Never both simultaneously.
+```
+
+## Quick Reference
+
+| Pattern | Thread-Safe | Runtime Cost | Use When |
+|---------|-------------|--------------|----------|
+| `&mut T` | N/A | Zero | Exclusive mutable access |
+| `Cell<T>` | No | Zero | Copy types, no refs needed |
+| `RefCell<T>` | No | Runtime check | Non-Copy, need runtime borrow |
+| `Mutex<T>` | Yes | Lock contention | Thread-safe mutation |
+| `RwLock<T>` | Yes | Lock contention | Many readers, few writers |
+| `Atomic*` | Yes | Minimal | Simple types (bool, usize) |
+
+## Error Code Reference
+
+| Error | Cause | Quick Fix |
+|-------|-------|-----------|
+| E0596 | Borrowing immutable as mutable | Add `mut` or redesign |
+| E0499 | Multiple mutable borrows | Restructure code flow |
+| E0502 | &mut while & exists | Separate borrow scopes |
+
+---
+
+## Interior Mutability Decision
+
+| Scenario | Choose |
+|----------|--------|
+| T: Copy, single-thread | `Cell<T>` |
+| T: !Copy, single-thread | `RefCell<T>` |
+| T: Copy, multi-thread | `AtomicXxx` |
+| T: !Copy, multi-thread | `Mutex<T>` or `RwLock<T>` |
+| Read-heavy, multi-thread | `RwLock<T>` |
+| Simple flags/counters | `AtomicBool`, `AtomicUsize` |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| RefCell everywhere | Runtime panics | Clear ownership design |
+| Mutex for single-thread | Unnecessary overhead | RefCell |
+| Ignore RefCell panic | Hard to debug | Handle or restructure |
+| Lock inside hot loop | Performance killer | Batch operations |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Smart pointer choice | m02-resource |
+| Thread safety | m07-concurrency |
+| Data structure design | m09-domain |
+| Anti-patterns | m15-anti-pattern |

--- a/.agents/skills/m04-zero-cost/SKILL.md
+++ b/.agents/skills/m04-zero-cost/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: m04-zero-cost
+description: "CRITICAL: Use for generics, traits, zero-cost abstraction. Triggers: E0277, E0308, E0599, generic, trait, impl, dyn, where, monomorphization, static dispatch, dynamic dispatch, impl Trait, trait bound not satisfied, 泛型, 特征, 零成本抽象, 单态化"
+user-invocable: false
+---
+
+# Zero-Cost Abstraction
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Do we need compile-time or runtime polymorphism?**
+
+Before choosing between generics and trait objects:
+- Is the type known at compile time?
+- Is a heterogeneous collection needed?
+- What's the performance priority?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0277 | "Add trait bound" | Is this abstraction at the right level? |
+| E0308 | "Fix the type" | Should types be unified or distinct? |
+| E0599 | "Import the trait" | Is the trait the right abstraction? |
+| E0038 | "Make object-safe" | Do we really need dynamic dispatch? |
+
+---
+
+## Thinking Prompt
+
+Before adding trait bounds:
+
+1. **What abstraction is needed?**
+   - Same behavior, different types → trait
+   - Different behavior, same type → enum
+   - No abstraction needed → concrete type
+
+2. **When is type known?**
+   - Compile time → generics (static dispatch)
+   - Runtime → trait objects (dynamic dispatch)
+
+3. **What's the trade-off priority?**
+   - Performance → generics
+   - Compile time → trait objects
+   - Flexibility → depends
+
+---
+
+## Trace Up ↑
+
+When type system fights back:
+
+```
+E0277 (trait bound not satisfied)
+    ↑ Ask: Is the abstraction level correct?
+    ↑ Check: m09-domain (what behavior is being abstracted?)
+    ↑ Check: m05-type-driven (should use newtype?)
+```
+
+| Persistent Error | Trace To | Question |
+|-----------------|----------|----------|
+| Complex trait bounds | m09-domain | Is the abstraction right? |
+| Object safety issues | m05-type-driven | Can typestate help? |
+| Type explosion | m10-performance | Accept dyn overhead? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need to abstract over types with same behavior"
+    ↓ Types known at compile time → impl Trait or generics
+    ↓ Types determined at runtime → dyn Trait
+
+"Need collection of different types"
+    ↓ Closed set → enum
+    ↓ Open set → Vec<Box<dyn Trait>>
+
+"Need to return different types"
+    ↓ Same type → impl Trait
+    ↓ Different types → Box<dyn Trait>
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Dispatch | Code Size | Runtime Cost |
+|---------|----------|-----------|--------------|
+| `fn foo<T: Trait>()` | Static | +bloat | Zero |
+| `fn foo(x: &dyn Trait)` | Dynamic | Minimal | vtable lookup |
+| `impl Trait` return | Static | +bloat | Zero |
+| `Box<dyn Trait>` | Dynamic | Minimal | Allocation + vtable |
+
+## Syntax Comparison
+
+```rust
+// Static dispatch - type known at compile time
+fn process(x: impl Display) { }      // argument position
+fn process<T: Display>(x: T) { }     // explicit generic
+fn get() -> impl Display { }         // return position
+
+// Dynamic dispatch - type determined at runtime
+fn process(x: &dyn Display) { }      // reference
+fn process(x: Box<dyn Display>) { }  // owned
+```
+
+## Error Code Reference
+
+| Error | Cause | Quick Fix |
+|-------|-------|-----------|
+| E0277 | Type doesn't impl trait | Add impl or change bound |
+| E0308 | Type mismatch | Check generic params |
+| E0599 | No method found | Import trait with `use` |
+| E0038 | Trait not object-safe | Use generics or redesign |
+
+---
+
+## Decision Guide
+
+| Scenario | Choose | Why |
+|----------|--------|-----|
+| Performance critical | Generics | Zero runtime cost |
+| Heterogeneous collection | `dyn Trait` | Different types at runtime |
+| Plugin architecture | `dyn Trait` | Unknown types at compile |
+| Reduce compile time | `dyn Trait` | Less monomorphization |
+| Small, known type set | `enum` | No indirection |
+
+---
+
+## Object Safety
+
+A trait is object-safe if it:
+- Doesn't have `Self: Sized` bound
+- Doesn't return `Self`
+- Doesn't have generic methods
+- Uses `where Self: Sized` for non-object-safe methods
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Over-generic everything | Compile time, complexity | Concrete types when possible |
+| `dyn` for known types | Unnecessary indirection | Generics |
+| Complex trait hierarchies | Hard to understand | Simpler design |
+| Ignore object safety | Limits flexibility | Plan for dyn if needed |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Type-driven design | m05-type-driven |
+| Domain abstraction | m09-domain |
+| Performance concerns | m10-performance |
+| Send/Sync bounds | m07-concurrency |

--- a/.agents/skills/m05-type-driven/SKILL.md
+++ b/.agents/skills/m05-type-driven/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: m05-type-driven
+description: "CRITICAL: Use for type-driven design. Triggers: type state, PhantomData, newtype, marker trait, builder pattern, make invalid states unrepresentable, compile-time validation, sealed trait, ZST, 类型状态, 新类型模式, 类型驱动设计"
+user-invocable: false
+---
+
+# Type-Driven Design
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**How can the type system prevent invalid states?**
+
+Before reaching for runtime checks:
+- Can the compiler catch this error?
+- Can invalid states be unrepresentable?
+- Can the type encode the invariant?
+
+---
+
+## Error → Design Question
+
+| Pattern | Don't Just Say | Ask Instead |
+|---------|----------------|-------------|
+| Primitive obsession | "It's just a string" | What does this value represent? |
+| Boolean flags | "Add an is_valid flag" | Can states be types? |
+| Optional everywhere | "Check for None" | Is absence really possible? |
+| Validation at runtime | "Return Err if invalid" | Can we validate at construction? |
+
+---
+
+## Thinking Prompt
+
+Before adding runtime validation:
+
+1. **Can the type encode the constraint?**
+   - Numeric range → bounded types or newtypes
+   - Valid states → type state pattern
+   - Semantic meaning → newtype
+
+2. **When is validation possible?**
+   - At construction → validated newtype
+   - At state transition → type state
+   - Only at runtime → Result with clear error
+
+3. **Who needs to know the invariant?**
+   - Compiler → type-level encoding
+   - API users → clear type signatures
+   - Runtime only → documentation
+
+---
+
+## Trace Up ↑
+
+When type design is unclear:
+
+```
+"Need to validate email format"
+    ↑ Ask: Is this a domain value object?
+    ↑ Check: m09-domain (Email as Value Object)
+    ↑ Check: domain-* (validation requirements)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| What types to create | m09-domain | What's the domain model? |
+| State machine design | m09-domain | What are valid transitions? |
+| Marker trait usage | m04-zero-cost | Static or dynamic dispatch? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need type-safe wrapper for primitives"
+    ↓ Newtype: struct UserId(u64);
+
+"Need compile-time state validation"
+    ↓ Type State: Connection<Connected>
+
+"Need to track phantom type parameters"
+    ↓ PhantomData: PhantomData<T>
+
+"Need capability markers"
+    ↓ Marker Trait: trait Validated {}
+
+"Need gradual construction"
+    ↓ Builder: Builder::new().field(x).build()
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Purpose | Example |
+|---------|---------|---------|
+| Newtype | Type safety | `struct UserId(u64);` |
+| Type State | State machine | `Connection<Connected>` |
+| PhantomData | Variance/lifetime | `PhantomData<&'a T>` |
+| Marker Trait | Capability flag | `trait Validated {}` |
+| Builder | Gradual construction | `Builder::new().name("x").build()` |
+| Sealed Trait | Prevent external impl | `mod private { pub trait Sealed {} }` |
+
+## Pattern Examples
+
+### Newtype
+
+```rust
+struct Email(String);  // Not just any string
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, ValidationError> {
+        // Validate once, trust forever
+        validate_email(s)?;
+        Ok(Self(s.to_string()))
+    }
+}
+```
+
+### Type State
+
+```rust
+struct Connection<State>(TcpStream, PhantomData<State>);
+
+struct Disconnected;
+struct Connected;
+struct Authenticated;
+
+impl Connection<Disconnected> {
+    fn connect(self) -> Connection<Connected> { ... }
+}
+
+impl Connection<Connected> {
+    fn authenticate(self) -> Connection<Authenticated> { ... }
+}
+```
+
+---
+
+## Decision Guide
+
+| Need | Pattern |
+|------|---------|
+| Type safety for primitives | Newtype |
+| Compile-time state validation | Type State |
+| Lifetime/variance markers | PhantomData |
+| Capability flags | Marker Trait |
+| Gradual construction | Builder |
+| Closed set of impls | Sealed Trait |
+| Zero-sized type marker | ZST struct |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Boolean flags for states | Runtime errors | Type state |
+| String for semantic types | No type safety | Newtype |
+| Option for uninitialized | Unclear invariant | Builder |
+| Public fields with invariants | Invariant violation | Private + validated new() |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Domain modeling | m09-domain |
+| Trait design | m04-zero-cost |
+| Error handling in constructors | m06-error-handling |
+| Anti-patterns | m15-anti-pattern |

--- a/.agents/skills/m06-error-handling/SKILL.md
+++ b/.agents/skills/m06-error-handling/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: m06-error-handling
+description: "CRITICAL: Use for error handling. Triggers: Result, Option, Error, ?, unwrap, expect, panic, anyhow, thiserror, when to panic vs return Result, custom error, error propagation, 错误处理, Result 用法, 什么时候用 panic"
+user-invocable: false
+---
+
+# Error Handling
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this failure expected or a bug?**
+
+Before choosing error handling strategy:
+- Can this fail in normal operation?
+- Who should handle this failure?
+- What context does the caller need?
+
+---
+
+## Error → Design Question
+
+| Pattern | Don't Just Say | Ask Instead |
+|---------|----------------|-------------|
+| unwrap panics | "Use ?" | Is None/Err actually possible here? |
+| Type mismatch on ? | "Use anyhow" | Are error types designed correctly? |
+| Lost error context | "Add .context()" | What does the caller need to know? |
+| Too many error variants | "Use Box<dyn Error>" | Is error granularity right? |
+
+---
+
+## Thinking Prompt
+
+Before handling an error:
+
+1. **What kind of failure is this?**
+   - Expected → Result<T, E>
+   - Absence normal → Option<T>
+   - Bug/invariant → panic!
+   - Unrecoverable → panic!
+
+2. **Who handles this?**
+   - Caller → propagate with ?
+   - Current function → match/if-let
+   - User → friendly error message
+   - Programmer → panic with message
+
+3. **What context is needed?**
+   - Type of error → thiserror variants
+   - Call chain → anyhow::Context
+   - Debug info → anyhow or tracing
+
+---
+
+## Trace Up ↑
+
+When error strategy is unclear:
+
+```
+"Should I return Result or Option?"
+    ↑ Ask: Is absence/failure normal or exceptional?
+    ↑ Check: m09-domain (what does domain say?)
+    ↑ Check: domain-* (error handling requirements)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Too many unwraps | m09-domain | Is the data model right? |
+| Error context design | m13-domain-error | What recovery is needed? |
+| Library vs app errors | m11-ecosystem | Who are the consumers? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Expected failure, library code"
+    ↓ Use: thiserror for typed errors
+
+"Expected failure, application code"
+    ↓ Use: anyhow for ergonomic errors
+
+"Absence is normal (find, get, lookup)"
+    ↓ Use: Option<T>
+
+"Bug or invariant violation"
+    ↓ Use: panic!, assert!, unreachable!
+
+"Need to propagate with context"
+    ↓ Use: .context("what was happening")
+```
+
+---
+
+## Quick Reference
+
+| Pattern | When | Example |
+|---------|------|---------|
+| `Result<T, E>` | Recoverable error | `fn read() -> Result<String, io::Error>` |
+| `Option<T>` | Absence is normal | `fn find() -> Option<&Item>` |
+| `?` | Propagate error | `let data = file.read()?;` |
+| `unwrap()` | Dev/test only | `config.get("key").unwrap()` |
+| `expect()` | Invariant holds | `env.get("HOME").expect("HOME set")` |
+| `panic!` | Unrecoverable | `panic!("critical failure")` |
+
+## Library vs Application
+
+| Context | Error Crate | Why |
+|---------|-------------|-----|
+| Library | `thiserror` | Typed errors for consumers |
+| Application | `anyhow` | Ergonomic error handling |
+| Mixed | Both | thiserror at boundaries, anyhow internally |
+
+## Decision Flowchart
+
+```
+Is failure expected?
+├─ Yes → Is absence the only "failure"?
+│        ├─ Yes → Option<T>
+│        └─ No → Result<T, E>
+│                 ├─ Library → thiserror
+│                 └─ Application → anyhow
+└─ No → Is it a bug?
+        ├─ Yes → panic!, assert!
+        └─ No → Consider if really unrecoverable
+
+Use ? → Need context?
+├─ Yes → .context("message")
+└─ No → Plain ?
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `unwrap()` panic | Unhandled None/Err | Use `?` or match |
+| Type mismatch | Different error types | Use `anyhow` or `From` |
+| Lost context | `?` without context | Add `.context()` |
+| `cannot use ?` | Missing Result return | Return `Result<(), E>` |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.unwrap()` everywhere | Panics in production | `.expect("reason")` or `?` |
+| Ignore errors silently | Bugs hidden | Handle or propagate |
+| `panic!` for expected errors | Bad UX, no recovery | Result |
+| Box<dyn Error> everywhere | Lost type info | thiserror |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Domain error strategy | m13-domain-error |
+| Crate boundaries | m11-ecosystem |
+| Type-safe errors | m05-type-driven |
+| Mental models | m14-mental-model |

--- a/.agents/skills/m06-error-handling/examples/library-vs-app.md
+++ b/.agents/skills/m06-error-handling/examples/library-vs-app.md
@@ -1,0 +1,332 @@
+# Error Handling: Library vs Application
+
+## Library Error Design
+
+### Principles
+1. **Define specific error types** - Don't use `anyhow` in libraries
+2. **Implement std::error::Error** - For compatibility
+3. **Provide error variants** - Let users match on errors
+4. **Include source errors** - Enable error chains
+5. **Be `Send + Sync`** - For async compatibility
+
+### Example: Library Error Type
+```rust
+// lib.rs
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("connection failed: {host}:{port}")]
+    ConnectionFailed {
+        host: String,
+        port: u16,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("query failed: {query}")]
+    QueryFailed {
+        query: String,
+        #[source]
+        source: SqlError,
+    },
+
+    #[error("record not found: {table}.{id}")]
+    NotFound { table: String, id: String },
+
+    #[error("constraint violation: {0}")]
+    ConstraintViolation(String),
+}
+
+// Public Result alias
+pub type Result<T> = std::result::Result<T, DatabaseError>;
+
+// Library functions
+pub fn connect(host: &str, port: u16) -> Result<Connection> {
+    // ...
+}
+
+pub fn query(conn: &Connection, sql: &str) -> Result<Rows> {
+    // ...
+}
+```
+
+### Library Usage of Errors
+```rust
+impl Database {
+    pub fn get_user(&self, id: &str) -> Result<User> {
+        let rows = self.query(&format!("SELECT * FROM users WHERE id = '{}'", id))?;
+
+        rows.first()
+            .cloned()
+            .ok_or_else(|| DatabaseError::NotFound {
+                table: "users".to_string(),
+                id: id.to_string(),
+            })
+    }
+}
+```
+
+---
+
+## Application Error Design
+
+### Principles
+1. **Use anyhow for convenience** - Or custom unified error
+2. **Add context liberally** - Help debugging
+3. **Log at boundaries** - Don't log in libraries
+4. **Convert to user-friendly messages** - For display
+
+### Example: Application Error Handling
+```rust
+// main.rs
+use anyhow::{Context, Result};
+use tracing::{error, info};
+
+async fn run_server() -> Result<()> {
+    let config = load_config()
+        .context("failed to load configuration")?;
+
+    let db = Database::connect(&config.db_url)
+        .await
+        .context("failed to connect to database")?;
+
+    let server = Server::new(config.port)
+        .context("failed to create server")?;
+
+    info!("Server starting on port {}", config.port);
+
+    server.run(db).await
+        .context("server error")?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::init();
+
+    if let Err(e) = run_server().await {
+        error!("Application error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+```
+
+### Converting Library Errors
+```rust
+use mylib::DatabaseError;
+
+async fn get_user_handler(id: &str) -> Result<Response> {
+    match db.get_user(id).await {
+        Ok(user) => Ok(Response::json(user)),
+
+        Err(DatabaseError::NotFound { .. }) => {
+            Ok(Response::not_found("User not found"))
+        }
+
+        Err(DatabaseError::ConnectionFailed { .. }) => {
+            error!("Database connection failed");
+            Ok(Response::internal_error("Service unavailable"))
+        }
+
+        Err(e) => {
+            error!("Database error: {}", e);
+            Err(e.into())  // Convert to anyhow::Error
+        }
+    }
+}
+```
+
+---
+
+## Error Handling Layers
+
+```
+┌─────────────────────────────────────┐
+│           Application Layer          │
+│  - Use anyhow or unified error       │
+│  - Add context at boundaries         │
+│  - Log errors                        │
+│  - Convert to user messages          │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Service Layer              │
+│  - Map between error types           │
+│  - Add business context              │
+│  - Handle recoverable errors         │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Library Layer              │
+│  - Define specific error types       │
+│  - Use thiserror                     │
+│  - Include source errors             │
+│  - No logging                        │
+└─────────────────────────────────────┘
+```
+
+---
+
+## Practical Examples
+
+### HTTP API Error Response
+```rust
+use axum::{response::IntoResponse, http::StatusCode};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    code: String,
+}
+
+enum AppError {
+    NotFound(String),
+    BadRequest(String),
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, error, code) = match self {
+            AppError::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, msg, "NOT_FOUND")
+            }
+            AppError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, msg, "BAD_REQUEST")
+            }
+            AppError::Internal(e) => {
+                tracing::error!("Internal error: {:#}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                    "INTERNAL_ERROR",
+                )
+            }
+        };
+
+        let body = ErrorResponse {
+            error,
+            code: code.to_string(),
+        };
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+```
+
+### CLI Error Handling
+```rust
+use anyhow::{Context, Result};
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long)]
+    config: String,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+
+    let config = std::fs::read_to_string(&args.config)
+        .context(format!("Failed to read config file: {}", args.config))?;
+
+    let parsed: Config = toml::from_str(&config)
+        .context("Failed to parse config file")?;
+
+    process(parsed)?;
+
+    println!("Done!");
+    Ok(())
+}
+```
+
+---
+
+## Testing Error Handling
+
+### Testing Error Cases
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_found_error() {
+        let result = db.get_user("nonexistent");
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::NotFound { table, id })
+            if table == "users" && id == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn test_error_message() {
+        let err = DatabaseError::NotFound {
+            table: "users".to_string(),
+            id: "123".to_string(),
+        };
+
+        assert_eq!(err.to_string(), "record not found: users.123");
+    }
+
+    #[test]
+    fn test_error_chain() {
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused"
+        );
+
+        let err = DatabaseError::ConnectionFailed {
+            host: "localhost".to_string(),
+            port: 5432,
+            source: io_err,
+        };
+
+        // Check source is preserved
+        assert!(err.source().is_some());
+    }
+}
+```
+
+### Testing with anyhow
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_context() -> anyhow::Result<()> {
+        let result = process("valid input")?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_error_context() {
+        let err = process("invalid")
+            .context("processing failed")
+            .unwrap_err();
+
+        // Check error chain contains expected text
+        let chain = format!("{:#}", err);
+        assert!(chain.contains("processing failed"));
+    }
+}
+```

--- a/.agents/skills/m06-error-handling/patterns/error-patterns.md
+++ b/.agents/skills/m06-error-handling/patterns/error-patterns.md
@@ -1,0 +1,404 @@
+# Error Handling Patterns
+
+## The ? Operator
+
+### Basic Usage
+```rust
+fn read_config() -> Result<Config, io::Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    let config: Config = toml::from_str(&content)?;  // needs From impl
+    Ok(config)
+}
+```
+
+### With Different Error Types
+```rust
+use std::error::Error;
+
+// Box<dyn Error> for quick prototyping
+fn process() -> Result<(), Box<dyn Error>> {
+    let file = std::fs::read_to_string("data.txt")?;
+    let num: i32 = file.trim().parse()?;  // different error type
+    Ok(())
+}
+```
+
+### Custom Conversion with From
+```rust
+#[derive(Debug)]
+enum MyError {
+    Io(std::io::Error),
+    Parse(std::num::ParseIntError),
+}
+
+impl From<std::io::Error> for MyError {
+    fn from(err: std::io::Error) -> Self {
+        MyError::Io(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for MyError {
+    fn from(err: std::num::ParseIntError) -> Self {
+        MyError::Parse(err)
+    }
+}
+
+fn process() -> Result<i32, MyError> {
+    let content = std::fs::read_to_string("num.txt")?;  // auto-converts
+    let num: i32 = content.trim().parse()?;  // auto-converts
+    Ok(num)
+}
+```
+
+---
+
+## Error Type Design
+
+### Simple Enum Error
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigError {
+    NotFound,
+    InvalidFormat,
+    MissingField(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::NotFound => write!(f, "configuration file not found"),
+            ConfigError::InvalidFormat => write!(f, "invalid configuration format"),
+            ConfigError::MissingField(field) => write!(f, "missing field: {}", field),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+```
+
+### Error with Source (Wrapping)
+```rust
+#[derive(Debug)]
+pub struct AppError {
+    kind: AppErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AppErrorKind {
+    Config,
+    Database,
+    Network,
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            AppErrorKind::Config => write!(f, "configuration error"),
+            AppErrorKind::Database => write!(f, "database error"),
+            AppErrorKind::Network => write!(f, "network error"),
+        }
+    }
+}
+
+impl std::error::Error for AppError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as _)
+    }
+}
+```
+
+---
+
+## Using thiserror
+
+### Basic Usage
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DataError {
+    #[error("file not found: {path}")]
+    NotFound { path: String },
+
+    #[error("invalid data format")]
+    InvalidFormat,
+
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+
+    #[error("parse error: {0}")]
+    Parse(#[from] std::num::ParseIntError),
+}
+
+// Usage
+fn load_data(path: &str) -> Result<Data, DataError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|_| DataError::NotFound { path: path.to_string() })?;
+    let num: i32 = content.trim().parse()?;  // auto-converts with #[from]
+    Ok(Data { value: num })
+}
+```
+
+### Transparent Wrapper
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct MyError(#[from] InnerError);
+
+// Useful for newtype error wrappers
+```
+
+---
+
+## Using anyhow
+
+### For Applications
+```rust
+use anyhow::{Context, Result, bail, ensure};
+
+fn process_file(path: &str) -> Result<Data> {
+    let content = std::fs::read_to_string(path)
+        .context("failed to read config file")?;
+
+    ensure!(!content.is_empty(), "config file is empty");
+
+    let data: Data = serde_json::from_str(&content)
+        .context("failed to parse JSON")?;
+
+    if data.version < 1 {
+        bail!("unsupported config version: {}", data.version);
+    }
+
+    Ok(data)
+}
+
+fn main() -> Result<()> {
+    let data = process_file("config.json")
+        .context("failed to load configuration")?;
+    Ok(())
+}
+```
+
+### Error Chain
+```rust
+use anyhow::{Context, Result};
+
+fn deep_function() -> Result<()> {
+    std::fs::read_to_string("missing.txt")
+        .context("failed to read file")?;
+    Ok(())
+}
+
+fn middle_function() -> Result<()> {
+    deep_function()
+        .context("failed in deep function")?;
+    Ok(())
+}
+
+fn top_function() -> Result<()> {
+    middle_function()
+        .context("failed in middle function")?;
+    Ok(())
+}
+
+// Error output shows full chain:
+// Error: failed in middle function
+// Caused by:
+//     0: failed in deep function
+//     1: failed to read file
+//     2: No such file or directory (os error 2)
+```
+
+---
+
+## Option Handling
+
+### Converting Option to Result
+```rust
+fn find_user(id: u32) -> Option<User> { ... }
+
+// Using ok_or for static error
+fn get_user(id: u32) -> Result<User, &'static str> {
+    find_user(id).ok_or("user not found")
+}
+
+// Using ok_or_else for dynamic error
+fn get_user(id: u32) -> Result<User, String> {
+    find_user(id).ok_or_else(|| format!("user {} not found", id))
+}
+```
+
+### Chaining Options
+```rust
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()?
+        .nested
+        .as_ref()?
+        .value
+        .as_deref()
+}
+
+// Equivalent with and_then
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()
+        .and_then(|c| c.nested.as_ref())
+        .and_then(|n| n.value.as_deref())
+}
+```
+
+---
+
+## Pattern: Result Combinators
+
+### map and map_err
+```rust
+fn parse_port(s: &str) -> Result<u16, ParseError> {
+    s.parse::<u16>()
+        .map_err(|e| ParseError::InvalidPort(e))
+}
+
+fn get_url(config: &Config) -> Result<String, Error> {
+    config.url()
+        .map(|u| format!("https://{}", u))
+}
+```
+
+### and_then (flatMap)
+```rust
+fn validate_and_save(input: &str) -> Result<(), Error> {
+    validate(input)
+        .and_then(|valid| save(valid))
+        .and_then(|saved| notify(saved))
+}
+```
+
+### unwrap_or and unwrap_or_else
+```rust
+// Default value
+let port = config.port().unwrap_or(8080);
+
+// Computed default
+let port = config.port().unwrap_or_else(|| find_free_port());
+
+// Default for Result
+let data = load_data().unwrap_or_default();
+```
+
+---
+
+## Pattern: Early Return vs Combinators
+
+### Early Return Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    let step1 = validate(input)?;
+    if !step1.is_valid {
+        return Err(Error::Invalid);
+    }
+
+    let step2 = transform(step1)?;
+    let step3 = save(step2)?;
+
+    Ok(step3)
+}
+```
+
+### Combinator Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    validate(input)
+        .and_then(|s| {
+            if s.is_valid {
+                Ok(s)
+            } else {
+                Err(Error::Invalid)
+            }
+        })
+        .and_then(transform)
+        .and_then(save)
+}
+```
+
+### When to Use Which
+
+| Style | Best For |
+|-------|----------|
+| Early return (`?`) | Most cases, clearer flow |
+| Combinators | Functional pipelines, one-liners |
+| Match | Complex branching on errors |
+
+---
+
+## Panic vs Result
+
+### When to Panic
+```rust
+// 1. Unrecoverable programmer error
+fn get_config() -> &'static Config {
+    CONFIG.get().expect("config must be initialized")
+}
+
+// 2. In tests
+#[test]
+fn test_parsing() {
+    let result = parse("valid").unwrap();  // OK in tests
+    assert_eq!(result, expected);
+}
+
+// 3. Prototype/examples
+fn main() {
+    let data = load().unwrap();  // OK for quick examples
+}
+```
+
+### When to Return Result
+```rust
+// 1. Any I/O operation
+fn read_file(path: &str) -> Result<String, io::Error>
+
+// 2. User input validation
+fn parse_port(s: &str) -> Result<u16, ParseError>
+
+// 3. Network operations
+async fn fetch(url: &str) -> Result<Response, Error>
+
+// 4. Anything that can fail at runtime
+fn connect(addr: &str) -> Result<Connection, Error>
+```
+
+---
+
+## Error Context Best Practices
+
+### Add Context at Boundaries
+```rust
+fn load_user_config(user_id: u64) -> Result<Config, Error> {
+    let path = format!("/home/{}/config.toml", user_id);
+
+    std::fs::read_to_string(&path)
+        .context(format!("failed to read config for user {}", user_id))?
+        // NOT: .context("failed to read file")  // too generic
+
+    // ...
+}
+```
+
+### Include Relevant Data
+```rust
+// Good: includes the problematic value
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context(format!("invalid age value: '{}'", s))
+}
+
+// Bad: no context about what failed
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context("parse error")
+}
+```

--- a/.agents/skills/m07-concurrency/SKILL.md
+++ b/.agents/skills/m07-concurrency/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: m07-concurrency
+description: "CRITICAL: Use for concurrency/async. Triggers: E0277 Send Sync, cannot be sent between threads, thread, spawn, channel, mpsc, Mutex, RwLock, Atomic, async, await, Future, tokio, deadlock, race condition, 并发, 线程, 异步, 死锁"
+user-invocable: false
+---
+
+# Concurrency
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this CPU-bound or I/O-bound, and what's the sharing model?**
+
+Before choosing concurrency primitives:
+- What's the workload type?
+- What data needs to be shared?
+- What's the thread safety requirement?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0277 Send | "Add Send bound" | Should this type cross threads? |
+| E0277 Sync | "Wrap in Mutex" | Is shared access really needed? |
+| Future not Send | "Use spawn_local" | Is async the right choice? |
+| Deadlock | "Reorder locks" | Is the locking design correct? |
+
+---
+
+## Thinking Prompt
+
+Before adding concurrency:
+
+1. **What's the workload?**
+   - CPU-bound → threads (std::thread, rayon)
+   - I/O-bound → async (tokio, async-std)
+   - Mixed → hybrid approach
+
+2. **What's the sharing model?**
+   - No sharing → message passing (channels)
+   - Immutable sharing → Arc<T>
+   - Mutable sharing → Arc<Mutex<T>> or Arc<RwLock<T>>
+
+3. **What are the Send/Sync requirements?**
+   - Cross-thread ownership → Send
+   - Cross-thread references → Sync
+   - Single-thread async → spawn_local
+
+---
+
+## Trace Up ↑ (MANDATORY)
+
+**CRITICAL**: Don't just fix the error. Trace UP to find domain constraints.
+
+### Domain Detection Table
+
+| Context Keywords | Load Domain Skill | Key Constraint |
+|-----------------|-------------------|----------------|
+| Web API, HTTP, axum, actix, handler | **domain-web** | Handlers run on any thread |
+| 交易, 支付, trading, payment | **domain-fintech** | Audit + thread safety |
+| gRPC, kubernetes, microservice | **domain-cloud-native** | Distributed tracing |
+| CLI, terminal, clap | **domain-cli** | Usually single-thread OK |
+
+### Example: Web API + Rc Error
+
+```
+"Rc cannot be sent between threads" in Web API context
+    ↑ DETECT: "Web API" → Load domain-web
+    ↑ FIND: domain-web says "Shared state must be thread-safe"
+    ↑ FIND: domain-web says "Rc in state" is Common Mistake
+    ↓ DESIGN: Use Arc<T> with State extractor
+    ↓ IMPL: axum::extract::State<Arc<AppConfig>>
+```
+
+### Generic Trace
+
+```
+"Send not satisfied for my type"
+    ↑ Ask: What domain is this? Load domain-* skill
+    ↑ Ask: Does this type need to cross thread boundaries?
+    ↑ Check: m09-domain (is the data model correct?)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Send/Sync in Web | **domain-web** | What's the state management pattern? |
+| Send/Sync in CLI | **domain-cli** | Is multi-thread really needed? |
+| Mutex vs channels | m09-domain | Shared state or message passing? |
+| Async vs threads | m10-performance | What's the workload profile? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need parallelism for CPU work"
+    ↓ Use: std::thread or rayon
+
+"Need concurrency for I/O"
+    ↓ Use: async/await with tokio
+
+"Need to share immutable data across threads"
+    ↓ Use: Arc<T>
+
+"Need to share mutable data across threads"
+    ↓ Use: Arc<Mutex<T>> or Arc<RwLock<T>>
+    ↓ Or: channels for message passing
+
+"Need simple atomic operations"
+    ↓ Use: AtomicBool, AtomicUsize, etc.
+```
+
+---
+
+## Send/Sync Markers
+
+| Marker | Meaning | Example |
+|--------|---------|---------|
+| `Send` | Can transfer ownership between threads | Most types |
+| `Sync` | Can share references between threads | `Arc<T>` |
+| `!Send` | Must stay on one thread | `Rc<T>` |
+| `!Sync` | No shared refs across threads | `RefCell<T>` |
+
+## Quick Reference
+
+| Pattern | Thread-Safe | Blocking | Use When |
+|---------|-------------|----------|----------|
+| `std::thread` | Yes | Yes | CPU-bound parallelism |
+| `async/await` | Yes | No | I/O-bound concurrency |
+| `Mutex<T>` | Yes | Yes | Shared mutable state |
+| `RwLock<T>` | Yes | Yes | Read-heavy shared state |
+| `mpsc::channel` | Yes | Optional | Message passing |
+| `Arc<Mutex<T>>` | Yes | Yes | Shared mutable across threads |
+
+## Decision Flowchart
+
+```
+What type of work?
+├─ CPU-bound → std::thread or rayon
+├─ I/O-bound → async/await
+└─ Mixed → hybrid (spawn_blocking)
+
+Need to share data?
+├─ No → message passing (channels)
+├─ Immutable → Arc<T>
+└─ Mutable →
+   ├─ Read-heavy → Arc<RwLock<T>>
+   └─ Write-heavy → Arc<Mutex<T>>
+   └─ Simple counter → AtomicUsize
+
+Async context?
+├─ Type is Send → tokio::spawn
+├─ Type is !Send → spawn_local
+└─ Blocking code → spawn_blocking
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| E0277 `Send` not satisfied | Non-Send in async | Use Arc or spawn_local |
+| E0277 `Sync` not satisfied | Non-Sync shared | Wrap with Mutex |
+| Deadlock | Lock ordering | Consistent lock order |
+| `future is not Send` | Non-Send across await | Drop before await |
+| `MutexGuard` across await | Guard held during suspend | Scope guard properly |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Arc<Mutex<T>> everywhere | Contention, complexity | Message passing |
+| thread::sleep in async | Blocks executor | tokio::time::sleep |
+| Holding locks across await | Blocks other tasks | Scope locks tightly |
+| Ignoring deadlock risk | Hard to debug | Lock ordering, try_lock |
+
+---
+
+## Async-Specific Patterns
+
+### Avoid MutexGuard Across Await
+
+```rust
+// Bad: guard held across await
+let guard = mutex.lock().await;
+do_async().await;  // guard still held!
+
+// Good: scope the lock
+{
+    let guard = mutex.lock().await;
+    // use guard
+}  // guard dropped
+do_async().await;
+```
+
+### Non-Send Types in Async
+
+```rust
+// Rc is !Send, can't cross await in spawned task
+// Option 1: use Arc instead
+// Option 2: use spawn_local (single-thread runtime)
+// Option 3: ensure Rc is dropped before .await
+```
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Smart pointer choice | m02-resource |
+| Interior mutability | m03-mutability |
+| Performance tuning | m10-performance |
+| Domain concurrency needs | domain-* |

--- a/.agents/skills/m07-concurrency/comparison.md
+++ b/.agents/skills/m07-concurrency/comparison.md
@@ -1,0 +1,312 @@
+# Concurrency: Comparison with Other Languages
+
+## Rust vs Go
+
+### Concurrency Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Model | Ownership + Send/Sync | CSP (Communicating Sequential Processes) |
+| Primitives | Arc, Mutex, channels | goroutines, channels |
+| Safety | Compile-time | Runtime (race detector) |
+| Async | async/await + runtime | Built-in scheduler |
+
+### Goroutines vs Rust Tasks
+
+```rust
+// Rust: explicit about thread safety
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+let data = Arc::new(Mutex::new(vec![]));
+let data_clone = Arc::clone(&data);
+
+tokio::spawn(async move {
+    let mut guard = data_clone.lock().await;
+    guard.push(1);  // Safe: Mutex protects access
+});
+
+// Go: implicit sharing (potential race)
+// data := []int{}
+// go func() {
+//     data = append(data, 1)  // RACE CONDITION!
+// }()
+```
+
+### Channel Comparison
+
+```rust
+// Rust: typed channels with ownership
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<String>(100);
+
+tokio::spawn(async move {
+    tx.send("hello".to_string()).await.unwrap();
+    // tx is moved, can't be used elsewhere
+});
+
+// Go: channels are more flexible but less safe
+// ch := make(chan string, 100)
+// go func() {
+//     ch <- "hello"
+//     // ch can still be used anywhere
+// }()
+```
+
+---
+
+## Rust vs Java
+
+### Thread Safety Model
+
+| Aspect | Rust | Java |
+|--------|------|------|
+| Safety | Compile-time (Send/Sync) | Runtime (synchronized, volatile) |
+| Null | No null (Option) | NullPointerException risk |
+| Locks | RAII (drop releases) | try-finally or try-with-resources |
+| Memory | No GC | GC with stop-the-world |
+
+### Synchronization Comparison
+
+```rust
+// Rust: lock is tied to data
+use std::sync::Mutex;
+
+let data = Mutex::new(vec![1, 2, 3]);
+{
+    let mut guard = data.lock().unwrap();
+    guard.push(4);
+}  // lock released automatically
+
+// Java: lock and data are separate
+// List<Integer> data = new ArrayList<>();
+// synchronized(data) {
+//     data.add(4);
+// }  // easy to forget synchronization elsewhere
+```
+
+### Thread Pool Comparison
+
+```rust
+// Rust: rayon for data parallelism
+use rayon::prelude::*;
+
+let sum: i32 = (0..1000)
+    .into_par_iter()
+    .map(|x| x * x)
+    .sum();
+
+// Java: Stream API
+// int sum = IntStream.range(0, 1000)
+//     .parallel()
+//     .map(x -> x * x)
+//     .sum();
+```
+
+---
+
+## Rust vs C++
+
+### Safety Guarantees
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Data races | Prevented at compile-time | Undefined behavior |
+| Deadlocks | Not prevented (same as C++) | Not prevented |
+| Thread safety | Send/Sync traits | Convention only |
+| Memory ordering | Explicit Ordering enum | memory_order enum |
+
+### Atomic Comparison
+
+```rust
+// Rust: clear memory ordering
+use std::sync::atomic::{AtomicI32, Ordering};
+
+let counter = AtomicI32::new(0);
+counter.fetch_add(1, Ordering::SeqCst);
+let value = counter.load(Ordering::Acquire);
+
+// C++: similar but without safety
+// std::atomic<int> counter{0};
+// counter.fetch_add(1, std::memory_order_seq_cst);
+// int value = counter.load(std::memory_order_acquire);
+```
+
+### Mutex Comparison
+
+```rust
+// Rust: data protected by Mutex
+use std::sync::Mutex;
+
+struct SafeCounter {
+    count: Mutex<i32>,  // Mutex contains the data
+}
+
+impl SafeCounter {
+    fn increment(&self) {
+        *self.count.lock().unwrap() += 1;
+    }
+}
+
+// C++: mutex separate from data (error-prone)
+// class Counter {
+//     std::mutex mtx;
+//     int count;  // NOT protected by type system
+// public:
+//     void increment() {
+//         std::lock_guard<std::mutex> lock(mtx);
+//         count++;
+//     }
+//     void unsafe_increment() {
+//         count++;  // Compiles! But wrong.
+//     }
+// };
+```
+
+---
+
+## Async Models Comparison
+
+| Language | Model | Runtime |
+|----------|-------|---------|
+| Rust | async/await, zero-cost | tokio, async-std (bring your own) |
+| Go | goroutines | Built-in scheduler |
+| JavaScript | async/await, Promises | Event loop (single-threaded) |
+| Python | async/await | asyncio (single-threaded) |
+| Java | CompletableFuture, Virtual Threads | ForkJoinPool, Loom |
+
+### Rust vs JavaScript Async
+
+```rust
+// Rust: async requires explicit runtime, can use multiple threads
+#[tokio::main]
+async fn main() {
+    let results = tokio::join!(
+        fetch("url1"),  // runs concurrently
+        fetch("url2"),
+    );
+}
+
+// JavaScript: single-threaded event loop
+// async function main() {
+//     const results = await Promise.all([
+//         fetch("url1"),
+//         fetch("url2"),
+//     ]);
+// }
+```
+
+### Rust vs Python Async
+
+```rust
+// Rust: true parallelism possible
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| tokio::spawn(fetch(url)))  // spawns on thread pool
+        .collect();
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
+// Python: asyncio is single-threaded (use ProcessPoolExecutor for CPU)
+# async def main():
+#     tasks = [asyncio.create_task(fetch(url)) for url in urls]
+#     await asyncio.gather(*tasks)  # all on same thread
+```
+
+---
+
+## Send and Sync: Rust's Unique Feature
+
+No other mainstream language has compile-time thread safety markers:
+
+| Trait | Meaning | Auto-impl |
+|-------|---------|-----------|
+| `Send` | Safe to transfer between threads | Most types |
+| `Sync` | Safe to share `&T` between threads | Types with thread-safe `&` |
+| `!Send` | Must stay on one thread | Rc, raw pointers |
+| `!Sync` | References can't be shared | RefCell, Cell |
+
+### Why This Matters
+
+```rust
+// Rust PREVENTS this at compile time:
+use std::rc::Rc;
+
+let rc = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", rc);  // ERROR: Rc is not Send
+});
+
+// In other languages, this would be a runtime bug:
+// - Go: race detector might catch it
+// - Java: undefined behavior
+// - Python: GIL usually saves you
+// - C++: undefined behavior
+```
+
+---
+
+## Performance Characteristics
+
+| Aspect | Rust | Go | Java | C++ |
+|--------|------|-----|------|-----|
+| Thread overhead | System threads or M:N | M:N (goroutines) | System or virtual | System threads |
+| Context switch | OS-level or cooperative | Cheap (goroutines) | OS-level | OS-level |
+| Memory | Predictable (no GC) | GC pauses | GC pauses | Predictable |
+| Async overhead | Zero-cost futures | Runtime overhead | Boxing overhead | Depends |
+
+### When to Use What
+
+| Scenario | Best Choice |
+|----------|-------------|
+| CPU-bound parallelism | Rust (rayon), C++ |
+| I/O-bound concurrency | Rust (tokio), Go, Node.js |
+| Low latency required | Rust, C++ |
+| Rapid development | Go, Python |
+| Complex concurrent state | Rust (compile-time safety) |
+
+---
+
+## Mental Model Shifts
+
+### From Go
+
+```
+Before: "Just use goroutines and channels"
+After:  "Explicitly declare what can be shared and how"
+```
+
+Key shifts:
+- `Arc<Mutex<T>>` instead of implicit sharing
+- Compiler enforces thread safety
+- Async needs explicit runtime
+
+### From Java
+
+```
+Before: "synchronized everywhere, hope for the best"
+After:  "Types encode thread safety, compiler enforces"
+```
+
+Key shifts:
+- No need for synchronized keyword
+- Mutex contains data, not separate
+- No GC pauses in critical sections
+
+### From C++
+
+```
+Before: "Be careful, read the docs, use sanitizers"
+After:  "Compiler catches data races, trust the type system"
+```
+
+Key shifts:
+- Send/Sync replace convention
+- RAII locks are mandatory, not optional
+- Much harder to write incorrect concurrent code

--- a/.agents/skills/m07-concurrency/examples/thread-patterns.md
+++ b/.agents/skills/m07-concurrency/examples/thread-patterns.md
@@ -1,0 +1,396 @@
+# Thread-Based Concurrency Patterns
+
+## Thread Spawning Best Practices
+
+### Basic Thread Spawn
+```rust
+use std::thread;
+
+fn main() {
+    let handle = thread::spawn(|| {
+        println!("Hello from thread!");
+        42  // return value
+    });
+
+    let result = handle.join().unwrap();
+    println!("Thread returned: {}", result);
+}
+```
+
+### Named Threads for Debugging
+```rust
+use std::thread;
+
+let builder = thread::Builder::new()
+    .name("worker-1".to_string())
+    .stack_size(32 * 1024);  // 32KB stack
+
+let handle = builder.spawn(|| {
+    println!("Thread name: {:?}", thread::current().name());
+}).unwrap();
+```
+
+### Scoped Threads (No 'static Required)
+```rust
+use std::thread;
+
+fn process_data(data: &[u32]) -> Vec<u32> {
+    thread::scope(|s| {
+        let handles: Vec<_> = data
+            .chunks(2)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk.iter().map(|x| x * 2).collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect()
+    })
+}
+
+fn main() {
+    let data = vec![1, 2, 3, 4, 5, 6];
+    let result = process_data(&data);  // No 'static needed!
+    println!("{:?}", result);
+}
+```
+
+---
+
+## Shared State Patterns
+
+### Arc + Mutex (Read-Write)
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+fn shared_counter() {
+    let counter = Arc::new(Mutex::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        let handle = thread::spawn(move || {
+            let mut num = counter.lock().unwrap();
+            *num += 1;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", *counter.lock().unwrap());
+}
+```
+
+### Arc + RwLock (Read-Heavy)
+```rust
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+fn read_heavy_cache() {
+    let cache = Arc::new(RwLock::new(vec![1, 2, 3]));
+
+    // Many readers
+    for i in 0..5 {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let data = cache.read().unwrap();
+            println!("Reader {}: {:?}", i, *data);
+        });
+    }
+
+    // Occasional writer
+    {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let mut data = cache.write().unwrap();
+            data.push(4);
+            println!("Writer: added element");
+        });
+    }
+}
+```
+
+### Atomic for Simple Types
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+fn atomic_counter() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            for _ in 0..1000 {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", counter.load(Ordering::SeqCst));
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC Channel
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn producer_consumer() {
+    let (tx, rx) = mpsc::channel();
+
+    // Multiple producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            for j in 0..5 {
+                tx.send(format!("msg {}-{}", i, j)).unwrap();
+            }
+        });
+    }
+    drop(tx);  // Drop original sender
+
+    // Single consumer
+    for received in rx {
+        println!("Got: {}", received);
+    }
+}
+```
+
+### Sync Channel (Bounded)
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn bounded_channel() {
+    let (tx, rx) = mpsc::sync_channel(2);  // buffer size 2
+
+    thread::spawn(move || {
+        for i in 0..5 {
+            println!("Sending {}", i);
+            tx.send(i).unwrap();  // blocks if buffer full
+            println!("Sent {}", i);
+        }
+    });
+
+    thread::sleep(std::time::Duration::from_millis(500));
+    for received in rx {
+        println!("Received: {}", received);
+        thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+```
+
+---
+
+## Thread Pool Patterns
+
+### Using rayon for Parallel Iteration
+```rust
+use rayon::prelude::*;
+
+fn parallel_map() {
+    let numbers: Vec<i32> = (0..1000).collect();
+
+    let squares: Vec<i32> = numbers
+        .par_iter()  // parallel iterator
+        .map(|x| x * x)
+        .collect();
+
+    println!("Processed {} items", squares.len());
+}
+
+fn parallel_filter_map() {
+    let data: Vec<String> = get_data();
+
+    let results: Vec<_> = data
+        .par_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| expensive_process(s))
+        .collect();
+}
+```
+
+### Custom Thread Pool with crossbeam
+```rust
+use crossbeam::channel;
+use std::thread;
+
+fn custom_pool(num_workers: usize) {
+    let (tx, rx) = channel::bounded::<Box<dyn FnOnce() + Send>>(100);
+
+    // Spawn workers
+    let workers: Vec<_> = (0..num_workers)
+        .map(|_| {
+            let rx = rx.clone();
+            thread::spawn(move || {
+                while let Ok(task) = rx.recv() {
+                    task();
+                }
+            })
+        })
+        .collect();
+
+    // Submit tasks
+    for i in 0..100 {
+        tx.send(Box::new(move || {
+            println!("Processing task {}", i);
+        })).unwrap();
+    }
+
+    drop(tx);  // Close channel
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+}
+```
+
+---
+
+## Synchronization Primitives
+
+### Barrier (Wait for All)
+```rust
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn barrier_example() {
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = vec![];
+
+    for i in 0..3 {
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            println!("Thread {} starting", i);
+            thread::sleep(std::time::Duration::from_millis(i as u64 * 100));
+
+            barrier.wait();  // All threads wait here
+
+            println!("Thread {} after barrier", i);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+```
+
+### Condvar (Condition Variable)
+```rust
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+
+fn condvar_example() {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_clone = Arc::clone(&pair);
+
+    // Waiter thread
+    let waiter = thread::spawn(move || {
+        let (lock, cvar) = &*pair_clone;
+        let mut started = lock.lock().unwrap();
+        while !*started {
+            started = cvar.wait(started).unwrap();
+        }
+        println!("Waiter: condition met!");
+    });
+
+    // Notifier
+    thread::sleep(std::time::Duration::from_millis(100));
+    let (lock, cvar) = &*pair;
+    {
+        let mut started = lock.lock().unwrap();
+        *started = true;
+    }
+    cvar.notify_one();
+
+    waiter.join().unwrap();
+}
+```
+
+### Once (One-Time Initialization)
+```rust
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+static mut CONFIG: Option<Config> = None;
+
+fn get_config() -> &'static Config {
+    INIT.call_once(|| {
+        unsafe {
+            CONFIG = Some(load_config());
+        }
+    });
+    unsafe { CONFIG.as_ref().unwrap() }
+}
+
+// Better: use once_cell or lazy_static
+use once_cell::sync::Lazy;
+
+static CONFIG: Lazy<Config> = Lazy::new(|| {
+    load_config()
+});
+```
+
+---
+
+## Error Handling in Threads
+
+### Handling Panics
+```rust
+use std::thread;
+
+fn handle_panic() {
+    let handle = thread::spawn(|| {
+        panic!("Thread panicked!");
+    });
+
+    match handle.join() {
+        Ok(_) => println!("Thread completed successfully"),
+        Err(e) => {
+            if let Some(s) = e.downcast_ref::<&str>() {
+                println!("Thread panicked with: {}", s);
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                println!("Thread panicked with: {}", s);
+            } else {
+                println!("Thread panicked with unknown error");
+            }
+        }
+    }
+}
+```
+
+### Catching Panics
+```rust
+use std::panic;
+
+fn catch_panic() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(value) => println!("Success: {:?}", value),
+        Err(_) => println!("Operation panicked, continuing..."),
+    }
+}
+```

--- a/.agents/skills/m07-concurrency/patterns/async-patterns.md
+++ b/.agents/skills/m07-concurrency/patterns/async-patterns.md
@@ -1,0 +1,409 @@
+# Async Patterns in Rust
+
+## Task Spawning
+
+### Basic Spawn
+```rust
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    // Spawn a task that runs concurrently
+    let handle = task::spawn(async {
+        expensive_computation().await
+    });
+
+    // Do other work while task runs
+    other_work().await;
+
+    // Wait for result
+    let result = handle.await.unwrap();
+}
+```
+
+### Spawn with Shared State
+```rust
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+async fn process_with_state() {
+    let state = Arc::new(Mutex::new(vec![]));
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let state = Arc::clone(&state);
+            tokio::spawn(async move {
+                let mut guard = state.lock().await;
+                guard.push(i);
+            })
+        })
+        .collect();
+
+    // Wait for all tasks
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Select Pattern
+
+### Racing Multiple Futures
+```rust
+use tokio::select;
+use tokio::time::{sleep, Duration};
+
+async fn first_response() {
+    select! {
+        result = fetch_from_server_a() => {
+            println!("A responded first: {:?}", result);
+        }
+        result = fetch_from_server_b() => {
+            println!("B responded first: {:?}", result);
+        }
+    }
+}
+```
+
+### Select with Timeout
+```rust
+use tokio::time::timeout;
+
+async fn with_timeout() -> Result<Data, Error> {
+    select! {
+        result = fetch_data() => result,
+        _ = sleep(Duration::from_secs(5)) => {
+            Err(Error::Timeout)
+        }
+    }
+}
+
+// Or use timeout directly
+async fn with_timeout2() -> Result<Data, Error> {
+    timeout(Duration::from_secs(5), fetch_data())
+        .await
+        .map_err(|_| Error::Timeout)?
+}
+```
+
+### Select with Channel
+```rust
+use tokio::sync::mpsc;
+
+async fn process_messages(mut rx: mpsc::Receiver<Message>) {
+    loop {
+        select! {
+            Some(msg) = rx.recv() => {
+                handle_message(msg).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC (Multi-Producer, Single-Consumer)
+```rust
+use tokio::sync::mpsc;
+
+async fn producer_consumer() {
+    let (tx, mut rx) = mpsc::channel(100);
+
+    // Spawn producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            tx.send(format!("Message from {}", i)).await.unwrap();
+        });
+    }
+
+    // Drop original sender so channel closes
+    drop(tx);
+
+    // Consume
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+}
+```
+
+### Oneshot (Single-Shot Response)
+```rust
+use tokio::sync::oneshot;
+
+async fn request_response() {
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let result = compute_something().await;
+        tx.send(result).unwrap();
+    });
+
+    // Wait for response
+    let response = rx.await.unwrap();
+}
+```
+
+### Broadcast (Multi-Consumer)
+```rust
+use tokio::sync::broadcast;
+
+async fn pub_sub() {
+    let (tx, _) = broadcast::channel(16);
+
+    // Subscribe multiple consumers
+    let mut rx1 = tx.subscribe();
+    let mut rx2 = tx.subscribe();
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx1.recv().await {
+            println!("Consumer 1: {}", msg);
+        }
+    });
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx2.recv().await {
+            println!("Consumer 2: {}", msg);
+        }
+    });
+
+    // Publish
+    tx.send("Hello").unwrap();
+}
+```
+
+### Watch (Single Latest Value)
+```rust
+use tokio::sync::watch;
+
+async fn config_updates() {
+    let (tx, mut rx) = watch::channel(Config::default());
+
+    // Consumer watches for changes
+    tokio::spawn(async move {
+        while rx.changed().await.is_ok() {
+            let config = rx.borrow();
+            apply_config(&config);
+        }
+    });
+
+    // Update config
+    tx.send(Config::new()).unwrap();
+}
+```
+
+---
+
+## Structured Concurrency
+
+### JoinSet for Task Groups
+```rust
+use tokio::task::JoinSet;
+
+async fn parallel_fetch(urls: Vec<String>) -> Vec<Result<Response, Error>> {
+    let mut set = JoinSet::new();
+
+    for url in urls {
+        set.spawn(async move {
+            fetch(&url).await
+        });
+    }
+
+    let mut results = vec![];
+    while let Some(res) = set.join_next().await {
+        results.push(res.unwrap());
+    }
+    results
+}
+```
+
+### Scoped Tasks (no 'static)
+```rust
+// Using tokio-scoped or async-scoped crate
+use async_scoped::TokioScope;
+
+async fn scoped_example(data: &[u32]) {
+    let results = TokioScope::scope_and_block(|scope| {
+        for item in data {
+            scope.spawn(async move {
+                process(item).await
+            });
+        }
+    });
+}
+```
+
+---
+
+## Cancellation Patterns
+
+### Using CancellationToken
+```rust
+use tokio_util::sync::CancellationToken;
+
+async fn cancellable_task(token: CancellationToken) {
+    loop {
+        select! {
+            _ = token.cancelled() => {
+                println!("Task cancelled");
+                break;
+            }
+            _ = do_work() => {
+                // Continue working
+            }
+        }
+    }
+}
+
+async fn main_with_cancellation() {
+    let token = CancellationToken::new();
+    let task_token = token.clone();
+
+    let handle = tokio::spawn(cancellable_task(task_token));
+
+    // Cancel after some condition
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    token.cancel();
+
+    handle.await.unwrap();
+}
+```
+
+### Graceful Shutdown
+```rust
+async fn serve_with_shutdown(shutdown: impl Future) {
+    let server = TcpListener::bind("0.0.0.0:8080").await.unwrap();
+
+    loop {
+        select! {
+            Ok((socket, _)) = server.accept() => {
+                tokio::spawn(handle_connection(socket));
+            }
+            _ = &mut shutdown => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await.unwrap();
+    };
+
+    serve_with_shutdown(ctrl_c).await;
+}
+```
+
+---
+
+## Backpressure Patterns
+
+### Bounded Channels
+```rust
+use tokio::sync::mpsc;
+
+async fn with_backpressure() {
+    // Buffer of 10 - producers will wait if full
+    let (tx, mut rx) = mpsc::channel(10);
+
+    let producer = tokio::spawn(async move {
+        for i in 0..1000 {
+            // This will wait if channel is full
+            tx.send(i).await.unwrap();
+        }
+    });
+
+    let consumer = tokio::spawn(async move {
+        while let Some(item) = rx.recv().await {
+            // Slow consumer
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            process(item);
+        }
+    });
+
+    let _ = tokio::join!(producer, consumer);
+}
+```
+
+### Semaphore for Rate Limiting
+```rust
+use tokio::sync::Semaphore;
+use std::sync::Arc;
+
+async fn rate_limited_requests(urls: Vec<String>) {
+    let semaphore = Arc::new(Semaphore::new(10));  // max 10 concurrent
+
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| {
+            let sem = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
+                fetch(&url).await
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Error Handling in Async
+
+### Propagating Errors
+```rust
+async fn fetch_and_parse(url: &str) -> Result<Data, Error> {
+    let response = fetch(url).await?;
+    let data = parse(response).await?;
+    Ok(data)
+}
+```
+
+### Handling Task Panics
+```rust
+async fn robust_spawn() {
+    let handle = tokio::spawn(async {
+        risky_operation().await
+    });
+
+    match handle.await {
+        Ok(result) => println!("Success: {:?}", result),
+        Err(e) if e.is_panic() => {
+            println!("Task panicked: {:?}", e);
+        }
+        Err(e) => {
+            println!("Task cancelled: {:?}", e);
+        }
+    }
+}
+```
+
+### Try-Join for Multiple Results
+```rust
+use tokio::try_join;
+
+async fn fetch_all() -> Result<(A, B, C), Error> {
+    // All must succeed, or first error returned
+    try_join!(
+        fetch_a(),
+        fetch_b(),
+        fetch_c(),
+    )
+}
+```

--- a/.agents/skills/m07-concurrency/patterns/common-errors.md
+++ b/.agents/skills/m07-concurrency/patterns/common-errors.md
@@ -1,0 +1,331 @@
+# Common Concurrency Errors & Fixes
+
+## E0277: Cannot Send Between Threads
+
+### Error Pattern
+```rust
+use std::rc::Rc;
+
+let data = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", data);  // ERROR: Rc<i32> cannot be sent between threads
+});
+```
+
+### Fix Options
+
+**Option 1: Use Arc instead**
+```rust
+use std::sync::Arc;
+
+let data = Arc::new(42);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{}", data_clone);  // OK: Arc is Send
+});
+```
+
+**Option 2: Move owned data**
+```rust
+let data = 42;  // i32 is Copy and Send
+std::thread::spawn(move || {
+    println!("{}", data);  // OK
+});
+```
+
+---
+
+## E0277: Cannot Share Between Threads (Not Sync)
+
+### Error Pattern
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+
+let data = Arc::new(RefCell::new(42));
+// ERROR: RefCell is not Sync
+```
+
+### Fix Options
+
+**Option 1: Use Mutex for thread-safe interior mutability**
+```rust
+use std::sync::{Arc, Mutex};
+
+let data = Arc::new(Mutex::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let mut guard = data_clone.lock().unwrap();
+    *guard += 1;
+});
+```
+
+**Option 2: Use RwLock for read-heavy workloads**
+```rust
+use std::sync::{Arc, RwLock};
+
+let data = Arc::new(RwLock::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let guard = data_clone.read().unwrap();
+    println!("{}", *guard);
+});
+```
+
+---
+
+## Deadlock Patterns
+
+### Pattern 1: Lock Ordering Deadlock
+```rust
+// DANGER: potential deadlock
+use std::sync::{Arc, Mutex};
+
+let a = Arc::new(Mutex::new(1));
+let b = Arc::new(Mutex::new(2));
+
+// Thread 1: locks a then b
+let a1 = Arc::clone(&a);
+let b1 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();  // waits for b
+});
+
+// Thread 2: locks b then a (opposite order!)
+let a2 = Arc::clone(&a);
+let b2 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _b = b2.lock().unwrap();
+    let _a = a2.lock().unwrap();  // waits for a - DEADLOCK
+});
+```
+
+### Fix: Consistent Lock Ordering
+```rust
+// SAFE: always lock in same order (a before b)
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();
+});
+
+std::thread::spawn(move || {
+    let _a = a2.lock().unwrap();  // same order
+    let _b = b2.lock().unwrap();
+});
+```
+
+### Pattern 2: Self-Deadlock
+```rust
+// DANGER: locking same mutex twice
+let m = Mutex::new(42);
+let _g1 = m.lock().unwrap();
+let _g2 = m.lock().unwrap();  // DEADLOCK on std::Mutex
+
+// FIX: use parking_lot::ReentrantMutex if needed
+// or restructure code to avoid double locking
+```
+
+---
+
+## Mutex Guard Across Await
+
+### Error Pattern
+```rust
+use std::sync::Mutex;
+use tokio::time::sleep;
+
+async fn bad_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().unwrap();
+    sleep(Duration::from_secs(1)).await;  // WARNING: guard held across await
+    println!("{}", *guard);
+}
+```
+
+### Fix Options
+
+**Option 1: Scope the lock**
+```rust
+async fn good_async() {
+    let m = Mutex::new(42);
+    let value = {
+        let guard = m.lock().unwrap();
+        *guard  // copy value
+    };  // guard dropped here
+    sleep(Duration::from_secs(1)).await;
+    println!("{}", value);
+}
+```
+
+**Option 2: Use tokio::sync::Mutex**
+```rust
+use tokio::sync::Mutex;
+
+async fn good_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().await;  // async lock
+    sleep(Duration::from_secs(1)).await;  // OK with tokio::Mutex
+    println!("{}", *guard);
+}
+```
+
+---
+
+## Data Race Prevention
+
+### Pattern: Missing Synchronization
+```rust
+// This WON'T compile - Rust prevents data races
+use std::sync::Arc;
+
+let data = Arc::new(0);
+let d1 = Arc::clone(&data);
+let d2 = Arc::clone(&data);
+
+std::thread::spawn(move || {
+    // *d1 += 1;  // ERROR: cannot mutate through Arc
+});
+
+std::thread::spawn(move || {
+    // *d2 += 1;  // ERROR: cannot mutate through Arc
+});
+```
+
+### Fix: Add Synchronization
+```rust
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+// Option 1: Mutex
+let data = Arc::new(Mutex::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    *d1.lock().unwrap() += 1;
+});
+
+// Option 2: Atomic (for simple types)
+let data = Arc::new(AtomicI32::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    d1.fetch_add(1, Ordering::SeqCst);
+});
+```
+
+---
+
+## Channel Errors
+
+### Disconnected Channel
+```rust
+use std::sync::mpsc;
+
+let (tx, rx) = mpsc::channel();
+drop(tx);  // sender dropped
+match rx.recv() {
+    Ok(v) => println!("{}", v),
+    Err(_) => println!("channel disconnected"),  // this happens
+}
+```
+
+### Fix: Handle Disconnection
+```rust
+// Use try_recv for non-blocking
+loop {
+    match rx.try_recv() {
+        Ok(msg) => handle(msg),
+        Err(TryRecvError::Empty) => continue,
+        Err(TryRecvError::Disconnected) => break,
+    }
+}
+
+// Or iterate (stops on disconnect)
+for msg in rx {
+    handle(msg);
+}
+```
+
+---
+
+## Async Common Errors
+
+### Forgetting to Spawn
+```rust
+// WRONG: future not polled
+async fn fetch_data() -> Result<Data, Error> { ... }
+
+fn process() {
+    fetch_data();  // does nothing! returns Future that's dropped
+}
+
+// RIGHT: await or spawn
+async fn process() {
+    let data = fetch_data().await;  // awaited
+}
+
+fn process_sync() {
+    tokio::spawn(fetch_data());  // spawned
+}
+```
+
+### Blocking in Async Context
+```rust
+// WRONG: blocks the executor
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocks!
+    std::fs::read_to_string("file.txt").unwrap();  // blocks!
+}
+
+// RIGHT: use async versions
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::fs::read_to_string("file.txt").await.unwrap();
+}
+
+// Or spawn_blocking for CPU-bound work
+async fn compute() {
+    let result = tokio::task::spawn_blocking(|| {
+        heavy_computation()  // OK to block here
+    }).await.unwrap();
+}
+```
+
+---
+
+## Thread Panic Handling
+
+### Unhandled Panic
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+// Main thread continues, might miss the error
+handle.join().unwrap();  // panics here
+```
+
+### Proper Error Handling
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+match handle.join() {
+    Ok(result) => println!("Success: {:?}", result),
+    Err(e) => println!("Thread panicked: {:?}", e),
+}
+
+// For async: use catch_unwind
+use std::panic;
+
+async fn safe_task() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(v) => use_value(v),
+        Err(_) => log_error("task panicked"),
+    }
+}
+```

--- a/.agents/skills/m09-domain/SKILL.md
+++ b/.agents/skills/m09-domain/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: m09-domain
+description: "CRITICAL: Use for domain modeling. Triggers: domain model, DDD, domain-driven design, entity, value object, aggregate, repository pattern, business rules, validation, invariant, 领域模型, 领域驱动设计, 业务规则"
+user-invocable: false
+---
+
+# Domain Modeling
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**What is this concept's role in the domain?**
+
+Before modeling in code, understand:
+- Is it an Entity (identity matters) or Value Object (interchangeable)?
+- What invariants must be maintained?
+- Where are the aggregate boundaries?
+
+---
+
+## Domain Concept → Rust Pattern
+
+| Domain Concept | Rust Pattern | Ownership Implication |
+|----------------|--------------|----------------------|
+| Entity | struct + Id | Owned, unique identity |
+| Value Object | struct + Clone/Copy | Shareable, immutable |
+| Aggregate Root | struct owns children | Clear ownership tree |
+| Repository | trait | Abstracts persistence |
+| Domain Event | enum | Captures state changes |
+| Service | impl block / free fn | Stateless operations |
+
+---
+
+## Thinking Prompt
+
+Before creating a domain type:
+
+1. **What's the concept's identity?**
+   - Needs unique identity → Entity (Id field)
+   - Interchangeable by value → Value Object (Clone/Copy)
+
+2. **What invariants must hold?**
+   - Always valid → private fields + validated constructor
+   - Transition rules → type state pattern
+
+3. **Who owns this data?**
+   - Single owner (parent) → owned field
+   - Shared reference → Arc/Rc
+   - Weak reference → Weak
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"How should I model a Transaction?"
+    ↑ Ask: What domain rules govern transactions?
+    ↑ Check: domain-fintech (audit, precision requirements)
+    ↑ Check: Business stakeholders (what invariants?)
+```
+
+| Design Question | Trace To | Ask |
+|-----------------|----------|-----|
+| Entity vs Value Object | domain-* | What makes two instances "the same"? |
+| Aggregate boundaries | domain-* | What must be consistent together? |
+| Validation rules | domain-* | What business rules apply? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Model as Entity"
+    ↓ m01-ownership: Owned, unique
+    ↓ m05-type-driven: Newtype for Id
+
+"Model as Value Object"
+    ↓ m01-ownership: Clone/Copy OK
+    ↓ m05-type-driven: Validate at construction
+
+"Model as Aggregate"
+    ↓ m01-ownership: Parent owns children
+    ↓ m02-resource: Consider Rc for shared within aggregate
+```
+
+---
+
+## Quick Reference
+
+| DDD Concept | Rust Pattern | Example |
+|-------------|--------------|---------|
+| Value Object | Newtype | `struct Email(String);` |
+| Entity | Struct + ID | `struct User { id: UserId, ... }` |
+| Aggregate | Module boundary | `mod order { ... }` |
+| Repository | Trait | `trait UserRepo { fn find(...) }` |
+| Domain Event | Enum | `enum OrderEvent { Created, ... }` |
+
+## Pattern Templates
+
+### Value Object
+
+```rust
+struct Email(String);
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, ValidationError> {
+        validate_email(s)?;
+        Ok(Self(s.to_string()))
+    }
+}
+```
+
+### Entity
+
+```rust
+struct UserId(Uuid);
+
+struct User {
+    id: UserId,
+    email: Email,
+    // ... other fields
+}
+
+impl PartialEq for User {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id  // Identity equality
+    }
+}
+```
+
+### Aggregate
+
+```rust
+mod order {
+    pub struct Order {
+        id: OrderId,
+        items: Vec<OrderItem>,  // Owned children
+        // ...
+    }
+
+    impl Order {
+        pub fn add_item(&mut self, item: OrderItem) {
+            // Enforce aggregate invariants
+        }
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Why Wrong | Better |
+|---------|-----------|--------|
+| Primitive obsession | No type safety | Newtype wrappers |
+| Public fields with invariants | Invariants violated | Private + accessor |
+| Leaked aggregate internals | Broken encapsulation | Methods on root |
+| String for semantic types | No validation | Validated newtype |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Type-driven implementation | m05-type-driven |
+| Ownership for aggregates | m01-ownership |
+| Domain error handling | m13-domain-error |
+| Specific domain rules | domain-* |

--- a/.agents/skills/m10-performance/SKILL.md
+++ b/.agents/skills/m10-performance/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: m10-performance
+description: "CRITICAL: Use for performance optimization. Triggers: performance, optimization, benchmark, profiling, flamegraph, criterion, slow, fast, allocation, cache, SIMD, make it faster, 性能优化, 基准测试"
+user-invocable: false
+---
+
+# Performance Optimization
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**What's the bottleneck, and is optimization worth it?**
+
+Before optimizing:
+- Have you measured? (Don't guess)
+- What's the acceptable performance?
+- Will optimization add complexity?
+
+---
+
+## Performance Decision → Implementation
+
+| Goal | Design Choice | Implementation |
+|------|---------------|----------------|
+| Reduce allocations | Pre-allocate, reuse | `with_capacity`, object pools |
+| Improve cache | Contiguous data | `Vec`, `SmallVec` |
+| Parallelize | Data parallelism | `rayon`, threads |
+| Avoid copies | Zero-copy | References, `Cow<T>` |
+| Reduce indirection | Inline data | `smallvec`, arrays |
+
+---
+
+## Thinking Prompt
+
+Before optimizing:
+
+1. **Have you measured?**
+   - Profile first → flamegraph, perf
+   - Benchmark → criterion, cargo bench
+   - Identify actual hotspots
+
+2. **What's the priority?**
+   - Algorithm (10x-1000x improvement)
+   - Data structure (2x-10x)
+   - Allocation (2x-5x)
+   - Cache (1.5x-3x)
+
+3. **What's the trade-off?**
+   - Complexity vs speed
+   - Memory vs CPU
+   - Latency vs throughput
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"How fast does this need to be?"
+    ↑ Ask: What's the performance SLA?
+    ↑ Check: domain-* (latency requirements)
+    ↑ Check: Business requirements (acceptable response time)
+```
+
+| Question | Trace To | Ask |
+|----------|----------|-----|
+| Latency requirements | domain-* | What's acceptable response time? |
+| Throughput needs | domain-* | How many requests per second? |
+| Memory constraints | domain-* | What's the memory budget? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Need to reduce allocations"
+    ↓ m01-ownership: Use references, avoid clone
+    ↓ m02-resource: Pre-allocate with_capacity
+
+"Need to parallelize"
+    ↓ m07-concurrency: Choose rayon or threads
+    ↓ m07-concurrency: Consider async for I/O-bound
+
+"Need cache efficiency"
+    ↓ Data layout: Prefer Vec over HashMap when possible
+    ↓ Access patterns: Sequential over random access
+```
+
+---
+
+## Quick Reference
+
+| Tool | Purpose |
+|------|---------|
+| `cargo bench` | Micro-benchmarks |
+| `criterion` | Statistical benchmarks |
+| `perf` / `flamegraph` | CPU profiling |
+| `heaptrack` | Allocation tracking |
+| `valgrind` / `cachegrind` | Cache analysis |
+
+## Optimization Priority
+
+```
+1. Algorithm choice     (10x - 1000x)
+2. Data structure       (2x - 10x)
+3. Allocation reduction (2x - 5x)
+4. Cache optimization   (1.5x - 3x)
+5. SIMD/Parallelism     (2x - 8x)
+```
+
+## Common Techniques
+
+| Technique | When | How |
+|-----------|------|-----|
+| Pre-allocation | Known size | `Vec::with_capacity(n)` |
+| Avoid cloning | Hot paths | Use references or `Cow<T>` |
+| Batch operations | Many small ops | Collect then process |
+| SmallVec | Usually small | `smallvec::SmallVec<[T; N]>` |
+| Inline buffers | Fixed-size data | Arrays over Vec |
+
+---
+
+## Common Mistakes
+
+| Mistake | Why Wrong | Better |
+|---------|-----------|--------|
+| Optimize without profiling | Wrong target | Profile first |
+| Benchmark in debug mode | Meaningless | Always `--release` |
+| Use LinkedList | Cache unfriendly | `Vec` or `VecDeque` |
+| Hidden `.clone()` | Unnecessary allocs | Use references |
+| Premature optimization | Wasted effort | Make it work first |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Clone to avoid lifetimes | Performance cost | Proper ownership |
+| Box everything | Indirection cost | Stack when possible |
+| HashMap for small sets | Overhead | Vec with linear search |
+| String concat in loop | O(n^2) | `String::with_capacity` or `format!` |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Reducing clones | m01-ownership |
+| Concurrency options | m07-concurrency |
+| Smart pointer choice | m02-resource |
+| Domain requirements | domain-* |

--- a/.agents/skills/m10-performance/patterns/optimization-guide.md
+++ b/.agents/skills/m10-performance/patterns/optimization-guide.md
@@ -1,0 +1,365 @@
+# Rust Performance Optimization Guide
+
+## Profiling First
+
+### Tools
+```bash
+# CPU profiling
+cargo install flamegraph
+cargo flamegraph --bin myapp
+
+# Memory profiling
+cargo install cargo-instruments  # macOS
+heaptrack ./target/release/myapp  # Linux
+
+# Benchmarking
+cargo bench  # with criterion
+
+# Cache analysis
+valgrind --tool=cachegrind ./target/release/myapp
+```
+
+### Criterion Benchmarks
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark_parse(c: &mut Criterion) {
+    let input = "test data".repeat(1000);
+
+    c.bench_function("parse_v1", |b| {
+        b.iter(|| parse_v1(&input))
+    });
+
+    c.bench_function("parse_v2", |b| {
+        b.iter(|| parse_v2(&input))
+    });
+}
+
+criterion_group!(benches, benchmark_parse);
+criterion_main!(benches);
+```
+
+---
+
+## Common Optimizations
+
+### 1. Avoid Unnecessary Allocations
+
+```rust
+// BAD: allocates on every call
+fn to_uppercase(s: &str) -> String {
+    s.to_uppercase()
+}
+
+// GOOD: return Cow, allocate only if needed
+use std::borrow::Cow;
+
+fn to_uppercase(s: &str) -> Cow<'_, str> {
+    if s.chars().all(|c| c.is_uppercase()) {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(s.to_uppercase())
+    }
+}
+```
+
+### 2. Reuse Allocations
+
+```rust
+// BAD: creates new Vec each iteration
+for item in items {
+    let mut buffer = Vec::new();
+    process(&mut buffer, item);
+}
+
+// GOOD: reuse buffer
+let mut buffer = Vec::new();
+for item in items {
+    buffer.clear();
+    process(&mut buffer, item);
+}
+```
+
+### 3. Use Appropriate Collections
+
+| Need | Collection | Notes |
+|------|------------|-------|
+| Sequential access | `Vec<T>` | Best cache locality |
+| Random access by key | `HashMap<K, V>` | O(1) lookup |
+| Ordered keys | `BTreeMap<K, V>` | O(log n) lookup |
+| Small sets (<20) | `Vec<T>` + linear search | Lower overhead |
+| FIFO queue | `VecDeque<T>` | O(1) push/pop both ends |
+
+### 4. Pre-allocate Capacity
+
+```rust
+// BAD: many reallocations
+let mut v = Vec::new();
+for i in 0..10000 {
+    v.push(i);
+}
+
+// GOOD: single allocation
+let mut v = Vec::with_capacity(10000);
+for i in 0..10000 {
+    v.push(i);
+}
+```
+
+---
+
+## String Optimization
+
+### Avoid String Concatenation in Loops
+
+```rust
+// BAD: O(n²) allocations
+let mut result = String::new();
+for s in strings {
+    result = result + &s;
+}
+
+// GOOD: O(n) with push_str
+let mut result = String::new();
+for s in strings {
+    result.push_str(&s);
+}
+
+// BETTER: pre-calculate capacity
+let total_len: usize = strings.iter().map(|s| s.len()).sum();
+let mut result = String::with_capacity(total_len);
+for s in strings {
+    result.push_str(&s);
+}
+
+// BEST: use join for simple cases
+let result = strings.join("");
+```
+
+### Use &str When Possible
+
+```rust
+// BAD: requires allocation
+fn greet(name: String) {
+    println!("Hello, {}", name);
+}
+
+// GOOD: borrows, no allocation
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// Works with both:
+greet("world");                    // &str
+greet(&String::from("world"));     // &String coerces to &str
+```
+
+---
+
+## Iterator Optimization
+
+### Use Iterators Over Indexing
+
+```rust
+// BAD: bounds checking on each access
+let mut sum = 0;
+for i in 0..vec.len() {
+    sum += vec[i];
+}
+
+// GOOD: no bounds checking
+let sum: i32 = vec.iter().sum();
+
+// GOOD: when index needed
+for (i, item) in vec.iter().enumerate() {
+    // ...
+}
+```
+
+### Lazy Evaluation
+
+```rust
+// Iterators are lazy - computation happens at collect
+let result: Vec<_> = data
+    .iter()
+    .filter(|x| x.is_valid())
+    .map(|x| x.process())
+    .take(10)  // stop after 10 items
+    .collect();
+```
+
+### Avoid Collecting When Not Needed
+
+```rust
+// BAD: unnecessary intermediate allocation
+let filtered: Vec<_> = items.iter().filter(|x| x.valid).collect();
+let count = filtered.len();
+
+// GOOD: no allocation
+let count = items.iter().filter(|x| x.valid).count();
+```
+
+---
+
+## Parallelism with Rayon
+
+```rust
+use rayon::prelude::*;
+
+// Sequential
+let sum: i32 = (0..1_000_000).map(|x| x * x).sum();
+
+// Parallel (automatic work stealing)
+let sum: i32 = (0..1_000_000).into_par_iter().map(|x| x * x).sum();
+
+// Parallel with custom chunk size
+let results: Vec<_> = data
+    .par_chunks(1000)
+    .map(|chunk| process_chunk(chunk))
+    .collect();
+```
+
+---
+
+## Memory Layout
+
+### Use Appropriate Integer Sizes
+
+```rust
+// If values are small, use smaller types
+struct Item {
+    count: u8,      // 0-255, not u64
+    flags: u8,      // small enum
+    id: u32,        // if 4 billion is enough
+}
+```
+
+### Pack Structs Efficiently
+
+```rust
+// BAD: 24 bytes due to padding
+struct Bad {
+    a: u8,   // 1 byte + 7 padding
+    b: u64,  // 8 bytes
+    c: u8,   // 1 byte + 7 padding
+}
+
+// GOOD: 16 bytes (or use #[repr(packed)])
+struct Good {
+    b: u64,  // 8 bytes
+    a: u8,   // 1 byte
+    c: u8,   // 1 byte + 6 padding
+}
+```
+
+### Box Large Values
+
+```rust
+// Large enum variants waste space
+enum Message {
+    Quit,
+    Data([u8; 10000]),  // all variants are 10000+ bytes
+}
+
+// Better: box the large variant
+enum Message {
+    Quit,
+    Data(Box<[u8; 10000]>),  // variants are pointer-sized
+}
+```
+
+---
+
+## Async Performance
+
+### Avoid Blocking in Async
+
+```rust
+// BAD: blocks the executor
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocking!
+    std::fs::read_to_string("file.txt").unwrap();  // blocking!
+}
+
+// GOOD: use async versions
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::fs::read_to_string("file.txt").await.unwrap();
+}
+
+// For CPU work: spawn_blocking
+async fn compute() -> i32 {
+    tokio::task::spawn_blocking(|| {
+        heavy_computation()
+    }).await.unwrap()
+}
+```
+
+### Buffer Async I/O
+
+```rust
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+// BAD: many small reads
+async fn bad(file: File) {
+    let mut byte = [0u8];
+    while file.read(&mut byte).await.unwrap() > 0 {
+        process(byte[0]);
+    }
+}
+
+// GOOD: buffered reading
+async fn good(file: File) {
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        process(&line);
+    }
+}
+```
+
+---
+
+## Release Build Optimization
+
+### Cargo.toml Settings
+
+```toml
+[profile.release]
+lto = true           # Link-time optimization
+codegen-units = 1    # Single codegen unit (slower compile, faster code)
+panic = "abort"      # Smaller binary, no unwinding
+strip = true         # Strip symbols
+
+[profile.release-fast]
+inherits = "release"
+opt-level = 3        # Maximum optimization
+
+[profile.release-small]
+inherits = "release"
+opt-level = "s"      # Optimize for size
+```
+
+### Compile-Time Assertions
+
+```rust
+// Zero runtime cost
+const _: () = assert!(std::mem::size_of::<MyStruct>() <= 64);
+```
+
+---
+
+## Checklist
+
+Before optimizing:
+- [ ] Profile to find actual bottlenecks
+- [ ] Have benchmarks to measure improvement
+- [ ] Consider if optimization is worth complexity
+
+Common wins:
+- [ ] Reduce allocations (Cow, reuse buffers)
+- [ ] Use appropriate collections
+- [ ] Pre-allocate with_capacity
+- [ ] Use iterators instead of indexing
+- [ ] Enable LTO for release builds
+- [ ] Use rayon for parallel workloads

--- a/.agents/skills/m11-ecosystem/SKILL.md
+++ b/.agents/skills/m11-ecosystem/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: m11-ecosystem
+description: "Use when integrating crates or ecosystem questions. Keywords: E0425, E0433, E0603, crate, cargo, dependency, feature flag, workspace, which crate to use, using external C libraries, creating Python extensions, PyO3, wasm, WebAssembly, bindgen, cbindgen, napi-rs, cannot find, private, crate recommendation, best crate for, Cargo.toml, features, crate 推荐, 依赖管理, 特性标志, 工作空间, Python 绑定"
+user-invocable: false
+---
+
+## Current Dependencies (Auto-Injected)
+
+!`grep -A 100 '^\[dependencies\]' Cargo.toml 2>/dev/null | head -30 || echo "No Cargo.toml found"`
+
+---
+
+# Ecosystem Integration
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**What's the right crate for this job, and how should it integrate?**
+
+Before adding dependencies:
+- Is there a standard solution?
+- What's the maintenance status?
+- What's the API stability?
+
+---
+
+## Integration Decision → Implementation
+
+| Need | Choice | Crates |
+|------|--------|--------|
+| Serialization | Derive-based | serde, serde_json |
+| Async runtime | tokio or async-std | tokio (most popular) |
+| HTTP client | Ergonomic | reqwest |
+| HTTP server | Modern | axum, actix-web |
+| Database | SQL or ORM | sqlx, diesel |
+| CLI parsing | Derive-based | clap |
+| Error handling | App vs lib | anyhow, thiserror |
+| Logging | Facade | tracing, log |
+
+---
+
+## Thinking Prompt
+
+Before adding a dependency:
+
+1. **Is it well-maintained?**
+   - Recent commits?
+   - Active issue response?
+   - Breaking changes frequency?
+
+2. **What's the scope?**
+   - Do you need the full crate or just a feature?
+   - Can feature flags reduce bloat?
+
+3. **How does it integrate?**
+   - Trait-based or concrete types?
+   - Sync or async?
+   - What bounds does it require?
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"Which HTTP framework should I use?"
+    ↑ Ask: What are the performance requirements?
+    ↑ Check: domain-web (latency, throughput needs)
+    ↑ Check: Team expertise (familiarity with framework)
+```
+
+| Question | Trace To | Ask |
+|----------|----------|-----|
+| Framework choice | domain-* | What constraints matter? |
+| Library vs build | domain-* | What's the deployment model? |
+| API design | domain-* | Who are the consumers? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Integrate external crate"
+    ↓ m04-zero-cost: Trait bounds and generics
+    ↓ m06-error-handling: Error type compatibility
+
+"FFI integration"
+    ↓ unsafe-checker: Safety requirements
+    ↓ m12-lifecycle: Resource cleanup
+```
+
+---
+
+## Quick Reference
+
+### Language Interop
+
+| Integration | Crate/Tool | Use Case |
+|-------------|------------|----------|
+| C/C++ → Rust | `bindgen` | Auto-generate bindings |
+| Rust → C | `cbindgen` | Export C headers |
+| Python ↔ Rust | `pyo3` | Python extensions |
+| Node.js ↔ Rust | `napi-rs` | Node addons |
+| WebAssembly | `wasm-bindgen` | Browser/WASI |
+
+### Cargo Features
+
+| Feature | Purpose |
+|---------|---------|
+| `[features]` | Optional functionality |
+| `default = [...]` | Default features |
+| `feature = "serde"` | Conditional deps |
+| `[workspace]` | Multi-crate projects |
+
+## Error Code Reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| E0433 | Can't find crate | Add to Cargo.toml |
+| E0603 | Private item | Check crate docs |
+| Feature not enabled | Optional feature | Enable in `features` |
+| Version conflict | Incompatible deps | `cargo update` or pin |
+| Duplicate types | Different crate versions | Unify in workspace |
+
+---
+
+## Crate Selection Criteria
+
+| Criterion | Good Sign | Warning Sign |
+|-----------|-----------|--------------|
+| Maintenance | Recent commits | Years inactive |
+| Community | Active issues/PRs | No response |
+| Documentation | Examples, API docs | Minimal docs |
+| Stability | Semantic versioning | Frequent breaking |
+| Dependencies | Minimal, well-known | Heavy, obscure |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `extern crate` | Outdated (2018+) | Just `use` |
+| `#[macro_use]` | Global pollution | Explicit import |
+| Wildcard deps `*` | Unpredictable | Specific versions |
+| Too many deps | Supply chain risk | Evaluate necessity |
+| Vendoring everything | Maintenance burden | Trust crates.io |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Error type design | m06-error-handling |
+| Trait integration | m04-zero-cost |
+| FFI safety | unsafe-checker |
+| Resource management | m12-lifecycle |

--- a/.agents/skills/m12-lifecycle/SKILL.md
+++ b/.agents/skills/m12-lifecycle/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: m12-lifecycle
+description: "Use when designing resource lifecycles. Keywords: RAII, Drop, resource lifecycle, connection pool, lazy initialization, connection pool design, resource cleanup patterns, cleanup, scope, OnceCell, Lazy, once_cell, OnceLock, transaction, session management, when is Drop called, cleanup on error, guard pattern, scope guard, 资源生命周期, 连接池, 惰性初始化, 资源清理, RAII 模式"
+user-invocable: false
+---
+
+# Resource Lifecycle
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**When should this resource be created, used, and cleaned up?**
+
+Before implementing lifecycle:
+- What's the resource's scope?
+- Who owns the cleanup responsibility?
+- What happens on error?
+
+---
+
+## Lifecycle Pattern → Implementation
+
+| Pattern | When | Implementation |
+|---------|------|----------------|
+| RAII | Auto cleanup | `Drop` trait |
+| Lazy init | Deferred creation | `OnceLock`, `LazyLock` |
+| Pool | Reuse expensive resources | `r2d2`, `deadpool` |
+| Guard | Scoped access | `MutexGuard` pattern |
+| Scope | Transaction boundary | Custom struct + Drop |
+
+---
+
+## Thinking Prompt
+
+Before designing lifecycle:
+
+1. **What's the resource cost?**
+   - Cheap → create per use
+   - Expensive → pool or cache
+   - Global → lazy singleton
+
+2. **What's the scope?**
+   - Function-local → stack allocation
+   - Request-scoped → passed or extracted
+   - Application-wide → static or Arc
+
+3. **What about errors?**
+   - Cleanup must happen → Drop
+   - Cleanup is optional → explicit close
+   - Cleanup can fail → Result from close
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"How should I manage database connections?"
+    ↑ Ask: What's the connection cost?
+    ↑ Check: domain-* (latency requirements)
+    ↑ Check: Infrastructure (connection limits)
+```
+
+| Question | Trace To | Ask |
+|----------|----------|-----|
+| Connection pooling | domain-* | What's acceptable latency? |
+| Resource limits | domain-* | What are infra constraints? |
+| Transaction scope | domain-* | What must be atomic? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Need automatic cleanup"
+    ↓ m02-resource: Implement Drop
+    ↓ m01-ownership: Clear owner for cleanup
+
+"Need lazy initialization"
+    ↓ m03-mutability: OnceLock for thread-safe
+    ↓ m07-concurrency: LazyLock for sync
+
+"Need connection pool"
+    ↓ m07-concurrency: Thread-safe pool
+    ↓ m02-resource: Arc for sharing
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Type | Use Case |
+|---------|------|----------|
+| RAII | `Drop` trait | Auto cleanup on scope exit |
+| Lazy Init | `OnceLock`, `LazyLock` | Deferred initialization |
+| Pool | `r2d2`, `deadpool` | Connection reuse |
+| Guard | `MutexGuard` | Scoped lock release |
+| Scope | Custom struct | Transaction boundaries |
+
+## Lifecycle Events
+
+| Event | Rust Mechanism |
+|-------|----------------|
+| Creation | `new()`, `Default` |
+| Lazy Init | `OnceLock::get_or_init` |
+| Usage | `&self`, `&mut self` |
+| Cleanup | `Drop::drop()` |
+
+## Pattern Templates
+
+### RAII Guard
+
+```rust
+struct FileGuard {
+    path: PathBuf,
+    _handle: File,
+}
+
+impl Drop for FileGuard {
+    fn drop(&mut self) {
+        // Cleanup: remove temp file
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+```
+
+### Lazy Singleton
+
+```rust
+use std::sync::OnceLock;
+
+static CONFIG: OnceLock<Config> = OnceLock::new();
+
+fn get_config() -> &'static Config {
+    CONFIG.get_or_init(|| {
+        Config::load().expect("config required")
+    })
+}
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Resource leak | Forgot Drop | Implement Drop or RAII wrapper |
+| Double free | Manual memory | Let Rust handle |
+| Use after drop | Dangling reference | Check lifetimes |
+| E0509 move out of Drop | Moving owned field | `Option::take()` |
+| Pool exhaustion | Not returned | Ensure Drop returns |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Manual cleanup | Easy to forget | RAII/Drop |
+| `lazy_static!` | External dep | `std::sync::OnceLock` |
+| Global mutable state | Thread unsafety | `OnceLock` or proper sync |
+| Forget to close | Resource leak | Drop impl |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Smart pointers | m02-resource |
+| Thread-safe init | m07-concurrency |
+| Domain scopes | m09-domain |
+| Error in cleanup | m06-error-handling |

--- a/.agents/skills/m13-domain-error/SKILL.md
+++ b/.agents/skills/m13-domain-error/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: m13-domain-error
+description: "Use when designing domain error handling. Keywords: domain error, error categorization, recovery strategy, retry, fallback, domain error hierarchy, user-facing vs internal errors, error code design, circuit breaker, graceful degradation, resilience, error context, backoff, retry with backoff, error recovery, transient vs permanent error, 领域错误, 错误分类, 恢复策略, 重试, 熔断器, 优雅降级"
+user-invocable: false
+---
+
+# Domain Error Strategy
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**Who needs to handle this error, and how should they recover?**
+
+Before designing error types:
+- Is this user-facing or internal?
+- Is recovery possible?
+- What context is needed for debugging?
+
+---
+
+## Error Categorization
+
+| Error Type | Audience | Recovery | Example |
+|------------|----------|----------|---------|
+| User-facing | End users | Guide action | `InvalidEmail`, `NotFound` |
+| Internal | Developers | Debug info | `DatabaseError`, `ParseError` |
+| System | Ops/SRE | Monitor/alert | `ConnectionTimeout`, `RateLimited` |
+| Transient | Automation | Retry | `NetworkError`, `ServiceUnavailable` |
+| Permanent | Human | Investigate | `ConfigInvalid`, `DataCorrupted` |
+
+---
+
+## Thinking Prompt
+
+Before designing error types:
+
+1. **Who sees this error?**
+   - End user → friendly message, actionable
+   - Developer → detailed, debuggable
+   - Ops → structured, alertable
+
+2. **Can we recover?**
+   - Transient → retry with backoff
+   - Degradable → fallback value
+   - Permanent → fail fast, alert
+
+3. **What context is needed?**
+   - Call chain → anyhow::Context
+   - Request ID → structured logging
+   - Input data → error payload
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"How should I handle payment failures?"
+    ↑ Ask: What are the business rules for retries?
+    ↑ Check: domain-fintech (transaction requirements)
+    ↑ Check: SLA (availability requirements)
+```
+
+| Question | Trace To | Ask |
+|----------|----------|-----|
+| Retry policy | domain-* | What's acceptable latency for retry? |
+| User experience | domain-* | What message should users see? |
+| Compliance | domain-* | What must be logged for audit? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Need typed errors"
+    ↓ m06-error-handling: thiserror for library
+    ↓ m04-zero-cost: Error enum design
+
+"Need error context"
+    ↓ m06-error-handling: anyhow::Context
+    ↓ Logging: tracing with fields
+
+"Need retry logic"
+    ↓ m07-concurrency: async retry patterns
+    ↓ Crates: tokio-retry, backoff
+```
+
+---
+
+## Quick Reference
+
+| Recovery Pattern | When | Implementation |
+|------------------|------|----------------|
+| Retry | Transient failures | exponential backoff |
+| Fallback | Degraded mode | cached/default value |
+| Circuit Breaker | Cascading failures | failsafe-rs |
+| Timeout | Slow operations | `tokio::time::timeout` |
+| Bulkhead | Isolation | separate thread pools |
+
+## Error Hierarchy
+
+```rust
+#[derive(thiserror::Error, Debug)]
+pub enum AppError {
+    // User-facing
+    #[error("Invalid input: {0}")]
+    Validation(String),
+
+    // Transient (retryable)
+    #[error("Service temporarily unavailable")]
+    ServiceUnavailable(#[source] reqwest::Error),
+
+    // Internal (log details, show generic)
+    #[error("Internal error")]
+    Internal(#[source] anyhow::Error),
+}
+
+impl AppError {
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::ServiceUnavailable(_))
+    }
+}
+```
+
+## Retry Pattern
+
+```rust
+use tokio_retry::{Retry, strategy::ExponentialBackoff};
+
+async fn with_retry<F, T, E>(f: F) -> Result<T, E>
+where
+    F: Fn() -> impl Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let strategy = ExponentialBackoff::from_millis(100)
+        .max_delay(Duration::from_secs(10))
+        .take(5);
+
+    Retry::spawn(strategy, || f()).await
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Why Wrong | Better |
+|---------|-----------|--------|
+| Same error for all | No actionability | Categorize by audience |
+| Retry everything | Wasted resources | Only transient errors |
+| Infinite retry | DoS self | Max attempts + backoff |
+| Expose internal errors | Security risk | User-friendly messages |
+| No context | Hard to debug | .context() everywhere |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| String errors | No structure | thiserror types |
+| panic! for recoverable | Bad UX | Result with context |
+| Ignore errors | Silent failures | Log or propagate |
+| Box<dyn Error> everywhere | Lost type info | thiserror |
+| Error in happy path | Performance | Early validation |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Error handling basics | m06-error-handling |
+| Retry implementation | m07-concurrency |
+| Domain modeling | m09-domain |
+| User-facing APIs | domain-* |

--- a/.agents/skills/m14-mental-model/SKILL.md
+++ b/.agents/skills/m14-mental-model/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: m14-mental-model
+description: "Use when learning Rust concepts. Keywords: mental model, how to think about ownership, understanding borrow checker, visualizing memory layout, analogy, misconception, explaining ownership, why does Rust, help me understand, confused about, learning Rust, explain like I'm, ELI5, intuition for, coming from Java, coming from Python, 心智模型, 如何理解所有权, 学习 Rust, Rust 入门, 为什么 Rust"
+user-invocable: false
+---
+
+# Mental Models
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**What's the right way to think about this Rust concept?**
+
+When learning or explaining Rust:
+- What's the correct mental model?
+- What misconceptions should be avoided?
+- What analogies help understanding?
+
+---
+
+## Key Mental Models
+
+| Concept | Mental Model | Analogy |
+|---------|--------------|---------|
+| Ownership | Unique key | Only one person has the house key |
+| Move | Key handover | Giving away your key |
+| `&T` | Lending for reading | Lending a book |
+| `&mut T` | Exclusive editing | Only you can edit the doc |
+| Lifetime `'a` | Valid scope | "Ticket valid until..." |
+| `Box<T>` | Heap pointer | Remote control to TV |
+| `Rc<T>` | Shared ownership | Multiple remotes, last turns off |
+| `Arc<T>` | Thread-safe Rc | Remotes from any room |
+
+---
+
+## Coming From Other Languages
+
+| From | Key Shift |
+|------|-----------|
+| Java/C# | Values are owned, not references by default |
+| C/C++ | Compiler enforces safety rules |
+| Python/Go | No GC, deterministic destruction |
+| Functional | Mutability is safe via ownership |
+| JavaScript | No null, use Option instead |
+
+---
+
+## Thinking Prompt
+
+When confused about Rust:
+
+1. **What's the ownership model?**
+   - Who owns this data?
+   - How long does it live?
+   - Who can access it?
+
+2. **What guarantee is Rust providing?**
+   - No data races
+   - No dangling pointers
+   - No use-after-free
+
+3. **What's the compiler telling me?**
+   - Error = violation of safety rule
+   - Solution = work with the rules
+
+---
+
+## Trace Up ↑
+
+To design understanding (Layer 2):
+
+```
+"Why can't I do X in Rust?"
+    ↑ Ask: What safety guarantee would be violated?
+    ↑ Check: m01-m07 for the rule being enforced
+    ↑ Ask: What's the intended design pattern?
+```
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"I understand the concept, now how do I implement?"
+    ↓ m01-ownership: Ownership patterns
+    ↓ m02-resource: Smart pointer choice
+    ↓ m07-concurrency: Thread safety
+```
+
+---
+
+## Common Misconceptions
+
+| Error | Wrong Model | Correct Model |
+|-------|-------------|---------------|
+| E0382 use after move | GC cleans up | Ownership = unique key transfer |
+| E0502 borrow conflict | Multiple writers OK | Only one writer at a time |
+| E0499 multiple mut borrows | Aliased mutation | Exclusive access for mutation |
+| E0106 missing lifetime | Ignoring scope | References have validity scope |
+| E0507 cannot move from `&T` | Implicit clone | References don't own data |
+
+## Deprecated Thinking
+
+| Deprecated | Better |
+|------------|--------|
+| "Rust is like C++" | Different ownership model |
+| "Lifetimes are GC" | Compile-time validity scope |
+| "Clone solves everything" | Restructure ownership |
+| "Fight the borrow checker" | Work with the compiler |
+| "`unsafe` to avoid rules" | Understand safe patterns first |
+
+---
+
+## Ownership Visualization
+
+```
+Stack                          Heap
++----------------+            +----------------+
+| main()         |            |                |
+|   s1 ─────────────────────> │ "hello"        |
+|                |            |                |
+| fn takes(s) {  |            |                |
+|   s2 (moved) ─────────────> │ "hello"        |
+| }              |            | (s1 invalid)   |
++----------------+            +----------------+
+
+After move: s1 is no longer valid
+```
+
+## Reference Visualization
+
+```
++----------------+
+| data: String   |────────────> "hello"
++----------------+
+       ↑
+       │ &data (immutable borrow)
+       │
++------+------+
+| reader1    reader2    (multiple OK)
++------+------+
+
++----------------+
+| data: String   |────────────> "hello"
++----------------+
+       ↑
+       │ &mut data (mutable borrow)
+       │
++------+
+| writer (only one)
++------+
+```
+
+---
+
+## Learning Path
+
+| Stage | Focus | Skills |
+|-------|-------|--------|
+| Beginner | Ownership basics | m01-ownership, m14-mental-model |
+| Intermediate | Smart pointers, error handling | m02, m06 |
+| Advanced | Concurrency, unsafe | m07, unsafe-checker |
+| Expert | Design patterns | m09-m15, domain-* |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Ownership errors | m01-ownership |
+| Smart pointers | m02-resource |
+| Concurrency | m07-concurrency |
+| Anti-patterns | m15-anti-pattern |

--- a/.agents/skills/m14-mental-model/patterns/thinking-in-rust.md
+++ b/.agents/skills/m14-mental-model/patterns/thinking-in-rust.md
@@ -1,0 +1,286 @@
+# Thinking in Rust: Mental Models
+
+## Core Mental Models
+
+### 1. Ownership as Resource Management
+
+```
+Traditional: "Who has a pointer to this data?"
+Rust:        "Who OWNS this data and is responsible for freeing it?"
+```
+
+Key insight: Every value has exactly one owner. When the owner goes out of scope, the value is dropped.
+
+```rust
+{
+    let s = String::from("hello");  // s owns the String
+    // use s...
+}  // s goes out of scope, String is dropped (memory freed)
+```
+
+### 2. Borrowing as Temporary Access
+
+```
+Traditional: "I'll just read from this pointer"
+Rust:        "I'm borrowing this value, owner still responsible for it"
+```
+
+Key insight: Borrows are like library books - you can read them, but must return them.
+
+```rust
+fn print_length(s: &String) {  // borrows s
+    println!("{}", s.len());
+}  // borrow ends, caller still owns s
+
+let my_string = String::from("hello");
+print_length(&my_string);  // lend to function
+println!("{}", my_string);  // still have it
+```
+
+### 3. Lifetimes as Validity Scopes
+
+```
+Traditional: "Hope this pointer is still valid"
+Rust:        "Compiler tracks exactly how long references are valid"
+```
+
+Key insight: A reference can't outlive the data it points to.
+
+```rust
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    // 'a means: the returned reference is valid as long as BOTH inputs are valid
+    if x.len() > y.len() { x } else { y }
+}
+```
+
+---
+
+## Shifting Perspectives
+
+### From "Everything is a Reference" (Java/C#)
+
+Java mental model:
+```java
+// Everything is implicitly a reference
+User user = new User("Alice");  // user is a reference
+List<User> users = new ArrayList<>();
+users.add(user);  // shares the reference
+user.setName("Bob");  // affects the list too!
+```
+
+Rust mental model:
+```rust
+// Values are owned, sharing is explicit
+let user = User::new("Alice");  // user is owned
+let mut users = vec![];
+users.push(user);  // user moved into vec, can't use user anymore
+// user.set_name("Bob");  // ERROR: user was moved
+
+// If you need sharing:
+use std::rc::Rc;
+let user = Rc::new(User::new("Alice"));
+let user2 = Rc::clone(&user);  // explicit shared ownership
+```
+
+### From "Manual Memory Management" (C/C++)
+
+C mental model:
+```c
+char* s = malloc(100);
+// ... must remember to free(s) ...
+// ... what if we return early? ...
+// ... what if an exception occurs? ...
+free(s);
+```
+
+Rust mental model:
+```rust
+let s = String::with_capacity(100);
+// ... use s ...
+// No need to free - Rust drops s automatically when scope ends
+// Even with early returns, panics, or any control flow
+```
+
+### From "Garbage Collection" (Go/Python)
+
+GC mental model:
+```python
+# Create objects, GC will figure it out
+users = []
+for name in names:
+    users.append(User(name))
+# GC runs sometime later, when it feels like it
+```
+
+Rust mental model:
+```rust
+let users: Vec<User> = names
+    .iter()
+    .map(|name| User::new(name))
+    .collect();
+// Memory is freed EXACTLY when users goes out of scope
+// Deterministic, no GC pauses, no unpredictable memory usage
+```
+
+---
+
+## Key Questions to Ask
+
+### When Designing Functions
+
+1. **Does this function need to own the data, or just read it?**
+   - Need to keep it: take ownership (`fn process(data: Vec<T>)`)
+   - Just reading: borrow (`fn process(data: &[T])`)
+   - Need to modify: mutable borrow (`fn process(data: &mut Vec<T>)`)
+
+2. **Does the return value contain references to inputs?**
+   - Yes: need lifetime annotations
+   - No: lifetime elision usually works
+
+### When Designing Structs
+
+1. **Should this struct own its data or reference it?**
+   - Long-lived, independent: own (`name: String`)
+   - Short-lived view: reference (`name: &'a str`)
+
+2. **Do multiple parts need to access the same data?**
+   - Single-threaded: `Rc<T>` or `Rc<RefCell<T>>`
+   - Multi-threaded: `Arc<T>` or `Arc<Mutex<T>>`
+
+### When Hitting Borrow Checker Errors
+
+1. **Am I trying to use a value after moving it?**
+   - Clone it, borrow it, or restructure the code
+
+2. **Am I trying to have multiple mutable references?**
+   - Scope the mutations, use interior mutability, or redesign
+
+3. **Does a reference outlive its source?**
+   - Return owned data instead, or use `'static`
+
+---
+
+## Common Patterns
+
+### The Clone Escape Hatch
+
+When fighting the borrow checker, `.clone()` often works:
+
+```rust
+// Can't do this - double borrow
+let mut map = HashMap::new();
+for key in map.keys() {
+    map.insert(key.clone(), process(key));  // ERROR: map borrowed twice
+}
+
+// Clone to escape
+let keys: Vec<_> = map.keys().cloned().collect();
+for key in keys {
+    map.insert(key.clone(), process(&key));  // OK
+}
+```
+
+But ask: "Is there a better design?" Often, restructuring is better than cloning.
+
+### The "Make It Own" Pattern
+
+When lifetimes get complex, make the struct own its data:
+
+```rust
+// Complex: struct with references
+struct Parser<'a> {
+    input: &'a str,
+    current: &'a str,
+}
+
+// Simpler: struct owns data
+struct Parser {
+    input: String,
+    position: usize,
+}
+```
+
+### The "Split the Borrow" Pattern
+
+```rust
+struct Data {
+    field_a: Vec<i32>,
+    field_b: Vec<i32>,
+}
+
+// Can't borrow self mutably twice
+fn process(&mut self) {
+    // for a in &self.field_a {
+    //     self.field_b.push(*a);  // ERROR
+    // }
+
+    // Split the borrow
+    let Data { field_a, field_b } = self;
+    for a in field_a.iter() {
+        field_b.push(*a);  // OK: separate borrows
+    }
+}
+```
+
+---
+
+## The Rust Way
+
+### Embrace the Type System
+
+```rust
+// Don't: stringly-typed
+fn connect(host: &str, port: &str) { ... }
+connect("8080", "localhost");  // oops, wrong order
+
+// Do: strongly-typed
+struct Host(String);
+struct Port(u16);
+fn connect(host: Host, port: Port) { ... }
+// connect(Port(8080), Host("localhost".into()));  // compile error!
+```
+
+### Make Invalid States Unrepresentable
+
+```rust
+// Don't: runtime checks
+struct Connection {
+    socket: Option<Socket>,
+    connected: bool,
+}
+
+// Do: types enforce states
+enum Connection {
+    Disconnected,
+    Connected { socket: Socket },
+}
+```
+
+### Let the Compiler Guide You
+
+```rust
+// Start with what you want
+fn process(data: ???) -> ???
+
+// Let compiler errors tell you:
+// - What types are needed
+// - What lifetimes are needed
+// - What bounds are needed
+
+// The error messages are documentation!
+```
+
+---
+
+## Summary: The Rust Mental Model
+
+1. **Values have owners** - exactly one at a time
+2. **Borrowing is lending** - temporary access, owner retains responsibility
+3. **Lifetimes are scopes** - compiler tracks validity
+4. **Types encode constraints** - use them to prevent bugs
+5. **The compiler is your friend** - work with it, not against it
+
+When stuck:
+- Clone to make progress
+- Restructure to own instead of borrow
+- Ask: "What is the compiler trying to tell me?"

--- a/.agents/skills/m15-anti-pattern/SKILL.md
+++ b/.agents/skills/m15-anti-pattern/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: m15-anti-pattern
+description: "Use when reviewing code for anti-patterns. Keywords: anti-pattern, common mistake, pitfall, code smell, bad practice, code review, is this an anti-pattern, better way to do this, common mistake to avoid, why is this bad, idiomatic way, beginner mistake, fighting borrow checker, clone everywhere, unwrap in production, should I refactor, 反模式, 常见错误, 代码异味, 最佳实践, 地道写法"
+user-invocable: false
+---
+
+# Anti-Patterns
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**Is this pattern hiding a design problem?**
+
+When reviewing code:
+- Is this solving the symptom or the cause?
+- Is there a more idiomatic approach?
+- Does this fight or flow with Rust?
+
+---
+
+## Anti-Pattern → Better Pattern
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.clone()` everywhere | Hides ownership issues | Proper references or ownership |
+| `.unwrap()` in production | Runtime panics | `?`, `expect`, or handling |
+| `Rc` when single owner | Unnecessary overhead | Simple ownership |
+| `unsafe` for convenience | UB risk | Find safe pattern |
+| OOP via `Deref` | Misleading API | Composition, traits |
+| Giant match arms | Unmaintainable | Extract to methods |
+| `String` everywhere | Allocation waste | `&str`, `Cow<str>` |
+| Ignoring `#[must_use]` | Lost errors | Handle or `let _ =` |
+
+---
+
+## Thinking Prompt
+
+When seeing suspicious code:
+
+1. **Is this symptom or cause?**
+   - Clone to avoid borrow? → Ownership design issue
+   - Unwrap "because it won't fail"? → Unhandled case
+
+2. **What would idiomatic code look like?**
+   - References instead of clones
+   - Iterators instead of index loops
+   - Pattern matching instead of flags
+
+3. **Does this fight Rust?**
+   - Fighting borrow checker → restructure
+   - Excessive unsafe → find safe pattern
+
+---
+
+## Trace Up ↑
+
+To design understanding:
+
+```
+"Why does my code have so many clones?"
+    ↑ Ask: Is the ownership model correct?
+    ↑ Check: m09-domain (data flow design)
+    ↑ Check: m01-ownership (reference patterns)
+```
+
+| Anti-Pattern | Trace To | Question |
+|--------------|----------|----------|
+| Clone everywhere | m01-ownership | Who should own this data? |
+| Unwrap everywhere | m06-error-handling | What's the error strategy? |
+| Rc everywhere | m09-domain | Is ownership clear? |
+| Fighting lifetimes | m09-domain | Should data structure change? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Replace clone with proper ownership"
+    ↓ m01-ownership: Reference patterns
+    ↓ m02-resource: Smart pointer if needed
+
+"Replace unwrap with proper handling"
+    ↓ m06-error-handling: ? operator
+    ↓ m06-error-handling: expect with message
+```
+
+---
+
+## Top 5 Beginner Mistakes
+
+| Rank | Mistake | Fix |
+|------|---------|-----|
+| 1 | Clone to escape borrow checker | Use references |
+| 2 | Unwrap in production | Propagate with `?` |
+| 3 | String for everything | Use `&str` |
+| 4 | Index loops | Use iterators |
+| 5 | Fighting lifetimes | Restructure to own data |
+
+## Code Smell → Refactoring
+
+| Smell | Indicates | Refactoring |
+|-------|-----------|-------------|
+| Many `.clone()` | Ownership unclear | Clarify data flow |
+| Many `.unwrap()` | Error handling missing | Add proper handling |
+| Many `pub` fields | Encapsulation broken | Private + accessors |
+| Deep nesting | Complex logic | Extract methods |
+| Long functions | Multiple responsibilities | Split |
+| Giant enums | Missing abstraction | Trait + types |
+
+---
+
+## Common Error Patterns
+
+| Error | Anti-Pattern Cause | Fix |
+|-------|-------------------|-----|
+| E0382 use after move | Cloning vs ownership | Proper references |
+| Panic in production | Unwrap everywhere | ?, matching |
+| Slow performance | String for all text | &str, Cow |
+| Borrow checker fights | Wrong structure | Restructure |
+| Memory bloat | Rc/Arc everywhere | Simple ownership |
+
+---
+
+## Deprecated → Better
+
+| Deprecated | Better |
+|------------|--------|
+| Index-based loops | `.iter()`, `.enumerate()` |
+| `collect::<Vec<_>>()` then iterate | Chain iterators |
+| Manual unsafe cell | `Cell`, `RefCell` |
+| `mem::transmute` for casts | `as` or `TryFrom` |
+| Custom linked list | `Vec`, `VecDeque` |
+| `lazy_static!` | `std::sync::OnceLock` |
+
+---
+
+## Quick Review Checklist
+
+- [ ] No `.clone()` without justification
+- [ ] No `.unwrap()` in library code
+- [ ] No `pub` fields with invariants
+- [ ] No index loops when iterator works
+- [ ] No `String` where `&str` suffices
+- [ ] No ignored `#[must_use]` warnings
+- [ ] No `unsafe` without SAFETY comment
+- [ ] No giant functions (>50 lines)
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Ownership patterns | m01-ownership |
+| Error handling | m06-error-handling |
+| Mental models | m14-mental-model |
+| Performance | m10-performance |

--- a/.agents/skills/m15-anti-pattern/patterns/common-mistakes.md
+++ b/.agents/skills/m15-anti-pattern/patterns/common-mistakes.md
@@ -1,0 +1,421 @@
+# Common Rust Anti-Patterns & Mistakes
+
+## Ownership Anti-Patterns
+
+### 1. Clone Everything
+
+```rust
+// ANTI-PATTERN: clone to avoid borrow checker
+fn process(data: Vec<String>) {
+    for item in data.clone() {  // unnecessary clone
+        println!("{}", item);
+    }
+    use_data(data);
+}
+
+// BETTER: borrow when you don't need ownership
+fn process(data: Vec<String>) {
+    for item in &data {  // borrow instead
+        println!("{}", item);
+    }
+    use_data(data);
+}
+```
+
+### 2. Unnecessary Box
+
+```rust
+// ANTI-PATTERN: boxing everything
+fn get_value() -> Box<String> {
+    Box::new(String::from("hello"))
+}
+
+// BETTER: return value directly
+fn get_value() -> String {
+    String::from("hello")
+}
+```
+
+### 3. Holding References Too Long
+
+```rust
+// ANTI-PATTERN: borrow prevents mutation
+let mut data = vec![1, 2, 3];
+let first = &data[0];
+data.push(4);  // ERROR: data is borrowed
+println!("{}", first);
+
+// BETTER: scope the borrow
+let mut data = vec![1, 2, 3];
+let first = data[0];  // copy the value
+data.push(4);  // OK
+println!("{}", first);
+```
+
+---
+
+## Error Handling Anti-Patterns
+
+### 4. Unwrap Everywhere
+
+```rust
+// ANTI-PATTERN: crashes on error
+fn process_file(path: &str) {
+    let content = std::fs::read_to_string(path).unwrap();
+    let config: Config = toml::from_str(&content).unwrap();
+}
+
+// BETTER: propagate errors
+fn process_file(path: &str) -> Result<Config, Error> {
+    let content = std::fs::read_to_string(path)?;
+    let config: Config = toml::from_str(&content)?;
+    Ok(config)
+}
+```
+
+### 5. Ignoring Errors
+
+```rust
+// ANTI-PATTERN: silent failure
+let _ = file.write_all(data);
+
+// BETTER: handle or propagate
+file.write_all(data)?;
+// or at minimum, log the error
+if let Err(e) = file.write_all(data) {
+    eprintln!("Warning: failed to write: {}", e);
+}
+```
+
+### 6. Panic in Library Code
+
+```rust
+// ANTI-PATTERN: library panics
+pub fn parse(input: &str) -> Data {
+    if input.is_empty() {
+        panic!("input cannot be empty");
+    }
+    // ...
+}
+
+// BETTER: return Result
+pub fn parse(input: &str) -> Result<Data, ParseError> {
+    if input.is_empty() {
+        return Err(ParseError::EmptyInput);
+    }
+    // ...
+}
+```
+
+---
+
+## String Anti-Patterns
+
+### 7. String Instead of &str
+
+```rust
+// ANTI-PATTERN: forces allocation
+fn greet(name: String) {
+    println!("Hello, {}", name);
+}
+
+greet("world".to_string());  // allocation
+
+// BETTER: accept &str
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+greet("world");  // no allocation
+```
+
+### 8. Format for Simple Concatenation
+
+```rust
+// ANTI-PATTERN: format overhead
+let greeting = format!("{}{}", "Hello, ", name);
+
+// BETTER for simple cases: push_str
+let mut greeting = String::from("Hello, ");
+greeting.push_str(name);
+
+// Or use + for String + &str
+let greeting = String::from("Hello, ") + name;
+```
+
+### 9. Repeated String Operations
+
+```rust
+// ANTI-PATTERN: O(n²) allocations
+let mut result = String::new();
+for word in words {
+    result = result + word + " ";
+}
+
+// BETTER: join
+let result = words.join(" ");
+
+// Or with_capacity + push_str
+let mut result = String::with_capacity(total_len);
+for word in words {
+    result.push_str(word);
+    result.push(' ');
+}
+```
+
+---
+
+## Collection Anti-Patterns
+
+### 10. Index Instead of Iterator
+
+```rust
+// ANTI-PATTERN: bounds checking overhead
+for i in 0..vec.len() {
+    process(vec[i]);
+}
+
+// BETTER: iterator
+for item in &vec {
+    process(item);
+}
+```
+
+### 11. Collect Then Iterate
+
+```rust
+// ANTI-PATTERN: unnecessary allocation
+let filtered: Vec<_> = items.iter().filter(|x| x.valid).collect();
+for item in filtered {
+    process(item);
+}
+
+// BETTER: chain iterators
+for item in items.iter().filter(|x| x.valid) {
+    process(item);
+}
+```
+
+### 12. Wrong Collection Type
+
+```rust
+// ANTI-PATTERN: Vec for frequent membership checks
+let allowed: Vec<&str> = vec!["a", "b", "c"];
+if allowed.contains(&input) { ... }  // O(n)
+
+// BETTER: HashSet for membership
+use std::collections::HashSet;
+let allowed: HashSet<&str> = ["a", "b", "c"].into();
+if allowed.contains(input) { ... }  // O(1)
+```
+
+---
+
+## Concurrency Anti-Patterns
+
+### 13. Mutex for Read-Heavy Data
+
+```rust
+// ANTI-PATTERN: Mutex when mostly reading
+let data = Arc::new(Mutex::new(config));
+// All readers block each other
+
+// BETTER: RwLock for read-heavy workloads
+let data = Arc::new(RwLock::new(config));
+// Multiple readers can proceed in parallel
+```
+
+### 14. Holding Lock Across Await
+
+```rust
+// ANTI-PATTERN: lock held across await
+async fn bad() {
+    let guard = mutex.lock().unwrap();
+    some_async_op().await;  // lock held!
+    use(guard);
+}
+
+// BETTER: scope the lock
+async fn good() {
+    let value = {
+        let guard = mutex.lock().unwrap();
+        guard.clone()
+    };  // lock released
+    some_async_op().await;
+    use(value);
+}
+```
+
+### 15. Blocking in Async
+
+```rust
+// ANTI-PATTERN: blocking call in async
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocks executor!
+}
+
+// BETTER: async sleep
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+
+// For CPU work: spawn_blocking
+async fn compute() {
+    tokio::task::spawn_blocking(|| heavy_work()).await
+}
+```
+
+---
+
+## Type System Anti-Patterns
+
+### 16. Stringly Typed
+
+```rust
+// ANTI-PATTERN: strings for everything
+fn connect(host: &str, port: &str, timeout: &str) { ... }
+connect("8080", "localhost", "30");  // wrong order!
+
+// BETTER: strong types
+struct Host(String);
+struct Port(u16);
+struct Timeout(Duration);
+
+fn connect(host: Host, port: Port, timeout: Timeout) { ... }
+```
+
+### 17. Boolean Parameters
+
+```rust
+// ANTI-PATTERN: what does true mean?
+fn fetch(url: &str, use_cache: bool, validate_ssl: bool) { ... }
+fetch("https://...", true, false);  // unclear
+
+// BETTER: builder or named parameters
+struct FetchOptions {
+    use_cache: bool,
+    validate_ssl: bool,
+}
+
+fn fetch(url: &str, options: FetchOptions) { ... }
+fetch("https://...", FetchOptions {
+    use_cache: true,
+    validate_ssl: false,
+});
+```
+
+### 18. Option<Option<T>>
+
+```rust
+// ANTI-PATTERN: nested Option
+fn find(id: u32) -> Option<Option<User>> { ... }
+// What does None vs Some(None) mean?
+
+// BETTER: use Result or custom enum
+enum FindResult {
+    Found(User),
+    NotFound,
+    Error(String),
+}
+```
+
+---
+
+## API Design Anti-Patterns
+
+### 19. Taking Ownership Unnecessarily
+
+```rust
+// ANTI-PATTERN: takes ownership but doesn't need it
+fn validate(config: Config) -> bool {
+    config.timeout > 0 && config.retries >= 0
+}
+
+// BETTER: borrow
+fn validate(config: &Config) -> bool {
+    config.timeout > 0 && config.retries >= 0
+}
+```
+
+### 20. Returning References to Temporaries
+
+```rust
+// ANTI-PATTERN: impossible lifetime
+fn get_default() -> &str {
+    let s = String::from("default");
+    &s  // ERROR: s is dropped
+}
+
+// BETTER: return owned
+fn get_default() -> String {
+    String::from("default")
+}
+
+// Or return static
+fn get_default() -> &'static str {
+    "default"
+}
+```
+
+### 21. Overly Generic Functions
+
+```rust
+// ANTI-PATTERN: complex generics for simple function
+fn process<T, U, V>(input: T) -> V
+where
+    T: Into<U>,
+    U: AsRef<str> + Clone,
+    V: From<String>,
+{ ... }
+
+// BETTER: concrete types if generics not needed
+fn process(input: &str) -> String { ... }
+```
+
+---
+
+## Macro Anti-Patterns
+
+### 22. Macro When Function Works
+
+```rust
+// ANTI-PATTERN: macro for simple operation
+macro_rules! add {
+    ($a:expr, $b:expr) => { $a + $b };
+}
+
+// BETTER: just use a function
+fn add(a: i32, b: i32) -> i32 { a + b }
+```
+
+### 23. Complex Macro Without Tests
+
+```rust
+// ANTI-PATTERN: complex macro with no tests
+macro_rules! define_api {
+    // ... 100 lines of macro code ...
+}
+
+// BETTER: test macro outputs
+#[test]
+fn test_macro_expansion() {
+    // Use cargo-expand or trybuild
+}
+```
+
+---
+
+## Quick Reference
+
+| Anti-Pattern | Better Alternative |
+|--------------|-------------------|
+| Clone everywhere | Borrow when possible |
+| Unwrap everywhere | Propagate with `?` |
+| `String` parameters | `&str` parameters |
+| Index loops | Iterator loops |
+| Collect then process | Chain iterators |
+| Mutex for reads | RwLock for read-heavy |
+| Lock across await | Scope the lock |
+| Blocking in async | spawn_blocking |
+| Stringly typed | Strong types |
+| Boolean params | Builders or enums |

--- a/.agents/skills/meta-cognition-parallel/SKILL.md
+++ b/.agents/skills/meta-cognition-parallel/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: meta-cognition-parallel
+description: "EXPERIMENTAL: Three-layer parallel meta-cognition analysis. Triggers on: /meta-parallel, 三层分析, parallel analysis, 并行元认知"
+argument-hint: "<rust_question>"
+---
+
+# Meta-Cognition Parallel Analysis (Experimental)
+
+> **Status:** Experimental | **Version:** 0.2.0 | **Last Updated:** 2025-01-27
+>
+> This skill tests parallel three-layer cognitive analysis.
+
+## Concept
+
+Instead of sequential analysis, this skill launches three parallel analyzers - one for each cognitive layer - then synthesizes their results.
+
+```
+User Question
+     │
+     ▼
+┌─────────────────────────────────────────────────────┐
+│            meta-cognition-parallel                   │
+│                  (Coordinator)                       │
+└─────────────────────────────────────────────────────┘
+     │
+     ├─── Layer 1 ──► Language Mechanics ──► L1 Result
+     │
+     ├─── Layer 2 ──► Design Choices     ──► L2 Result
+     │                                            ├── Parallel (Agent Mode)
+     │                                            │   or Sequential (Inline)
+     └─── Layer 3 ──► Domain Constraints ──► L3 Result
+     │
+     ▼
+┌─────────────────────────────────────────────────────┐
+│              Cross-Layer Synthesis                   │
+│         (In main context with all results)          │
+└─────────────────────────────────────────────────────┘
+     │
+     ▼
+Domain-Correct Architectural Solution
+```
+
+## Usage
+
+```
+/meta-parallel <your Rust question>
+```
+
+**Example:**
+```
+/meta-parallel 我的交易系统报 E0382 错误，应该用 clone 吗？
+```
+
+## Execution Mode Detection
+
+**CRITICAL: Check agent file availability first to determine execution mode.**
+
+Try to read layer analyzer files:
+- `../../agents/layer1-analyzer.md`
+- `../../agents/layer2-analyzer.md`
+- `../../agents/layer3-analyzer.md`
+
+---
+
+## Agent Mode (Plugin Install) - Parallel Execution
+
+**When all layer analyzer files exist at `../../agents/`:**
+
+### Step 1: Parse User Query
+
+Extract from `$ARGUMENTS`:
+- The original question
+- Any code snippets
+- Domain hints (trading, web, embedded, etc.)
+
+### Step 2: Launch Three Parallel Agents
+
+**CRITICAL: Launch all three Tasks in a SINGLE message to enable parallel execution.**
+
+```
+Read agent files, then launch in parallel:
+
+Task(
+  subagent_type: "general-purpose",
+  run_in_background: true,
+  prompt: <content of ../../agents/layer1-analyzer.md>
+          + "\n\n## User Query\n" + $ARGUMENTS
+)
+
+Task(
+  subagent_type: "general-purpose",
+  run_in_background: true,
+  prompt: <content of ../../agents/layer2-analyzer.md>
+          + "\n\n## User Query\n" + $ARGUMENTS
+)
+
+Task(
+  subagent_type: "general-purpose",
+  run_in_background: true,
+  prompt: <content of ../../agents/layer3-analyzer.md>
+          + "\n\n## User Query\n" + $ARGUMENTS
+)
+```
+
+### Step 3: Collect Results
+
+Wait for all three agents to complete. Each returns structured analysis.
+
+### Step 4: Cross-Layer Synthesis
+
+With all three results, perform synthesis per template below.
+
+---
+
+## Inline Mode (Skills-only Install) - Sequential Execution
+
+**When layer analyzer files are NOT available, execute analysis directly:**
+
+### Step 1: Parse User Query
+
+Same as Agent Mode - extract question, code, and domain hints from `$ARGUMENTS`.
+
+### Step 2: Execute Layer 1 - Language Mechanics
+
+Analyze the Rust language mechanics involved:
+
+```markdown
+## Layer 1: Language Mechanics
+
+**Error/Pattern Identified:**
+- Error code: E0XXX (if applicable)
+- Pattern: ownership/borrowing/lifetime/etc.
+
+**Root Cause:**
+[Explain why this error occurs in terms of Rust's ownership model]
+
+**Language-Level Solutions:**
+1. [Solution 1]: description
+2. [Solution 2]: description
+
+**Confidence:** HIGH | MEDIUM | LOW
+**Reasoning:** [Why this confidence level]
+```
+
+**Focus areas:**
+- Ownership rules (move, copy, borrow)
+- Lifetime annotations
+- Borrowing rules (shared vs mutable)
+- Error codes and their meanings
+
+### Step 3: Execute Layer 2 - Design Choices
+
+Analyze the design patterns and trade-offs:
+
+```markdown
+## Layer 2: Design Choices
+
+**Design Pattern Context:**
+- Current approach: [What pattern is being used]
+- Problem: [Why it conflicts with Rust's rules]
+
+**Design Alternatives:**
+| Pattern | Pros | Cons | When to Use |
+|---------|------|------|-------------|
+| Pattern A | ... | ... | ... |
+| Pattern B | ... | ... | ... |
+
+**Recommended Pattern:**
+[Which pattern fits best and why]
+
+**Confidence:** HIGH | MEDIUM | LOW
+**Reasoning:** [Why this confidence level]
+```
+
+**Focus areas:**
+- Smart pointer choices (Box, Rc, Arc)
+- Interior mutability patterns (Cell, RefCell, Mutex)
+- Ownership transfer vs sharing
+- Cloning vs references
+
+### Step 4: Execute Layer 3 - Domain Constraints
+
+Analyze domain-specific requirements:
+
+```markdown
+## Layer 3: Domain Constraints
+
+**Domain Identified:** [trading/fintech | web | CLI | embedded | etc.]
+
+**Domain-Specific Requirements:**
+- [ ] Performance: [requirements]
+- [ ] Safety: [requirements]
+- [ ] Concurrency: [requirements]
+- [ ] Auditability: [requirements]
+
+**Domain Best Practices:**
+1. [Best practice 1]
+2. [Best practice 2]
+
+**Constraints on Solution:**
+- MUST: [hard requirements]
+- SHOULD: [soft requirements]
+- AVOID: [anti-patterns for this domain]
+
+**Confidence:** HIGH | MEDIUM | LOW
+**Reasoning:** [Why this confidence level]
+```
+
+**Focus areas:**
+- Industry requirements (FinTech regulations, web scalability, etc.)
+- Performance constraints
+- Safety and correctness requirements
+- Common patterns in the domain
+
+### Step 5: Cross-Layer Synthesis
+
+Combine all three layers:
+
+```markdown
+## Cross-Layer Synthesis
+
+### Layer Results Summary
+
+| Layer | Key Finding | Confidence |
+|-------|-------------|------------|
+| L1 (Mechanics) | [Summary] | [Level] |
+| L2 (Design) | [Summary] | [Level] |
+| L3 (Domain) | [Summary] | [Level] |
+
+### Cross-Layer Reasoning
+
+1. **L3 → L2:** [How domain constraints affect design choice]
+2. **L2 → L1:** [How design choice determines mechanism]
+3. **L1 ← L3:** [Direct domain impact on language features]
+
+### Synthesized Recommendation
+
+**Problem:** [Restated with full context]
+
+**Solution:** [Domain-correct architectural solution]
+
+**Rationale:**
+- Domain requires: [L3 constraint]
+- Design pattern: [L2 pattern]
+- Mechanism: [L1 implementation]
+
+### Confidence Assessment
+
+- **Overall:** HIGH | MEDIUM | LOW
+- **Limiting Factor:** [Which layer had lowest confidence]
+```
+
+---
+
+## Output Template
+
+Both modes produce the same output format:
+
+```markdown
+# Three-Layer Meta-Cognition Analysis
+
+> Query: [User's question]
+
+---
+
+## Layer 1: Language Mechanics
+[L1 analysis result]
+
+---
+
+## Layer 2: Design Choices
+[L2 analysis result]
+
+---
+
+## Layer 3: Domain Constraints
+[L3 analysis result]
+
+---
+
+## Cross-Layer Synthesis
+
+### Reasoning Chain
+```
+L3 Domain: [Constraint]
+    ↓ implies
+L2 Design: [Pattern]
+    ↓ implemented via
+L1 Mechanism: [Feature]
+```
+
+### Final Recommendation
+
+**Do:** [Recommended approach]
+
+**Don't:** [What to avoid]
+
+**Code Pattern:**
+```rust
+// Recommended implementation
+```
+
+---
+
+*Analysis performed by meta-cognition-parallel v0.2.0 (experimental)*
+```
+
+---
+
+## Test Scenarios
+
+### Test 1: Trading System E0382
+```
+/meta-parallel 交易系统报 E0382，trade record 被 move 了
+```
+
+Expected: L3 identifies FinTech constraints → L2 suggests shared immutable → L1 recommends Arc<T>
+
+### Test 2: Web API Concurrency
+```
+/meta-parallel Web API 中多个 handler 需要共享数据库连接池
+```
+
+Expected: L3 identifies Web constraints → L2 suggests connection pooling → L1 recommends Arc<Pool>
+
+### Test 3: CLI Tool Config
+```
+/meta-parallel CLI 工具如何处理配置文件和命令行参数的优先级
+```
+
+Expected: L3 identifies CLI constraints → L2 suggests config precedence pattern → L1 recommends builder pattern
+
+---
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Agent files not found | Skills-only install | Use inline mode (sequential) |
+| Agent timeout | Complex analysis | Wait longer or use inline mode |
+| Incomplete layer result | Agent issue | Fill in with inline analysis |
+
+## Limitations
+
+- **Agent Mode:** Parallel execution, faster but requires plugin install
+- **Inline Mode:** Sequential execution, slower but works everywhere
+- Cross-layer synthesis quality depends on result structure
+- May have higher latency than simple single-layer analysis
+
+## Feedback
+
+This is experimental. Please report issues and suggestions to improve the three-layer analysis approach.

--- a/.agents/skills/rust-call-graph/SKILL.md
+++ b/.agents/skills/rust-call-graph/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: rust-call-graph
+description: "Visualize Rust function call graphs using LSP. Triggers on: /call-graph, call hierarchy, who calls, what calls, 调用图, 调用关系, 谁调用了, 调用了谁"
+argument-hint: "<function_name> [--depth N] [--direction in|out|both]"
+allowed-tools: ["LSP", "Read", "Glob"]
+---
+
+# Rust Call Graph
+
+Visualize function call relationships using LSP call hierarchy.
+
+## Usage
+
+```
+/rust-call-graph <function_name> [--depth N] [--direction in|out|both]
+```
+
+**Options:**
+- `--depth N`: How many levels to traverse (default: 3)
+- `--direction`: `in` (callers), `out` (callees), `both`
+
+**Examples:**
+- `/rust-call-graph process_request` - Show both callers and callees
+- `/rust-call-graph handle_error --direction in` - Show only callers
+- `/rust-call-graph main --direction out --depth 5` - Deep callee analysis
+
+## LSP Operations
+
+### 1. Prepare Call Hierarchy
+
+Get the call hierarchy item for a function.
+
+```
+LSP(
+  operation: "prepareCallHierarchy",
+  filePath: "src/handler.rs",
+  line: 45,
+  character: 8
+)
+```
+
+### 2. Incoming Calls (Who calls this?)
+
+```
+LSP(
+  operation: "incomingCalls",
+  filePath: "src/handler.rs",
+  line: 45,
+  character: 8
+)
+```
+
+### 3. Outgoing Calls (What does this call?)
+
+```
+LSP(
+  operation: "outgoingCalls",
+  filePath: "src/handler.rs",
+  line: 45,
+  character: 8
+)
+```
+
+## Workflow
+
+```
+User: "Show call graph for process_request"
+    │
+    ▼
+[1] Find function location
+    LSP(workspaceSymbol) or Grep
+    │
+    ▼
+[2] Prepare call hierarchy
+    LSP(prepareCallHierarchy)
+    │
+    ▼
+[3] Get incoming calls (callers)
+    LSP(incomingCalls)
+    │
+    ▼
+[4] Get outgoing calls (callees)
+    LSP(outgoingCalls)
+    │
+    ▼
+[5] Recursively expand to depth N
+    │
+    ▼
+[6] Generate ASCII visualization
+```
+
+## Output Format
+
+### Incoming Calls (Who calls this?)
+
+```
+## Callers of `process_request`
+
+main
+└── run_server
+    └── handle_connection
+        └── process_request  ◄── YOU ARE HERE
+```
+
+### Outgoing Calls (What does this call?)
+
+```
+## Callees of `process_request`
+
+process_request  ◄── YOU ARE HERE
+├── parse_headers
+│   └── validate_header
+├── authenticate
+│   ├── check_token
+│   └── load_user
+├── execute_handler
+│   └── [dynamic dispatch]
+└── send_response
+    └── serialize_body
+```
+
+### Bidirectional (Both)
+
+```
+## Call Graph for `process_request`
+
+                    ┌─────────────────┐
+                    │      main       │
+                    └────────┬────────┘
+                             │
+                    ┌────────▼────────┐
+                    │   run_server    │
+                    └────────┬────────┘
+                             │
+                    ┌────────▼────────┐
+                    │handle_connection│
+                    └────────┬────────┘
+                             │
+        ┌────────────────────┼────────────────────┐
+        │                    │                    │
+┌───────▼───────┐   ┌───────▼───────┐   ┌───────▼───────┐
+│ parse_headers │   │ authenticate  │   │send_response  │
+└───────────────┘   └───────┬───────┘   └───────────────┘
+                            │
+                    ┌───────┴───────┐
+                    │               │
+             ┌──────▼──────┐ ┌──────▼──────┐
+             │ check_token │ │  load_user  │
+             └─────────────┘ └─────────────┘
+```
+
+## Analysis Insights
+
+After generating the call graph, provide insights:
+
+```
+## Analysis
+
+**Entry Points:** main, test_process_request
+**Leaf Functions:** validate_header, serialize_body
+**Hot Path:** main → run_server → handle_connection → process_request
+**Complexity:** 12 functions, 3 levels deep
+
+**Potential Issues:**
+- `authenticate` has high fan-out (4 callees)
+- `process_request` is called from 3 places (consider if this is intentional)
+```
+
+## Common Patterns
+
+| User Says | Direction | Use Case |
+|-----------|-----------|----------|
+| "Who calls X?" | incoming | Impact analysis |
+| "What does X call?" | outgoing | Understanding implementation |
+| "Show call graph" | both | Full picture |
+| "Trace from main to X" | outgoing | Execution path |
+
+## Visualization Options
+
+| Style | Best For |
+|-------|----------|
+| Tree (default) | Simple hierarchies |
+| Box diagram | Complex relationships |
+| Flat list | Many connections |
+| Mermaid | Export to docs |
+
+### Mermaid Export
+
+```mermaid
+graph TD
+    main --> run_server
+    run_server --> handle_connection
+    handle_connection --> process_request
+    process_request --> parse_headers
+    process_request --> authenticate
+    process_request --> send_response
+```
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Find definition | rust-code-navigator |
+| Project structure | rust-symbol-analyzer |
+| Trait implementations | rust-trait-explorer |
+| Safe refactoring | rust-refactor-helper |

--- a/.agents/skills/rust-code-navigator/SKILL.md
+++ b/.agents/skills/rust-code-navigator/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: rust-code-navigator
+description: "Navigate Rust code using LSP. Triggers on: /navigate, go to definition, find references, where is defined, 跳转定义, 查找引用, 定义在哪, 谁用了这个"
+argument-hint: "<symbol> [in file.rs:line]"
+allowed-tools: ["LSP", "Read", "Glob"]
+---
+
+# Rust Code Navigator
+
+Navigate large Rust codebases efficiently using Language Server Protocol.
+
+## Usage
+
+```
+/rust-code-navigator <symbol> [in file.rs:line]
+```
+
+**Examples:**
+- `/rust-code-navigator parse_config` - Find definition of parse_config
+- `/rust-code-navigator MyStruct in src/lib.rs:42` - Navigate from specific location
+
+## LSP Operations
+
+### 1. Go to Definition
+
+Find where a symbol is defined.
+
+```
+LSP(
+  operation: "goToDefinition",
+  filePath: "src/main.rs",
+  line: 25,
+  character: 10
+)
+```
+
+**Use when:**
+- User asks "where is X defined?"
+- User wants to understand a type/function
+- Ctrl+click equivalent
+
+### 2. Find References
+
+Find all usages of a symbol.
+
+```
+LSP(
+  operation: "findReferences",
+  filePath: "src/lib.rs",
+  line: 15,
+  character: 8
+)
+```
+
+**Use when:**
+- User asks "who uses X?"
+- Before refactoring/renaming
+- Understanding impact of changes
+
+### 3. Hover Information
+
+Get type and documentation for a symbol.
+
+```
+LSP(
+  operation: "hover",
+  filePath: "src/main.rs",
+  line: 30,
+  character: 15
+)
+```
+
+**Use when:**
+- User asks "what type is X?"
+- User wants documentation
+- Quick type checking
+
+## Workflow
+
+```
+User: "Where is the Config struct defined?"
+    │
+    ▼
+[1] Search for "Config" in workspace
+    LSP(operation: "workspaceSymbol", ...)
+    │
+    ▼
+[2] If multiple results, ask user to clarify
+    │
+    ▼
+[3] Go to definition
+    LSP(operation: "goToDefinition", ...)
+    │
+    ▼
+[4] Show file path and context
+    Read surrounding code for context
+```
+
+## Output Format
+
+### Definition Found
+
+```
+## Config (struct)
+
+**Defined in:** `src/config.rs:15`
+
+​```rust
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub name: String,
+    pub port: u16,
+    pub debug: bool,
+}
+​```
+
+**Documentation:** Configuration for the application server.
+```
+
+### References Found
+
+```
+## References to `Config` (5 found)
+
+| Location | Context |
+|----------|---------|
+| src/main.rs:10 | `let config = Config::load()?;` |
+| src/server.rs:25 | `fn new(config: Config) -> Self` |
+| src/server.rs:42 | `self.config.port` |
+| src/tests.rs:15 | `Config::default()` |
+| src/cli.rs:8 | `config: Option<Config>` |
+```
+
+## Common Patterns
+
+| User Says | LSP Operation |
+|-----------|---------------|
+| "Where is X defined?" | goToDefinition |
+| "Who uses X?" | findReferences |
+| "What type is X?" | hover |
+| "Find all structs" | workspaceSymbol |
+| "What's in this file?" | documentSymbol |
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "No LSP server" | rust-analyzer not running | Suggest: `rustup component add rust-analyzer` |
+| "Symbol not found" | Typo or not in scope | Search with workspaceSymbol first |
+| "Multiple definitions" | Generics or macros | Show all and let user choose |
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Call relationships | rust-call-graph |
+| Project structure | rust-symbol-analyzer |
+| Trait implementations | rust-trait-explorer |
+| Safe refactoring | rust-refactor-helper |

--- a/.agents/skills/rust-daily/SKILL.md
+++ b/.agents/skills/rust-daily/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: rust-daily
+description: |
+  CRITICAL: Use for Rust news and daily/weekly/monthly reports. Triggers on:
+  rust news, rust daily, rust weekly, TWIR, rust blog,
+  Rust 日报, Rust 周报, Rust 新闻, Rust 动态
+argument-hint: "[today|week|month]"
+context: fork
+agent: Explore
+---
+
+# Rust Daily Report
+
+> **Version:** 2.1.0 | **Last Updated:** 2025-01-27
+
+Fetch Rust community updates, filtered by time range.
+
+## Data Sources
+
+| Category | Sources |
+|----------|---------|
+| Ecosystem | Reddit r/rust, This Week in Rust |
+| Official | blog.rust-lang.org, Inside Rust |
+| Foundation | rustfoundation.org (news, blog, events) |
+
+## Parameters
+
+- `time_range`: day | week | month (default: week)
+- `category`: all | ecosystem | official | foundation
+
+## Execution Mode Detection
+
+**CRITICAL: Check agent file availability first to determine execution mode.**
+
+Try to read: `../../agents/rust-daily-reporter.md`
+
+---
+
+## Agent Mode (Plugin Install)
+
+**When `../../agents/rust-daily-reporter.md` exists:**
+
+### Workflow
+
+```
+1. Read: ../../agents/rust-daily-reporter.md
+2. Task(subagent_type: "general-purpose", run_in_background: false, prompt: <agent content>)
+3. Wait for result
+4. Format and present to user
+```
+
+---
+
+## Inline Mode (Skills-only Install)
+
+**When agent file is NOT available, execute each source directly:**
+
+### 1. Reddit r/rust
+
+```bash
+# Using agent-browser CLI
+agent-browser open "https://www.reddit.com/r/rust/hot/"
+agent-browser get text ".Post" --limit 10
+agent-browser close
+```
+
+**Or with WebFetch fallback:**
+```
+WebFetch("https://www.reddit.com/r/rust/hot/", "Extract top 10 posts with scores and titles")
+```
+
+**Parse output into:**
+| Score | Title | Link |
+|-------|-------|------|
+
+### 2. This Week in Rust
+
+```bash
+# Check actionbook first
+mcp__actionbook__search_actions("this week in rust")
+mcp__actionbook__get_action_by_id(<action_id>)
+
+# Then fetch
+agent-browser open "https://this-week-in-rust.org/"
+agent-browser get text "<selector_from_actionbook>"
+agent-browser close
+```
+
+**Parse output into:**
+- Issue #{number} ({date}): highlights
+
+### 3. Rust Blog (Official)
+
+```bash
+agent-browser open "https://blog.rust-lang.org/"
+agent-browser get text "article" --limit 5
+agent-browser close
+```
+
+**Or with WebFetch fallback:**
+```
+WebFetch("https://blog.rust-lang.org/", "Extract latest 5 blog posts with dates and titles")
+```
+
+**Parse output into:**
+| Date | Title | Summary |
+|------|-------|---------|
+
+### 4. Inside Rust
+
+```bash
+agent-browser open "https://blog.rust-lang.org/inside-rust/"
+agent-browser get text "article" --limit 3
+agent-browser close
+```
+
+**Or with WebFetch fallback:**
+```
+WebFetch("https://blog.rust-lang.org/inside-rust/", "Extract latest 3 posts with dates and titles")
+```
+
+### 5. Rust Foundation
+
+```bash
+# News
+agent-browser open "https://rustfoundation.org/media/category/news/"
+agent-browser get text "article" --limit 3
+agent-browser close
+
+# Blog
+agent-browser open "https://rustfoundation.org/media/category/blog/"
+agent-browser get text "article" --limit 3
+agent-browser close
+
+# Events
+agent-browser open "https://rustfoundation.org/events/"
+agent-browser get text "article" --limit 3
+agent-browser close
+```
+
+### Time Filtering
+
+After fetching all sources, filter by time range:
+
+| Range | Filter |
+|-------|--------|
+| day | Last 24 hours |
+| week | Last 7 days |
+| month | Last 30 days |
+
+### Combining Results
+
+After fetching all sources, combine into the output format below.
+
+---
+
+## Tool Chain Priority
+
+Both modes use the same tool chain order:
+
+1. **actionbook MCP** - Check for cached/pre-fetched content first
+   ```
+   mcp__actionbook__search_actions("rust news {date}")
+   mcp__actionbook__search_actions("this week in rust")
+   mcp__actionbook__search_actions("rust blog")
+   ```
+
+2. **agent-browser CLI** - For dynamic web content
+   ```bash
+   agent-browser open "<url>"
+   agent-browser get text "<selector>"
+   agent-browser close
+   ```
+
+3. **WebFetch** - Fallback if agent-browser unavailable
+
+| Source | Primary Tool | Fallback |
+|--------|--------------|----------|
+| Reddit | agent-browser | WebFetch |
+| TWIR | actionbook → agent-browser | WebFetch |
+| Rust Blog | actionbook → WebFetch | - |
+| Foundation | actionbook → WebFetch | - |
+
+**DO NOT use:**
+- Chrome MCP directly
+- WebSearch for fetching news pages
+
+---
+
+## Output Format
+
+```markdown
+# Rust {Weekly|Daily|Monthly} Report
+
+**Time Range:** {start} - {end}
+
+## Ecosystem
+
+### Reddit r/rust
+| Score | Title | Link |
+|-------|-------|------|
+| {score} | {title} | [link]({url}) |
+
+### This Week in Rust
+- Issue #{number} ({date}): highlights
+
+## Official
+| Date | Title | Summary |
+|------|-------|---------|
+| {date} | {title} | {summary} |
+
+## Foundation
+| Date | Title | Summary |
+|------|-------|---------|
+| {date} | {title} | {summary} |
+```
+
+---
+
+## Validation
+
+- Each source should have at least 1 result, otherwise mark "No updates"
+- On fetch failure, retry with alternative tool
+- Report reason if all tools fail for a source
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Agent file not found | Skills-only install | Use inline mode |
+| agent-browser unavailable | CLI not installed | Use WebFetch |
+| Site timeout | Network issues | Retry once, then skip source |
+| Empty results | Selector mismatch | Report and use fallback |

--- a/.agents/skills/rust-deps-visualizer/SKILL.md
+++ b/.agents/skills/rust-deps-visualizer/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: rust-deps-visualizer
+description: "Visualize Rust project dependencies as ASCII art. Triggers on: /deps-viz, dependency graph, show dependencies, visualize deps, 依赖图, 依赖可视化, 显示依赖"
+argument-hint: "[--depth N] [--features]"
+allowed-tools: ["Bash", "Read", "Glob"]
+---
+
+# Rust Dependencies Visualizer
+
+Generate ASCII art visualizations of your Rust project's dependency tree.
+
+## Usage
+
+```
+/rust-deps-visualizer [--depth N] [--features]
+```
+
+**Options:**
+- `--depth N`: Limit tree depth (default: 3)
+- `--features`: Show feature flags
+
+## Output Format
+
+### Simple Tree (Default)
+
+```
+my-project v0.1.0
+├── tokio v1.49.0
+│   ├── pin-project-lite v0.2.x
+│   └── bytes v1.x
+├── serde v1.0.x
+│   └── serde_derive v1.0.x
+└── anyhow v1.x
+```
+
+### Feature-Aware Tree
+
+```
+my-project v0.1.0
+├── tokio v1.49.0 [rt, rt-multi-thread, macros, fs, io-util]
+│   ├── pin-project-lite v0.2.x
+│   └── bytes v1.x
+├── serde v1.0.x [derive]
+│   └── serde_derive v1.0.x (proc-macro)
+└── anyhow v1.x [std]
+```
+
+## Implementation
+
+**Step 1:** Parse Cargo.toml for direct dependencies
+
+```bash
+cargo metadata --format-version=1 --no-deps 2>/dev/null
+```
+
+**Step 2:** Get full dependency tree
+
+```bash
+cargo tree --depth=${DEPTH:-3} ${FEATURES:+--features} 2>/dev/null
+```
+
+**Step 3:** Format as ASCII art tree
+
+Use these box-drawing characters:
+- `├──` for middle items
+- `└──` for last items
+- `│   ` for continuation lines
+
+## Visual Enhancements
+
+### Dependency Categories
+
+```
+my-project v0.1.0
+│
+├─[Runtime]─────────────────────
+│ ├── tokio v1.49.0
+│ └── async-trait v0.1.x
+│
+├─[Serialization]───────────────
+│ ├── serde v1.0.x
+│ └── serde_json v1.x
+│
+└─[Development]─────────────────
+  ├── criterion v0.5.x
+  └── proptest v1.x
+```
+
+### Size Visualization (Optional)
+
+```
+my-project v0.1.0
+├── tokio v1.49.0        ████████████ 2.1 MB
+├── serde v1.0.x         ███████ 1.2 MB
+├── regex v1.x           █████ 890 KB
+└── anyhow v1.x          ██ 120 KB
+                         ─────────────────
+                         Total: 4.3 MB
+```
+
+## Workflow
+
+1. Check for Cargo.toml in current directory
+2. Run `cargo tree` with specified options
+3. Parse output and generate ASCII visualization
+4. Optionally categorize by purpose (runtime, dev, build)
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Crate selection advice | m11-ecosystem |
+| Workspace management | m11-ecosystem |
+| Feature flag decisions | m11-ecosystem |

--- a/.agents/skills/rust-learner/SKILL.md
+++ b/.agents/skills/rust-learner/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: rust-learner
+description: "Use when asking about Rust versions or crate info. Keywords: latest version, what's new, changelog, Rust 1.x, Rust release, stable, nightly, crate info, crates.io, lib.rs, docs.rs, API documentation, crate features, dependencies, which crate, what version, Rust edition, edition 2021, edition 2024, cargo add, cargo update, 最新版本, 版本号, 稳定版, 最新, 哪个版本, crate 信息, 文档, 依赖, Rust 版本, 新特性, 有什么特性"
+allowed-tools: ["Task", "Read", "Glob", "mcp__actionbook__*", "Bash"]
+---
+
+# Rust Learner
+
+> **Version:** 2.1.0 | **Last Updated:** 2025-01-27
+
+You are an expert at fetching Rust and crate information. Help users by:
+- **Version queries**: Get latest Rust/crate versions
+- **API documentation**: Fetch docs from docs.rs
+- **Changelog**: Get Rust version features from releases.rs
+
+**Primary skill for fetching Rust/crate information.**
+
+## Execution Mode Detection
+
+**CRITICAL: Check agent file availability first to determine execution mode.**
+
+Try to read the agent file for your query type. The execution mode depends on whether the file exists:
+
+| Query Type | Agent File Path |
+|------------|-----------------|
+| Crate info/version | `../../agents/crate-researcher.md` |
+| Rust version features | `../../agents/rust-changelog.md` |
+| Std library docs | `../../agents/std-docs-researcher.md` |
+| Third-party crate docs | `../../agents/docs-researcher.md` |
+| Clippy lints | `../../agents/clippy-researcher.md` |
+
+---
+
+## Agent Mode (Plugin Install)
+
+**When agent files exist at `../../agents/`:**
+
+### Workflow
+
+1. Read the appropriate agent file (relative to this skill)
+2. Launch Task with `run_in_background: true`
+3. Continue with other work or wait for completion
+4. Summarize results to user
+
+```
+Task(
+  subagent_type: "general-purpose",
+  run_in_background: true,
+  prompt: <read from ../../agents/*.md file>
+)
+```
+
+### Agent Routing Table
+
+| Query Type | Agent File | Source |
+|------------|------------|--------|
+| Rust version features | `../../agents/rust-changelog.md` | releases.rs |
+| Crate info/version | `../../agents/crate-researcher.md` | lib.rs, crates.io |
+| **Std library docs** (Send, Sync, Arc, etc.) | `../../agents/std-docs-researcher.md` | doc.rust-lang.org |
+| Third-party crate docs (tokio, serde, etc.) | `../../agents/docs-researcher.md` | docs.rs |
+| Clippy lints | `../../agents/clippy-researcher.md` | rust-clippy docs |
+
+### Agent Mode Examples
+
+**Crate Version Query:**
+```
+User: "tokio latest version"
+
+Claude:
+1. Read ../../agents/crate-researcher.md
+2. Task(subagent_type: "general-purpose", run_in_background: true, prompt: <agent content>)
+3. Wait for agent
+4. Summarize results
+```
+
+**Rust Changelog Query:**
+```
+User: "What's new in Rust 1.85?"
+
+Claude:
+1. Read ../../agents/rust-changelog.md
+2. Task(subagent_type: "general-purpose", run_in_background: true, prompt: <agent content>)
+3. Wait for agent
+4. Summarize features
+```
+
+---
+
+## Inline Mode (Skills-only Install)
+
+**When agent files are NOT available, execute directly using these steps:**
+
+### Crate Info Query
+
+```
+1. actionbook: mcp__actionbook__search_actions("lib.rs crate info")
+2. Get action details: mcp__actionbook__get_action_by_id(<action_id>)
+3. agent-browser CLI (or WebFetch fallback):
+   - open "https://lib.rs/crates/{crate_name}"
+   - get text using selector from actionbook
+   - close
+4. Parse and format output
+```
+
+**Output Format:**
+```markdown
+## {Crate Name}
+
+**Version:** {latest}
+**Description:** {description}
+
+**Features:**
+- `feature1`: description
+
+**Links:**
+- [docs.rs](https://docs.rs/{crate}) | [crates.io](https://crates.io/crates/{crate}) | [repo]({repo_url})
+```
+
+### Rust Version Query
+
+```
+1. actionbook: mcp__actionbook__search_actions("releases.rs rust changelog")
+2. Get action details for selectors
+3. agent-browser CLI (or WebFetch fallback):
+   - open "https://releases.rs/docs/1.{version}.0/"
+   - get text using selector from actionbook
+   - close
+4. Parse and format output
+```
+
+**Output Format:**
+```markdown
+## Rust 1.{version}
+
+**Release Date:** {date}
+
+### Language Features
+- Feature 1: description
+- Feature 2: description
+
+### Library Changes
+- std::module: new API
+
+### Stabilized APIs
+- `api_name`: description
+```
+
+### Std Library Docs (std::*, Send, Sync, Arc, etc.)
+
+```
+1. Construct URL: "https://doc.rust-lang.org/std/{path}/"
+   - Traits: std/{module}/trait.{Name}.html
+   - Structs: std/{module}/struct.{Name}.html
+   - Modules: std/{module}/index.html
+2. agent-browser CLI (or WebFetch fallback):
+   - open <url>
+   - get text "main .docblock"
+   - close
+3. Parse and format output
+```
+
+**Common Std Library Paths:**
+| Item | Path |
+|------|------|
+| Send, Sync, Copy, Clone | `std/marker/trait.{Name}.html` |
+| Arc, Mutex, RwLock | `std/sync/struct.{Name}.html` |
+| Rc, Weak | `std/rc/struct.{Name}.html` |
+| RefCell, Cell | `std/cell/struct.{Name}.html` |
+| Box | `std/boxed/struct.Box.html` |
+| Vec | `std/vec/struct.Vec.html` |
+| String | `std/string/struct.String.html` |
+
+**Output Format:**
+```markdown
+## std::{path}::{Name}
+
+**Signature:**
+```rust
+{signature}
+```
+
+**Description:**
+{description}
+
+**Examples:**
+```rust
+{example_code}
+```
+```
+
+### Third-Party Crate Docs (tokio, serde, etc.)
+
+```
+1. Construct URL: "https://docs.rs/{crate}/latest/{crate}/{path}"
+2. agent-browser CLI (or WebFetch fallback):
+   - open <url>
+   - get text ".docblock"
+   - close
+3. Parse and format output
+```
+
+**Output Format:**
+```markdown
+## {crate}::{path}
+
+**Signature:**
+```rust
+{signature}
+```
+
+**Description:**
+{description}
+
+**Examples:**
+```rust
+{example_code}
+```
+```
+
+### Clippy Lints
+
+```
+1. agent-browser CLI (or WebFetch fallback):
+   - open "https://rust-lang.github.io/rust-clippy/stable/"
+   - search for lint name in page
+   - get text ".lint-doc" for matching lint
+   - close
+2. Parse and format output
+```
+
+**Output Format:**
+```markdown
+## Clippy Lint: {lint_name}
+
+**Level:** {warn|deny|allow}
+**Category:** {category}
+
+**Description:**
+{what_it_checks}
+
+**Example (Bad):**
+```rust
+{bad_code}
+```
+
+**Example (Good):**
+```rust
+{good_code}
+```
+```
+
+---
+
+## Tool Chain Priority
+
+Both modes use the same tool chain order:
+
+1. **actionbook MCP** - Get pre-computed selectors first
+   - `mcp__actionbook__search_actions("site_name")` → get action ID
+   - `mcp__actionbook__get_action_by_id(id)` → get URL + selectors
+
+2. **agent-browser CLI** - Primary execution tool
+   ```bash
+   agent-browser open <url>
+   agent-browser get text <selector_from_actionbook>
+   agent-browser close
+   ```
+
+3. **WebFetch** - Last resort only if agent-browser unavailable
+
+### Fallback Principle (CRITICAL)
+
+```
+actionbook → agent-browser → WebFetch (only if agent-browser unavailable)
+```
+
+**DO NOT:**
+- Skip agent-browser because it's slower
+- Use WebFetch as primary when agent-browser is available
+- Block on WebFetch without trying agent-browser first
+
+---
+
+## Deprecated Patterns
+
+| Deprecated | Use Instead | Reason |
+|------------|-------------|--------|
+| WebSearch for crate info | Task + agent or inline mode | Structured data |
+| Direct WebFetch | actionbook + agent-browser | Pre-computed selectors |
+| Guessing version numbers | Always fetch from source | Prevents misinformation |
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Agent file not found | Skills-only install | Use inline mode |
+| actionbook unavailable | MCP not configured | Fall back to WebFetch |
+| agent-browser not found | CLI not installed | Fall back to WebFetch |
+| Agent timeout | Site slow/down | Retry or inform user |
+| Empty results | Selector mismatch | Report and use WebFetch fallback |
+
+## Proactive Triggering
+
+This skill triggers AUTOMATICALLY when:
+- Any Rust crate name mentioned (tokio, serde, axum, sqlx, etc.)
+- Questions about "latest", "new", "version", "changelog"
+- API documentation requests
+- Dependency/feature questions
+
+**DO NOT use WebSearch for Rust crate info. Use agents or inline mode instead.**

--- a/.agents/skills/rust-refactor-helper/SKILL.md
+++ b/.agents/skills/rust-refactor-helper/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: rust-refactor-helper
+description: "Safe Rust refactoring with LSP analysis. Triggers on: /refactor, rename symbol, move function, extract, 重构, 重命名, 提取函数, 安全重构"
+argument-hint: "<action> <target> [--dry-run]"
+allowed-tools: ["LSP", "Read", "Glob", "Grep", "Edit"]
+---
+
+# Rust Refactor Helper
+
+Perform safe refactoring with comprehensive impact analysis.
+
+## Usage
+
+```
+/rust-refactor-helper <action> <target> [--dry-run]
+```
+
+**Actions:**
+- `rename <old> <new>` - Rename symbol
+- `extract-fn <selection>` - Extract to function
+- `inline <fn>` - Inline function
+- `move <symbol> <dest>` - Move to module
+
+**Examples:**
+- `/rust-refactor-helper rename parse_config load_config`
+- `/rust-refactor-helper extract-fn src/main.rs:20-35`
+- `/rust-refactor-helper move UserService src/services/`
+
+## LSP Operations Used
+
+### Pre-Refactor Analysis
+
+```
+# Find all references before renaming
+LSP(
+  operation: "findReferences",
+  filePath: "src/lib.rs",
+  line: 25,
+  character: 8
+)
+
+# Get symbol info
+LSP(
+  operation: "hover",
+  filePath: "src/lib.rs",
+  line: 25,
+  character: 8
+)
+
+# Check call hierarchy for move operations
+LSP(
+  operation: "incomingCalls",
+  filePath: "src/lib.rs",
+  line: 25,
+  character: 8
+)
+```
+
+## Refactoring Workflows
+
+### 1. Rename Symbol
+
+```
+User: "Rename parse_config to load_config"
+    │
+    ▼
+[1] Find symbol definition
+    LSP(goToDefinition)
+    │
+    ▼
+[2] Find ALL references
+    LSP(findReferences)
+    │
+    ▼
+[3] Categorize by file
+    │
+    ▼
+[4] Check for conflicts
+    - Is 'load_config' already used?
+    - Are there macro-generated uses?
+    │
+    ▼
+[5] Show impact analysis (--dry-run)
+    │
+    ▼
+[6] Apply changes with Edit tool
+```
+
+**Output:**
+
+```
+## Rename: parse_config → load_config
+
+### Impact Analysis
+
+**Definition:** src/config.rs:25
+**References found:** 8
+
+| File | Line | Context | Change |
+|------|------|---------|--------|
+| src/config.rs | 25 | `pub fn parse_config(` | Definition |
+| src/config.rs | 45 | `parse_config(path)?` | Call |
+| src/main.rs | 12 | `config::parse_config` | Import |
+| src/main.rs | 30 | `let cfg = parse_config(` | Call |
+| src/lib.rs | 8 | `pub use config::parse_config` | Re-export |
+| tests/config_test.rs | 15 | `parse_config("test.toml")` | Test |
+| tests/config_test.rs | 25 | `parse_config("")` | Test |
+| docs/api.md | 42 | `parse_config` | Documentation |
+
+### Potential Issues
+
+⚠️ **Documentation reference:** docs/api.md:42 may need manual update
+⚠️ **Re-export:** src/lib.rs:8 - public API change
+
+### Proceed?
+- [x] --dry-run (preview only)
+- [ ] Apply changes
+```
+
+### 2. Extract Function
+
+```
+User: "Extract lines 20-35 in main.rs to a function"
+    │
+    ▼
+[1] Read the selected code block
+    │
+    ▼
+[2] Analyze variables
+    - Which are inputs? (used but not defined in block)
+    - Which are outputs? (defined and used after block)
+    - Which are local? (defined and used only in block)
+    │
+    ▼
+[3] Determine function signature
+    │
+    ▼
+[4] Check for early returns, loops, etc.
+    │
+    ▼
+[5] Generate extracted function
+    │
+    ▼
+[6] Replace original code with call
+```
+
+**Output:**
+
+```
+## Extract Function: src/main.rs:20-35
+
+### Selected Code
+​```rust
+let file = File::open(&path)?;
+let mut contents = String::new();
+file.read_to_string(&mut contents)?;
+let config: Config = toml::from_str(&contents)?;
+validate_config(&config)?;
+​```
+
+### Analysis
+
+**Inputs:** path: &Path
+**Outputs:** config: Config
+**Side Effects:** File I/O, may return error
+
+### Extracted Function
+
+​```rust
+fn load_and_validate_config(path: &Path) -> Result<Config> {
+    let file = File::open(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let config: Config = toml::from_str(&contents)?;
+    validate_config(&config)?;
+    Ok(config)
+}
+​```
+
+### Replacement
+
+​```rust
+let config = load_and_validate_config(&path)?;
+​```
+```
+
+### 3. Move Symbol
+
+```
+User: "Move UserService to src/services/"
+    │
+    ▼
+[1] Find symbol and all its dependencies
+    │
+    ▼
+[2] Find all references (callers)
+    LSP(findReferences)
+    │
+    ▼
+[3] Analyze import changes needed
+    │
+    ▼
+[4] Check for circular dependencies
+    │
+    ▼
+[5] Generate move plan
+```
+
+**Output:**
+
+```
+## Move: UserService → src/services/user.rs
+
+### Current Location
+src/handlers/auth.rs:50-120
+
+### Dependencies (will be moved together)
+- struct UserService (50-80)
+- impl UserService (82-120)
+- const DEFAULT_TIMEOUT (48)
+
+### Import Changes Required
+
+| File | Current | New |
+|------|---------|-----|
+| src/main.rs | `use handlers::auth::UserService` | `use services::user::UserService` |
+| src/handlers/api.rs | `use super::auth::UserService` | `use crate::services::user::UserService` |
+| tests/auth_test.rs | `use crate::handlers::auth::UserService` | `use crate::services::user::UserService` |
+
+### New File Structure
+
+​```
+src/
+├── services/
+│   ├── mod.rs (NEW - add `pub mod user;`)
+│   └── user.rs (NEW - UserService moved here)
+├── handlers/
+│   └── auth.rs (UserService removed)
+​```
+
+### Circular Dependency Check
+✅ No circular dependencies detected
+```
+
+## Safety Checks
+
+| Check | Purpose |
+|-------|---------|
+| Reference completeness | Ensure all uses are found |
+| Name conflicts | Detect existing symbols with same name |
+| Visibility changes | Warn if pub/private scope changes |
+| Macro-generated code | Warn about code in macros |
+| Documentation | Flag doc comments mentioning symbol |
+| Test coverage | Show affected tests |
+
+## Dry Run Mode
+
+Always use `--dry-run` first to preview changes:
+
+```
+/rust-refactor-helper rename old_name new_name --dry-run
+```
+
+This shows all changes without applying them.
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Navigate to symbol | rust-code-navigator |
+| Understand call flow | rust-call-graph |
+| Project structure | rust-symbol-analyzer |
+| Trait implementations | rust-trait-explorer |

--- a/.agents/skills/rust-router/SKILL.md
+++ b/.agents/skills/rust-router/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: rust-router
+description: "CRITICAL: Use for ALL Rust questions including errors, design, and coding.
+HIGHEST PRIORITY for: 比较, 对比, compare, vs, versus, 区别, difference, 最佳实践, best practice,
+tokio vs, async-std vs, 比较 tokio, 比较 async,
+Triggers on: Rust, cargo, rustc, crate, Cargo.toml,
+意图分析, 问题分析, 语义分析, analyze intent, question analysis,
+compile error, borrow error, lifetime error, ownership error, type error, trait error,
+value moved, cannot borrow, does not live long enough, mismatched types, not satisfied,
+E0382, E0597, E0277, E0308, E0499, E0502, E0596,
+async, await, Send, Sync, tokio, concurrency, error handling,
+编译错误, compile error, 所有权, ownership, 借用, borrow, 生命周期, lifetime, 类型错误, type error,
+异步, async, 并发, concurrency, 错误处理, error handling,
+问题, problem, question, 怎么用, how to use, 如何, how to, 为什么, why,
+什么是, what is, 帮我写, help me write, 实现, implement, 解释, explain"
+globs: ["**/Cargo.toml", "**/*.rs"]
+---
+
+---
+
+# Rust Question Router
+
+> **Version:** 2.0.0 | **Last Updated:** 2025-01-22
+>
+> **v2.0:** Context optimized - detailed examples moved to sub-files
+
+## Meta-Cognition Framework
+
+### Core Principle
+
+**Don't answer directly. Trace through the cognitive layers first.**
+
+```
+Layer 3: Domain Constraints (WHY)
+├── Business rules, regulatory requirements
+├── domain-fintech, domain-web, domain-cli, etc.
+└── "Why is it designed this way?"
+
+Layer 2: Design Choices (WHAT)
+├── Architecture patterns, DDD concepts
+├── m09-m15 skills
+└── "What pattern should I use?"
+
+Layer 1: Language Mechanics (HOW)
+├── Ownership, borrowing, lifetimes, traits
+├── m01-m07 skills
+└── "How do I implement this in Rust?"
+```
+
+### Routing by Entry Point
+
+| User Signal | Entry Layer | Direction | First Skill |
+|-------------|-------------|-----------|-------------|
+| E0xxx error | Layer 1 | Trace UP ↑ | m01-m07 |
+| Compile error | Layer 1 | Trace UP ↑ | Error table below |
+| "How to design..." | Layer 2 | Check L3, then DOWN ↓ | m09-domain |
+| "Building [domain] app" | Layer 3 | Trace DOWN ↓ | domain-* |
+| "Best practice..." | Layer 2 | Both directions | m09-m15 |
+| Performance issue | Layer 1 → 2 | UP then DOWN | m10-performance |
+
+### CRITICAL: Dual-Skill Loading
+
+**When domain keywords are present, you MUST load BOTH skills:**
+
+| Domain Keywords | L1 Skill | L3 Skill |
+|-----------------|----------|----------|
+| Web API, HTTP, axum, handler | m07-concurrency | **domain-web** |
+| 交易, 支付, trading, payment | m01-ownership | **domain-fintech** |
+| CLI, terminal, clap | m07-concurrency | **domain-cli** |
+| kubernetes, grpc, microservice | m07-concurrency | **domain-cloud-native** |
+| embedded, no_std, MCU | m02-resource | **domain-embedded** |
+
+---
+
+## INSTRUCTIONS FOR CLAUDE
+
+### CRITICAL: Negotiation Protocol Trigger
+
+**BEFORE answering, check if negotiation is required:**
+
+| Query Contains | Action |
+|----------------|--------|
+| "比较", "对比", "compare", "vs", "versus" | **MUST use negotiation** |
+| "最佳实践", "best practice" | **MUST use negotiation** |
+| Domain + error (e.g., "交易系统 E0382") | **MUST use negotiation** |
+| Ambiguous scope (e.g., "tokio 性能") | **SHOULD use negotiation** |
+
+**When negotiation is required, include:**
+
+```markdown
+## Negotiation Analysis
+
+**Query Type:** [Comparative | Cross-domain | Synthesis | Ambiguous]
+**Negotiation:** Enabled
+
+### Source: [Agent/Skill Name]
+**Confidence:** HIGH | MEDIUM | LOW | UNCERTAIN
+**Gaps:** [What's missing]
+
+## Synthesized Answer
+[Answer]
+
+**Overall Confidence:** [Level]
+**Disclosed Gaps:** [Gaps user should know]
+```
+
+> **详细协议见:** `patterns/negotiation.md`
+
+---
+
+### Default Project Settings
+
+When creating new Rust projects or Cargo.toml files, ALWAYS use:
+
+```toml
+[package]
+edition = "2024"  # ALWAYS use latest stable edition
+rust-version = "1.85"
+
+[lints.rust]
+unsafe_code = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+```
+
+---
+
+## Layer 1 Skills (Language Mechanics)
+
+| Pattern | Route To |
+|---------|----------|
+| move, borrow, lifetime, E0382, E0597 | m01-ownership |
+| Box, Rc, Arc, RefCell, Cell | m02-resource |
+| mut, interior mutability, E0499, E0502, E0596 | m03-mutability |
+| generic, trait, inline, monomorphization | m04-zero-cost |
+| type state, phantom, newtype | m05-type-driven |
+| Result, Error, panic, ?, anyhow, thiserror | m06-error-handling |
+| Send, Sync, thread, async, channel | m07-concurrency |
+| unsafe, FFI, extern, raw pointer, transmute | **unsafe-checker** |
+
+## Layer 2 Skills (Design Choices)
+
+| Pattern | Route To |
+|---------|----------|
+| domain model, business logic | m09-domain |
+| performance, optimization, benchmark | m10-performance |
+| integration, interop, bindings | m11-ecosystem |
+| resource lifecycle, RAII, Drop | m12-lifecycle |
+| domain error, recovery strategy | m13-domain-error |
+| mental model, how to think | m14-mental-model |
+| anti-pattern, common mistake, pitfall | m15-anti-pattern |
+
+## Layer 3 Skills (Domain Constraints)
+
+| Domain Keywords | Route To |
+|-----------------|----------|
+| fintech, trading, decimal, currency | domain-fintech |
+| ml, tensor, model, inference | domain-ml |
+| kubernetes, docker, grpc, microservice | domain-cloud-native |
+| embedded, sensor, mqtt, iot | domain-iot |
+| web server, HTTP, REST, axum, actix | domain-web |
+| CLI, command line, clap, terminal | domain-cli |
+| no_std, microcontroller, firmware | domain-embedded |
+
+---
+
+## Error Code Routing
+
+| Error Code | Route To | Common Cause |
+|------------|----------|--------------|
+| E0382 | m01-ownership | Use of moved value |
+| E0597 | m01-ownership | Lifetime too short |
+| E0506 | m01-ownership | Cannot assign to borrowed |
+| E0507 | m01-ownership | Cannot move out of borrowed |
+| E0515 | m01-ownership | Return local reference |
+| E0716 | m01-ownership | Temporary value dropped |
+| E0106 | m01-ownership | Missing lifetime specifier |
+| E0596 | m03-mutability | Cannot borrow as mutable |
+| E0499 | m03-mutability | Multiple mutable borrows |
+| E0502 | m03-mutability | Borrow conflict |
+| E0277 | m04/m07 | Trait bound not satisfied |
+| E0308 | m04-zero-cost | Type mismatch |
+| E0599 | m04-zero-cost | No method found |
+| E0038 | m04-zero-cost | Trait not object-safe |
+| E0433 | m11-ecosystem | Cannot find crate/module |
+
+---
+
+## Functional Routing Table
+
+| Pattern | Route To | Action |
+|---------|----------|--------|
+| latest version, what's new | **rust-learner** | Use agents |
+| API, docs, documentation | **docs-researcher** | Use agent |
+| code style, naming, clippy | **coding-guidelines** | Read skill |
+| unsafe code, FFI | **unsafe-checker** | Read skill |
+| code review | **os-checker** | See `integrations/os-checker.md` |
+
+---
+
+## Priority Order
+
+1. **Identify cognitive layer** (L1/L2/L3)
+2. **Load entry skill** (m0x/m1x/domain)
+3. **Trace through layers** (UP or DOWN)
+4. **Cross-reference skills** as indicated in "Trace" sections
+5. **Answer with reasoning chain**
+
+### Keyword Conflict Resolution
+
+| Keyword | Resolution |
+|---------|------------|
+| `unsafe` | **unsafe-checker** (more specific than m11) |
+| `error` | **m06** for general, **m13** for domain-specific |
+| `RAII` | **m12** for design, **m01** for implementation |
+| `crate` | **rust-learner** for version, **m11** for integration |
+| `tokio` | **tokio-*** for API, **m07** for concepts |
+
+**Priority Hierarchy:**
+
+```
+1. Error codes (E0xxx) → Direct lookup, highest priority
+2. Negotiation triggers (compare, vs, best practice) → Enable negotiation
+3. Domain keywords + error → Load BOTH domain + error skills
+4. Specific crate keywords → Route to crate-specific skill if exists
+5. General concept keywords → Route to meta-question skill
+```
+
+---
+
+## Sub-Files Reference
+
+| File | Content |
+|------|---------|
+| `patterns/negotiation.md` | Negotiation protocol details |
+| `examples/workflow.md` | Workflow examples |
+| `integrations/os-checker.md` | OS-Checker integration |

--- a/.agents/skills/rust-router/examples/workflow.md
+++ b/.agents/skills/rust-router/examples/workflow.md
@@ -1,0 +1,85 @@
+# Workflow Examples
+
+> rust-router 的工作流程示例
+
+## Example 1: Error Code with Domain Context
+
+```
+User: "Why am I getting E0382 in my trading system?"
+
+Analysis:
+1. Entry: Layer 1 (E0382 = ownership/move error)
+2. Load: m01-ownership skill
+3. Context: "trading system" → domain-fintech
+
+Trace UP ↑:
+- E0382 in trading context
+- Check domain-fintech: "immutable audit records"
+- Finding: Trading data should be shared, not moved
+
+Response:
+"E0382 indicates a value was moved when still needed.
+In a trading system (domain-fintech), transaction records
+should be immutable and shareable for audit purposes.
+
+Instead of cloning, consider:
+- Arc<TradeRecord> for shared immutable access
+- This aligns with financial audit requirements
+
+See: m01-ownership (Trace Up section),
+     domain-fintech (Audit Requirements)"
+```
+
+## Example 2: Design Question
+
+```
+User: "How should I handle user authentication?"
+
+1. Entry: Layer 2 (design question)
+2. Trace UP to Layer 3: domain-web constraints
+3. Load: domain-web skill (security, stateless HTTP)
+4. Trace DOWN: m06-error-handling, m07-concurrency
+5. Answer: JWT with proper error types, async handlers
+```
+
+## Example 3: Comparative Query
+
+```
+User: "Compare tokio and async-std"
+
+1. Detect: "compare" → Enable negotiation
+2. Load both runtime knowledge sources
+3. Assess confidence for each
+4. Synthesize with disclosed gaps
+5. Answer: Structured comparison table
+```
+
+## Example 4: Multi-Layer Trace
+
+```
+User: "My web API reports Rc cannot be sent between threads"
+
+1. Entry: Layer 1 (Send/Sync error)
+2. Load: m07-concurrency
+3. Detect: "web API" → domain-web
+4. Dual-skill loading:
+   - m07: Explain Send/Sync bounds
+   - domain-web: Web state management patterns
+5. Answer: Use Arc instead of Rc, or move to thread-local
+```
+
+## Example 5: Intent Analysis Request
+
+```
+User: "Analyze this question: How do I share state in actix-web?"
+
+Analysis Steps:
+1. Extract Keywords: share, state, actix-web
+2. Identify Entry Layer: Layer 1 (sharing = concurrency) + Layer 3 (actix-web = web)
+3. Map to Skills: m07-concurrency, domain-web
+4. Report:
+   - Layer 1: Concurrency (state sharing mechanisms)
+   - Layer 3: Web domain (HTTP handler patterns)
+   - Suggested trace: L1 → L3
+5. Invoke: m07-concurrency first, then domain-web
+```

--- a/.agents/skills/rust-router/integrations/os-checker.md
+++ b/.agents/skills/rust-router/integrations/os-checker.md
@@ -1,0 +1,56 @@
+# OS-Checker Integration
+
+> 代码审查和安全审计工具集成
+
+## Available Commands
+
+| Use Case | Command | Tools |
+|----------|---------|-------|
+| Daily check | `/rust-review` | clippy |
+| Security audit | `/audit security` | cargo audit, geiger |
+| Unsafe audit | `/audit safety` | miri, rudra |
+| Concurrency audit | `/audit concurrency` | lockbud |
+| Full audit | `/audit full` | all os-checker tools |
+
+## When to Suggest OS-Checker
+
+| User Intent | Suggest |
+|-------------|---------|
+| Code review request | `/rust-review` |
+| Security concerns | `/audit security` |
+| Unsafe code review | `/audit safety` |
+| Deadlock/race concerns | `/audit concurrency` |
+| Pre-release check | `/audit full` |
+
+## Tool Descriptions
+
+### clippy
+Standard Rust linter for code style and common mistakes.
+
+### cargo audit
+Security vulnerability scanner for dependencies.
+
+### geiger
+Counts unsafe code usage in dependencies.
+
+### miri
+Interprets MIR to detect undefined behavior.
+
+### rudra
+Memory safety bug detector.
+
+### lockbud
+Deadlock and concurrency bug detector.
+
+## Integration Flow
+
+```
+User: "Review my unsafe code"
+     │
+     ▼
+Router detects: unsafe + review
+     │
+     ├── Load: unsafe-checker skill (for manual review)
+     │
+     └── Suggest: `/audit safety` (for automated check)
+```

--- a/.agents/skills/rust-router/patterns/negotiation.md
+++ b/.agents/skills/rust-router/patterns/negotiation.md
@@ -1,0 +1,154 @@
+# Negotiation Protocol
+
+> 比较查询和跨领域问题的处理协议
+
+## When to Enable Negotiation
+
+For complex queries requiring structured agent responses, enable negotiation mode.
+
+| Query Pattern | Enable Negotiation | Reason |
+|---------------|-------------------|--------|
+| Single error code lookup | No | Direct answer |
+| Single crate version | No | Direct lookup |
+| "Compare X and Y" | **Yes** | Multi-faceted |
+| Domain + error | **Yes** | Cross-layer context |
+| "Best practices for..." | **Yes** | Requires synthesis |
+| Ambiguous scope | **Yes** | Needs clarification |
+| Multi-crate question | **Yes** | Multiple sources |
+
+## Negotiation Decision Flow
+
+```
+Query Received
+     │
+     ▼
+┌─────────────────────────────┐
+│ Is query single-lookup?     │
+│ (version, error code, def)  │
+└─────────────────────────────┘
+     │
+     ├── Yes → Direct dispatch (no negotiation)
+     │
+     ▼ No
+┌─────────────────────────────┐
+│ Does query require:         │
+│ - Comparison?               │
+│ - Cross-domain context?     │
+│ - Synthesis/aggregation?    │
+│ - Multiple sources?         │
+└─────────────────────────────┘
+     │
+     ├── Yes → Dispatch with negotiation: true
+     │
+     ▼ No
+┌─────────────────────────────┐
+│ Is scope ambiguous?         │
+└─────────────────────────────┘
+     │
+     ├── Yes → Dispatch with negotiation: true
+     │
+     ▼ No
+     └── Direct dispatch (no negotiation)
+```
+
+## Negotiation Dispatch
+
+When dispatching with negotiation:
+
+```
+1. Set `negotiation: true`
+2. Include original query context
+3. Expect structured response:
+   - Findings
+   - Confidence (HIGH/MEDIUM/LOW/UNCERTAIN)
+   - Gaps identified
+   - Context questions (if any)
+4. Evaluate response against original intent
+```
+
+## Orchestrator Evaluation
+
+After receiving negotiation response:
+
+| Confidence | Intent Coverage | Action |
+|------------|-----------------|--------|
+| HIGH | Complete | Synthesize answer |
+| HIGH | Partial | May need supplementary query |
+| MEDIUM | Complete | Accept with disclosed gaps |
+| MEDIUM | Partial | Refine with context |
+| LOW | Any | Refine or try alternative |
+| UNCERTAIN | Any | Try alternative or escalate |
+
+## Refinement Loop
+
+If response insufficient:
+
+```
+Round 1: Initial query
+  │
+  ▼ (LOW confidence or gaps block intent)
+Round 2: Refined query with:
+  - Answers to agent's context questions
+  - Narrowed scope
+  │
+  ▼ (still insufficient)
+Round 3: Final attempt with:
+  - Alternative agent/source
+  - Maximum context provided
+  │
+  ▼ (still insufficient)
+Synthesize best-effort answer with disclosed gaps
+```
+
+## Integration with 3-Strike Rule
+
+Negotiation follows the 3-Strike escalation:
+
+```
+Strike 1: Initial query returns LOW confidence
+  → Refine with more context
+
+Strike 2: Refined query still LOW
+  → Try alternative agent/source
+
+Strike 3: Still insufficient
+  → Synthesize best-effort answer
+  → Report gaps to user explicitly
+```
+
+See `_meta/error-protocol.md` for full escalation rules.
+
+## Negotiation Routing Examples
+
+**Example 1: No Negotiation Needed**
+```
+Query: "What is tokio's latest version?"
+Analysis: Single lookup
+Action: Direct dispatch to crate-researcher
+```
+
+**Example 2: Negotiation Required**
+```
+Query: "Compare tokio and async-std for a web server"
+Analysis: Comparative + domain context
+Action: Dispatch with negotiation: true
+Expected: Structured responses from both runtime lookups
+Evaluation: Check if web-server specific data found
+```
+
+**Example 3: Cross-Domain Negotiation**
+```
+Query: "E0382 in my trading system"
+Analysis: Error code + domain context
+Action:
+  - Dispatch m01-ownership (standard - error is defined)
+  - Dispatch domain-fintech (negotiation: true - domain context)
+Synthesis: Combine error explanation with domain-appropriate fix
+```
+
+## Related Documents
+
+- `_meta/negotiation-protocol.md` - Full protocol specification
+- `_meta/negotiation-templates.md` - Response templates
+- `_meta/error-protocol.md` - 3-Strike escalation
+- `agents/_negotiation/response-format.md` - Agent response format

--- a/.agents/skills/rust-skill-creator/SKILL.md
+++ b/.agents/skills/rust-skill-creator/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: rust-skill-creator
+description: "Use when creating skills for Rust crates or std library documentation. Keywords: create rust skill, create crate skill, create std skill, 创建 rust skill, 创建 crate skill, 创建 std skill, 动态 rust skill, 动态 crate skill, skill for tokio, skill for serde, skill for axum, generate rust skill, rust 技能, crate 技能, 从文档创建skill, from docs create skill"
+argument-hint: "<crate_name|std::module>"
+context: fork
+agent: general-purpose
+---
+
+# Rust Skill Creator
+
+> **Version:** 2.1.0 | **Last Updated:** 2025-01-27
+>
+> Create dynamic skills for Rust crates and std library documentation.
+
+## When to Use
+
+This skill handles requests to create skills for:
+- Third-party crates (tokio, serde, axum, etc.)
+- Rust standard library (std::sync, std::marker, etc.)
+- Any Rust documentation URL
+
+## Execution Mode Detection
+
+**CRITICAL: Check if related commands/skills are available.**
+
+This skill relies on:
+- `/create-llms-for-skills` command
+- `/create-skills-via-llms` command
+
+---
+
+## Agent Mode (Plugin Install)
+
+**When the commands above are available (full plugin installation):**
+
+### Workflow
+
+#### 1. Identify the Target
+
+| User Request | Target Type | URL Pattern |
+|--------------|-------------|-------------|
+| "create tokio skill" | Third-party crate | `docs.rs/tokio/latest/tokio/` |
+| "create Send trait skill" | Std library | `doc.rust-lang.org/std/marker/trait.Send.html` |
+| "create skill from URL" + URL | Custom URL | User-provided URL |
+
+#### 2. Execute the Command
+
+Use the `/create-llms-for-skills` command:
+
+```
+/create-llms-for-skills <url> [requirements]
+```
+
+**Examples:**
+
+```bash
+# For third-party crate
+/create-llms-for-skills https://docs.rs/tokio/latest/tokio/
+
+# For std library
+/create-llms-for-skills https://doc.rust-lang.org/std/marker/trait.Send.html
+
+# With specific requirements
+/create-llms-for-skills https://docs.rs/axum/latest/axum/ "Focus on routing and extractors"
+```
+
+#### 3. Follow-up with Skill Creation
+
+After llms.txt is generated, use:
+
+```
+/create-skills-via-llms <crate_name> <llms_path> [version]
+```
+
+---
+
+## Inline Mode (Skills-only Install)
+
+**When the commands above are NOT available, create skills manually:**
+
+### Step 1: Identify Target and Construct URL
+
+| Target | URL Template |
+|--------|--------------|
+| Crate overview | `https://docs.rs/{crate}/latest/{crate}/` |
+| Crate module | `https://docs.rs/{crate}/latest/{crate}/{module}/` |
+| Std trait | `https://doc.rust-lang.org/std/{module}/trait.{Name}.html` |
+| Std struct | `https://doc.rust-lang.org/std/{module}/struct.{Name}.html` |
+| Std module | `https://doc.rust-lang.org/std/{module}/index.html` |
+
+### Step 2: Fetch Documentation
+
+```bash
+# Using agent-browser CLI
+agent-browser open "<documentation_url>"
+agent-browser get text ".docblock"
+agent-browser close
+```
+
+**Or with WebFetch fallback:**
+```
+WebFetch("<documentation_url>", "Extract API documentation including types, functions, and examples")
+```
+
+### Step 3: Create Skill Directory
+
+```bash
+mkdir -p ~/.claude/skills/{crate_name}
+mkdir -p ~/.claude/skills/{crate_name}/references
+```
+
+### Step 4: Generate SKILL.md
+
+Create `~/.claude/skills/{crate_name}/SKILL.md` with this template:
+
+```markdown
+---
+name: {crate_name}
+description: "Documentation for {crate_name} crate. Keywords: {keywords}"
+---
+
+# {Crate Name}
+
+> **Version:** {version} | **Source:** docs.rs
+
+## Overview
+
+{Brief description from documentation}
+
+## Key Types
+
+### {Type1}
+{Description and usage}
+
+### {Type2}
+{Description and usage}
+
+## Common Patterns
+
+{Usage patterns extracted from documentation}
+
+## Examples
+
+```rust
+{Example code from documentation}
+```
+
+## Documentation
+
+- `./references/overview.md` - Main overview
+- `./references/{module}.md` - Module documentation
+
+## Links
+
+- [docs.rs](https://docs.rs/{crate})
+- [crates.io](https://crates.io/crates/{crate})
+```
+
+### Step 5: Generate Reference Files
+
+For each major module or type, create a reference file:
+
+```bash
+# Fetch and save module documentation
+agent-browser open "https://docs.rs/{crate}/latest/{crate}/{module}/"
+agent-browser get text ".docblock" > ~/.claude/skills/{crate_name}/references/{module}.md
+agent-browser close
+```
+
+### Step 6: Verify Skill
+
+```bash
+# Check skill structure
+ls -la ~/.claude/skills/{crate_name}/
+cat ~/.claude/skills/{crate_name}/SKILL.md
+```
+
+---
+
+## URL Construction Helper
+
+| Target | URL Template |
+|--------|--------------|
+| Crate overview | `https://docs.rs/{crate}/latest/{crate}/` |
+| Crate module | `https://docs.rs/{crate}/latest/{crate}/{module}/` |
+| Std trait | `https://doc.rust-lang.org/std/{module}/trait.{Name}.html` |
+| Std struct | `https://doc.rust-lang.org/std/{module}/struct.{Name}.html` |
+| Std module | `https://doc.rust-lang.org/std/{module}/index.html` |
+
+## Common Std Library Paths
+
+| Item | Path |
+|------|------|
+| Send, Sync, Copy, Clone | `std/marker/trait.{Name}.html` |
+| Arc, Mutex, RwLock | `std/sync/struct.{Name}.html` |
+| Rc, Weak | `std/rc/struct.{Name}.html` |
+| RefCell, Cell | `std/cell/struct.{Name}.html` |
+| Box | `std/boxed/struct.Box.html` |
+| Vec | `std/vec/struct.Vec.html` |
+| String | `std/string/struct.String.html` |
+| Option | `std/option/enum.Option.html` |
+| Result | `std/result/enum.Result.html` |
+
+---
+
+## Example Interactions
+
+### Example 1: Create Crate Skill (Agent Mode)
+
+```
+User: "Create a dynamic skill for tokio"
+
+Claude:
+1. Identify: Third-party crate "tokio"
+2. Execute: /create-llms-for-skills https://docs.rs/tokio/latest/tokio/
+3. Wait for llms.txt generation
+4. Execute: /create-skills-via-llms tokio ~/tmp/{timestamp}-tokio-llms.txt
+```
+
+### Example 2: Create Crate Skill (Inline Mode)
+
+```
+User: "Create a dynamic skill for tokio"
+
+Claude:
+1. Identify: Third-party crate "tokio"
+2. Fetch: agent-browser open "https://docs.rs/tokio/latest/tokio/"
+3. Extract documentation
+4. Create: ~/.claude/skills/tokio/SKILL.md
+5. Create: ~/.claude/skills/tokio/references/
+6. Save reference files for key modules (sync, task, runtime, etc.)
+```
+
+### Example 3: Create Std Library Skill
+
+```
+User: "Create a skill for Send and Sync traits"
+
+Claude:
+1. Identify: Std library traits
+2. (Agent Mode) Execute: /create-llms-for-skills https://doc.rust-lang.org/std/marker/trait.Send.html https://doc.rust-lang.org/std/marker/trait.Sync.html
+   (Inline Mode) Fetch each URL, create skill manually
+3. Complete skill creation
+```
+
+---
+
+## DO NOT
+
+- Use `best-skill-creator` for Rust-related skill creation
+- Guess documentation URLs without verification
+- Skip documentation fetching step
+
+## Output Location
+
+All generated skills are saved to: `~/.claude/skills/`
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Commands not found | Skills-only install | Use inline mode |
+| URL not found | Invalid crate/module | Verify crate exists on crates.io |
+| Empty documentation | API changed | Use alternative selectors |
+| Permission denied | Directory issue | Check ~/.claude/skills/ permissions |

--- a/.agents/skills/rust-skills/AGENTS.md
+++ b/.agents/skills/rust-skills/AGENTS.md
@@ -1,0 +1,335 @@
+---
+name: rust-skills
+description: >
+  Comprehensive Rust coding guidelines with 179 rules across 14 categories.
+  Use when writing, reviewing, or refactoring Rust code. Covers ownership,
+  error handling, async patterns, API design, memory optimization, performance,
+  testing, and common anti-patterns. Invoke with /rust-skills.
+license: MIT
+metadata:
+  author: leonardomso
+  version: "1.0.0"
+  sources:
+    - Rust API Guidelines
+    - Rust Performance Book
+    - ripgrep, tokio, serde, polars codebases
+---
+
+# Rust Best Practices
+
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 179 rules across 14 categories, prioritized by impact to guide LLMs in code generation and refactoring.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new Rust functions, structs, or modules
+- Implementing error handling or async code
+- Designing public APIs for libraries
+- Reviewing code for ownership/borrowing issues
+- Optimizing memory usage or reducing allocations
+- Tuning performance for hot paths
+- Refactoring existing Rust code
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix | Rules |
+|----------|----------|--------|--------|-------|
+| 1 | Ownership & Borrowing | CRITICAL | `own-` | 12 |
+| 2 | Error Handling | CRITICAL | `err-` | 12 |
+| 3 | Memory Optimization | CRITICAL | `mem-` | 15 |
+| 4 | API Design | HIGH | `api-` | 15 |
+| 5 | Async/Await | HIGH | `async-` | 15 |
+| 6 | Compiler Optimization | HIGH | `opt-` | 12 |
+| 7 | Naming Conventions | MEDIUM | `name-` | 16 |
+| 8 | Type Safety | MEDIUM | `type-` | 10 |
+| 9 | Testing | MEDIUM | `test-` | 13 |
+| 10 | Documentation | MEDIUM | `doc-` | 11 |
+| 11 | Performance Patterns | MEDIUM | `perf-` | 11 |
+| 12 | Project Structure | LOW | `proj-` | 11 |
+| 13 | Clippy & Linting | LOW | `lint-` | 11 |
+| 14 | Anti-patterns | REFERENCE | `anti-` | 15 |
+
+---
+
+## Quick Reference
+
+### 1. Ownership & Borrowing (CRITICAL)
+
+- [`own-borrow-over-clone`](rules/own-borrow-over-clone.md) - Prefer `&T` borrowing over `.clone()`
+- [`own-slice-over-vec`](rules/own-slice-over-vec.md) - Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+- [`own-cow-conditional`](rules/own-cow-conditional.md) - Use `Cow<'a, T>` for conditional ownership
+- [`own-arc-shared`](rules/own-arc-shared.md) - Use `Arc<T>` for thread-safe shared ownership
+- [`own-rc-single-thread`](rules/own-rc-single-thread.md) - Use `Rc<T>` for single-threaded sharing
+- [`own-refcell-interior`](rules/own-refcell-interior.md) - Use `RefCell<T>` for interior mutability (single-thread)
+- [`own-mutex-interior`](rules/own-mutex-interior.md) - Use `Mutex<T>` for interior mutability (multi-thread)
+- [`own-rwlock-readers`](rules/own-rwlock-readers.md) - Use `RwLock<T>` when reads dominate writes
+- [`own-copy-small`](rules/own-copy-small.md) - Derive `Copy` for small, trivial types
+- [`own-clone-explicit`](rules/own-clone-explicit.md) - Make `Clone` explicit, avoid implicit copies
+- [`own-move-large`](rules/own-move-large.md) - Move large data instead of cloning
+- [`own-lifetime-elision`](rules/own-lifetime-elision.md) - Rely on lifetime elision when possible
+
+### 2. Error Handling (CRITICAL)
+
+- [`err-thiserror-lib`](rules/err-thiserror-lib.md) - Use `thiserror` for library error types
+- [`err-anyhow-app`](rules/err-anyhow-app.md) - Use `anyhow` for application error handling
+- [`err-result-over-panic`](rules/err-result-over-panic.md) - Return `Result`, don't panic on expected errors
+- [`err-context-chain`](rules/err-context-chain.md) - Add context with `.context()` or `.with_context()`
+- [`err-no-unwrap-prod`](rules/err-no-unwrap-prod.md) - Never use `.unwrap()` in production code
+- [`err-expect-bugs-only`](rules/err-expect-bugs-only.md) - Use `.expect()` only for programming errors
+- [`err-question-mark`](rules/err-question-mark.md) - Use `?` operator for clean propagation
+- [`err-from-impl`](rules/err-from-impl.md) - Use `#[from]` for automatic error conversion
+- [`err-source-chain`](rules/err-source-chain.md) - Use `#[source]` to chain underlying errors
+- [`err-lowercase-msg`](rules/err-lowercase-msg.md) - Error messages: lowercase, no trailing punctuation
+- [`err-doc-errors`](rules/err-doc-errors.md) - Document errors with `# Errors` section
+- [`err-custom-type`](rules/err-custom-type.md) - Create custom error types, not `Box<dyn Error>`
+
+### 3. Memory Optimization (CRITICAL)
+
+- [`mem-with-capacity`](rules/mem-with-capacity.md) - Use `with_capacity()` when size is known
+- [`mem-smallvec`](rules/mem-smallvec.md) - Use `SmallVec` for usually-small collections
+- [`mem-arrayvec`](rules/mem-arrayvec.md) - Use `ArrayVec` for bounded-size collections
+- [`mem-box-large-variant`](rules/mem-box-large-variant.md) - Box large enum variants to reduce type size
+- [`mem-boxed-slice`](rules/mem-boxed-slice.md) - Use `Box<[T]>` instead of `Vec<T>` when fixed
+- [`mem-thinvec`](rules/mem-thinvec.md) - Use `ThinVec` for often-empty vectors
+- [`mem-clone-from`](rules/mem-clone-from.md) - Use `clone_from()` to reuse allocations
+- [`mem-reuse-collections`](rules/mem-reuse-collections.md) - Reuse collections with `clear()` in loops
+- [`mem-avoid-format`](rules/mem-avoid-format.md) - Avoid `format!()` when string literals work
+- [`mem-write-over-format`](rules/mem-write-over-format.md) - Use `write!()` instead of `format!()` 
+- [`mem-arena-allocator`](rules/mem-arena-allocator.md) - Use arena allocators for batch allocations
+- [`mem-zero-copy`](rules/mem-zero-copy.md) - Use zero-copy patterns with slices and `Bytes`
+- [`mem-compact-string`](rules/mem-compact-string.md) - Use `CompactString` for small string optimization
+- [`mem-smaller-integers`](rules/mem-smaller-integers.md) - Use smallest integer type that fits
+- [`mem-assert-type-size`](rules/mem-assert-type-size.md) - Assert hot type sizes to prevent regressions
+
+### 4. API Design (HIGH)
+
+- [`api-builder-pattern`](rules/api-builder-pattern.md) - Use Builder pattern for complex construction
+- [`api-builder-must-use`](rules/api-builder-must-use.md) - Add `#[must_use]` to builder types
+- [`api-newtype-safety`](rules/api-newtype-safety.md) - Use newtypes for type-safe distinctions
+- [`api-typestate`](rules/api-typestate.md) - Use typestate for compile-time state machines
+- [`api-sealed-trait`](rules/api-sealed-trait.md) - Seal traits to prevent external implementations
+- [`api-extension-trait`](rules/api-extension-trait.md) - Use extension traits to add methods to foreign types
+- [`api-parse-dont-validate`](rules/api-parse-dont-validate.md) - Parse into validated types at boundaries
+- [`api-impl-into`](rules/api-impl-into.md) - Accept `impl Into<T>` for flexible string inputs
+- [`api-impl-asref`](rules/api-impl-asref.md) - Accept `impl AsRef<T>` for borrowed inputs
+- [`api-must-use`](rules/api-must-use.md) - Add `#[must_use]` to `Result` returning functions
+- [`api-non-exhaustive`](rules/api-non-exhaustive.md) - Use `#[non_exhaustive]` for future-proof enums/structs
+- [`api-from-not-into`](rules/api-from-not-into.md) - Implement `From`, not `Into` (auto-derived)
+- [`api-default-impl`](rules/api-default-impl.md) - Implement `Default` for sensible defaults
+- [`api-common-traits`](rules/api-common-traits.md) - Implement `Debug`, `Clone`, `PartialEq` eagerly
+- [`api-serde-optional`](rules/api-serde-optional.md) - Gate `Serialize`/`Deserialize` behind feature flag
+
+### 5. Async/Await (HIGH)
+
+- [`async-tokio-runtime`](rules/async-tokio-runtime.md) - Use Tokio for production async runtime
+- [`async-no-lock-await`](rules/async-no-lock-await.md) - Never hold `Mutex`/`RwLock` across `.await`
+- [`async-spawn-blocking`](rules/async-spawn-blocking.md) - Use `spawn_blocking` for CPU-intensive work
+- [`async-tokio-fs`](rules/async-tokio-fs.md) - Use `tokio::fs` not `std::fs` in async code
+- [`async-cancellation-token`](rules/async-cancellation-token.md) - Use `CancellationToken` for graceful shutdown
+- [`async-join-parallel`](rules/async-join-parallel.md) - Use `tokio::join!` for parallel operations
+- [`async-try-join`](rules/async-try-join.md) - Use `tokio::try_join!` for fallible parallel ops
+- [`async-select-racing`](rules/async-select-racing.md) - Use `tokio::select!` for racing/timeouts
+- [`async-bounded-channel`](rules/async-bounded-channel.md) - Use bounded channels for backpressure
+- [`async-mpsc-queue`](rules/async-mpsc-queue.md) - Use `mpsc` for work queues
+- [`async-broadcast-pubsub`](rules/async-broadcast-pubsub.md) - Use `broadcast` for pub/sub patterns
+- [`async-watch-latest`](rules/async-watch-latest.md) - Use `watch` for latest-value sharing
+- [`async-oneshot-response`](rules/async-oneshot-response.md) - Use `oneshot` for request/response
+- [`async-joinset-structured`](rules/async-joinset-structured.md) - Use `JoinSet` for dynamic task groups
+- [`async-clone-before-await`](rules/async-clone-before-await.md) - Clone data before await, release locks
+
+### 6. Compiler Optimization (HIGH)
+
+- [`opt-inline-small`](rules/opt-inline-small.md) - Use `#[inline]` for small hot functions
+- [`opt-inline-always-rare`](rules/opt-inline-always-rare.md) - Use `#[inline(always)]` sparingly
+- [`opt-inline-never-cold`](rules/opt-inline-never-cold.md) - Use `#[inline(never)]` for cold paths
+- [`opt-cold-unlikely`](rules/opt-cold-unlikely.md) - Use `#[cold]` for error/unlikely paths
+- [`opt-likely-hint`](rules/opt-likely-hint.md) - Use `likely()`/`unlikely()` for branch hints
+- [`opt-lto-release`](rules/opt-lto-release.md) - Enable LTO in release builds
+- [`opt-codegen-units`](rules/opt-codegen-units.md) - Use `codegen-units = 1` for max optimization
+- [`opt-pgo-profile`](rules/opt-pgo-profile.md) - Use PGO for production builds
+- [`opt-target-cpu`](rules/opt-target-cpu.md) - Set `target-cpu=native` for local builds
+- [`opt-bounds-check`](rules/opt-bounds-check.md) - Use iterators to avoid bounds checks
+- [`opt-simd-portable`](rules/opt-simd-portable.md) - Use portable SIMD for data-parallel ops
+- [`opt-cache-friendly`](rules/opt-cache-friendly.md) - Design cache-friendly data layouts (SoA)
+
+### 7. Naming Conventions (MEDIUM)
+
+- [`name-types-camel`](rules/name-types-camel.md) - Use `UpperCamelCase` for types, traits, enums
+- [`name-variants-camel`](rules/name-variants-camel.md) - Use `UpperCamelCase` for enum variants
+- [`name-funcs-snake`](rules/name-funcs-snake.md) - Use `snake_case` for functions, methods, modules
+- [`name-consts-screaming`](rules/name-consts-screaming.md) - Use `SCREAMING_SNAKE_CASE` for constants/statics
+- [`name-lifetime-short`](rules/name-lifetime-short.md) - Use short lowercase lifetimes: `'a`, `'de`, `'src`
+- [`name-type-param-single`](rules/name-type-param-single.md) - Use single uppercase for type params: `T`, `E`, `K`, `V`
+- [`name-as-free`](rules/name-as-free.md) - `as_` prefix: free reference conversion
+- [`name-to-expensive`](rules/name-to-expensive.md) - `to_` prefix: expensive conversion
+- [`name-into-ownership`](rules/name-into-ownership.md) - `into_` prefix: ownership transfer
+- [`name-no-get-prefix`](rules/name-no-get-prefix.md) - No `get_` prefix for simple getters
+- [`name-is-has-bool`](rules/name-is-has-bool.md) - Use `is_`, `has_`, `can_` for boolean methods
+- [`name-iter-convention`](rules/name-iter-convention.md) - Use `iter`/`iter_mut`/`into_iter` for iterators
+- [`name-iter-method`](rules/name-iter-method.md) - Name iterator methods consistently
+- [`name-iter-type-match`](rules/name-iter-type-match.md) - Iterator type names match method
+- [`name-acronym-word`](rules/name-acronym-word.md) - Treat acronyms as words: `Uuid` not `UUID`
+- [`name-crate-no-rs`](rules/name-crate-no-rs.md) - Crate names: no `-rs` suffix
+
+### 8. Type Safety (MEDIUM)
+
+- [`type-newtype-ids`](rules/type-newtype-ids.md) - Wrap IDs in newtypes: `UserId(u64)`
+- [`type-newtype-validated`](rules/type-newtype-validated.md) - Newtypes for validated data: `Email`, `Url`
+- [`type-enum-states`](rules/type-enum-states.md) - Use enums for mutually exclusive states
+- [`type-option-nullable`](rules/type-option-nullable.md) - Use `Option<T>` for nullable values
+- [`type-result-fallible`](rules/type-result-fallible.md) - Use `Result<T, E>` for fallible operations
+- [`type-phantom-marker`](rules/type-phantom-marker.md) - Use `PhantomData<T>` for type-level markers
+- [`type-never-diverge`](rules/type-never-diverge.md) - Use `!` type for functions that never return
+- [`type-generic-bounds`](rules/type-generic-bounds.md) - Add trait bounds only where needed
+- [`type-no-stringly`](rules/type-no-stringly.md) - Avoid stringly-typed APIs, use enums/newtypes
+- [`type-repr-transparent`](rules/type-repr-transparent.md) - Use `#[repr(transparent)]` for FFI newtypes
+
+### 9. Testing (MEDIUM)
+
+- [`test-cfg-test-module`](rules/test-cfg-test-module.md) - Use `#[cfg(test)] mod tests { }`
+- [`test-use-super`](rules/test-use-super.md) - Use `use super::*;` in test modules
+- [`test-integration-dir`](rules/test-integration-dir.md) - Put integration tests in `tests/` directory
+- [`test-descriptive-names`](rules/test-descriptive-names.md) - Use descriptive test names
+- [`test-arrange-act-assert`](rules/test-arrange-act-assert.md) - Structure tests as arrange/act/assert
+- [`test-proptest-properties`](rules/test-proptest-properties.md) - Use `proptest` for property-based testing
+- [`test-mockall-mocking`](rules/test-mockall-mocking.md) - Use `mockall` for trait mocking
+- [`test-mock-traits`](rules/test-mock-traits.md) - Use traits for dependencies to enable mocking
+- [`test-fixture-raii`](rules/test-fixture-raii.md) - Use RAII pattern (Drop) for test cleanup
+- [`test-tokio-async`](rules/test-tokio-async.md) - Use `#[tokio::test]` for async tests
+- [`test-should-panic`](rules/test-should-panic.md) - Use `#[should_panic]` for panic tests
+- [`test-criterion-bench`](rules/test-criterion-bench.md) - Use `criterion` for benchmarking
+- [`test-doctest-examples`](rules/test-doctest-examples.md) - Keep doc examples as executable tests
+
+### 10. Documentation (MEDIUM)
+
+- [`doc-all-public`](rules/doc-all-public.md) - Document all public items with `///`
+- [`doc-module-inner`](rules/doc-module-inner.md) - Use `//!` for module-level documentation
+- [`doc-examples-section`](rules/doc-examples-section.md) - Include `# Examples` with runnable code
+- [`doc-errors-section`](rules/doc-errors-section.md) - Include `# Errors` for fallible functions
+- [`doc-panics-section`](rules/doc-panics-section.md) - Include `# Panics` for panicking functions
+- [`doc-safety-section`](rules/doc-safety-section.md) - Include `# Safety` for unsafe functions
+- [`doc-question-mark`](rules/doc-question-mark.md) - Use `?` in examples, not `.unwrap()`
+- [`doc-hidden-setup`](rules/doc-hidden-setup.md) - Use `# ` prefix to hide example setup code
+- [`doc-intra-links`](rules/doc-intra-links.md) - Use intra-doc links: `[Vec]`
+- [`doc-link-types`](rules/doc-link-types.md) - Link related types and functions in docs
+- [`doc-cargo-metadata`](rules/doc-cargo-metadata.md) - Fill `Cargo.toml` metadata
+
+### 11. Performance Patterns (MEDIUM)
+
+- [`perf-iter-over-index`](rules/perf-iter-over-index.md) - Prefer iterators over manual indexing
+- [`perf-iter-lazy`](rules/perf-iter-lazy.md) - Keep iterators lazy, collect() only when needed
+- [`perf-collect-once`](rules/perf-collect-once.md) - Don't `collect()` intermediate iterators
+- [`perf-entry-api`](rules/perf-entry-api.md) - Use `entry()` API for map insert-or-update
+- [`perf-drain-reuse`](rules/perf-drain-reuse.md) - Use `drain()` to reuse allocations
+- [`perf-extend-batch`](rules/perf-extend-batch.md) - Use `extend()` for batch insertions
+- [`perf-chain-avoid`](rules/perf-chain-avoid.md) - Avoid `chain()` in hot loops
+- [`perf-collect-into`](rules/perf-collect-into.md) - Use `collect_into()` for reusing containers
+- [`perf-black-box-bench`](rules/perf-black-box-bench.md) - Use `black_box()` in benchmarks
+- [`perf-release-profile`](rules/perf-release-profile.md) - Optimize release profile settings
+- [`perf-profile-first`](rules/perf-profile-first.md) - Profile before optimizing
+
+### 12. Project Structure (LOW)
+
+- [`proj-lib-main-split`](rules/proj-lib-main-split.md) - Keep `main.rs` minimal, logic in `lib.rs`
+- [`proj-mod-by-feature`](rules/proj-mod-by-feature.md) - Organize modules by feature, not type
+- [`proj-flat-small`](rules/proj-flat-small.md) - Keep small projects flat
+- [`proj-mod-rs-dir`](rules/proj-mod-rs-dir.md) - Use `mod.rs` for multi-file modules
+- [`proj-pub-crate-internal`](rules/proj-pub-crate-internal.md) - Use `pub(crate)` for internal APIs
+- [`proj-pub-super-parent`](rules/proj-pub-super-parent.md) - Use `pub(super)` for parent-only visibility
+- [`proj-pub-use-reexport`](rules/proj-pub-use-reexport.md) - Use `pub use` for clean public API
+- [`proj-prelude-module`](rules/proj-prelude-module.md) - Create `prelude` module for common imports
+- [`proj-bin-dir`](rules/proj-bin-dir.md) - Put multiple binaries in `src/bin/`
+- [`proj-workspace-large`](rules/proj-workspace-large.md) - Use workspaces for large projects
+- [`proj-workspace-deps`](rules/proj-workspace-deps.md) - Use workspace dependency inheritance
+
+### 13. Clippy & Linting (LOW)
+
+- [`lint-deny-correctness`](rules/lint-deny-correctness.md) - `#![deny(clippy::correctness)]`
+- [`lint-warn-suspicious`](rules/lint-warn-suspicious.md) - `#![warn(clippy::suspicious)]`
+- [`lint-warn-style`](rules/lint-warn-style.md) - `#![warn(clippy::style)]`
+- [`lint-warn-complexity`](rules/lint-warn-complexity.md) - `#![warn(clippy::complexity)]`
+- [`lint-warn-perf`](rules/lint-warn-perf.md) - `#![warn(clippy::perf)]`
+- [`lint-pedantic-selective`](rules/lint-pedantic-selective.md) - Enable `clippy::pedantic` selectively
+- [`lint-missing-docs`](rules/lint-missing-docs.md) - `#![warn(missing_docs)]`
+- [`lint-unsafe-doc`](rules/lint-unsafe-doc.md) - `#![warn(clippy::undocumented_unsafe_blocks)]`
+- [`lint-cargo-metadata`](rules/lint-cargo-metadata.md) - `#![warn(clippy::cargo)]` for published crates
+- [`lint-rustfmt-check`](rules/lint-rustfmt-check.md) - Run `cargo fmt --check` in CI
+- [`lint-workspace-lints`](rules/lint-workspace-lints.md) - Configure lints at workspace level
+
+### 14. Anti-patterns (REFERENCE)
+
+- [`anti-unwrap-abuse`](rules/anti-unwrap-abuse.md) - Don't use `.unwrap()` in production code
+- [`anti-expect-lazy`](rules/anti-expect-lazy.md) - Don't use `.expect()` for recoverable errors
+- [`anti-clone-excessive`](rules/anti-clone-excessive.md) - Don't clone when borrowing works
+- [`anti-lock-across-await`](rules/anti-lock-across-await.md) - Don't hold locks across `.await`
+- [`anti-string-for-str`](rules/anti-string-for-str.md) - Don't accept `&String` when `&str` works
+- [`anti-vec-for-slice`](rules/anti-vec-for-slice.md) - Don't accept `&Vec<T>` when `&[T]` works
+- [`anti-index-over-iter`](rules/anti-index-over-iter.md) - Don't use indexing when iterators work
+- [`anti-panic-expected`](rules/anti-panic-expected.md) - Don't panic on expected/recoverable errors
+- [`anti-empty-catch`](rules/anti-empty-catch.md) - Don't use empty `if let Err(_) = ...` blocks
+- [`anti-over-abstraction`](rules/anti-over-abstraction.md) - Don't over-abstract with excessive generics
+- [`anti-premature-optimize`](rules/anti-premature-optimize.md) - Don't optimize before profiling
+- [`anti-type-erasure`](rules/anti-type-erasure.md) - Don't use `Box<dyn Trait>` when `impl Trait` works
+- [`anti-format-hot-path`](rules/anti-format-hot-path.md) - Don't use `format!()` in hot paths
+- [`anti-collect-intermediate`](rules/anti-collect-intermediate.md) - Don't `collect()` intermediate iterators
+- [`anti-stringly-typed`](rules/anti-stringly-typed.md) - Don't use strings for structured data
+
+---
+
+## Recommended Cargo.toml Settings
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3  # Optimize dependencies in dev
+```
+
+---
+
+## How to Use
+
+This skill provides rule identifiers for quick reference. When generating or reviewing Rust code:
+
+1. **Check relevant category** based on task type
+2. **Apply rules** with matching prefix
+3. **Prioritize** CRITICAL > HIGH > MEDIUM > LOW
+4. **Read rule files** in `rules/` for detailed examples
+
+### Rule Application by Task
+
+| Task | Primary Categories |
+|------|-------------------|
+| New function | `own-`, `err-`, `name-` |
+| New struct/API | `api-`, `type-`, `doc-` |
+| Async code | `async-`, `own-` |
+| Error handling | `err-`, `api-` |
+| Memory optimization | `mem-`, `own-`, `perf-` |
+| Performance tuning | `opt-`, `mem-`, `perf-` |
+| Code review | `anti-`, `lint-` |
+
+---
+
+## Sources
+
+This skill synthesizes best practices from:
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Production codebases: ripgrep, tokio, serde, polars, axum, deno
+- Clippy lint documentation
+- Community conventions (2024-2025)

--- a/.agents/skills/rust-skills/CLAUDE.md
+++ b/.agents/skills/rust-skills/CLAUDE.md
@@ -1,0 +1,335 @@
+---
+name: rust-skills
+description: >
+  Comprehensive Rust coding guidelines with 179 rules across 14 categories.
+  Use when writing, reviewing, or refactoring Rust code. Covers ownership,
+  error handling, async patterns, API design, memory optimization, performance,
+  testing, and common anti-patterns. Invoke with /rust-skills.
+license: MIT
+metadata:
+  author: leonardomso
+  version: "1.0.0"
+  sources:
+    - Rust API Guidelines
+    - Rust Performance Book
+    - ripgrep, tokio, serde, polars codebases
+---
+
+# Rust Best Practices
+
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 179 rules across 14 categories, prioritized by impact to guide LLMs in code generation and refactoring.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new Rust functions, structs, or modules
+- Implementing error handling or async code
+- Designing public APIs for libraries
+- Reviewing code for ownership/borrowing issues
+- Optimizing memory usage or reducing allocations
+- Tuning performance for hot paths
+- Refactoring existing Rust code
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix | Rules |
+|----------|----------|--------|--------|-------|
+| 1 | Ownership & Borrowing | CRITICAL | `own-` | 12 |
+| 2 | Error Handling | CRITICAL | `err-` | 12 |
+| 3 | Memory Optimization | CRITICAL | `mem-` | 15 |
+| 4 | API Design | HIGH | `api-` | 15 |
+| 5 | Async/Await | HIGH | `async-` | 15 |
+| 6 | Compiler Optimization | HIGH | `opt-` | 12 |
+| 7 | Naming Conventions | MEDIUM | `name-` | 16 |
+| 8 | Type Safety | MEDIUM | `type-` | 10 |
+| 9 | Testing | MEDIUM | `test-` | 13 |
+| 10 | Documentation | MEDIUM | `doc-` | 11 |
+| 11 | Performance Patterns | MEDIUM | `perf-` | 11 |
+| 12 | Project Structure | LOW | `proj-` | 11 |
+| 13 | Clippy & Linting | LOW | `lint-` | 11 |
+| 14 | Anti-patterns | REFERENCE | `anti-` | 15 |
+
+---
+
+## Quick Reference
+
+### 1. Ownership & Borrowing (CRITICAL)
+
+- [`own-borrow-over-clone`](rules/own-borrow-over-clone.md) - Prefer `&T` borrowing over `.clone()`
+- [`own-slice-over-vec`](rules/own-slice-over-vec.md) - Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+- [`own-cow-conditional`](rules/own-cow-conditional.md) - Use `Cow<'a, T>` for conditional ownership
+- [`own-arc-shared`](rules/own-arc-shared.md) - Use `Arc<T>` for thread-safe shared ownership
+- [`own-rc-single-thread`](rules/own-rc-single-thread.md) - Use `Rc<T>` for single-threaded sharing
+- [`own-refcell-interior`](rules/own-refcell-interior.md) - Use `RefCell<T>` for interior mutability (single-thread)
+- [`own-mutex-interior`](rules/own-mutex-interior.md) - Use `Mutex<T>` for interior mutability (multi-thread)
+- [`own-rwlock-readers`](rules/own-rwlock-readers.md) - Use `RwLock<T>` when reads dominate writes
+- [`own-copy-small`](rules/own-copy-small.md) - Derive `Copy` for small, trivial types
+- [`own-clone-explicit`](rules/own-clone-explicit.md) - Make `Clone` explicit, avoid implicit copies
+- [`own-move-large`](rules/own-move-large.md) - Move large data instead of cloning
+- [`own-lifetime-elision`](rules/own-lifetime-elision.md) - Rely on lifetime elision when possible
+
+### 2. Error Handling (CRITICAL)
+
+- [`err-thiserror-lib`](rules/err-thiserror-lib.md) - Use `thiserror` for library error types
+- [`err-anyhow-app`](rules/err-anyhow-app.md) - Use `anyhow` for application error handling
+- [`err-result-over-panic`](rules/err-result-over-panic.md) - Return `Result`, don't panic on expected errors
+- [`err-context-chain`](rules/err-context-chain.md) - Add context with `.context()` or `.with_context()`
+- [`err-no-unwrap-prod`](rules/err-no-unwrap-prod.md) - Never use `.unwrap()` in production code
+- [`err-expect-bugs-only`](rules/err-expect-bugs-only.md) - Use `.expect()` only for programming errors
+- [`err-question-mark`](rules/err-question-mark.md) - Use `?` operator for clean propagation
+- [`err-from-impl`](rules/err-from-impl.md) - Use `#[from]` for automatic error conversion
+- [`err-source-chain`](rules/err-source-chain.md) - Use `#[source]` to chain underlying errors
+- [`err-lowercase-msg`](rules/err-lowercase-msg.md) - Error messages: lowercase, no trailing punctuation
+- [`err-doc-errors`](rules/err-doc-errors.md) - Document errors with `# Errors` section
+- [`err-custom-type`](rules/err-custom-type.md) - Create custom error types, not `Box<dyn Error>`
+
+### 3. Memory Optimization (CRITICAL)
+
+- [`mem-with-capacity`](rules/mem-with-capacity.md) - Use `with_capacity()` when size is known
+- [`mem-smallvec`](rules/mem-smallvec.md) - Use `SmallVec` for usually-small collections
+- [`mem-arrayvec`](rules/mem-arrayvec.md) - Use `ArrayVec` for bounded-size collections
+- [`mem-box-large-variant`](rules/mem-box-large-variant.md) - Box large enum variants to reduce type size
+- [`mem-boxed-slice`](rules/mem-boxed-slice.md) - Use `Box<[T]>` instead of `Vec<T>` when fixed
+- [`mem-thinvec`](rules/mem-thinvec.md) - Use `ThinVec` for often-empty vectors
+- [`mem-clone-from`](rules/mem-clone-from.md) - Use `clone_from()` to reuse allocations
+- [`mem-reuse-collections`](rules/mem-reuse-collections.md) - Reuse collections with `clear()` in loops
+- [`mem-avoid-format`](rules/mem-avoid-format.md) - Avoid `format!()` when string literals work
+- [`mem-write-over-format`](rules/mem-write-over-format.md) - Use `write!()` instead of `format!()` 
+- [`mem-arena-allocator`](rules/mem-arena-allocator.md) - Use arena allocators for batch allocations
+- [`mem-zero-copy`](rules/mem-zero-copy.md) - Use zero-copy patterns with slices and `Bytes`
+- [`mem-compact-string`](rules/mem-compact-string.md) - Use `CompactString` for small string optimization
+- [`mem-smaller-integers`](rules/mem-smaller-integers.md) - Use smallest integer type that fits
+- [`mem-assert-type-size`](rules/mem-assert-type-size.md) - Assert hot type sizes to prevent regressions
+
+### 4. API Design (HIGH)
+
+- [`api-builder-pattern`](rules/api-builder-pattern.md) - Use Builder pattern for complex construction
+- [`api-builder-must-use`](rules/api-builder-must-use.md) - Add `#[must_use]` to builder types
+- [`api-newtype-safety`](rules/api-newtype-safety.md) - Use newtypes for type-safe distinctions
+- [`api-typestate`](rules/api-typestate.md) - Use typestate for compile-time state machines
+- [`api-sealed-trait`](rules/api-sealed-trait.md) - Seal traits to prevent external implementations
+- [`api-extension-trait`](rules/api-extension-trait.md) - Use extension traits to add methods to foreign types
+- [`api-parse-dont-validate`](rules/api-parse-dont-validate.md) - Parse into validated types at boundaries
+- [`api-impl-into`](rules/api-impl-into.md) - Accept `impl Into<T>` for flexible string inputs
+- [`api-impl-asref`](rules/api-impl-asref.md) - Accept `impl AsRef<T>` for borrowed inputs
+- [`api-must-use`](rules/api-must-use.md) - Add `#[must_use]` to `Result` returning functions
+- [`api-non-exhaustive`](rules/api-non-exhaustive.md) - Use `#[non_exhaustive]` for future-proof enums/structs
+- [`api-from-not-into`](rules/api-from-not-into.md) - Implement `From`, not `Into` (auto-derived)
+- [`api-default-impl`](rules/api-default-impl.md) - Implement `Default` for sensible defaults
+- [`api-common-traits`](rules/api-common-traits.md) - Implement `Debug`, `Clone`, `PartialEq` eagerly
+- [`api-serde-optional`](rules/api-serde-optional.md) - Gate `Serialize`/`Deserialize` behind feature flag
+
+### 5. Async/Await (HIGH)
+
+- [`async-tokio-runtime`](rules/async-tokio-runtime.md) - Use Tokio for production async runtime
+- [`async-no-lock-await`](rules/async-no-lock-await.md) - Never hold `Mutex`/`RwLock` across `.await`
+- [`async-spawn-blocking`](rules/async-spawn-blocking.md) - Use `spawn_blocking` for CPU-intensive work
+- [`async-tokio-fs`](rules/async-tokio-fs.md) - Use `tokio::fs` not `std::fs` in async code
+- [`async-cancellation-token`](rules/async-cancellation-token.md) - Use `CancellationToken` for graceful shutdown
+- [`async-join-parallel`](rules/async-join-parallel.md) - Use `tokio::join!` for parallel operations
+- [`async-try-join`](rules/async-try-join.md) - Use `tokio::try_join!` for fallible parallel ops
+- [`async-select-racing`](rules/async-select-racing.md) - Use `tokio::select!` for racing/timeouts
+- [`async-bounded-channel`](rules/async-bounded-channel.md) - Use bounded channels for backpressure
+- [`async-mpsc-queue`](rules/async-mpsc-queue.md) - Use `mpsc` for work queues
+- [`async-broadcast-pubsub`](rules/async-broadcast-pubsub.md) - Use `broadcast` for pub/sub patterns
+- [`async-watch-latest`](rules/async-watch-latest.md) - Use `watch` for latest-value sharing
+- [`async-oneshot-response`](rules/async-oneshot-response.md) - Use `oneshot` for request/response
+- [`async-joinset-structured`](rules/async-joinset-structured.md) - Use `JoinSet` for dynamic task groups
+- [`async-clone-before-await`](rules/async-clone-before-await.md) - Clone data before await, release locks
+
+### 6. Compiler Optimization (HIGH)
+
+- [`opt-inline-small`](rules/opt-inline-small.md) - Use `#[inline]` for small hot functions
+- [`opt-inline-always-rare`](rules/opt-inline-always-rare.md) - Use `#[inline(always)]` sparingly
+- [`opt-inline-never-cold`](rules/opt-inline-never-cold.md) - Use `#[inline(never)]` for cold paths
+- [`opt-cold-unlikely`](rules/opt-cold-unlikely.md) - Use `#[cold]` for error/unlikely paths
+- [`opt-likely-hint`](rules/opt-likely-hint.md) - Use `likely()`/`unlikely()` for branch hints
+- [`opt-lto-release`](rules/opt-lto-release.md) - Enable LTO in release builds
+- [`opt-codegen-units`](rules/opt-codegen-units.md) - Use `codegen-units = 1` for max optimization
+- [`opt-pgo-profile`](rules/opt-pgo-profile.md) - Use PGO for production builds
+- [`opt-target-cpu`](rules/opt-target-cpu.md) - Set `target-cpu=native` for local builds
+- [`opt-bounds-check`](rules/opt-bounds-check.md) - Use iterators to avoid bounds checks
+- [`opt-simd-portable`](rules/opt-simd-portable.md) - Use portable SIMD for data-parallel ops
+- [`opt-cache-friendly`](rules/opt-cache-friendly.md) - Design cache-friendly data layouts (SoA)
+
+### 7. Naming Conventions (MEDIUM)
+
+- [`name-types-camel`](rules/name-types-camel.md) - Use `UpperCamelCase` for types, traits, enums
+- [`name-variants-camel`](rules/name-variants-camel.md) - Use `UpperCamelCase` for enum variants
+- [`name-funcs-snake`](rules/name-funcs-snake.md) - Use `snake_case` for functions, methods, modules
+- [`name-consts-screaming`](rules/name-consts-screaming.md) - Use `SCREAMING_SNAKE_CASE` for constants/statics
+- [`name-lifetime-short`](rules/name-lifetime-short.md) - Use short lowercase lifetimes: `'a`, `'de`, `'src`
+- [`name-type-param-single`](rules/name-type-param-single.md) - Use single uppercase for type params: `T`, `E`, `K`, `V`
+- [`name-as-free`](rules/name-as-free.md) - `as_` prefix: free reference conversion
+- [`name-to-expensive`](rules/name-to-expensive.md) - `to_` prefix: expensive conversion
+- [`name-into-ownership`](rules/name-into-ownership.md) - `into_` prefix: ownership transfer
+- [`name-no-get-prefix`](rules/name-no-get-prefix.md) - No `get_` prefix for simple getters
+- [`name-is-has-bool`](rules/name-is-has-bool.md) - Use `is_`, `has_`, `can_` for boolean methods
+- [`name-iter-convention`](rules/name-iter-convention.md) - Use `iter`/`iter_mut`/`into_iter` for iterators
+- [`name-iter-method`](rules/name-iter-method.md) - Name iterator methods consistently
+- [`name-iter-type-match`](rules/name-iter-type-match.md) - Iterator type names match method
+- [`name-acronym-word`](rules/name-acronym-word.md) - Treat acronyms as words: `Uuid` not `UUID`
+- [`name-crate-no-rs`](rules/name-crate-no-rs.md) - Crate names: no `-rs` suffix
+
+### 8. Type Safety (MEDIUM)
+
+- [`type-newtype-ids`](rules/type-newtype-ids.md) - Wrap IDs in newtypes: `UserId(u64)`
+- [`type-newtype-validated`](rules/type-newtype-validated.md) - Newtypes for validated data: `Email`, `Url`
+- [`type-enum-states`](rules/type-enum-states.md) - Use enums for mutually exclusive states
+- [`type-option-nullable`](rules/type-option-nullable.md) - Use `Option<T>` for nullable values
+- [`type-result-fallible`](rules/type-result-fallible.md) - Use `Result<T, E>` for fallible operations
+- [`type-phantom-marker`](rules/type-phantom-marker.md) - Use `PhantomData<T>` for type-level markers
+- [`type-never-diverge`](rules/type-never-diverge.md) - Use `!` type for functions that never return
+- [`type-generic-bounds`](rules/type-generic-bounds.md) - Add trait bounds only where needed
+- [`type-no-stringly`](rules/type-no-stringly.md) - Avoid stringly-typed APIs, use enums/newtypes
+- [`type-repr-transparent`](rules/type-repr-transparent.md) - Use `#[repr(transparent)]` for FFI newtypes
+
+### 9. Testing (MEDIUM)
+
+- [`test-cfg-test-module`](rules/test-cfg-test-module.md) - Use `#[cfg(test)] mod tests { }`
+- [`test-use-super`](rules/test-use-super.md) - Use `use super::*;` in test modules
+- [`test-integration-dir`](rules/test-integration-dir.md) - Put integration tests in `tests/` directory
+- [`test-descriptive-names`](rules/test-descriptive-names.md) - Use descriptive test names
+- [`test-arrange-act-assert`](rules/test-arrange-act-assert.md) - Structure tests as arrange/act/assert
+- [`test-proptest-properties`](rules/test-proptest-properties.md) - Use `proptest` for property-based testing
+- [`test-mockall-mocking`](rules/test-mockall-mocking.md) - Use `mockall` for trait mocking
+- [`test-mock-traits`](rules/test-mock-traits.md) - Use traits for dependencies to enable mocking
+- [`test-fixture-raii`](rules/test-fixture-raii.md) - Use RAII pattern (Drop) for test cleanup
+- [`test-tokio-async`](rules/test-tokio-async.md) - Use `#[tokio::test]` for async tests
+- [`test-should-panic`](rules/test-should-panic.md) - Use `#[should_panic]` for panic tests
+- [`test-criterion-bench`](rules/test-criterion-bench.md) - Use `criterion` for benchmarking
+- [`test-doctest-examples`](rules/test-doctest-examples.md) - Keep doc examples as executable tests
+
+### 10. Documentation (MEDIUM)
+
+- [`doc-all-public`](rules/doc-all-public.md) - Document all public items with `///`
+- [`doc-module-inner`](rules/doc-module-inner.md) - Use `//!` for module-level documentation
+- [`doc-examples-section`](rules/doc-examples-section.md) - Include `# Examples` with runnable code
+- [`doc-errors-section`](rules/doc-errors-section.md) - Include `# Errors` for fallible functions
+- [`doc-panics-section`](rules/doc-panics-section.md) - Include `# Panics` for panicking functions
+- [`doc-safety-section`](rules/doc-safety-section.md) - Include `# Safety` for unsafe functions
+- [`doc-question-mark`](rules/doc-question-mark.md) - Use `?` in examples, not `.unwrap()`
+- [`doc-hidden-setup`](rules/doc-hidden-setup.md) - Use `# ` prefix to hide example setup code
+- [`doc-intra-links`](rules/doc-intra-links.md) - Use intra-doc links: `[Vec]`
+- [`doc-link-types`](rules/doc-link-types.md) - Link related types and functions in docs
+- [`doc-cargo-metadata`](rules/doc-cargo-metadata.md) - Fill `Cargo.toml` metadata
+
+### 11. Performance Patterns (MEDIUM)
+
+- [`perf-iter-over-index`](rules/perf-iter-over-index.md) - Prefer iterators over manual indexing
+- [`perf-iter-lazy`](rules/perf-iter-lazy.md) - Keep iterators lazy, collect() only when needed
+- [`perf-collect-once`](rules/perf-collect-once.md) - Don't `collect()` intermediate iterators
+- [`perf-entry-api`](rules/perf-entry-api.md) - Use `entry()` API for map insert-or-update
+- [`perf-drain-reuse`](rules/perf-drain-reuse.md) - Use `drain()` to reuse allocations
+- [`perf-extend-batch`](rules/perf-extend-batch.md) - Use `extend()` for batch insertions
+- [`perf-chain-avoid`](rules/perf-chain-avoid.md) - Avoid `chain()` in hot loops
+- [`perf-collect-into`](rules/perf-collect-into.md) - Use `collect_into()` for reusing containers
+- [`perf-black-box-bench`](rules/perf-black-box-bench.md) - Use `black_box()` in benchmarks
+- [`perf-release-profile`](rules/perf-release-profile.md) - Optimize release profile settings
+- [`perf-profile-first`](rules/perf-profile-first.md) - Profile before optimizing
+
+### 12. Project Structure (LOW)
+
+- [`proj-lib-main-split`](rules/proj-lib-main-split.md) - Keep `main.rs` minimal, logic in `lib.rs`
+- [`proj-mod-by-feature`](rules/proj-mod-by-feature.md) - Organize modules by feature, not type
+- [`proj-flat-small`](rules/proj-flat-small.md) - Keep small projects flat
+- [`proj-mod-rs-dir`](rules/proj-mod-rs-dir.md) - Use `mod.rs` for multi-file modules
+- [`proj-pub-crate-internal`](rules/proj-pub-crate-internal.md) - Use `pub(crate)` for internal APIs
+- [`proj-pub-super-parent`](rules/proj-pub-super-parent.md) - Use `pub(super)` for parent-only visibility
+- [`proj-pub-use-reexport`](rules/proj-pub-use-reexport.md) - Use `pub use` for clean public API
+- [`proj-prelude-module`](rules/proj-prelude-module.md) - Create `prelude` module for common imports
+- [`proj-bin-dir`](rules/proj-bin-dir.md) - Put multiple binaries in `src/bin/`
+- [`proj-workspace-large`](rules/proj-workspace-large.md) - Use workspaces for large projects
+- [`proj-workspace-deps`](rules/proj-workspace-deps.md) - Use workspace dependency inheritance
+
+### 13. Clippy & Linting (LOW)
+
+- [`lint-deny-correctness`](rules/lint-deny-correctness.md) - `#![deny(clippy::correctness)]`
+- [`lint-warn-suspicious`](rules/lint-warn-suspicious.md) - `#![warn(clippy::suspicious)]`
+- [`lint-warn-style`](rules/lint-warn-style.md) - `#![warn(clippy::style)]`
+- [`lint-warn-complexity`](rules/lint-warn-complexity.md) - `#![warn(clippy::complexity)]`
+- [`lint-warn-perf`](rules/lint-warn-perf.md) - `#![warn(clippy::perf)]`
+- [`lint-pedantic-selective`](rules/lint-pedantic-selective.md) - Enable `clippy::pedantic` selectively
+- [`lint-missing-docs`](rules/lint-missing-docs.md) - `#![warn(missing_docs)]`
+- [`lint-unsafe-doc`](rules/lint-unsafe-doc.md) - `#![warn(clippy::undocumented_unsafe_blocks)]`
+- [`lint-cargo-metadata`](rules/lint-cargo-metadata.md) - `#![warn(clippy::cargo)]` for published crates
+- [`lint-rustfmt-check`](rules/lint-rustfmt-check.md) - Run `cargo fmt --check` in CI
+- [`lint-workspace-lints`](rules/lint-workspace-lints.md) - Configure lints at workspace level
+
+### 14. Anti-patterns (REFERENCE)
+
+- [`anti-unwrap-abuse`](rules/anti-unwrap-abuse.md) - Don't use `.unwrap()` in production code
+- [`anti-expect-lazy`](rules/anti-expect-lazy.md) - Don't use `.expect()` for recoverable errors
+- [`anti-clone-excessive`](rules/anti-clone-excessive.md) - Don't clone when borrowing works
+- [`anti-lock-across-await`](rules/anti-lock-across-await.md) - Don't hold locks across `.await`
+- [`anti-string-for-str`](rules/anti-string-for-str.md) - Don't accept `&String` when `&str` works
+- [`anti-vec-for-slice`](rules/anti-vec-for-slice.md) - Don't accept `&Vec<T>` when `&[T]` works
+- [`anti-index-over-iter`](rules/anti-index-over-iter.md) - Don't use indexing when iterators work
+- [`anti-panic-expected`](rules/anti-panic-expected.md) - Don't panic on expected/recoverable errors
+- [`anti-empty-catch`](rules/anti-empty-catch.md) - Don't use empty `if let Err(_) = ...` blocks
+- [`anti-over-abstraction`](rules/anti-over-abstraction.md) - Don't over-abstract with excessive generics
+- [`anti-premature-optimize`](rules/anti-premature-optimize.md) - Don't optimize before profiling
+- [`anti-type-erasure`](rules/anti-type-erasure.md) - Don't use `Box<dyn Trait>` when `impl Trait` works
+- [`anti-format-hot-path`](rules/anti-format-hot-path.md) - Don't use `format!()` in hot paths
+- [`anti-collect-intermediate`](rules/anti-collect-intermediate.md) - Don't `collect()` intermediate iterators
+- [`anti-stringly-typed`](rules/anti-stringly-typed.md) - Don't use strings for structured data
+
+---
+
+## Recommended Cargo.toml Settings
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3  # Optimize dependencies in dev
+```
+
+---
+
+## How to Use
+
+This skill provides rule identifiers for quick reference. When generating or reviewing Rust code:
+
+1. **Check relevant category** based on task type
+2. **Apply rules** with matching prefix
+3. **Prioritize** CRITICAL > HIGH > MEDIUM > LOW
+4. **Read rule files** in `rules/` for detailed examples
+
+### Rule Application by Task
+
+| Task | Primary Categories |
+|------|-------------------|
+| New function | `own-`, `err-`, `name-` |
+| New struct/API | `api-`, `type-`, `doc-` |
+| Async code | `async-`, `own-` |
+| Error handling | `err-`, `api-` |
+| Memory optimization | `mem-`, `own-`, `perf-` |
+| Performance tuning | `opt-`, `mem-`, `perf-` |
+| Code review | `anti-`, `lint-` |
+
+---
+
+## Sources
+
+This skill synthesizes best practices from:
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Production codebases: ripgrep, tokio, serde, polars, axum, deno
+- Clippy lint documentation
+- Community conventions (2024-2025)

--- a/.agents/skills/rust-skills/LICENSE
+++ b/.agents/skills/rust-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Leonardo Maldonado
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/rust-skills/README.md
+++ b/.agents/skills/rust-skills/README.md
@@ -1,0 +1,196 @@
+# Rust Skills
+
+179 Rust rules your AI coding agent can use to write better code.
+
+Works with Claude Code, Cursor, Windsurf, Copilot, Codex, Aider, Zed, Amp, Cline, and pretty much any other agent that supports skills.
+
+## Install
+
+```bash
+npx add-skill leonardomso/rust-skills
+```
+
+That's it. The CLI figures out which agents you have and installs the skill to the right place.
+
+## How to use it
+
+After installing, just ask your agent:
+
+```
+/rust-skills review this function
+```
+
+```
+/rust-skills is my error handling idiomatic?
+```
+
+```
+/rust-skills check for memory issues
+```
+
+The agent loads the relevant rules and applies them to your code.
+
+## What's in here
+
+179 rules split into 14 categories:
+
+| Category | Rules | What it covers |
+|----------|-------|----------------|
+| **Ownership & Borrowing** | 12 | When to borrow vs clone, Arc/Rc, lifetimes |
+| **Error Handling** | 12 | thiserror for libs, anyhow for apps, the `?` operator |
+| **Memory** | 15 | SmallVec, arenas, avoiding allocations |
+| **API Design** | 15 | Builder pattern, newtypes, sealed traits |
+| **Async** | 15 | Tokio patterns, channels, spawn_blocking |
+| **Optimization** | 12 | LTO, inlining, PGO, SIMD |
+| **Naming** | 16 | Following Rust API Guidelines |
+| **Type Safety** | 10 | Newtypes, parse don't validate |
+| **Testing** | 13 | Proptest, mockall, criterion |
+| **Docs** | 11 | Doc examples, intra-doc links |
+| **Performance** | 11 | Iterators, entry API, collect patterns |
+| **Project Structure** | 11 | Workspaces, module layout |
+| **Linting** | 11 | Clippy config, CI setup |
+| **Anti-patterns** | 15 | Common mistakes and how to fix them |
+
+Each rule has:
+- Why it matters
+- Bad code example
+- Good code example
+- Links to official docs when relevant
+
+## Manual install
+
+If `add-skill` doesn't work for your setup, here's how to install manually:
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+Global (applies to all projects):
+```bash
+git clone https://github.com/leonardomso/rust-skills.git ~/.claude/skills/rust-skills
+```
+
+Or just for one project:
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .claude/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>OpenCode</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .opencode/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .cursor/skills/rust-skills
+```
+
+Or just grab the skill file:
+```bash
+curl -o .cursorrules https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+```bash
+mkdir -p .windsurf/rules
+curl -o .windsurf/rules/rust-skills.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>OpenAI Codex</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .codex/skills/rust-skills
+```
+
+Or use the AGENTS.md standard:
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>GitHub Copilot</b></summary>
+
+```bash
+mkdir -p .github
+curl -o .github/copilot-instructions.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Aider</b></summary>
+
+Add to `.aider.conf.yml`:
+```yaml
+read: path/to/rust-skills/SKILL.md
+```
+
+Or pass it directly:
+```bash
+aider --read path/to/rust-skills/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Zed</b></summary>
+
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Amp</b></summary>
+
+```bash
+git clone https://github.com/leonardomso/rust-skills.git .agents/skills/rust-skills
+```
+</details>
+
+<details>
+<summary><b>Cline / Roo Code</b></summary>
+
+```bash
+mkdir -p .clinerules
+curl -o .clinerules/rust-skills.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+<details>
+<summary><b>Other agents (AGENTS.md)</b></summary>
+
+If your agent supports the [AGENTS.md](https://agents.md) standard:
+```bash
+curl -o AGENTS.md https://raw.githubusercontent.com/leonardomso/rust-skills/master/SKILL.md
+```
+</details>
+
+## All rules
+
+See [SKILL.md](./SKILL.md) for the full list with links to each rule file.
+
+## Where these rules come from
+
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Real code from ripgrep, tokio, serde, polars, axum
+- Clippy docs
+
+## Contributing
+
+PRs welcome. Just follow the format of existing rules.
+
+## License
+
+MIT

--- a/.agents/skills/rust-skills/SKILL.md
+++ b/.agents/skills/rust-skills/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: rust-skills
+description: >
+  Comprehensive Rust coding guidelines with 179 rules across 14 categories.
+  Use when writing, reviewing, or refactoring Rust code. Covers ownership,
+  error handling, async patterns, API design, memory optimization, performance,
+  testing, and common anti-patterns. Invoke with /rust-skills.
+license: MIT
+metadata:
+  author: leonardomso
+  version: "1.0.0"
+  sources:
+    - Rust API Guidelines
+    - Rust Performance Book
+    - ripgrep, tokio, serde, polars codebases
+---
+
+# Rust Best Practices
+
+Comprehensive guide for writing high-quality, idiomatic, and highly optimized Rust code. Contains 179 rules across 14 categories, prioritized by impact to guide LLMs in code generation and refactoring.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing new Rust functions, structs, or modules
+- Implementing error handling or async code
+- Designing public APIs for libraries
+- Reviewing code for ownership/borrowing issues
+- Optimizing memory usage or reducing allocations
+- Tuning performance for hot paths
+- Refactoring existing Rust code
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix | Rules |
+|----------|----------|--------|--------|-------|
+| 1 | Ownership & Borrowing | CRITICAL | `own-` | 12 |
+| 2 | Error Handling | CRITICAL | `err-` | 12 |
+| 3 | Memory Optimization | CRITICAL | `mem-` | 15 |
+| 4 | API Design | HIGH | `api-` | 15 |
+| 5 | Async/Await | HIGH | `async-` | 15 |
+| 6 | Compiler Optimization | HIGH | `opt-` | 12 |
+| 7 | Naming Conventions | MEDIUM | `name-` | 16 |
+| 8 | Type Safety | MEDIUM | `type-` | 10 |
+| 9 | Testing | MEDIUM | `test-` | 13 |
+| 10 | Documentation | MEDIUM | `doc-` | 11 |
+| 11 | Performance Patterns | MEDIUM | `perf-` | 11 |
+| 12 | Project Structure | LOW | `proj-` | 11 |
+| 13 | Clippy & Linting | LOW | `lint-` | 11 |
+| 14 | Anti-patterns | REFERENCE | `anti-` | 15 |
+
+---
+
+## Quick Reference
+
+### 1. Ownership & Borrowing (CRITICAL)
+
+- [`own-borrow-over-clone`](rules/own-borrow-over-clone.md) - Prefer `&T` borrowing over `.clone()`
+- [`own-slice-over-vec`](rules/own-slice-over-vec.md) - Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+- [`own-cow-conditional`](rules/own-cow-conditional.md) - Use `Cow<'a, T>` for conditional ownership
+- [`own-arc-shared`](rules/own-arc-shared.md) - Use `Arc<T>` for thread-safe shared ownership
+- [`own-rc-single-thread`](rules/own-rc-single-thread.md) - Use `Rc<T>` for single-threaded sharing
+- [`own-refcell-interior`](rules/own-refcell-interior.md) - Use `RefCell<T>` for interior mutability (single-thread)
+- [`own-mutex-interior`](rules/own-mutex-interior.md) - Use `Mutex<T>` for interior mutability (multi-thread)
+- [`own-rwlock-readers`](rules/own-rwlock-readers.md) - Use `RwLock<T>` when reads dominate writes
+- [`own-copy-small`](rules/own-copy-small.md) - Derive `Copy` for small, trivial types
+- [`own-clone-explicit`](rules/own-clone-explicit.md) - Make `Clone` explicit, avoid implicit copies
+- [`own-move-large`](rules/own-move-large.md) - Move large data instead of cloning
+- [`own-lifetime-elision`](rules/own-lifetime-elision.md) - Rely on lifetime elision when possible
+
+### 2. Error Handling (CRITICAL)
+
+- [`err-thiserror-lib`](rules/err-thiserror-lib.md) - Use `thiserror` for library error types
+- [`err-anyhow-app`](rules/err-anyhow-app.md) - Use `anyhow` for application error handling
+- [`err-result-over-panic`](rules/err-result-over-panic.md) - Return `Result`, don't panic on expected errors
+- [`err-context-chain`](rules/err-context-chain.md) - Add context with `.context()` or `.with_context()`
+- [`err-no-unwrap-prod`](rules/err-no-unwrap-prod.md) - Never use `.unwrap()` in production code
+- [`err-expect-bugs-only`](rules/err-expect-bugs-only.md) - Use `.expect()` only for programming errors
+- [`err-question-mark`](rules/err-question-mark.md) - Use `?` operator for clean propagation
+- [`err-from-impl`](rules/err-from-impl.md) - Use `#[from]` for automatic error conversion
+- [`err-source-chain`](rules/err-source-chain.md) - Use `#[source]` to chain underlying errors
+- [`err-lowercase-msg`](rules/err-lowercase-msg.md) - Error messages: lowercase, no trailing punctuation
+- [`err-doc-errors`](rules/err-doc-errors.md) - Document errors with `# Errors` section
+- [`err-custom-type`](rules/err-custom-type.md) - Create custom error types, not `Box<dyn Error>`
+
+### 3. Memory Optimization (CRITICAL)
+
+- [`mem-with-capacity`](rules/mem-with-capacity.md) - Use `with_capacity()` when size is known
+- [`mem-smallvec`](rules/mem-smallvec.md) - Use `SmallVec` for usually-small collections
+- [`mem-arrayvec`](rules/mem-arrayvec.md) - Use `ArrayVec` for bounded-size collections
+- [`mem-box-large-variant`](rules/mem-box-large-variant.md) - Box large enum variants to reduce type size
+- [`mem-boxed-slice`](rules/mem-boxed-slice.md) - Use `Box<[T]>` instead of `Vec<T>` when fixed
+- [`mem-thinvec`](rules/mem-thinvec.md) - Use `ThinVec` for often-empty vectors
+- [`mem-clone-from`](rules/mem-clone-from.md) - Use `clone_from()` to reuse allocations
+- [`mem-reuse-collections`](rules/mem-reuse-collections.md) - Reuse collections with `clear()` in loops
+- [`mem-avoid-format`](rules/mem-avoid-format.md) - Avoid `format!()` when string literals work
+- [`mem-write-over-format`](rules/mem-write-over-format.md) - Use `write!()` instead of `format!()` 
+- [`mem-arena-allocator`](rules/mem-arena-allocator.md) - Use arena allocators for batch allocations
+- [`mem-zero-copy`](rules/mem-zero-copy.md) - Use zero-copy patterns with slices and `Bytes`
+- [`mem-compact-string`](rules/mem-compact-string.md) - Use `CompactString` for small string optimization
+- [`mem-smaller-integers`](rules/mem-smaller-integers.md) - Use smallest integer type that fits
+- [`mem-assert-type-size`](rules/mem-assert-type-size.md) - Assert hot type sizes to prevent regressions
+
+### 4. API Design (HIGH)
+
+- [`api-builder-pattern`](rules/api-builder-pattern.md) - Use Builder pattern for complex construction
+- [`api-builder-must-use`](rules/api-builder-must-use.md) - Add `#[must_use]` to builder types
+- [`api-newtype-safety`](rules/api-newtype-safety.md) - Use newtypes for type-safe distinctions
+- [`api-typestate`](rules/api-typestate.md) - Use typestate for compile-time state machines
+- [`api-sealed-trait`](rules/api-sealed-trait.md) - Seal traits to prevent external implementations
+- [`api-extension-trait`](rules/api-extension-trait.md) - Use extension traits to add methods to foreign types
+- [`api-parse-dont-validate`](rules/api-parse-dont-validate.md) - Parse into validated types at boundaries
+- [`api-impl-into`](rules/api-impl-into.md) - Accept `impl Into<T>` for flexible string inputs
+- [`api-impl-asref`](rules/api-impl-asref.md) - Accept `impl AsRef<T>` for borrowed inputs
+- [`api-must-use`](rules/api-must-use.md) - Add `#[must_use]` to `Result` returning functions
+- [`api-non-exhaustive`](rules/api-non-exhaustive.md) - Use `#[non_exhaustive]` for future-proof enums/structs
+- [`api-from-not-into`](rules/api-from-not-into.md) - Implement `From`, not `Into` (auto-derived)
+- [`api-default-impl`](rules/api-default-impl.md) - Implement `Default` for sensible defaults
+- [`api-common-traits`](rules/api-common-traits.md) - Implement `Debug`, `Clone`, `PartialEq` eagerly
+- [`api-serde-optional`](rules/api-serde-optional.md) - Gate `Serialize`/`Deserialize` behind feature flag
+
+### 5. Async/Await (HIGH)
+
+- [`async-tokio-runtime`](rules/async-tokio-runtime.md) - Use Tokio for production async runtime
+- [`async-no-lock-await`](rules/async-no-lock-await.md) - Never hold `Mutex`/`RwLock` across `.await`
+- [`async-spawn-blocking`](rules/async-spawn-blocking.md) - Use `spawn_blocking` for CPU-intensive work
+- [`async-tokio-fs`](rules/async-tokio-fs.md) - Use `tokio::fs` not `std::fs` in async code
+- [`async-cancellation-token`](rules/async-cancellation-token.md) - Use `CancellationToken` for graceful shutdown
+- [`async-join-parallel`](rules/async-join-parallel.md) - Use `tokio::join!` for parallel operations
+- [`async-try-join`](rules/async-try-join.md) - Use `tokio::try_join!` for fallible parallel ops
+- [`async-select-racing`](rules/async-select-racing.md) - Use `tokio::select!` for racing/timeouts
+- [`async-bounded-channel`](rules/async-bounded-channel.md) - Use bounded channels for backpressure
+- [`async-mpsc-queue`](rules/async-mpsc-queue.md) - Use `mpsc` for work queues
+- [`async-broadcast-pubsub`](rules/async-broadcast-pubsub.md) - Use `broadcast` for pub/sub patterns
+- [`async-watch-latest`](rules/async-watch-latest.md) - Use `watch` for latest-value sharing
+- [`async-oneshot-response`](rules/async-oneshot-response.md) - Use `oneshot` for request/response
+- [`async-joinset-structured`](rules/async-joinset-structured.md) - Use `JoinSet` for dynamic task groups
+- [`async-clone-before-await`](rules/async-clone-before-await.md) - Clone data before await, release locks
+
+### 6. Compiler Optimization (HIGH)
+
+- [`opt-inline-small`](rules/opt-inline-small.md) - Use `#[inline]` for small hot functions
+- [`opt-inline-always-rare`](rules/opt-inline-always-rare.md) - Use `#[inline(always)]` sparingly
+- [`opt-inline-never-cold`](rules/opt-inline-never-cold.md) - Use `#[inline(never)]` for cold paths
+- [`opt-cold-unlikely`](rules/opt-cold-unlikely.md) - Use `#[cold]` for error/unlikely paths
+- [`opt-likely-hint`](rules/opt-likely-hint.md) - Use `likely()`/`unlikely()` for branch hints
+- [`opt-lto-release`](rules/opt-lto-release.md) - Enable LTO in release builds
+- [`opt-codegen-units`](rules/opt-codegen-units.md) - Use `codegen-units = 1` for max optimization
+- [`opt-pgo-profile`](rules/opt-pgo-profile.md) - Use PGO for production builds
+- [`opt-target-cpu`](rules/opt-target-cpu.md) - Set `target-cpu=native` for local builds
+- [`opt-bounds-check`](rules/opt-bounds-check.md) - Use iterators to avoid bounds checks
+- [`opt-simd-portable`](rules/opt-simd-portable.md) - Use portable SIMD for data-parallel ops
+- [`opt-cache-friendly`](rules/opt-cache-friendly.md) - Design cache-friendly data layouts (SoA)
+
+### 7. Naming Conventions (MEDIUM)
+
+- [`name-types-camel`](rules/name-types-camel.md) - Use `UpperCamelCase` for types, traits, enums
+- [`name-variants-camel`](rules/name-variants-camel.md) - Use `UpperCamelCase` for enum variants
+- [`name-funcs-snake`](rules/name-funcs-snake.md) - Use `snake_case` for functions, methods, modules
+- [`name-consts-screaming`](rules/name-consts-screaming.md) - Use `SCREAMING_SNAKE_CASE` for constants/statics
+- [`name-lifetime-short`](rules/name-lifetime-short.md) - Use short lowercase lifetimes: `'a`, `'de`, `'src`
+- [`name-type-param-single`](rules/name-type-param-single.md) - Use single uppercase for type params: `T`, `E`, `K`, `V`
+- [`name-as-free`](rules/name-as-free.md) - `as_` prefix: free reference conversion
+- [`name-to-expensive`](rules/name-to-expensive.md) - `to_` prefix: expensive conversion
+- [`name-into-ownership`](rules/name-into-ownership.md) - `into_` prefix: ownership transfer
+- [`name-no-get-prefix`](rules/name-no-get-prefix.md) - No `get_` prefix for simple getters
+- [`name-is-has-bool`](rules/name-is-has-bool.md) - Use `is_`, `has_`, `can_` for boolean methods
+- [`name-iter-convention`](rules/name-iter-convention.md) - Use `iter`/`iter_mut`/`into_iter` for iterators
+- [`name-iter-method`](rules/name-iter-method.md) - Name iterator methods consistently
+- [`name-iter-type-match`](rules/name-iter-type-match.md) - Iterator type names match method
+- [`name-acronym-word`](rules/name-acronym-word.md) - Treat acronyms as words: `Uuid` not `UUID`
+- [`name-crate-no-rs`](rules/name-crate-no-rs.md) - Crate names: no `-rs` suffix
+
+### 8. Type Safety (MEDIUM)
+
+- [`type-newtype-ids`](rules/type-newtype-ids.md) - Wrap IDs in newtypes: `UserId(u64)`
+- [`type-newtype-validated`](rules/type-newtype-validated.md) - Newtypes for validated data: `Email`, `Url`
+- [`type-enum-states`](rules/type-enum-states.md) - Use enums for mutually exclusive states
+- [`type-option-nullable`](rules/type-option-nullable.md) - Use `Option<T>` for nullable values
+- [`type-result-fallible`](rules/type-result-fallible.md) - Use `Result<T, E>` for fallible operations
+- [`type-phantom-marker`](rules/type-phantom-marker.md) - Use `PhantomData<T>` for type-level markers
+- [`type-never-diverge`](rules/type-never-diverge.md) - Use `!` type for functions that never return
+- [`type-generic-bounds`](rules/type-generic-bounds.md) - Add trait bounds only where needed
+- [`type-no-stringly`](rules/type-no-stringly.md) - Avoid stringly-typed APIs, use enums/newtypes
+- [`type-repr-transparent`](rules/type-repr-transparent.md) - Use `#[repr(transparent)]` for FFI newtypes
+
+### 9. Testing (MEDIUM)
+
+- [`test-cfg-test-module`](rules/test-cfg-test-module.md) - Use `#[cfg(test)] mod tests { }`
+- [`test-use-super`](rules/test-use-super.md) - Use `use super::*;` in test modules
+- [`test-integration-dir`](rules/test-integration-dir.md) - Put integration tests in `tests/` directory
+- [`test-descriptive-names`](rules/test-descriptive-names.md) - Use descriptive test names
+- [`test-arrange-act-assert`](rules/test-arrange-act-assert.md) - Structure tests as arrange/act/assert
+- [`test-proptest-properties`](rules/test-proptest-properties.md) - Use `proptest` for property-based testing
+- [`test-mockall-mocking`](rules/test-mockall-mocking.md) - Use `mockall` for trait mocking
+- [`test-mock-traits`](rules/test-mock-traits.md) - Use traits for dependencies to enable mocking
+- [`test-fixture-raii`](rules/test-fixture-raii.md) - Use RAII pattern (Drop) for test cleanup
+- [`test-tokio-async`](rules/test-tokio-async.md) - Use `#[tokio::test]` for async tests
+- [`test-should-panic`](rules/test-should-panic.md) - Use `#[should_panic]` for panic tests
+- [`test-criterion-bench`](rules/test-criterion-bench.md) - Use `criterion` for benchmarking
+- [`test-doctest-examples`](rules/test-doctest-examples.md) - Keep doc examples as executable tests
+
+### 10. Documentation (MEDIUM)
+
+- [`doc-all-public`](rules/doc-all-public.md) - Document all public items with `///`
+- [`doc-module-inner`](rules/doc-module-inner.md) - Use `//!` for module-level documentation
+- [`doc-examples-section`](rules/doc-examples-section.md) - Include `# Examples` with runnable code
+- [`doc-errors-section`](rules/doc-errors-section.md) - Include `# Errors` for fallible functions
+- [`doc-panics-section`](rules/doc-panics-section.md) - Include `# Panics` for panicking functions
+- [`doc-safety-section`](rules/doc-safety-section.md) - Include `# Safety` for unsafe functions
+- [`doc-question-mark`](rules/doc-question-mark.md) - Use `?` in examples, not `.unwrap()`
+- [`doc-hidden-setup`](rules/doc-hidden-setup.md) - Use `# ` prefix to hide example setup code
+- [`doc-intra-links`](rules/doc-intra-links.md) - Use intra-doc links: `[Vec]`
+- [`doc-link-types`](rules/doc-link-types.md) - Link related types and functions in docs
+- [`doc-cargo-metadata`](rules/doc-cargo-metadata.md) - Fill `Cargo.toml` metadata
+
+### 11. Performance Patterns (MEDIUM)
+
+- [`perf-iter-over-index`](rules/perf-iter-over-index.md) - Prefer iterators over manual indexing
+- [`perf-iter-lazy`](rules/perf-iter-lazy.md) - Keep iterators lazy, collect() only when needed
+- [`perf-collect-once`](rules/perf-collect-once.md) - Don't `collect()` intermediate iterators
+- [`perf-entry-api`](rules/perf-entry-api.md) - Use `entry()` API for map insert-or-update
+- [`perf-drain-reuse`](rules/perf-drain-reuse.md) - Use `drain()` to reuse allocations
+- [`perf-extend-batch`](rules/perf-extend-batch.md) - Use `extend()` for batch insertions
+- [`perf-chain-avoid`](rules/perf-chain-avoid.md) - Avoid `chain()` in hot loops
+- [`perf-collect-into`](rules/perf-collect-into.md) - Use `collect_into()` for reusing containers
+- [`perf-black-box-bench`](rules/perf-black-box-bench.md) - Use `black_box()` in benchmarks
+- [`perf-release-profile`](rules/perf-release-profile.md) - Optimize release profile settings
+- [`perf-profile-first`](rules/perf-profile-first.md) - Profile before optimizing
+
+### 12. Project Structure (LOW)
+
+- [`proj-lib-main-split`](rules/proj-lib-main-split.md) - Keep `main.rs` minimal, logic in `lib.rs`
+- [`proj-mod-by-feature`](rules/proj-mod-by-feature.md) - Organize modules by feature, not type
+- [`proj-flat-small`](rules/proj-flat-small.md) - Keep small projects flat
+- [`proj-mod-rs-dir`](rules/proj-mod-rs-dir.md) - Use `mod.rs` for multi-file modules
+- [`proj-pub-crate-internal`](rules/proj-pub-crate-internal.md) - Use `pub(crate)` for internal APIs
+- [`proj-pub-super-parent`](rules/proj-pub-super-parent.md) - Use `pub(super)` for parent-only visibility
+- [`proj-pub-use-reexport`](rules/proj-pub-use-reexport.md) - Use `pub use` for clean public API
+- [`proj-prelude-module`](rules/proj-prelude-module.md) - Create `prelude` module for common imports
+- [`proj-bin-dir`](rules/proj-bin-dir.md) - Put multiple binaries in `src/bin/`
+- [`proj-workspace-large`](rules/proj-workspace-large.md) - Use workspaces for large projects
+- [`proj-workspace-deps`](rules/proj-workspace-deps.md) - Use workspace dependency inheritance
+
+### 13. Clippy & Linting (LOW)
+
+- [`lint-deny-correctness`](rules/lint-deny-correctness.md) - `#![deny(clippy::correctness)]`
+- [`lint-warn-suspicious`](rules/lint-warn-suspicious.md) - `#![warn(clippy::suspicious)]`
+- [`lint-warn-style`](rules/lint-warn-style.md) - `#![warn(clippy::style)]`
+- [`lint-warn-complexity`](rules/lint-warn-complexity.md) - `#![warn(clippy::complexity)]`
+- [`lint-warn-perf`](rules/lint-warn-perf.md) - `#![warn(clippy::perf)]`
+- [`lint-pedantic-selective`](rules/lint-pedantic-selective.md) - Enable `clippy::pedantic` selectively
+- [`lint-missing-docs`](rules/lint-missing-docs.md) - `#![warn(missing_docs)]`
+- [`lint-unsafe-doc`](rules/lint-unsafe-doc.md) - `#![warn(clippy::undocumented_unsafe_blocks)]`
+- [`lint-cargo-metadata`](rules/lint-cargo-metadata.md) - `#![warn(clippy::cargo)]` for published crates
+- [`lint-rustfmt-check`](rules/lint-rustfmt-check.md) - Run `cargo fmt --check` in CI
+- [`lint-workspace-lints`](rules/lint-workspace-lints.md) - Configure lints at workspace level
+
+### 14. Anti-patterns (REFERENCE)
+
+- [`anti-unwrap-abuse`](rules/anti-unwrap-abuse.md) - Don't use `.unwrap()` in production code
+- [`anti-expect-lazy`](rules/anti-expect-lazy.md) - Don't use `.expect()` for recoverable errors
+- [`anti-clone-excessive`](rules/anti-clone-excessive.md) - Don't clone when borrowing works
+- [`anti-lock-across-await`](rules/anti-lock-across-await.md) - Don't hold locks across `.await`
+- [`anti-string-for-str`](rules/anti-string-for-str.md) - Don't accept `&String` when `&str` works
+- [`anti-vec-for-slice`](rules/anti-vec-for-slice.md) - Don't accept `&Vec<T>` when `&[T]` works
+- [`anti-index-over-iter`](rules/anti-index-over-iter.md) - Don't use indexing when iterators work
+- [`anti-panic-expected`](rules/anti-panic-expected.md) - Don't panic on expected/recoverable errors
+- [`anti-empty-catch`](rules/anti-empty-catch.md) - Don't use empty `if let Err(_) = ...` blocks
+- [`anti-over-abstraction`](rules/anti-over-abstraction.md) - Don't over-abstract with excessive generics
+- [`anti-premature-optimize`](rules/anti-premature-optimize.md) - Don't optimize before profiling
+- [`anti-type-erasure`](rules/anti-type-erasure.md) - Don't use `Box<dyn Trait>` when `impl Trait` works
+- [`anti-format-hot-path`](rules/anti-format-hot-path.md) - Don't use `format!()` in hot paths
+- [`anti-collect-intermediate`](rules/anti-collect-intermediate.md) - Don't `collect()` intermediate iterators
+- [`anti-stringly-typed`](rules/anti-stringly-typed.md) - Don't use strings for structured data
+
+---
+
+## Recommended Cargo.toml Settings
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3  # Optimize dependencies in dev
+```
+
+---
+
+## How to Use
+
+This skill provides rule identifiers for quick reference. When generating or reviewing Rust code:
+
+1. **Check relevant category** based on task type
+2. **Apply rules** with matching prefix
+3. **Prioritize** CRITICAL > HIGH > MEDIUM > LOW
+4. **Read rule files** in `rules/` for detailed examples
+
+### Rule Application by Task
+
+| Task | Primary Categories |
+|------|-------------------|
+| New function | `own-`, `err-`, `name-` |
+| New struct/API | `api-`, `type-`, `doc-` |
+| Async code | `async-`, `own-` |
+| Error handling | `err-`, `api-` |
+| Memory optimization | `mem-`, `own-`, `perf-` |
+| Performance tuning | `opt-`, `mem-`, `perf-` |
+| Code review | `anti-`, `lint-` |
+
+---
+
+## Sources
+
+This skill synthesizes best practices from:
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/)
+- [Rust Performance Book](https://nnethercote.github.io/perf-book/)
+- [Rust Design Patterns](https://rust-unofficial.github.io/patterns/)
+- Production codebases: ripgrep, tokio, serde, polars, axum, deno
+- Clippy lint documentation
+- Community conventions (2024-2025)

--- a/.agents/skills/rust-skills/rules/anti-clone-excessive.md
+++ b/.agents/skills/rust-skills/rules/anti-clone-excessive.md
@@ -1,0 +1,124 @@
+# anti-clone-excessive
+
+> Don't clone when borrowing works
+
+## Why It Matters
+
+`.clone()` allocates memory and copies data. When you only need to read data, borrowing (`&T`) is free. Excessive cloning wastes memory, CPU cycles, and often indicates misunderstanding of ownership.
+
+## Bad
+
+```rust
+// Cloning to pass to a function that only reads
+fn print_name(name: String) {  // Takes ownership
+    println!("{}", name);
+}
+let name = "Alice".to_string();
+print_name(name.clone());  // Unnecessary clone
+print_name(name);          // Could have just done this
+
+// Cloning in a loop
+for item in items.clone() {  // Clones entire Vec
+    process(&item);
+}
+
+// Cloning for comparison
+if input.clone() == expected {  // Pointless clone
+    // ...
+}
+
+// Cloning struct fields
+fn get_name(&self) -> String {
+    self.name.clone()  // Caller might not need ownership
+}
+```
+
+## Good
+
+```rust
+// Accept reference if only reading
+fn print_name(name: &str) {
+    println!("{}", name);
+}
+let name = "Alice".to_string();
+print_name(&name);  // Borrow, no clone
+
+// Iterate by reference
+for item in &items {
+    process(item);
+}
+
+// Compare by reference
+if input == expected {
+    // ...
+}
+
+// Return reference when possible
+fn get_name(&self) -> &str {
+    &self.name
+}
+```
+
+## When to Clone
+
+```rust
+// Need owned data for async move
+let name = name.clone();
+tokio::spawn(async move {
+    process(name).await;
+});
+
+// Storing in a new struct
+struct Cache {
+    data: String,
+}
+impl Cache {
+    fn store(&mut self, data: &str) {
+        self.data = data.to_string();  // Must own
+    }
+}
+
+// Multiple owners (use Arc instead if frequent)
+let shared = data.clone();
+thread::spawn(move || use_data(shared));
+```
+
+## Alternatives to Clone
+
+| Instead of | Use |
+|------------|-----|
+| `s.clone()` for reading | `&s` |
+| `vec.clone()` for iteration | `&vec` or `vec.iter()` |
+| `Clone` for shared ownership | `Arc<T>` |
+| Clone in hot loop | Move outside loop |
+| `s.to_string()` from `&str` | Accept `&str` if possible |
+
+## Pattern: Clone on Write
+
+```rust
+use std::borrow::Cow;
+
+fn process(input: Cow<str>) -> Cow<str> {
+    if needs_modification(&input) {
+        Cow::Owned(modify(&input))  // Clone only if needed
+    } else {
+        input  // No clone
+    }
+}
+```
+
+## Detecting Excessive Clones
+
+```toml
+# Cargo.toml
+[lints.clippy]
+clone_on_copy = "warn"
+clone_on_ref_ptr = "warn"
+redundant_clone = "warn"
+```
+
+## See Also
+
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Borrowing patterns
+- [own-cow-conditional](./own-cow-conditional.md) - Clone on write
+- [own-arc-shared](./own-arc-shared.md) - Shared ownership

--- a/.agents/skills/rust-skills/rules/anti-collect-intermediate.md
+++ b/.agents/skills/rust-skills/rules/anti-collect-intermediate.md
@@ -1,0 +1,131 @@
+# anti-collect-intermediate
+
+> Don't collect intermediate iterators
+
+## Why It Matters
+
+Each `.collect()` allocates a new collection. Collecting intermediate results in a chain creates unnecessary allocations and prevents iterator fusion. Keep the chain lazy; collect only at the end.
+
+## Bad
+
+```rust
+// Three allocations, three passes
+fn process(data: Vec<i32>) -> Vec<i32> {
+    let step1: Vec<_> = data.into_iter()
+        .filter(|x| *x > 0)
+        .collect();
+    
+    let step2: Vec<_> = step1.into_iter()
+        .map(|x| x * 2)
+        .collect();
+    
+    step2.into_iter()
+        .filter(|x| *x < 100)
+        .collect()
+}
+
+// Collecting just to check length
+fn has_valid_items(items: &[Item]) -> bool {
+    let valid: Vec<_> = items.iter()
+        .filter(|i| i.is_valid())
+        .collect();
+    !valid.is_empty()
+}
+
+// Collecting to iterate again
+fn sum_valid(items: &[Item]) -> i64 {
+    let valid: Vec<_> = items.iter()
+        .filter(|i| i.is_valid())
+        .collect();
+    valid.iter().map(|i| i.value).sum()
+}
+```
+
+## Good
+
+```rust
+// Single allocation, single pass
+fn process(data: Vec<i32>) -> Vec<i32> {
+    data.into_iter()
+        .filter(|x| *x > 0)
+        .map(|x| x * 2)
+        .filter(|x| *x < 100)
+        .collect()
+}
+
+// No allocation - iterator short-circuits
+fn has_valid_items(items: &[Item]) -> bool {
+    items.iter().any(|i| i.is_valid())
+}
+
+// No intermediate allocation
+fn sum_valid(items: &[Item]) -> i64 {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .map(|i| i.value)
+        .sum()
+}
+```
+
+## When Collection Is Needed
+
+```rust
+// Need to iterate twice
+let valid: Vec<_> = items.iter()
+    .filter(|i| i.is_valid())
+    .collect();
+let count = valid.len();
+for item in &valid {
+    process(item);
+}
+
+// Need to sort (requires concrete collection)
+let mut sorted: Vec<_> = items.iter()
+    .filter(|i| i.is_active())
+    .collect();
+sorted.sort_by_key(|i| i.priority);
+
+// Need random access
+let indexed: Vec<_> = items.iter().collect();
+let middle = indexed.get(indexed.len() / 2);
+```
+
+## Iterator Methods That Avoid Collection
+
+| Instead of Collecting to... | Use |
+|-----------------------------|-----|
+| Check if empty | `.any(|_| true)` or `.next().is_some()` |
+| Check if any match | `.any(predicate)` |
+| Check if all match | `.all(predicate)` |
+| Count elements | `.count()` |
+| Sum elements | `.sum()` |
+| Find first | `.find(predicate)` |
+| Get first | `.next()` |
+| Get last | `.last()` |
+
+## Pattern: Deferred Collection
+
+```rust
+// Return iterator, let caller collect if needed
+fn valid_items(items: &[Item]) -> impl Iterator<Item = &Item> {
+    items.iter().filter(|i| i.is_valid())
+}
+
+// Caller decides
+let count = valid_items(&items).count();  // No collection
+let vec: Vec<_> = valid_items(&items).collect();  // Collection when needed
+```
+
+## Comparison
+
+| Pattern | Allocations | Passes |
+|---------|-------------|--------|
+| `.collect()` each step | N | N |
+| Single chain, one `.collect()` | 1 | 1 |
+| No collection (streaming) | 0 | 1 |
+
+## See Also
+
+- [perf-collect-once](./perf-collect-once.md) - Single collect
+- [perf-iter-lazy](./perf-iter-lazy.md) - Lazy evaluation
+- [perf-iter-over-index](./perf-iter-over-index.md) - Iterator patterns

--- a/.agents/skills/rust-skills/rules/anti-empty-catch.md
+++ b/.agents/skills/rust-skills/rules/anti-empty-catch.md
@@ -1,0 +1,132 @@
+# anti-empty-catch
+
+> Don't silently ignore errors
+
+## Why It Matters
+
+Empty error handling (`if let Err(_) = ...`, `let _ = result`, `.ok()`) silently discards errors. Failures go unnoticed, bugs hide, and debugging becomes impossible. Every error deserves acknowledgment—even if just logging.
+
+## Bad
+
+```rust
+// Silently ignores errors
+let _ = write_to_file(data);
+
+// Discards error completely
+if let Err(_) = send_notification() {
+    // Nothing - error vanishes
+}
+
+// Converts Result to Option, losing error info
+let value = risky_operation().ok();
+
+// Match with empty arm
+match database.save(record) {
+    Ok(_) => println!("saved"),
+    Err(_) => {}  // Silent failure
+}
+
+// Ignored in loop
+for item in items {
+    let _ = process(item);  // Failures unnoticed
+}
+```
+
+## Good
+
+```rust
+// Log the error
+if let Err(e) = write_to_file(data) {
+    error!("failed to write file: {}", e);
+}
+
+// Propagate if possible
+send_notification()?;
+
+// Or handle explicitly
+match send_notification() {
+    Ok(_) => info!("notification sent"),
+    Err(e) => warn!("notification failed: {}", e),
+}
+
+// Collect errors in batch operations
+let (successes, failures): (Vec<_>, Vec<_>) = items
+    .into_iter()
+    .map(process)
+    .partition(Result::is_ok);
+
+if !failures.is_empty() {
+    warn!("{} items failed to process", failures.len());
+}
+
+// Explicit documentation when ignoring
+// Intentionally ignored: cleanup failure is not critical
+let _ = cleanup_temp_file();  // Add comment explaining why
+```
+
+## Acceptable Ignoring (Documented)
+
+```rust
+// Close errors often ignored, but document it
+// INTENTIONAL: TCP close errors are not actionable
+let _ = stream.shutdown(Shutdown::Both);
+
+// Mutex poisoning recovery
+// INTENTIONAL: We'll reset the state anyway
+let guard = mutex.lock().unwrap_or_else(|e| e.into_inner());
+```
+
+## Pattern: Collect and Report
+
+```rust
+fn process_batch(items: Vec<Item>) -> BatchResult {
+    let mut errors = Vec::new();
+    
+    for item in items {
+        if let Err(e) = process_item(&item) {
+            errors.push((item.id, e));
+        }
+    }
+    
+    if errors.is_empty() {
+        BatchResult::AllSucceeded
+    } else {
+        BatchResult::PartialFailure(errors)
+    }
+}
+```
+
+## Pattern: Best-Effort Operations
+
+```rust
+// Metrics/telemetry can fail without affecting main flow
+fn report_metric(name: &str, value: f64) {
+    if let Err(e) = metrics_client.record(name, value) {
+        // Log but don't propagate - metrics are not critical
+        debug!("failed to record metric {}: {}", name, e);
+    }
+}
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+let_underscore_drop = "warn"
+ignored_unit_patterns = "warn"
+```
+
+## Decision Guide
+
+| Situation | Action |
+|-----------|--------|
+| Critical operation | `?` or handle explicitly |
+| Non-critical, debugging needed | Log the error |
+| Truly ignorable (rare) | `let _ =` with comment |
+| Batch operation | Collect errors, report |
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Proper error handling
+- [err-context-chain](./err-context-chain.md) - Adding context
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap issues

--- a/.agents/skills/rust-skills/rules/anti-expect-lazy.md
+++ b/.agents/skills/rust-skills/rules/anti-expect-lazy.md
@@ -1,0 +1,95 @@
+# anti-expect-lazy
+
+> Don't use expect for recoverable errors
+
+## Why It Matters
+
+`.expect()` panics with a custom message, but it's still a panic. Using it for errors that could reasonably occur in production (network failures, file not found, invalid input) crashes the program instead of handling the error gracefully.
+
+Reserve `.expect()` for programming errors where panic is appropriate.
+
+## Bad
+
+```rust
+// Network failures are expected - don't panic
+let response = client.get(url).await.expect("failed to fetch");
+
+// Files might not exist
+let config = fs::read_to_string("config.toml").expect("config not found");
+
+// User input can be invalid
+let age: u32 = input.parse().expect("invalid age");
+
+// Database queries can fail
+let user = db.find_user(id).await.expect("user not found");
+```
+
+## Good
+
+```rust
+// Handle recoverable errors properly
+let response = client.get(url).await
+    .context("failed to fetch URL")?;
+
+// Return error if file doesn't exist
+let config = fs::read_to_string("config.toml")
+    .context("failed to read config file")?;
+
+// Validate and return error
+let age: u32 = input.parse()
+    .map_err(|_| Error::InvalidInput("age must be a number"))?;
+
+// Handle missing data
+let user = db.find_user(id).await?
+    .ok_or(Error::NotFound("user"))?;
+```
+
+## When expect() Is Appropriate
+
+Use `.expect()` for invariants that indicate bugs:
+
+```rust
+// Mutex poisoning indicates a bug elsewhere
+let guard = mutex.lock().expect("mutex poisoned");
+
+// Regex is known valid at compile time
+let re = Regex::new(r"^\d{4}$").expect("invalid regex");
+
+// Thread spawn failure is unrecoverable
+let handle = thread::spawn(|| work()).expect("failed to spawn thread");
+
+// Static data that must be valid
+let config: Config = toml::from_str(EMBEDDED_CONFIG)
+    .expect("embedded config is invalid");
+```
+
+## Pattern: expect() vs unwrap()
+
+```rust
+// unwrap: no context, hard to debug
+let x = option.unwrap();
+
+// expect: gives context, still panics
+let x = option.expect("value should exist after validation");
+
+// ?: proper error handling
+let x = option.ok_or(Error::MissingValue)?;
+```
+
+## Decision Guide
+
+| Situation | Use |
+|-----------|-----|
+| User input | `?` with error |
+| File/network I/O | `?` with error |
+| Database operations | `?` with error |
+| Parsed constants | `.expect()` |
+| Thread/mutex operations | `.expect()` |
+| After validation check | `.expect()` with explanation |
+| Never expected to fail | `.expect()` documenting invariant |
+
+## See Also
+
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to use expect
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoiding unwrap
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap anti-pattern

--- a/.agents/skills/rust-skills/rules/anti-format-hot-path.md
+++ b/.agents/skills/rust-skills/rules/anti-format-hot-path.md
@@ -1,0 +1,141 @@
+# anti-format-hot-path
+
+> Don't use format! in hot paths
+
+## Why It Matters
+
+`format!()` allocates a new `String` every call. In hot paths (loops, frequently called functions), this creates allocation churn that impacts performance. Pre-allocate, reuse buffers, or use `write!()` to an existing buffer.
+
+## Bad
+
+```rust
+// format! in loop - allocates every iteration
+fn log_events(events: &[Event]) {
+    for event in events {
+        let message = format!("[{}] {}: {}", event.level, event.source, event.message);
+        logger.log(&message);
+    }
+}
+
+// format! for building parts
+fn build_url(base: &str, path: &str, params: &[(&str, &str)]) -> String {
+    let mut url = format!("{}{}", base, path);
+    for (key, value) in params {
+        url = format!("{}{}={}&", url, key, value);  // New allocation each time
+    }
+    url
+}
+
+// format! for simple concatenation
+fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)  // Fine for one-off, bad if called 1M times
+}
+```
+
+## Good
+
+```rust
+use std::fmt::Write;
+
+// Reuse buffer across iterations
+fn log_events(events: &[Event]) {
+    let mut buffer = String::with_capacity(256);
+    for event in events {
+        buffer.clear();
+        write!(buffer, "[{}] {}: {}", event.level, event.source, event.message).unwrap();
+        logger.log(&buffer);
+    }
+}
+
+// Build incrementally in single buffer
+fn build_url(base: &str, path: &str, params: &[(&str, &str)]) -> String {
+    let mut url = String::with_capacity(base.len() + path.len() + params.len() * 20);
+    url.push_str(base);
+    url.push_str(path);
+    for (key, value) in params {
+        write!(url, "{}={}&", key, value).unwrap();
+    }
+    url
+}
+
+// For truly hot paths, avoid allocation entirely
+fn greet_to_buf(name: &str, buffer: &mut String) {
+    buffer.clear();
+    buffer.push_str("Hello, ");
+    buffer.push_str(name);
+    buffer.push('!');
+}
+```
+
+## Comparison
+
+| Approach | Allocations | Performance |
+|----------|-------------|-------------|
+| `format!()` in loop | N | Slow |
+| `write!()` to reused buffer | 1 | Fast |
+| `push_str()` + `push()` | 1 | Fastest |
+| Pre-sized `String::with_capacity()` | 1 (no realloc) | Fast |
+
+## When format! Is Fine
+
+```rust
+// One-time initialization
+let config_path = format!("{}/config.toml", home_dir);
+
+// Error messages (not hot path)
+return Err(format!("invalid input: {}", input));
+
+// Debug output
+println!("Debug: {:?}", value);
+```
+
+## Pattern: Formatter Buffer Pool
+
+```rust
+use std::cell::RefCell;
+
+thread_local! {
+    static BUFFER: RefCell<String> = RefCell::new(String::with_capacity(256));
+}
+
+fn format_event(event: &Event) -> String {
+    BUFFER.with(|buf| {
+        let mut buf = buf.borrow_mut();
+        buf.clear();
+        write!(buf, "[{}] {}", event.level, event.message).unwrap();
+        buf.clone()  // Still one allocation per call, but no parsing
+    })
+}
+```
+
+## Pattern: Display Implementation
+
+```rust
+struct Event {
+    level: Level,
+    message: String,
+}
+
+impl std::fmt::Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.level, self.message)
+    }
+}
+
+// Caller controls allocation
+let mut buf = String::new();
+write!(buf, "{}", event)?;
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+format_in_format_args = "warn"
+```
+
+## See Also
+
+- [mem-avoid-format](./mem-avoid-format.md) - Avoiding format
+- [mem-write-over-format](./mem-write-over-format.md) - Using write!
+- [mem-reuse-collections](./mem-reuse-collections.md) - Buffer reuse

--- a/.agents/skills/rust-skills/rules/anti-index-over-iter.md
+++ b/.agents/skills/rust-skills/rules/anti-index-over-iter.md
@@ -1,0 +1,125 @@
+# anti-index-over-iter
+
+> Don't use indexing when iterators work
+
+## Why It Matters
+
+Manual indexing (`for i in 0..len`) requires bounds checks on every access, prevents SIMD optimization, and introduces off-by-one error risks. Iterators eliminate these issues and are more idiomatic Rust.
+
+## Bad
+
+```rust
+// Manual indexing - bounds checked every access
+fn sum_squares(data: &[i32]) -> i64 {
+    let mut result = 0i64;
+    for i in 0..data.len() {
+        result += (data[i] as i64) * (data[i] as i64);
+    }
+    result
+}
+
+// Index-based with multiple arrays
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len().min(b.len()) {
+        sum += a[i] * b[i];
+    }
+    sum
+}
+
+// Mutation with indices
+fn normalize(data: &mut [f64]) {
+    let max = data.iter().cloned().fold(0.0, f64::max);
+    for i in 0..data.len() {
+        data[i] /= max;
+    }
+}
+```
+
+## Good
+
+```rust
+// Iterator - no bounds checks, SIMD-friendly
+fn sum_squares(data: &[i32]) -> i64 {
+    data.iter()
+        .map(|&x| (x as i64) * (x as i64))
+        .sum()
+}
+
+// Zip - handles length mismatch automatically
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| x * y)
+        .sum()
+}
+
+// Mutable iteration
+fn normalize(data: &mut [f64]) {
+    let max = data.iter().cloned().fold(0.0, f64::max);
+    for x in data.iter_mut() {
+        *x /= max;
+    }
+}
+```
+
+## When Indices Are Needed
+
+Sometimes you genuinely need indices:
+
+```rust
+// Need index in output
+for (i, item) in items.iter().enumerate() {
+    println!("{}: {}", i, item);
+}
+
+// Non-sequential access
+for i in (0..len).step_by(2) {
+    swap(&mut data[i], &mut data[i + 1]);
+}
+
+// Multi-dimensional iteration
+for i in 0..rows {
+    for j in 0..cols {
+        matrix[i][j] = i * cols + j;
+    }
+}
+```
+
+## Comparison
+
+| Pattern | Bounds Checks | SIMD | Safety |
+|---------|---------------|------|--------|
+| `for i in 0..len { data[i] }` | Every access | Limited | Off-by-one risk |
+| `for x in &data` | None | Good | Safe |
+| `for x in data.iter()` | None | Good | Safe |
+| `data.iter().enumerate()` | None | Good | Safe |
+
+## Common Conversions
+
+| Index Pattern | Iterator Pattern |
+|---------------|------------------|
+| `for i in 0..v.len()` | `for x in &v` |
+| `v[0]` | `v.first()` |
+| `v[v.len()-1]` | `v.last()` |
+| `for i in 0..a.len() { a[i] + b[i] }` | `a.iter().zip(&b)` |
+| `for i in 0..v.len() { v[i] *= 2 }` | `for x in &mut v { *x *= 2 }` |
+
+## Performance Note
+
+```rust
+// Iterator version can auto-vectorize
+let sum: i32 = data.iter().sum();
+
+// Manual indexing prevents vectorization
+let mut sum = 0;
+for i in 0..data.len() {
+    sum += data[i];
+}
+```
+
+## See Also
+
+- [perf-iter-over-index](./perf-iter-over-index.md) - Performance details
+- [opt-bounds-check](./opt-bounds-check.md) - Bounds check elimination
+- [perf-iter-lazy](./perf-iter-lazy.md) - Lazy iterators

--- a/.agents/skills/rust-skills/rules/anti-lock-across-await.md
+++ b/.agents/skills/rust-skills/rules/anti-lock-across-await.md
@@ -1,0 +1,127 @@
+# anti-lock-across-await
+
+> Don't hold locks across await points
+
+## Why It Matters
+
+Holding a `Mutex` or `RwLock` guard across an `.await` causes the lock to be held while the task is suspended. Other tasks waiting for the lock block indefinitely. With `std::sync::Mutex`, this is even worse—it can deadlock the entire runtime.
+
+## Bad
+
+```rust
+use std::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+// DEADLOCK RISK: std::sync::Mutex held across await
+async fn bad_std_mutex(data: &Mutex<Vec<i32>>) {
+    let mut guard = data.lock().unwrap();
+    do_async_work().await;  // Lock held during await!
+    guard.push(42);
+}
+
+// BLOCKS OTHER TASKS: tokio Mutex held across await
+async fn bad_async_mutex(data: &AsyncMutex<Vec<i32>>) {
+    let mut guard = data.lock().await;
+    slow_network_call().await;  // Lock held for entire call!
+    guard.push(42);
+}
+```
+
+## Good
+
+```rust
+use std::sync::Mutex;
+use tokio::sync::Mutex as AsyncMutex;
+
+// Release lock before await
+async fn good_approach(data: &Mutex<Vec<i32>>) {
+    let value = {
+        let guard = data.lock().unwrap();
+        guard.last().copied()  // Extract what you need
+    };  // Lock released here
+    
+    let result = do_async_work(value).await;
+    
+    {
+        let mut guard = data.lock().unwrap();
+        guard.push(result);
+    }
+}
+
+// Minimize lock scope with async mutex
+async fn good_async_mutex(data: &AsyncMutex<Vec<i32>>, item: i32) {
+    // Quick lock, quick release
+    data.lock().await.push(item);
+    
+    // Async work without lock
+    let result = slow_network_call().await;
+    
+    // Quick lock again
+    data.lock().await.push(result);
+}
+```
+
+## Pattern: Clone Before Await
+
+```rust
+async fn process(data: &AsyncMutex<Config>) -> Result<()> {
+    // Clone inside lock scope
+    let config = data.lock().await.clone();
+    
+    // Now use config freely across awaits
+    let result = fetch_data(&config.url).await?;
+    process_result(&config, result).await?;
+    
+    Ok(())
+}
+```
+
+## Pattern: Restructure to Avoid Lock
+
+```rust
+// Instead of locking a shared map
+struct Service {
+    data: AsyncMutex<HashMap<String, Data>>,
+}
+
+// Use channels or owned data
+struct BetterService {
+    // Each task owns its data via channels
+    sender: mpsc::Sender<Request>,
+}
+
+impl BetterService {
+    async fn request(&self, key: String) -> Data {
+        let (tx, rx) = oneshot::channel();
+        self.sender.send(Request { key, respond: tx }).await?;
+        rx.await?
+    }
+}
+```
+
+## What Can Cross Await
+
+| Type | Safe Across Await? |
+|------|--------------------|
+| `std::sync::Mutex` guard | **NO** - can deadlock |
+| `std::sync::RwLock` guard | **NO** - can deadlock |
+| `tokio::sync::Mutex` guard | Allowed but blocks tasks |
+| `tokio::sync::RwLock` guard | Allowed but blocks tasks |
+| Owned values | Yes |
+| `Arc<T>` | Yes |
+| References | Depends on lifetime |
+
+## Detection
+
+```toml
+# Cargo.toml
+[lints.clippy]
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+```
+
+## See Also
+
+- [async-no-lock-await](./async-no-lock-await.md) - Async lock patterns
+- [async-clone-before-await](./async-clone-before-await.md) - Clone pattern
+- [own-mutex-interior](./own-mutex-interior.md) - Mutex usage

--- a/.agents/skills/rust-skills/rules/anti-over-abstraction.md
+++ b/.agents/skills/rust-skills/rules/anti-over-abstraction.md
@@ -1,0 +1,120 @@
+# anti-over-abstraction
+
+> Don't over-abstract with excessive generics
+
+## Why It Matters
+
+Generics and traits are powerful but come at a cost: compile times, binary size, and cognitive load. Over-abstraction—making everything generic "for flexibility"—often adds complexity without benefit. Start concrete; generalize when you have real use cases.
+
+## Bad
+
+```rust
+// Overly generic for a simple function
+fn add<T, U, R>(a: T, b: U) -> R
+where
+    T: Into<R>,
+    U: Into<R>,
+    R: std::ops::Add<Output = R>,
+{
+    a.into() + b.into()
+}
+
+// Just call add(1, 2) - why make it this complex?
+
+// Trait explosion
+trait Readable {}
+trait Writable {}
+trait ReadWritable: Readable + Writable {}
+trait AsyncReadable {}
+trait AsyncWritable {}
+trait AsyncReadWritable: AsyncReadable + AsyncWritable {}
+
+// Abstract factory pattern (Java flashback)
+trait Factory<T> {
+    fn create(&self) -> T;
+}
+trait FactoryFactory<F: Factory<T>, T> {
+    fn create_factory(&self) -> F;
+}
+```
+
+## Good
+
+```rust
+// Concrete implementation - clear and simple
+fn add_i32(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+// Generic when actually needed (e.g., library code)
+fn add<T: std::ops::Add<Output = T>>(a: T, b: T) -> T {
+    a + b
+}
+
+// Simple traits for actual polymorphism needs
+trait Storage {
+    fn save(&self, key: &str, value: &[u8]) -> Result<(), Error>;
+    fn load(&self, key: &str) -> Result<Vec<u8>, Error>;
+}
+
+// Concrete types first
+struct FileStorage { path: PathBuf }
+struct MemoryStorage { data: HashMap<String, Vec<u8>> }
+```
+
+## Signs of Over-Abstraction
+
+| Sign | Symptom |
+|------|---------|
+| Single implementation | Generic trait with only one impl |
+| Type parameter soup | `T, U, V, W` everywhere |
+| Marker traits | Traits with no methods |
+| Deep trait bounds | `where T: A + B + C + D + E` |
+| Phantom generics | Type parameters not used meaningfully |
+
+## When to Generalize
+
+Generalize when:
+- You have 2+ concrete types that share behavior
+- You're writing library code for public consumption
+- Performance requires static dispatch
+- The abstraction simplifies the API
+
+Don't generalize when:
+- You "might need it later" (YAGNI)
+- Only one type will ever implement it
+- It makes code harder to understand
+
+## Rule of Three
+
+Wait until you have three similar concrete implementations before abstracting:
+
+```rust
+// Version 1: Just FileStorage
+struct FileStorage { /* ... */ }
+
+// Version 2: Added MemoryStorage, similar interface
+struct MemoryStorage { /* ... */ }
+
+// Version 3: Now Redis too - time to abstract
+trait Storage {
+    fn save(&self, key: &str, value: &[u8]) -> Result<()>;
+    fn load(&self, key: &str) -> Result<Vec<u8>>;
+}
+```
+
+## Prefer Concrete Types in Private Code
+
+```rust
+// Internal function - concrete type is fine
+fn process_orders(db: &PostgresDb, orders: Vec<Order>) { }
+
+// Public API - might benefit from abstraction
+pub fn process_orders<S: Storage>(storage: &S, orders: Vec<Order>) { }
+```
+
+## See Also
+
+- [type-generic-bounds](./type-generic-bounds.md) - Minimal bounds
+- [api-sealed-trait](./api-sealed-trait.md) - Controlled extension
+- [anti-type-erasure](./anti-type-erasure.md) - When Box<dyn> is wrong

--- a/.agents/skills/rust-skills/rules/anti-panic-expected.md
+++ b/.agents/skills/rust-skills/rules/anti-panic-expected.md
@@ -1,0 +1,131 @@
+# anti-panic-expected
+
+> Don't panic on expected or recoverable errors
+
+## Why It Matters
+
+Panics crash the program. They're for unrecoverable situations—bugs, corrupted state, invariant violations. Using panic for expected conditions (network failures, file not found, invalid input) makes programs fragile and forces callers to catch panics or die.
+
+Use `Result` for recoverable errors.
+
+## Bad
+
+```rust
+// Network failures are expected
+fn fetch_data(url: &str) -> Data {
+    let response = reqwest::blocking::get(url)
+        .expect("network error");  // Crashes on timeout
+    response.json().expect("invalid json")  // Crashes on bad response
+}
+
+// User input is often invalid
+fn parse_config(input: &str) -> Config {
+    toml::from_str(input).expect("invalid config")  // Crashes on typo
+}
+
+// Files may not exist
+fn load_settings() -> Settings {
+    let content = fs::read_to_string("settings.json")
+        .expect("settings not found");  // Crashes if missing
+    serde_json::from_str(&content).expect("invalid settings")
+}
+
+// Custom panic for validation
+fn process_age(age: i32) {
+    if age < 0 {
+        panic!("age cannot be negative");  // Should return error
+    }
+}
+```
+
+## Good
+
+```rust
+// Return errors for expected failures
+fn fetch_data(url: &str) -> Result<Data, FetchError> {
+    let response = reqwest::blocking::get(url)
+        .context("failed to connect")?;
+    let data = response.json()
+        .context("failed to parse response")?;
+    Ok(data)
+}
+
+// Validate and return Result
+fn parse_config(input: &str) -> Result<Config, ConfigError> {
+    toml::from_str(input).map_err(ConfigError::Parse)
+}
+
+// Handle missing files gracefully
+fn load_settings() -> Result<Settings, SettingsError> {
+    let content = fs::read_to_string("settings.json")?;
+    let settings = serde_json::from_str(&content)?;
+    Ok(settings)
+}
+
+// Return error for validation failure
+fn process_age(age: i32) -> Result<(), ValidationError> {
+    if age < 0 {
+        return Err(ValidationError::NegativeAge);
+    }
+    Ok(())
+}
+```
+
+## When to Panic
+
+Panic IS appropriate for:
+
+```rust
+// Bug detection - invariant violated
+fn get_unchecked(&self, index: usize) -> &T {
+    assert!(index < self.len(), "index out of bounds - this is a bug");
+    unsafe { self.data.get_unchecked(index) }
+}
+
+// Unrecoverable state
+fn init() {
+    if !CAN_PROCEED {
+        panic!("system requirements not met");
+    }
+}
+
+// Tests
+#[test]
+fn test_fails() {
+    panic!("expected panic in test");
+}
+```
+
+## Decision Guide
+
+| Condition | Action |
+|-----------|--------|
+| Invalid user input | Return `Err` |
+| Network failure | Return `Err` |
+| File not found | Return `Err` |
+| Malformed data | Return `Err` |
+| Bug/impossible state | `panic!` or `unreachable!` |
+| Failed assertion in test | `panic!` |
+| Unrecoverable init failure | `panic!` |
+
+## Anti-pattern: panic! for Control Flow
+
+```rust
+// BAD: Using panic for control flow
+fn find_or_die(items: &[Item], id: u64) -> &Item {
+    items.iter()
+        .find(|i| i.id == id)
+        .unwrap_or_else(|| panic!("item {} not found", id))
+}
+
+// GOOD: Return Option or Result
+fn find(items: &[Item], id: u64) -> Option<&Item> {
+    items.iter().find(|i| i.id == id)
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Use Result
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Unwrap anti-pattern
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to expect

--- a/.agents/skills/rust-skills/rules/anti-premature-optimize.md
+++ b/.agents/skills/rust-skills/rules/anti-premature-optimize.md
@@ -1,0 +1,156 @@
+# anti-premature-optimize
+
+> Don't optimize before profiling
+
+## Why It Matters
+
+Premature optimization wastes time, complicates code, and often targets the wrong bottlenecks. Most code isn't performance-critical; the hot 10% matters. Profile first, then optimize the actual bottlenecks with data-driven decisions.
+
+## Bad
+
+```rust
+// "Optimizing" without measurement
+fn sum(data: &[i32]) -> i32 {
+    // Using unsafe "for performance" without profiling
+    unsafe {
+        let mut sum = 0;
+        for i in 0..data.len() {
+            sum += *data.get_unchecked(i);
+        }
+        sum
+    }
+}
+
+// Complex caching with no evidence it's needed
+lazy_static! {
+    static ref CACHE: RwLock<HashMap<String, Arc<Result>>> = 
+        RwLock::new(HashMap::new());
+}
+
+// Hand-rolled data structures "for speed"
+struct MyVec<T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+}
+```
+
+## Good
+
+```rust
+// Simple, idiomatic - let compiler optimize
+fn sum(data: &[i32]) -> i32 {
+    data.iter().sum()
+}
+
+// Profile, then optimize if needed
+fn sum_optimized(data: &[i32]) -> i32 {
+    // After profiling showed this is a bottleneck,
+    // we measured that manual SIMD gives 3x speedup
+    #[cfg(target_arch = "x86_64")]
+    {
+        // SIMD implementation with benchmark data
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        data.iter().sum()
+    }
+}
+
+// Use standard library - it's well-optimized
+let cache: HashMap<String, Result> = HashMap::new();
+```
+
+## Profiling Workflow
+
+```bash
+# 1. Write correct code first
+cargo build --release
+
+# 2. Profile with real workloads
+cargo flamegraph --bin my_app -- --real-args
+# or
+cargo bench
+
+# 3. Identify hotspots (top 10% of time)
+
+# 4. Measure before optimizing
+# 5. Optimize ONE thing
+# 6. Measure after - verify improvement
+# 7. Repeat if still slow
+```
+
+## Optimization Principles
+
+| Do | Don't |
+|----|-------|
+| Profile first | Guess at bottlenecks |
+| Optimize hotspots | Optimize everything |
+| Measure improvement | Assume it's faster |
+| Keep it simple | Add complexity speculatively |
+| Trust the compiler | Outsmart the compiler |
+
+## When to Optimize
+
+```rust
+// AFTER profiling shows this is 40% of runtime
+#[inline]
+fn hot_function(data: &[u8]) -> u64 {
+    // Optimized implementation justified by benchmarks
+}
+
+// Clear, measurable benefit documented
+/// Pre-allocated buffer for repeated formatting.
+/// Benchmarks show 3x speedup for >1000 calls/sec workloads.
+struct FormatterPool {
+    buffers: Vec<String>,
+}
+```
+
+## Common Premature Optimizations
+
+| Premature | Reality |
+|-----------|---------|
+| `#[inline(always)]` everywhere | Compiler usually knows better |
+| `unsafe` for bounds check removal | Iterator does this safely |
+| Custom allocator | Default is usually fine |
+| Object pooling | Allocator is fast enough |
+| Manual SIMD | Auto-vectorization works |
+
+## Profile Tools
+
+```bash
+# Sampling profiler
+perf record ./target/release/app && perf report
+
+# Flamegraph
+cargo install flamegraph
+cargo flamegraph
+
+# Criterion benchmarks
+cargo bench
+
+# Memory profiling
+valgrind --tool=massif ./target/release/app
+```
+
+## Document Optimizations
+
+```rust
+/// Lookup table for fast character classification.
+/// 
+/// # Performance
+/// 
+/// Benchmarked with criterion (benchmarks/char_class.rs):
+/// - Table lookup: 2.3ns/op
+/// - Match statement: 8.7ns/op
+/// 
+/// Justified for hot path in parser (called 10M+ times).
+static CHAR_CLASS: [CharClass; 256] = [/* ... */];
+```
+
+## See Also
+
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimize
+- [test-criterion-bench](./test-criterion-bench.md) - Benchmarking
+- [opt-inline-small](./opt-inline-small.md) - Inline guidelines

--- a/.agents/skills/rust-skills/rules/anti-string-for-str.md
+++ b/.agents/skills/rust-skills/rules/anti-string-for-str.md
@@ -1,0 +1,122 @@
+# anti-string-for-str
+
+> Don't accept &String when &str works
+
+## Why It Matters
+
+`&String` is strictly less flexible than `&str`. A `&str` can be created from `String`, `&str`, literals, and slices. A `&String` requires exactly a `String`. This forces callers to allocate when they might not need to.
+
+## Bad
+
+```rust
+// Forces callers to have a String
+fn greet(name: &String) {
+    println!("Hello, {}", name);
+}
+
+// Caller must allocate
+greet(&"Alice".to_string());  // Unnecessary allocation
+greet(&name);                 // Only works if name is String
+
+// In struct
+struct Config {
+    name: String,
+}
+
+impl Config {
+    fn set_name(&mut self, name: &String) {  // Too restrictive
+        self.name = name.clone();
+    }
+}
+```
+
+## Good
+
+```rust
+// Accept &str - works with String, &str, literals
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// All these work
+greet("Alice");           // String literal
+greet(&name);             // &String coerces to &str
+greet(name.as_str());     // Explicit &str
+
+// In struct
+impl Config {
+    fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
+    }
+    
+    // Or accept owned String if caller usually has one
+    fn set_name_owned(&mut self, name: String) {
+        self.name = name;
+    }
+    
+    // Or be generic
+    fn set_name_into(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+}
+```
+
+## Deref Coercion
+
+`String` implements `Deref<Target = str>`, so `&String` automatically coerces to `&str`:
+
+```rust
+fn takes_str(s: &str) { }
+
+let owned = String::from("hello");
+takes_str(&owned);  // &String -> &str via Deref
+```
+
+## When to Accept &String
+
+Rarely. Maybe if you need `String`-specific methods:
+
+```rust
+fn needs_capacity(s: &String) -> usize {
+    s.capacity()  // Only String has capacity()
+}
+```
+
+But usually you'd take `&str` and let the caller manage the `String`.
+
+## Pattern: Flexible APIs
+
+```rust
+// Most flexible: accept anything that can become &str
+fn process(input: impl AsRef<str>) {
+    let s: &str = input.as_ref();
+    // ...
+}
+
+process("literal");
+process(String::from("owned"));
+process(&some_string);
+```
+
+## Similar Anti-patterns
+
+| Anti-pattern | Better |
+|--------------|--------|
+| `&String` | `&str` |
+| `&Vec<T>` | `&[T]` |
+| `&Box<T>` | `&T` |
+| `&PathBuf` | `&Path` |
+| `&OsString` | `&OsStr` |
+
+## Clippy Detection
+
+```toml
+[lints.clippy]
+ptr_arg = "warn"  # Catches &String, &Vec, &PathBuf
+```
+
+## See Also
+
+- [anti-vec-for-slice](./anti-vec-for-slice.md) - Similar pattern for Vec
+- [own-slice-over-vec](./own-slice-over-vec.md) - Slice patterns
+- [api-impl-asref](./api-impl-asref.md) - AsRef pattern

--- a/.agents/skills/rust-skills/rules/anti-stringly-typed.md
+++ b/.agents/skills/rust-skills/rules/anti-stringly-typed.md
@@ -1,0 +1,167 @@
+# anti-stringly-typed
+
+> Don't use strings where enums or newtypes would provide type safety
+
+## Why It Matters
+
+Strings are the most primitive way to represent data—they accept any value, provide no validation, and offer no IDE support. When you have a fixed set of valid values or a semantic type, use enums or newtypes. The compiler catches mistakes at compile time instead of runtime.
+
+## Bad
+
+```rust
+fn process_order(status: &str, priority: &str) {
+    // What are valid statuses? "pending"? "Pending"? "PENDING"?
+    // What are valid priorities? "high"? "1"? "urgent"?
+    match status {
+        "pending" => { ... }
+        "completed" => { ... }
+        _ => panic!("unknown status"),  // Runtime error
+    }
+}
+
+struct User {
+    email: String,    // Any string, even "not an email"
+    phone: String,    // Any string, even "hello"
+    user_id: String,  // Could be confused with other string IDs
+}
+
+// Easy to make mistakes
+process_order("complete", "high");  // Typo: "complete" vs "completed"
+process_order("high", "pending");   // Swapped arguments - compiles!
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OrderStatus {
+    Pending,
+    Processing,
+    Completed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Priority {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+fn process_order(status: OrderStatus, priority: Priority) {
+    match status {
+        OrderStatus::Pending => { ... }
+        OrderStatus::Processing => { ... }
+        OrderStatus::Completed => { ... }
+        OrderStatus::Cancelled => { ... }
+    }  // Exhaustive - compiler checks all cases
+}
+
+// Validated newtypes
+struct Email(String);
+struct PhoneNumber(String);
+struct UserId(u64);
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, ValidationError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(ValidationError::InvalidEmail)
+        }
+    }
+}
+
+struct User {
+    email: Email,       // Must be valid email
+    phone: PhoneNumber, // Must be valid phone
+    user_id: UserId,    // Can't confuse with other IDs
+}
+
+// Compile errors catch mistakes
+process_order(OrderStatus::Completed, Priority::High);  // Clear and correct
+process_order(Priority::High, OrderStatus::Pending);    // Compile error!
+```
+
+## Parsing Strings to Types
+
+```rust
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy)]
+enum OrderStatus {
+    Pending,
+    Processing,
+    Completed,
+    Cancelled,
+}
+
+impl FromStr for OrderStatus {
+    type Err = ParseError;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "pending" => Ok(OrderStatus::Pending),
+            "processing" => Ok(OrderStatus::Processing),
+            "completed" => Ok(OrderStatus::Completed),
+            "cancelled" | "canceled" => Ok(OrderStatus::Cancelled),
+            _ => Err(ParseError::UnknownStatus(s.to_string())),
+        }
+    }
+}
+
+// Parse at boundary, use types internally
+fn handle_request(status_str: &str) -> Result<(), Error> {
+    let status: OrderStatus = status_str.parse()?;  // Validate once
+    process_order(status);  // Type-safe from here
+    Ok(())
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+// JSON: {"status": "in_progress"}
+// Deserialization validates automatically
+```
+
+## Error Messages
+
+```rust
+#[derive(Debug, Clone, Copy)]
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Color::Red => write!(f, "red"),
+            Color::Green => write!(f, "green"),
+            Color::Blue => write!(f, "blue"),
+        }
+    }
+}
+
+// Type-safe and displayable
+println!("Selected color: {}", Color::Red);
+```
+
+## See Also
+
+- [api-newtype-safety](./api-newtype-safety.md) - Newtype pattern
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Parse at boundaries
+- [type-newtype-ids](./type-newtype-ids.md) - Type-safe IDs

--- a/.agents/skills/rust-skills/rules/anti-type-erasure.md
+++ b/.agents/skills/rust-skills/rules/anti-type-erasure.md
@@ -1,0 +1,134 @@
+# anti-type-erasure
+
+> Don't use Box<dyn Trait> when impl Trait works
+
+## Why It Matters
+
+`Box<dyn Trait>` (type erasure) introduces heap allocation and dynamic dispatch overhead. When you have a single concrete type or can use generics, `impl Trait` provides the same flexibility with zero overhead through monomorphization.
+
+## Bad
+
+```rust
+// Unnecessary type erasure
+fn get_iterator() -> Box<dyn Iterator<Item = i32>> {
+    Box::new((0..10).map(|x| x * 2))
+}
+
+// Boxing for no reason
+fn make_handler() -> Box<dyn Fn(i32) -> i32> {
+    Box::new(|x| x + 1)
+}
+
+// Vec of boxed trait objects when one type would do
+fn get_validators() -> Vec<Box<dyn Validator>> {
+    vec![
+        Box::new(LengthValidator),
+        Box::new(RegexValidator),
+    ]
+}
+```
+
+## Good
+
+```rust
+// impl Trait - zero overhead, inlined
+fn get_iterator() -> impl Iterator<Item = i32> {
+    (0..10).map(|x| x * 2)
+}
+
+// impl Fn - no boxing
+fn make_handler() -> impl Fn(i32) -> i32 {
+    |x| x + 1
+}
+
+// When mixed types are genuinely needed, Box is OK
+fn get_validators() -> Vec<Box<dyn Validator>> {
+    // Actually different types at runtime - Box is appropriate
+    config.validators.iter()
+        .map(|v| v.create_validator())
+        .collect()
+}
+```
+
+## When to Use Box<dyn Trait>
+
+Type erasure IS appropriate when:
+
+```rust
+// Heterogeneous collection of different types
+let handlers: Vec<Box<dyn Handler>> = vec![
+    Box::new(LogHandler),
+    Box::new(MetricsHandler),
+    Box::new(AuthHandler),
+];
+
+// Type cannot be known at compile time
+fn create_from_config(config: &Config) -> Box<dyn Database> {
+    match config.db_type {
+        DbType::Postgres => Box::new(PostgresDb::new()),
+        DbType::Sqlite => Box::new(SqliteDb::new()),
+    }
+}
+
+// Recursive types
+struct Node {
+    value: i32,
+    children: Vec<Box<dyn NodeTrait>>,
+}
+
+// Breaking cycles in complex ownership
+struct EventLoop {
+    handlers: Vec<Box<dyn EventHandler>>,
+}
+```
+
+## Comparison
+
+| Approach | Allocation | Dispatch | Binary Size |
+|----------|------------|----------|-------------|
+| `impl Trait` | Stack/inline | Static | Larger (monomorphization) |
+| `Box<dyn Trait>` | Heap | Dynamic | Smaller |
+| Generics `<T>` | Stack/inline | Static | Larger |
+
+## impl Trait Positions
+
+```rust
+// Return position - caller doesn't need to know concrete type
+fn process() -> impl Future<Output = Result> { }
+
+// Argument position - like generics but simpler
+fn handle(handler: impl Handler) { }
+
+// Can't use in trait definitions (use associated types instead)
+trait Processor {
+    type Output: Display;  // Not impl Display
+    fn process(&self) -> Self::Output;
+}
+```
+
+## Pattern: Enum Instead of dyn
+
+```rust
+// Instead of Box<dyn Shape>
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+    Triangle { base: f64, height: f64 },
+}
+
+impl Shape {
+    fn area(&self) -> f64 {
+        match self {
+            Shape::Circle { radius } => PI * radius * radius,
+            Shape::Rectangle { width, height } => width * height,
+            Shape::Triangle { base, height } => 0.5 * base * height,
+        }
+    }
+}
+```
+
+## See Also
+
+- [anti-over-abstraction](./anti-over-abstraction.md) - Excessive generics
+- [type-generic-bounds](./type-generic-bounds.md) - Generic constraints
+- [mem-box-large-variant](./mem-box-large-variant.md) - Boxing enum variants

--- a/.agents/skills/rust-skills/rules/anti-unwrap-abuse.md
+++ b/.agents/skills/rust-skills/rules/anti-unwrap-abuse.md
@@ -1,0 +1,143 @@
+# anti-unwrap-abuse
+
+> Don't use `.unwrap()` in production code
+
+## Why It Matters
+
+`.unwrap()` panics on `None` or `Err`, crashing your program. In production, this means lost data, failed requests, and unhappy users. It also makes debugging harder since panic messages often lack context.
+
+## Bad
+
+```rust
+// Crashes if file doesn't exist
+let content = std::fs::read_to_string("config.toml").unwrap();
+
+// Crashes on invalid input
+let num: i32 = user_input.parse().unwrap();
+
+// Crashes if key missing
+let value = map.get("key").unwrap();
+
+// Crashes if channel closed
+let msg = receiver.recv().unwrap();
+```
+
+## Good
+
+```rust
+// Propagate with ?
+fn load_config() -> Result<Config, Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    Ok(toml::from_str(&content)?)
+}
+
+// Provide default
+let num: i32 = user_input.parse().unwrap_or(0);
+
+// Handle missing key
+let value = map.get("key").ok_or(Error::MissingKey)?;
+
+// Or use if-let
+if let Some(value) = map.get("key") {
+    process(value);
+}
+
+// Channel with proper handling
+match receiver.recv() {
+    Ok(msg) => handle(msg),
+    Err(_) => break,  // Channel closed
+}
+```
+
+## When unwrap() Is Acceptable
+
+```rust
+// 1. Tests - panics are expected failures
+#[test]
+fn test_parse() {
+    let result = parse("valid").unwrap();  // OK in tests
+    assert_eq!(result, expected);
+}
+
+// 2. Const/static initialization (compile-time guaranteed)
+static REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\d+$").unwrap()  // Known-valid pattern
+});
+
+// 3. After a check that guarantees success
+if map.contains_key("key") {
+    let value = map.get("key").unwrap();  // Just checked
+}
+// Better: use if-let or entry API instead
+
+// 4. Truly impossible cases with proof comment
+let last = vec.pop().unwrap();  
+// OK only if you just checked !vec.is_empty()
+// Better: use last() or pattern match
+```
+
+## Alternatives to unwrap()
+
+```rust
+// unwrap_or - provide default
+let x = opt.unwrap_or(default);
+
+// unwrap_or_default - use Default trait
+let x = opt.unwrap_or_default();
+
+// unwrap_or_else - compute default lazily
+let x = opt.unwrap_or_else(|| expensive_default());
+
+// ? operator - propagate errors
+let x = opt.ok_or(Error::Missing)?;
+
+// if let - handle Some/Ok case
+if let Some(x) = opt {
+    use_x(x);
+}
+
+// match - handle all cases
+match opt {
+    Some(x) => use_x(x),
+    None => handle_none(),
+}
+
+// map - transform if present
+let y = opt.map(|x| x + 1);
+
+// and_then - chain fallible operations
+let z = opt.and_then(|x| x.checked_add(1));
+```
+
+## expect() Is Slightly Better
+
+```rust
+// unwrap() - no context
+let file = File::open(path).unwrap();
+// Panics with: "called `Result::unwrap()` on an `Err` value: Os { code: 2, ... }"
+
+// expect() - adds context
+let file = File::open(path)
+    .expect("config file should exist at startup");
+// Panics with: "config file should exist at startup: Os { code: 2, ... }"
+
+// But still use only for invariants, not error handling
+```
+
+## Clippy Lint
+
+```rust
+// Enable these lints to catch unwrap usage:
+#![warn(clippy::unwrap_used)]
+#![warn(clippy::expect_used)]  // Stricter
+
+// Or per-function:
+#[allow(clippy::unwrap_used)]
+fn tests_only() { }
+```
+
+## See Also
+
+- [err-question-mark](err-question-mark.md) - Use ? for propagation
+- [err-result-over-panic](err-result-over-panic.md) - Return Result instead of panicking
+- [anti-expect-lazy](anti-expect-lazy.md) - Don't use expect for recoverable errors

--- a/.agents/skills/rust-skills/rules/anti-vec-for-slice.md
+++ b/.agents/skills/rust-skills/rules/anti-vec-for-slice.md
@@ -1,0 +1,121 @@
+# anti-vec-for-slice
+
+> Don't accept &Vec<T> when &[T] works
+
+## Why It Matters
+
+`&Vec<T>` is strictly less flexible than `&[T]`. A slice can be created from `Vec`, arrays, and other slice-like types. Accepting `&Vec<T>` forces callers to have exactly a `Vec`, preventing them from using arrays, slices, or other collections.
+
+## Bad
+
+```rust
+// Forces callers to have a Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// Caller must allocate
+let arr = [1, 2, 3, 4, 5];
+sum(&arr.to_vec());  // Unnecessary allocation
+
+// Slice won't work
+let slice: &[i32] = &[1, 2, 3];
+// sum(slice);  // Error: expected &Vec<i32>
+```
+
+## Good
+
+```rust
+// Accept slice - works with Vec, arrays, slices
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// All these work
+sum(&[1, 2, 3, 4, 5]);        // Array
+sum(&vec![1, 2, 3]);          // Vec
+sum(&numbers[1..3]);          // Slice of slice
+sum(numbers.as_slice());      // Explicit slice
+```
+
+## Deref Coercion
+
+`Vec<T>` implements `Deref<Target = [T]>`, so `&Vec<T>` automatically coerces to `&[T]`:
+
+```rust
+fn takes_slice(s: &[i32]) { }
+
+let vec = vec![1, 2, 3];
+takes_slice(&vec);  // &Vec<i32> -> &[i32] via Deref
+```
+
+## Mutable Slices
+
+Same applies to `&mut`:
+
+```rust
+// Bad
+fn double(numbers: &mut Vec<i32>) {
+    for n in numbers.iter_mut() {
+        *n *= 2;
+    }
+}
+
+// Good
+fn double(numbers: &mut [i32]) {
+    for n in numbers.iter_mut() {
+        *n *= 2;
+    }
+}
+```
+
+## When to Accept &Vec<T>
+
+Rarely. Only when you need Vec-specific operations:
+
+```rust
+fn needs_capacity(v: &Vec<i32>) -> usize {
+    v.capacity()  // Only Vec has capacity
+}
+
+fn might_grow(v: &mut Vec<i32>) {
+    v.push(42);  // Slice can't push
+}
+```
+
+## Pattern: Accepting Multiple Types
+
+```rust
+// Accept anything that can be viewed as a slice
+fn process<T: AsRef<[u8]>>(data: T) {
+    let bytes: &[u8] = data.as_ref();
+    // ...
+}
+
+process(&[1u8, 2, 3]);       // Array
+process(vec![1u8, 2, 3]);    // Vec
+process(&some_vec);          // &Vec
+process(b"bytes");           // Byte string
+```
+
+## Similar Anti-patterns
+
+| Anti-pattern | Better |
+|--------------|--------|
+| `&Vec<T>` | `&[T]` |
+| `&String` | `&str` |
+| `&PathBuf` | `&Path` |
+| `&Box<T>` | `&T` |
+
+## Clippy Detection
+
+```toml
+[lints.clippy]
+ptr_arg = "warn"  # Catches &Vec, &String, &PathBuf
+```
+
+## See Also
+
+- [anti-string-for-str](./anti-string-for-str.md) - Similar for String
+- [own-slice-over-vec](./own-slice-over-vec.md) - Slice patterns
+- [api-impl-asref](./api-impl-asref.md) - AsRef pattern

--- a/.agents/skills/rust-skills/rules/api-builder-must-use.md
+++ b/.agents/skills/rust-skills/rules/api-builder-must-use.md
@@ -1,0 +1,143 @@
+# api-builder-must-use
+
+> Mark builder methods with `#[must_use]` to prevent silent drops
+
+## Why It Matters
+
+Builder pattern methods return a modified builder. Without `#[must_use]`, calling a builder method and ignoring the return value silently does nothing—the builder is dropped, and the configuration is lost. This creates confusing bugs where code appears correct but has no effect.
+
+## Bad
+
+```rust
+struct RequestBuilder {
+    url: String,
+    timeout: Option<Duration>,
+    headers: Vec<(String, String)>,
+}
+
+impl RequestBuilder {
+    fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+    
+    fn header(mut self, key: &str, value: &str) -> Self {
+        self.headers.push((key.to_string(), value.to_string()));
+        self
+    }
+}
+
+// Bug: builder methods are ignored - no warning!
+let request = RequestBuilder::new("https://api.example.com");
+request.timeout(Duration::from_secs(30));  // Dropped silently!
+request.header("Authorization", "Bearer token");  // Dropped silently!
+let response = request.send();  // Sends with no timeout or headers
+```
+
+## Good
+
+```rust
+struct RequestBuilder {
+    url: String,
+    timeout: Option<Duration>,
+    headers: Vec<(String, String)>,
+}
+
+impl RequestBuilder {
+    #[must_use = "builder methods return modified builder - chain or assign"]
+    fn timeout(mut self, duration: Duration) -> Self {
+        self.timeout = Some(duration);
+        self
+    }
+    
+    #[must_use = "builder methods return modified builder - chain or assign"]
+    fn header(mut self, key: &str, value: &str) -> Self {
+        self.headers.push((key.to_string(), value.to_string()));
+        self
+    }
+}
+
+// Now warns: unused return value that must be used
+let request = RequestBuilder::new("https://api.example.com");
+request.timeout(Duration::from_secs(30));  // Warning!
+
+// Correct: chain methods
+let response = RequestBuilder::new("https://api.example.com")
+    .timeout(Duration::from_secs(30))
+    .header("Authorization", "Bearer token")
+    .send();
+```
+
+## Apply to Entire Type
+
+```rust
+#[must_use = "builders do nothing unless consumed"]
+struct ConfigBuilder {
+    log_level: Level,
+    max_connections: usize,
+}
+
+// Now all methods returning Self warn if ignored
+impl ConfigBuilder {
+    fn log_level(mut self, level: Level) -> Self {
+        self.log_level = level;
+        self
+    }
+    
+    fn max_connections(mut self, n: usize) -> Self {
+        self.max_connections = n;
+        self
+    }
+    
+    fn build(self) -> Config {
+        Config {
+            log_level: self.log_level,
+            max_connections: self.max_connections,
+        }
+    }
+}
+```
+
+## Message Guidelines
+
+```rust
+// Descriptive message helps users understand
+#[must_use = "builder methods return modified builder"]
+fn with_foo(self, foo: Foo) -> Self { ... }
+
+#[must_use = "this creates a new String and does not modify the original"]
+fn to_uppercase(&self) -> String { ... }
+
+#[must_use = "iterator adaptors are lazy - use .collect() to consume"]
+fn map<F>(self, f: F) -> Map<Self, F> { ... }
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+must_use_candidate = "warn"  # Suggests where #[must_use] would help
+return_self_not_must_use = "warn"  # Specifically for -> Self methods
+```
+
+## Standard Library Examples
+
+```rust
+// std::Option - must_use on map, and, or
+let x: Option<i32> = Some(5);
+x.map(|v| v * 2);  // Warning: unused return value
+
+// std::Result - must_use on the type itself
+#[must_use = "this `Result` may be an `Err` variant, which should be handled"]
+pub enum Result<T, E> { ... }
+
+// Iterator adaptors
+let v = vec![1, 2, 3];
+v.iter().map(|x| x * 2);  // Warning: iterators are lazy
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Builder pattern best practices
+- [api-must-use](./api-must-use.md) - General must_use guidelines
+- [err-result-over-panic](./err-result-over-panic.md) - Result types are must_use

--- a/.agents/skills/rust-skills/rules/api-builder-pattern.md
+++ b/.agents/skills/rust-skills/rules/api-builder-pattern.md
@@ -1,0 +1,187 @@
+# api-builder-pattern
+
+> Use Builder pattern for complex construction
+
+## Why It Matters
+
+When a type has many optional parameters or complex initialization, the Builder pattern provides a clear, flexible API. It avoids constructors with many parameters (which are error-prone) and makes the code self-documenting.
+
+## Bad
+
+```rust
+// Constructor with many parameters - hard to read, easy to get wrong
+let client = Client::new(
+    "https://api.example.com",  // Which is which?
+    30,                          // Timeout? Retries?
+    true,                        // What does this mean?
+    None,
+    Some("auth_token"),
+    false,
+);
+
+// Or many Option fields
+struct Client {
+    url: String,
+    timeout: Option<Duration>,
+    retries: Option<u32>,
+    // ... 10 more optional fields
+}
+```
+
+## Good
+
+```rust
+#[derive(Default)]
+#[must_use = "builders do nothing unless you call build()"]
+pub struct ClientBuilder {
+    base_url: Option<String>,
+    timeout: Option<Duration>,
+    max_retries: u32,
+    auth_token: Option<String>,
+}
+
+impl ClientBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    
+    /// Sets the base URL for all requests.
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+    
+    /// Sets the request timeout. Default is 30 seconds.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+    
+    /// Sets the maximum number of retries. Default is 3.
+    pub fn max_retries(mut self, n: u32) -> Self {
+        self.max_retries = n;
+        self
+    }
+    
+    /// Sets the authentication token.
+    pub fn auth_token(mut self, token: impl Into<String>) -> Self {
+        self.auth_token = Some(token.into());
+        self
+    }
+    
+    /// Builds the client with the configured options.
+    pub fn build(self) -> Result<Client, BuilderError> {
+        let base_url = self.base_url
+            .ok_or(BuilderError::MissingBaseUrl)?;
+        
+        Ok(Client {
+            base_url,
+            timeout: self.timeout.unwrap_or(Duration::from_secs(30)),
+            max_retries: self.max_retries,
+            auth_token: self.auth_token,
+        })
+    }
+}
+
+// Usage - clear and self-documenting
+let client = ClientBuilder::new()
+    .base_url("https://api.example.com")
+    .timeout(Duration::from_secs(10))
+    .max_retries(5)
+    .auth_token("secret")
+    .build()?;
+```
+
+## Builder Variations
+
+```rust
+// 1. Infallible builder (build() returns T, not Result)
+impl WidgetBuilder {
+    pub fn build(self) -> Widget {
+        Widget {
+            color: self.color.unwrap_or(Color::Black),
+            size: self.size.unwrap_or(Size::Medium),
+        }
+    }
+}
+
+// 2. Typestate builder (compile-time required field checking)
+pub struct ClientBuilder<Url> {
+    url: Url,
+    timeout: Option<Duration>,
+}
+
+pub struct NoUrl;
+pub struct HasUrl(String);
+
+impl ClientBuilder<NoUrl> {
+    pub fn new() -> Self {
+        Self { url: NoUrl, timeout: None }
+    }
+    
+    pub fn url(self, url: String) -> ClientBuilder<HasUrl> {
+        ClientBuilder { url: HasUrl(url), timeout: self.timeout }
+    }
+}
+
+impl ClientBuilder<HasUrl> {
+    pub fn build(self) -> Client {
+        // url is guaranteed to be set
+        Client { url: self.url.0, timeout: self.timeout }
+    }
+}
+
+// 3. Consuming vs borrowing (consuming is more common)
+// Consuming (takes self)
+pub fn timeout(mut self, t: Duration) -> Self { ... }
+
+// Borrowing (takes &mut self, allows reuse)
+pub fn timeout(&mut self, t: Duration) -> &mut Self { ... }
+```
+
+## Evidence from reqwest
+
+```rust
+// https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/client.rs
+
+#[must_use]
+pub struct ClientBuilder {
+    config: Config,
+}
+
+impl ClientBuilder {
+    pub fn new() -> ClientBuilder {
+        ClientBuilder {
+            config: Config::default(),
+        }
+    }
+    
+    pub fn timeout(mut self, timeout: Duration) -> ClientBuilder {
+        self.config.timeout = Some(timeout);
+        self
+    }
+    
+    pub fn build(self) -> Result<Client, Error> {
+        // Validation and construction
+    }
+}
+```
+
+## Key Attributes
+
+```rust
+#[derive(Default)]  // Enables MyBuilder::default()
+#[must_use = "builders do nothing unless you call build()"]
+pub struct MyBuilder { ... }
+
+impl MyBuilder {
+    #[must_use]  // Each method should have this
+    pub fn option(mut self, value: T) -> Self { ... }
+}
+```
+
+## See Also
+
+- [api-builder-must-use](api-builder-must-use.md) - Add #[must_use] to builders
+- [api-typestate](api-typestate.md) - Compile-time state machines
+- [api-impl-into](api-impl-into.md) - Accept impl Into for flexibility

--- a/.agents/skills/rust-skills/rules/api-common-traits.md
+++ b/.agents/skills/rust-skills/rules/api-common-traits.md
@@ -1,0 +1,165 @@
+# api-common-traits
+
+> Implement standard traits (Debug, Clone, PartialEq, etc.) for public types
+
+## Why It Matters
+
+Standard traits make your types interoperable with the Rust ecosystem. `Debug` enables `println!("{:?}")` and error messages. `Clone` allows explicit duplication. `PartialEq` enables `==`. Without these, users can't use your types in common patterns like testing, collections, or debugging.
+
+## Bad
+
+```rust
+// Bare struct - severely limited usability
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+// Can't debug
+println!("{:?}", point);  // Error: Debug not implemented
+
+// Can't compare
+if point1 == point2 { }  // Error: PartialEq not implemented
+
+// Can't use in HashMap
+let mut map: HashMap<Point, Value> = HashMap::new();  // Error: Hash not implemented
+
+// Can't clone
+let copy = point.clone();  // Error: Clone not implemented
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+// Now everything works
+println!("{:?}", point);
+assert_eq!(point1, point2);
+let copy = point;  // Copy, not just Clone
+
+// For hashable types
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UserId(u64);
+
+let mut map: HashMap<UserId, User> = HashMap::new();
+```
+
+## Trait Derivation Guide
+
+| Trait | Derive When | Requirements |
+|-------|-------------|--------------|
+| `Debug` | Always for public types | All fields implement Debug |
+| `Clone` | Type can be duplicated | All fields implement Clone |
+| `Copy` | Small, simple types | All fields implement Copy, no Drop |
+| `PartialEq` | Comparison makes sense | All fields implement PartialEq |
+| `Eq` | Total equality | PartialEq, no floating-point fields |
+| `Hash` | Used as HashMap/HashSet key | Eq, consistent with PartialEq |
+| `Default` | Sensible default exists | All fields implement Default |
+| `PartialOrd` | Ordering makes sense | PartialEq, all fields implement PartialOrd |
+| `Ord` | Total ordering | Eq + PartialOrd, no floating-point |
+
+## Common Trait Bundles
+
+```rust
+// ID types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct EntityId(u64);
+
+// Value types
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub struct Vector2 { x: f32, y: f32 }
+
+// Configuration
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Config {
+    name: String,
+    options: HashMap<String, String>,
+}
+
+// Error types
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    InvalidSyntax(String),
+    UnexpectedToken(Token),
+}
+```
+
+## Manual Implementations
+
+```rust
+// When derive doesn't do what you want
+struct CaseInsensitiveString(String);
+
+impl PartialEq for CaseInsensitiveString {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_lowercase() == other.0.to_lowercase()
+    }
+}
+
+impl Eq for CaseInsensitiveString {}
+
+impl Hash for CaseInsensitiveString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Must be consistent with PartialEq
+        self.0.to_lowercase().hash(state);
+    }
+}
+
+// Custom Debug for sensitive data
+struct Password(String);
+
+impl Debug for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Password([REDACTED])")
+    }
+}
+```
+
+## Serde Traits
+
+```rust
+use serde::{Serialize, Deserialize};
+
+// For serializable types
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApiResponse {
+    pub status: String,
+    pub data: Vec<Item>,
+}
+
+// With custom serialization
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub verbose: bool,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}
+```
+
+## Minimum Recommended
+
+```rust
+// At minimum, public types should have:
+#[derive(Debug, Clone, PartialEq)]
+pub struct MyType { ... }
+
+// Add based on use case:
+// + Eq, Hash       → for HashMap keys
+// + Ord, PartialOrd → for BTreeMap, sorting
+// + Default        → for Option::unwrap_or_default()
+// + Copy           → for small value types
+// + Serialize      → for serialization
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - When to implement Copy
+- [api-default-impl](./api-default-impl.md) - Implementing Default
+- [doc-examples-section](./doc-examples-section.md) - Documenting trait implementations

--- a/.agents/skills/rust-skills/rules/api-default-impl.md
+++ b/.agents/skills/rust-skills/rules/api-default-impl.md
@@ -1,0 +1,177 @@
+# api-default-impl
+
+> Implement `Default` for types with sensible default values
+
+## Why It Matters
+
+`Default` is a standard trait that provides a canonical way to create a default instance. It integrates with many ecosystem patterns: `Option::unwrap_or_default()`, `#[derive(Default)]`, struct update syntax `..Default::default()`, and generic code that requires `T: Default`. Implementing it makes your types more ergonomic.
+
+## Bad
+
+```rust
+struct Config {
+    timeout: Duration,
+    retries: u32,
+    verbose: bool,
+}
+
+impl Config {
+    // Custom constructor - works but non-standard
+    fn new() -> Self {
+        Config {
+            timeout: Duration::from_secs(30),
+            retries: 3,
+            verbose: false,
+        }
+    }
+}
+
+// Can't use with standard patterns
+let config: Config = Default::default();  // Error: Default not implemented
+let timeout = settings.get("timeout").unwrap_or_default();  // Won't work
+```
+
+## Good
+
+```rust
+#[derive(Default)]
+struct Config {
+    #[default = Duration::from_secs(30)]  // Nightly, or implement manually
+    timeout: Duration,
+    retries: u32,     // Defaults to 0 with derive
+    verbose: bool,    // Defaults to false with derive
+}
+
+// Or implement manually for custom defaults
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            timeout: Duration::from_secs(30),
+            retries: 3,
+            verbose: false,
+        }
+    }
+}
+
+// Now works with all standard patterns
+let config = Config::default();
+let config = Config { retries: 5, ..Default::default() };
+let value = map.get("key").cloned().unwrap_or_default();
+```
+
+## Derive vs Manual
+
+```rust
+// Derive: all fields use their own Default
+#[derive(Default)]
+struct Simple {
+    count: u32,      // 0
+    name: String,    // ""
+    items: Vec<i32>, // []
+}
+
+// Manual: when you need custom defaults
+struct Connection {
+    host: String,
+    port: u16,
+    timeout: Duration,
+}
+
+impl Default for Connection {
+    fn default() -> Self {
+        Connection {
+            host: "localhost".to_string(),
+            port: 8080,
+            timeout: Duration::from_secs(30),
+        }
+    }
+}
+```
+
+## Builder with Default
+
+```rust
+#[derive(Default)]
+struct ServerBuilder {
+    host: String,
+    port: u16,
+    workers: usize,
+}
+
+impl ServerBuilder {
+    fn host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+    
+    fn port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+}
+
+// Clean initialization
+let server = ServerBuilder::default()
+    .host("0.0.0.0")
+    .port(3000)
+    .build();
+```
+
+## Default with Required Fields
+
+```rust
+// When some fields have no sensible default, don't implement Default
+struct User {
+    id: UserId,       // No sensible default
+    name: String,     // Could default to ""
+}
+
+// Instead, provide a constructor
+impl User {
+    fn new(id: UserId, name: impl Into<String>) -> Self {
+        User { id, name: name.into() }
+    }
+}
+
+// Or use builder with required fields
+struct UserBuilder {
+    id: Option<UserId>,
+    name: String,
+}
+
+impl Default for UserBuilder {
+    fn default() -> Self {
+        UserBuilder {
+            id: None,
+            name: String::new(),
+        }
+    }
+}
+```
+
+## Generic Default
+
+```rust
+// Require Default in generic bounds when needed
+fn create_or_default<T: Default>(opt: Option<T>) -> T {
+    opt.unwrap_or_default()
+}
+
+// PhantomData is Default regardless of T
+use std::marker::PhantomData;
+struct Wrapper<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> Default for Wrapper<T> {
+    fn default() -> Self {
+        Wrapper { _marker: PhantomData }
+    }
+}
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Building complex types
+- [api-common-traits](./api-common-traits.md) - Other common traits to implement
+- [api-from-not-into](./api-from-not-into.md) - Conversion traits

--- a/.agents/skills/rust-skills/rules/api-extension-trait.md
+++ b/.agents/skills/rust-skills/rules/api-extension-trait.md
@@ -1,0 +1,163 @@
+# api-extension-trait
+
+> Use extension traits to add methods to external types
+
+## Why It Matters
+
+Rust's orphan rules prevent implementing external traits on external types. Extension traits provide a workaround: define a new trait with your methods, then implement it for the external type. This pattern is used extensively in the ecosystem (e.g., `itertools::Itertools`, `tokio::AsyncReadExt`).
+
+## Bad
+
+```rust
+// Can't add methods directly to external types
+impl Vec<u8> {
+    fn as_hex(&self) -> String {
+        // Error: cannot define inherent impl for a type outside this crate
+    }
+}
+
+// Can't implement external trait for external type
+impl SomeExternalTrait for Vec<u8> {
+    // Error: orphan rules violation
+}
+```
+
+## Good
+
+```rust
+// Define an extension trait
+pub trait ByteSliceExt {
+    fn as_hex(&self) -> String;
+    fn is_ascii_printable(&self) -> bool;
+}
+
+// Implement for the external type
+impl ByteSliceExt for [u8] {
+    fn as_hex(&self) -> String {
+        self.iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    }
+    
+    fn is_ascii_printable(&self) -> bool {
+        self.iter().all(|b| b.is_ascii_graphic() || b.is_ascii_whitespace())
+    }
+}
+
+// Usage: import the trait to use the methods
+use my_crate::ByteSliceExt;
+
+let data: &[u8] = b"hello";
+println!("{}", data.as_hex());  // "68656c6c6f"
+```
+
+## Convention: Ext Suffix
+
+```rust
+// Standard naming: TypeExt for extending Type
+pub trait OptionExt<T> {
+    fn unwrap_or_log(self, msg: &str) -> Option<T>;
+}
+
+impl<T> OptionExt<T> for Option<T> {
+    fn unwrap_or_log(self, msg: &str) -> Option<T> {
+        if self.is_none() {
+            log::warn!("{}", msg);
+        }
+        self
+    }
+}
+
+// For generic extensions
+pub trait ResultExt<T, E> {
+    fn log_err(self) -> Self;
+}
+
+impl<T, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
+    fn log_err(self) -> Self {
+        if let Err(ref e) = self {
+            log::error!("{}", e);
+        }
+        self
+    }
+}
+```
+
+## Ecosystem Examples
+
+```rust
+// itertools::Itertools
+use itertools::Itertools;
+let groups = vec![1, 1, 2, 2, 3].into_iter().group_by(|x| *x);
+
+// futures::StreamExt
+use futures::StreamExt;
+let next = stream.next().await;
+
+// tokio::io::AsyncReadExt
+use tokio::io::AsyncReadExt;
+let mut buf = [0u8; 1024];
+reader.read(&mut buf).await?;
+
+// anyhow::Context
+use anyhow::Context;
+let content = std::fs::read_to_string(path)
+    .with_context(|| format!("failed to read {}", path))?;
+```
+
+## Scoped Extensions
+
+```rust
+// Extension only visible where imported
+mod string_utils {
+    pub trait StringExt {
+        fn truncate_ellipsis(&self, max_len: usize) -> String;
+    }
+    
+    impl StringExt for str {
+        fn truncate_ellipsis(&self, max_len: usize) -> String {
+            if self.len() <= max_len {
+                self.to_string()
+            } else {
+                format!("{}...", &self[..max_len.saturating_sub(3)])
+            }
+        }
+    }
+}
+
+// Only available when explicitly imported
+use string_utils::StringExt;
+let short = "very long string".truncate_ellipsis(10);
+```
+
+## Generic Extensions with Bounds
+
+```rust
+pub trait VecExt<T> {
+    fn push_if_unique(&mut self, item: T)
+    where
+        T: PartialEq;
+}
+
+impl<T> VecExt<T> for Vec<T> {
+    fn push_if_unique(&mut self, item: T)
+    where
+        T: PartialEq,
+    {
+        if !self.contains(&item) {
+            self.push(item);
+        }
+    }
+}
+
+// Works with any T: PartialEq
+let mut v = vec![1, 2, 3];
+v.push_if_unique(2);  // No-op
+v.push_if_unique(4);  // Adds 4
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Controlling trait implementations
+- [api-impl-into](./api-impl-into.md) - Using standard conversion traits
+- [name-as-free](./name-as-free.md) - Naming conventions for conversions

--- a/.agents/skills/rust-skills/rules/api-from-not-into.md
+++ b/.agents/skills/rust-skills/rules/api-from-not-into.md
@@ -1,0 +1,146 @@
+# api-from-not-into
+
+> Implement `From<T>`, not `Into<U>` - From gives you Into for free
+
+## Why It Matters
+
+The standard library has a blanket implementation: `impl<T, U> Into<U> for T where U: From<T>`. This means implementing `From<T> for U` automatically gives you `Into<U> for T`. Implementing `Into` directly bypasses this and is considered non-idiomatic. Always implement `From`.
+
+## Bad
+
+```rust
+struct UserId(u64);
+
+// Non-idiomatic: implementing Into directly
+impl Into<UserId> for u64 {
+    fn into(self) -> UserId {
+        UserId(self)
+    }
+}
+
+// Works, but now you can't use From syntax
+let id = UserId::from(42);  // Error: From not implemented
+let id: UserId = 42.into(); // Works, but limited
+```
+
+## Good
+
+```rust
+struct UserId(u64);
+
+// Idiomatic: implement From
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        UserId(id)
+    }
+}
+
+// Now both work automatically
+let id = UserId::from(42);   // From syntax
+let id: UserId = 42.into();  // Into syntax (via blanket impl)
+
+// And Into bound works in generics
+fn process(id: impl Into<UserId>) {
+    let id: UserId = id.into();
+}
+process(42u64);  // Works!
+```
+
+## Blanket Implementation
+
+```rust
+// This is in std, you don't write it
+impl<T, U> Into<U> for T
+where
+    U: From<T>,
+{
+    fn into(self) -> U {
+        U::from(self)
+    }
+}
+
+// So when you implement From:
+impl From<String> for MyType { ... }
+
+// You automatically get:
+// impl Into<MyType> for String { ... }
+```
+
+## Multiple From Implementations
+
+```rust
+struct Email(String);
+
+impl From<String> for Email {
+    fn from(s: String) -> Self {
+        Email(s)
+    }
+}
+
+impl From<&str> for Email {
+    fn from(s: &str) -> Self {
+        Email(s.to_string())
+    }
+}
+
+// All of these work
+let e1 = Email::from("test@example.com");
+let e2 = Email::from(String::from("test@example.com"));
+let e3: Email = "test@example.com".into();
+let e4: Email = String::from("test@example.com").into();
+```
+
+## TryFrom for Fallible Conversions
+
+```rust
+use std::convert::TryFrom;
+
+struct PositiveInt(u32);
+
+// Fallible conversion
+impl TryFrom<i32> for PositiveInt {
+    type Error = &'static str;
+    
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value > 0 {
+            Ok(PositiveInt(value as u32))
+        } else {
+            Err("value must be positive")
+        }
+    }
+}
+
+// Usage
+let pos = PositiveInt::try_from(42)?;   // From-style
+let pos: PositiveInt = 42.try_into()?;  // Into-style (via blanket)
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+from_over_into = "warn"  # Warns when implementing Into instead of From
+```
+
+```rust
+// Clippy will warn:
+impl Into<Bar> for Foo {  // Warning: prefer From
+    fn into(self) -> Bar { ... }
+}
+```
+
+## When Into IS Needed (Rare)
+
+```rust
+// Only when implementing for external types in specific trait bounds
+// This is very rare and usually indicates a design issue
+
+// Example: you can't implement From<ExternalA> for ExternalB
+// because of orphan rules. But you usually shouldn't need to.
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - Using Into in function parameters
+- [err-from-impl](./err-from-impl.md) - From for error types
+- [api-newtype-safety](./api-newtype-safety.md) - Newtype conversions

--- a/.agents/skills/rust-skills/rules/api-impl-asref.md
+++ b/.agents/skills/rust-skills/rules/api-impl-asref.md
@@ -1,0 +1,142 @@
+# api-impl-asref
+
+> Use `AsRef<T>` when you only need to borrow the inner data
+
+## Why It Matters
+
+`AsRef<T>` provides a cheap borrowed view of data without taking ownership or copying. Functions accepting `impl AsRef<T>` can work with multiple types that contain or represent `T`, making APIs flexible while avoiding unnecessary allocations. Use `AsRef` when you only need to read, `Into` when you need to own.
+
+## Bad
+
+```rust
+// Forces callers to provide exact types
+fn process_text(text: &str) { ... }
+fn read_file(path: &Path) { ... }
+
+// Can't call directly with owned types
+let s = String::from("hello");
+process_text(&s);  // Works but verbose
+
+let p = PathBuf::from("/file");
+read_file(&p);  // Works but verbose
+read_file("/file");  // Error! &str != &Path
+```
+
+## Good
+
+```rust
+// Accept anything that can be viewed as the target type
+fn process_text(text: impl AsRef<str>) {
+    let s: &str = text.as_ref();
+    println!("{}", s);
+}
+
+fn read_file(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
+    std::fs::read(path.as_ref())
+}
+
+// All of these work:
+process_text("literal");        // &str
+process_text(String::from("owned"));  // String
+process_text(Cow::from("cow")); // Cow<str>
+
+read_file("/path/to/file");     // &str  
+read_file(Path::new("/path"));  // &Path
+read_file(PathBuf::from("/path")); // PathBuf
+read_file(OsStr::new("/path")); // &OsStr
+```
+
+## AsRef vs Into vs Borrow
+
+```rust
+// AsRef<T>: cheap borrow, no ownership transfer
+fn read(p: impl AsRef<Path>) {
+    let path: &Path = p.as_ref();
+}
+
+// Into<T>: ownership transfer, may allocate
+fn store(p: impl Into<PathBuf>) {
+    let owned: PathBuf = p.into();
+}
+
+// Borrow<T>: like AsRef but with Eq/Hash consistency guarantee
+use std::borrow::Borrow;
+fn lookup<Q: ?Sized>(map: &HashMap<String, V>, key: &Q) -> Option<&V>
+where
+    String: Borrow<Q>,
+    Q: Hash + Eq,
+{
+    map.get(key)
+}
+```
+
+## Implement AsRef for Custom Types
+
+```rust
+struct Name(String);
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Name {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+// Now Name works with functions expecting AsRef<str>
+fn greet(name: impl AsRef<str>) {
+    println!("Hello, {}!", name.as_ref());
+}
+
+greet(Name("Alice".into()));
+```
+
+## Common AsRef Implementations
+
+```rust
+// Standard library provides many
+impl AsRef<str> for String { ... }
+impl AsRef<str> for str { ... }
+impl AsRef<[u8]> for str { ... }
+impl AsRef<[u8]> for String { ... }
+impl AsRef<[u8]> for Vec<u8> { ... }
+impl AsRef<Path> for str { ... }
+impl AsRef<Path> for String { ... }
+impl AsRef<Path> for PathBuf { ... }
+impl AsRef<Path> for OsStr { ... }
+impl AsRef<OsStr> for str { ... }
+```
+
+## When to Use Which
+
+| Trait | Use When |
+|-------|----------|
+| `&T` | Single type, simple API |
+| `AsRef<T>` | Read-only access, multiple input types |
+| `Into<T>` | Need to store/own the value |
+| `Borrow<T>` | HashMap/HashSet keys, Eq/Hash needed |
+| `Deref<Target=T>` | Smart pointer semantics |
+
+## Pattern: Optional AsRef Bound
+
+```rust
+// When T itself might be passed
+fn process<T: AsRef<U>, U>(value: T) {
+    let inner: &U = value.as_ref();
+}
+
+// More flexible: accept T or &T
+fn process<T: AsRef<U> + ?Sized, U: ?Sized>(value: &T) {
+    let inner: &U = value.as_ref();
+}
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - When to use Into instead
+- [own-slice-over-vec](./own-slice-over-vec.md) - Using slices for flexibility
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Preferring borrows

--- a/.agents/skills/rust-skills/rules/api-impl-into.md
+++ b/.agents/skills/rust-skills/rules/api-impl-into.md
@@ -1,0 +1,160 @@
+# api-impl-into
+
+> Accept `impl Into<T>` for flexible APIs, implement `From<T>` for conversions
+
+## Why It Matters
+
+APIs that accept `impl Into<T>` are ergonomic—callers can pass the target type directly or any type that converts to it. This reduces boilerplate `.into()` calls at call sites. Implement `From<T>` rather than `Into<T>` because `From` implies `Into` through a blanket implementation.
+
+## Bad
+
+```rust
+// Requires exact type - forces callers to convert
+fn process_path(path: PathBuf) { ... }
+fn set_name(name: String) { ... }
+
+// Caller must convert explicitly
+process_path(PathBuf::from("/path/to/file"));
+process_path("/path/to/file".to_path_buf());  // Verbose
+process_path("/path/to/file".into());          // Explicit
+
+set_name(String::from("Alice"));
+set_name("Alice".to_string());  // Verbose
+```
+
+## Good
+
+```rust
+// Accept anything that converts to the target type
+fn process_path(path: impl Into<PathBuf>) {
+    let path = path.into();  // Convert once inside
+    // ...
+}
+
+fn set_name(name: impl Into<String>) {
+    let name = name.into();
+    // ...
+}
+
+// Callers are ergonomic
+process_path("/path/to/file");    // &str converts automatically
+process_path(PathBuf::from(".")); // PathBuf works too
+
+set_name("Alice");                // &str
+set_name(String::from("Alice"));  // String
+set_name(format!("User-{}", id)); // String from format!
+```
+
+## Implement From, Not Into
+
+```rust
+struct UserId(u64);
+
+// ✅ Implement From
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        UserId(id)
+    }
+}
+
+// Into is automatically provided by blanket impl
+let id: UserId = 42u64.into();  // Works!
+
+// ❌ Don't implement Into directly
+impl Into<UserId> for u64 {
+    fn into(self) -> UserId {
+        UserId(self)  // This works but is non-idiomatic
+    }
+}
+```
+
+## Common Conversions
+
+```rust
+// String-like types
+fn log_message(msg: impl Into<String>) { ... }
+log_message("literal");           // &str
+log_message(String::from("own")); // String
+log_message(Cow::from("cow"));    // Cow<str>
+
+// Path-like types  
+fn read_file(path: impl AsRef<Path>) { ... }  // AsRef for borrowed access
+fn write_file(path: impl Into<PathBuf>) { ... }  // Into when storing
+
+// Duration
+fn set_timeout(duration: impl Into<Duration>) { ... }
+set_timeout(Duration::from_secs(5));
+// Note: no blanket impl for integers, would need custom wrapper
+```
+
+## AsRef vs Into
+
+```rust
+// AsRef<T>: borrow as &T, no conversion cost
+fn count_bytes(data: impl AsRef<[u8]>) -> usize {
+    data.as_ref().len()  // Just borrows, no allocation
+}
+count_bytes("hello");  // &str -> &[u8]
+count_bytes(b"hello"); // &[u8] -> &[u8]
+count_bytes(vec![1, 2, 3]);  // &Vec<u8> -> &[u8]
+
+// Into<T>: convert to owned T, may allocate
+fn store_data(data: impl Into<Vec<u8>>) {
+    let owned: Vec<u8> = data.into();  // Takes ownership
+    // ...
+}
+```
+
+## When NOT to Use impl Into
+
+```rust
+// ❌ Trait objects need Sized
+fn process(handler: impl Into<Box<dyn Handler>>) { }
+// Better: just take Box<dyn Handler> directly
+
+// ❌ Recursive types
+struct Node {
+    children: Vec<impl Into<Node>>,  // Error: impl Trait not allowed here
+}
+
+// ❌ Performance-critical hot paths (minor overhead of trait dispatch)
+fn hot_path(value: impl Into<u64>) {
+    // Consider taking u64 directly if called billions of times
+}
+
+// ❌ When you need to name the type
+fn returns_impl() -> impl Into<String> { }  // Opaque, hard to use
+```
+
+## Builder Pattern with Into
+
+```rust
+struct Config {
+    name: String,
+    path: PathBuf,
+}
+
+impl Config {
+    fn new(name: impl Into<String>) -> Self {
+        Config {
+            name: name.into(),
+            path: PathBuf::new(),
+        }
+    }
+    
+    fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = path.into();
+        self
+    }
+}
+
+// Clean builder calls
+let config = Config::new("myapp")
+    .path("/etc/myapp");
+```
+
+## See Also
+
+- [api-impl-asref](./api-impl-asref.md) - When to use AsRef instead
+- [api-from-not-into](./api-from-not-into.md) - Why From is preferred
+- [err-from-impl](./err-from-impl.md) - From for error conversion

--- a/.agents/skills/rust-skills/rules/api-must-use.md
+++ b/.agents/skills/rust-skills/rules/api-must-use.md
@@ -1,0 +1,125 @@
+# api-must-use
+
+> Mark types and functions with `#[must_use]` when ignoring results is likely a bug
+
+## Why It Matters
+
+Some return values should never be ignored—`Result`, locks, RAII guards, computed values that have no side effects. Without `#[must_use]`, silently discarding these values can introduce subtle bugs that are hard to detect. The attribute generates compiler warnings when the value is unused.
+
+## Bad
+
+```rust
+// Result ignored - error silently dropped
+fn send_email(to: &str, body: &str) -> Result<(), EmailError> { ... }
+
+send_email("user@example.com", "Hello!");  // No warning if Result ignored!
+// Email may have failed, but we don't know
+
+// Computed value ignored - likely a bug
+fn compute_checksum(data: &[u8]) -> u32 { ... }
+
+let data = vec![1, 2, 3, 4];
+compute_checksum(&data);  // Result discarded - pointless call
+```
+
+## Good
+
+```rust
+#[must_use = "this `Result` may be an `Err` that should be handled"]
+fn send_email(to: &str, body: &str) -> Result<(), EmailError> { ... }
+
+send_email("user@example.com", "Hello!");  
+// Warning: unused `Result` that must be used
+
+// Mark pure functions
+#[must_use = "this returns a new value and does not modify the input"]
+fn compute_checksum(data: &[u8]) -> u32 { ... }
+
+compute_checksum(&data);
+// Warning: unused return value of `compute_checksum` that must be used
+```
+
+## Apply to Types
+
+```rust
+// Mark the type itself when it should always be used
+#[must_use = "futures do nothing unless polled"]
+struct MyFuture<T> { ... }
+
+// Mark RAII guards
+#[must_use = "if unused, the lock will be immediately released"]
+struct MutexGuard<'a, T> { ... }
+
+// Mark results/errors
+#[must_use = "errors should be handled"]
+enum AppError { ... }
+```
+
+## Standard Library Examples
+
+```rust
+// Result and Option are #[must_use]
+let v: Vec<i32> = vec![1, 2, 3];
+v.first();  // Warning: unused Option
+
+// Iterator adapters are #[must_use]
+v.iter().map(|x| x * 2);  // Warning: iterators are lazy
+
+// String methods that return new values
+let s = "hello";
+s.to_uppercase();  // Warning: unused String
+```
+
+## When to Apply
+
+```rust
+// ✅ Pure functions (no side effects)
+#[must_use]
+fn add(a: i32, b: i32) -> i32 { a + b }
+
+// ✅ Builder methods returning Self
+#[must_use = "builder methods return a new builder"]
+fn with_timeout(self, t: Duration) -> Self { ... }
+
+// ✅ Fallible operations
+#[must_use]
+fn try_parse(s: &str) -> Result<Data, ParseError> { ... }
+
+// ✅ Iterators and futures (lazy)
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+struct Map<I, F> { ... }
+
+// ❌ Side-effecting functions where result is optional
+fn log(msg: &str) -> Result<(), io::Error> { ... }  // Might be ok to ignore
+
+// ❌ Methods with useful side effects
+fn vec.push(item);  // Mutates vec, no return to use
+```
+
+## Custom Messages
+
+```rust
+#[must_use = "creating a guard does nothing without assignment"]
+struct ScopeGuard { ... }
+
+#[must_use = "this returns the old value"]
+fn replace(&mut self, new: T) -> T { ... }
+
+#[must_use = "use `.await` to execute the future"]
+async fn fetch() -> Data { ... }
+```
+
+## Clippy Lints
+
+```toml
+[lints.clippy]
+must_use_candidate = "warn"      # Suggests where to add #[must_use]
+unused_must_use = "deny"          # Built-in, treat warnings as errors
+double_must_use = "warn"          # Redundant #[must_use]
+```
+
+## See Also
+
+- [api-builder-must-use](./api-builder-must-use.md) - Builder pattern must_use
+- [err-result-over-panic](./err-result-over-panic.md) - Result types require handling
+- [lint-deny-correctness](./lint-deny-correctness.md) - Enabling useful lints

--- a/.agents/skills/rust-skills/rules/api-newtype-safety.md
+++ b/.agents/skills/rust-skills/rules/api-newtype-safety.md
@@ -1,0 +1,162 @@
+# api-newtype-safety
+
+> Use newtypes to prevent mixing semantically different values
+
+## Why It Matters
+
+Raw primitives like `u64` or `String` carry no semantic meaning. A function taking `(u64, u64)` can easily be called with arguments swapped. Newtypes wrap primitives in distinct types, making the compiler catch mistakes at compile time rather than runtime.
+
+## Bad
+
+```rust
+struct User {
+    id: u64,
+    group_id: u64,
+    created_at: u64,  // Unix timestamp
+}
+
+fn add_user_to_group(user_id: u64, group_id: u64) { ... }
+
+// Bug: arguments swapped - compiles fine, fails at runtime
+let user = User { id: 100, group_id: 5, created_at: 1234567890 };
+add_user_to_group(user.group_id, user.id);  // Silent bug!
+
+// Bug: wrong field used - timestamp passed as ID
+add_user_to_group(user.created_at, user.group_id);  // Compiles fine!
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UserId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct GroupId(u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct Timestamp(u64);
+
+struct User {
+    id: UserId,
+    group_id: GroupId,
+    created_at: Timestamp,
+}
+
+fn add_user_to_group(user_id: UserId, group_id: GroupId) { ... }
+
+// Compile error: expected UserId, found GroupId
+let user = User { ... };
+add_user_to_group(user.group_id, user.id);  // Error!
+
+// Compile error: expected UserId, found Timestamp
+add_user_to_group(user.created_at, user.group_id);  // Error!
+```
+
+## Derive Common Traits
+
+```rust
+// Minimal: just enough for your use case
+#[derive(Debug, Clone, Copy)]
+struct MeterId(u32);
+
+// Full ID type: hashable, comparable, displayable
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct OrderId(u64);
+
+impl std::fmt::Display for OrderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ORD-{:08}", self.0)
+    }
+}
+
+// With serde for serialization
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]  // Serializes as raw u64
+struct ProductId(u64);
+```
+
+## Constructor Patterns
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Email(String);
+
+impl Email {
+    /// Creates a new Email, validating the format.
+    pub fn new(s: &str) -> Result<Self, EmailError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(EmailError::InvalidFormat)
+        }
+    }
+    
+    /// Returns the email as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// Usage enforces validation
+let email = Email::new("user@example.com")?;  // Must go through validation
+```
+
+## Zero-Cost Abstraction
+
+```rust
+use std::mem::size_of;
+
+#[derive(Clone, Copy)]
+struct Miles(f64);
+
+#[derive(Clone, Copy)]
+struct Kilometers(f64);
+
+// Same size as raw f64
+assert_eq!(size_of::<Miles>(), size_of::<f64>());
+assert_eq!(size_of::<Kilometers>(), size_of::<f64>());
+
+// But can't accidentally mix them
+fn drive(distance: Miles) { ... }
+
+let km = Kilometers(100.0);
+drive(km);  // Error: expected Miles, found Kilometers
+
+// Explicit conversion
+impl From<Kilometers> for Miles {
+    fn from(km: Kilometers) -> Self {
+        Miles(km.0 * 0.621371)
+    }
+}
+
+drive(km.into());  // Explicit, visible conversion
+```
+
+## When Newtypes Help Most
+
+```rust
+// ✅ IDs that could be confused
+fn transfer(from: AccountId, to: AccountId, amount: Money) { ... }
+
+// ✅ Units that shouldn't mix
+struct Celsius(f64);
+struct Fahrenheit(f64);
+
+// ✅ Validated strings
+struct Username(String);  // Validated alphanumeric
+struct Password(String);  // Never logged
+
+// ✅ Different meanings of same type
+struct Milliseconds(u64);
+struct Seconds(u64);
+
+// ❌ Overkill: single use, no confusion possible
+struct X(i32);  // Just use i32
+```
+
+## See Also
+
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern for IDs
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven validation
+- [own-copy-small](./own-copy-small.md) - Making newtypes Copy

--- a/.agents/skills/rust-skills/rules/api-non-exhaustive.md
+++ b/.agents/skills/rust-skills/rules/api-non-exhaustive.md
@@ -1,0 +1,177 @@
+# api-non-exhaustive
+
+> Use `#[non_exhaustive]` on public enums and structs for forward compatibility
+
+## Why It Matters
+
+Adding a variant to a public enum or a field to a public struct is normally a breaking change—downstream code may match exhaustively or use struct literal syntax. `#[non_exhaustive]` forces external code to use wildcards in matches and constructors, allowing you to add variants/fields in minor versions without breaking callers.
+
+## Bad
+
+```rust
+// Public enum - adding variant breaks downstream matches
+pub enum ErrorKind {
+    NotFound,
+    PermissionDenied,
+    TimedOut,
+}
+
+// Downstream code
+match error.kind() {
+    ErrorKind::NotFound => ...,
+    ErrorKind::PermissionDenied => ...,
+    ErrorKind::TimedOut => ...,
+    // No wildcard - will break when you add ErrorKind::Interrupted
+}
+
+// Public struct - adding field breaks downstream construction
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Downstream code
+let config = Config { name: "test".into(), value: 42 };
+// Will break when you add `pub enabled: bool`
+```
+
+## Good
+
+```rust
+// Can add variants in minor versions
+#[non_exhaustive]
+pub enum ErrorKind {
+    NotFound,
+    PermissionDenied,
+    TimedOut,
+    // Future: can add Interrupted here without breaking changes
+}
+
+// Downstream code MUST have wildcard
+match error.kind() {
+    ErrorKind::NotFound => ...,
+    ErrorKind::PermissionDenied => ...,
+    ErrorKind::TimedOut => ...,
+    _ => ...,  // Required by non_exhaustive
+}
+
+// Can add fields in minor versions
+#[non_exhaustive]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Downstream CANNOT use struct literal syntax
+// let config = Config { name: "test".into(), value: 42 };  // Error!
+
+// Must use constructor
+impl Config {
+    pub fn new(name: impl Into<String>, value: i32) -> Self {
+        Config { name: name.into(), value }
+    }
+}
+```
+
+## How It Works
+
+```rust
+#[non_exhaustive]
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+// Inside your crate: exhaustive match is allowed
+fn internal(s: Status) {
+    match s {
+        Status::Active => {},
+        Status::Inactive => {},
+        // No wildcard needed inside defining crate
+    }
+}
+
+// Outside your crate: wildcard required
+fn external(s: my_crate::Status) {
+    match s {
+        my_crate::Status::Active => {},
+        my_crate::Status::Inactive => {},
+        _ => {},  // REQUIRED
+    }
+}
+```
+
+## Struct Usage
+
+```rust
+#[non_exhaustive]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl Point {
+    // Provide constructor
+    pub fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+}
+
+// External code can read fields but not construct with literals
+fn external(p: Point) {
+    println!("x: {}, y: {}", p.x, p.y);  // Reading is fine
+    
+    // let p2 = Point { x: 1.0, y: 2.0 };  // Error!
+    let p2 = Point::new(1.0, 2.0);  // Must use constructor
+}
+```
+
+## Non-Exhaustive Variants
+
+```rust
+pub enum Message {
+    // Specific variant is non-exhaustive
+    #[non_exhaustive]
+    Error { code: u32, message: String },
+    
+    Ok(Data),
+}
+
+// Can destructure Ok normally
+// But Error requires `..` to handle future fields
+match msg {
+    Message::Ok(data) => {},
+    Message::Error { code, message, .. } => {},  // `..` required
+}
+```
+
+## When to Use
+
+```rust
+// ✅ Use for public API types that may evolve
+#[non_exhaustive]
+pub enum ApiError { ... }
+
+#[non_exhaustive]
+pub struct Options { ... }
+
+// ✅ Use for error types
+#[non_exhaustive]
+pub enum MyError { ... }
+
+// ❌ Don't use for internal types
+enum InternalState { ... }  // Not public, no concern
+
+// ❌ Don't use for stable, complete types
+pub enum Ordering {  // Less, Equal, Greater is complete
+    Less,
+    Equal,
+    Greater,
+}
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Controlling trait implementations
+- [err-custom-type](./err-custom-type.md) - Error type design
+- [api-builder-pattern](./api-builder-pattern.md) - Alternative to struct literals

--- a/.agents/skills/rust-skills/rules/api-parse-dont-validate.md
+++ b/.agents/skills/rust-skills/rules/api-parse-dont-validate.md
@@ -1,0 +1,184 @@
+# api-parse-dont-validate
+
+> Parse into validated types at boundaries
+
+## Why It Matters
+
+Instead of validating data and hoping you remember to check everywhere, parse it into a type that can only be constructed from valid data. The type system then guarantees validity - you can't forget to validate because invalid states are unrepresentable.
+
+## Bad
+
+```rust
+// Validation scattered throughout codebase
+fn send_email(email: &str) -> Result<(), Error> {
+    // Did someone validate this already? Who knows!
+    if !is_valid_email(email) {
+        return Err(Error::InvalidEmail);
+    }
+    // Send email...
+}
+
+fn add_to_mailing_list(email: &str) -> Result<(), Error> {
+    // Duplicate validation, or did we forget?
+    if !is_valid_email(email) {
+        return Err(Error::InvalidEmail);
+    }
+    // Add to list...
+}
+
+// Easy to forget validation
+fn process_user_email(email: &str) {
+    // Oops, no validation!
+    database.store_email(email);
+}
+```
+
+## Good
+
+```rust
+/// A validated email address.
+/// Can only be constructed via `Email::parse()`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Email(String);
+
+impl Email {
+    /// Parses and validates an email address.
+    pub fn parse(s: impl Into<String>) -> Result<Self, EmailError> {
+        let s = s.into();
+        if Self::is_valid(&s) {
+            Ok(Email(s))
+        } else {
+            Err(EmailError::Invalid)
+        }
+    }
+    
+    fn is_valid(s: &str) -> bool {
+        s.contains('@') && s.len() > 3  // Simplified
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// Now functions can accept Email - guaranteed valid!
+fn send_email(email: &Email) -> Result<(), Error> {
+    // No validation needed - Email is always valid
+    smtp_send(email.as_str())
+}
+
+fn add_to_mailing_list(email: Email) {
+    // No validation needed
+    list.push(email);
+}
+```
+
+## More Examples
+
+```rust
+// Port number (1-65535)
+pub struct Port(u16);
+
+impl Port {
+    pub fn new(n: u16) -> Option<Self> {
+        if n > 0 { Some(Port(n)) } else { None }
+    }
+    
+    pub fn get(&self) -> u16 {
+        self.0
+    }
+}
+
+// Non-empty string
+pub struct NonEmptyString(String);
+
+impl NonEmptyString {
+    pub fn new(s: impl Into<String>) -> Option<Self> {
+        let s = s.into();
+        if s.is_empty() { None } else { Some(Self(s)) }
+    }
+}
+
+// Positive integer
+pub struct PositiveI32(i32);
+
+impl PositiveI32 {
+    pub fn new(n: i32) -> Option<Self> {
+        if n > 0 { Some(Self(n)) } else { None }
+    }
+}
+
+// Bounded value
+pub struct Percentage(u8);
+
+impl Percentage {
+    pub fn new(n: u8) -> Option<Self> {
+        if n <= 100 { Some(Self(n)) } else { None }
+    }
+}
+```
+
+## Parsing at Boundaries
+
+```rust
+// Parse at the system boundary (API, CLI, config file)
+fn handle_request(raw: RawRequest) -> Result<Response, Error> {
+    // Parse ALL inputs upfront
+    let email = Email::parse(&raw.email)?;
+    let age = Age::parse(raw.age)?;
+    let username = Username::parse(&raw.username)?;
+    
+    // Now work with validated types
+    process_user(email, age, username)
+}
+
+fn process_user(email: Email, age: Age, username: Username) {
+    // All inputs guaranteed valid - no checks needed
+}
+```
+
+## Evidence from sqlx
+
+```rust
+// sqlx parses SQL at compile time, ensuring query validity
+// https://github.com/launchbadge/sqlx/blob/master/src/macros/mod.rs
+
+// The query! macro parses and validates SQL
+let user = sqlx::query!("SELECT * FROM users WHERE id = ?", id)
+    .fetch_one(&pool)
+    .await?;
+
+// If SQL is invalid, compilation fails - invalid state unrepresentable
+```
+
+## Combining with Display
+
+```rust
+use std::fmt;
+
+pub struct Email(String);
+
+impl Email {
+    pub fn parse(s: &str) -> Result<Self, EmailError> { ... }
+}
+
+// Implement Display for easy printing
+impl fmt::Display for Email {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// Implement AsRef for easy borrowing
+impl AsRef<str> for Email {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## See Also
+
+- [api-newtype-safety](api-newtype-safety.md) - Use newtypes for type safety
+- [type-newtype-validated](type-newtype-validated.md) - Newtypes for validated data
+- [api-typestate](api-typestate.md) - Compile-time state machines

--- a/.agents/skills/rust-skills/rules/api-sealed-trait.md
+++ b/.agents/skills/rust-skills/rules/api-sealed-trait.md
@@ -1,0 +1,168 @@
+# api-sealed-trait
+
+> Use sealed traits to prevent external implementations while allowing use
+
+## Why It Matters
+
+Public traits can be implemented by anyone, which may be undesirable when you need to guarantee behavior or add methods in future versions. A sealed trait can be used by external code but not implemented by it, giving you control over implementations while maintaining a usable API.
+
+## Bad
+
+```rust
+// Anyone can implement this trait
+pub trait DatabaseDriver {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+}
+
+// External crate implements it incorrectly
+impl DatabaseDriver for MyBadDriver {
+    fn connect(&self, url: &str) -> Connection {
+        // Buggy implementation that doesn't handle errors
+        unsafe { force_connect(url) }
+    }
+}
+
+// Later, you want to add a required method - BREAKING CHANGE
+pub trait DatabaseDriver {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+    fn transaction(&self) -> Transaction;  // External impls now broken!
+}
+```
+
+## Good
+
+```rust
+// Create a private module with a private trait
+mod private {
+    pub trait Sealed {}
+}
+
+// Public trait requires the private trait
+pub trait DatabaseDriver: private::Sealed {
+    fn connect(&self, url: &str) -> Connection;
+    fn execute(&self, query: &str) -> Result<Rows, Error>;
+}
+
+// Only your crate can implement Sealed, thus DatabaseDriver
+pub struct PostgresDriver;
+impl private::Sealed for PostgresDriver {}
+impl DatabaseDriver for PostgresDriver {
+    fn connect(&self, url: &str) -> Connection { ... }
+    fn execute(&self, query: &str) -> Result<Rows, Error> { ... }
+}
+
+pub struct MySqlDriver;
+impl private::Sealed for MySqlDriver {}
+impl DatabaseDriver for MySqlDriver {
+    fn connect(&self, url: &str) -> Connection { ... }
+    fn execute(&self, query: &str) -> Result<Rows, Error> { ... }
+}
+
+// External crate cannot implement - private::Sealed is not accessible
+// impl DatabaseDriver for ExternalDriver { }  // Error!
+
+// But external code CAN use the trait
+fn use_driver(driver: &impl DatabaseDriver) {
+    let conn = driver.connect("postgres://localhost");
+}
+```
+
+## Full Pattern
+
+```rust
+pub mod db {
+    mod private {
+        pub trait Sealed {}
+    }
+    
+    /// Database driver trait.
+    /// 
+    /// This trait is sealed and cannot be implemented outside this crate.
+    pub trait Driver: private::Sealed {
+        /// Connects to the database.
+        fn connect(&self, url: &str) -> Result<Connection, Error>;
+        
+        /// Executes a query.
+        fn execute(&self, sql: &str) -> Result<Rows, Error>;
+    }
+    
+    pub struct Postgres;
+    impl private::Sealed for Postgres {}
+    impl Driver for Postgres { ... }
+    
+    pub struct Sqlite;
+    impl private::Sealed for Sqlite {}
+    impl Driver for Sqlite { ... }
+}
+
+// Usage works fine
+use db::{Driver, Postgres};
+
+fn query(driver: &impl Driver) {
+    driver.execute("SELECT 1")?;
+}
+
+query(&Postgres);
+```
+
+## Benefits of Sealing
+
+```rust
+// 1. Add methods without breaking changes
+pub trait Format: private::Sealed {
+    fn format(&self) -> String;
+    
+    // Added later - not breaking because no external impls exist
+    fn format_pretty(&self) -> String {
+        self.format()  // Default implementation
+    }
+}
+
+// 2. Guarantee invariants
+pub trait SafeBuffer: private::Sealed {
+    // You control all implementations, so you know they're all correct
+    fn get(&self, index: usize) -> Option<&u8>;
+}
+
+// 3. Use as marker traits
+pub trait ValidConfig: private::Sealed {}
+// Only validated configs implement this
+```
+
+## Partially Sealed
+
+```rust
+// Allow implementing some methods but not all
+mod private {
+    pub trait SealedCore {}
+}
+
+pub trait Plugin: private::SealedCore {
+    // Sealed - only we implement
+    fn initialize(&self);
+    fn shutdown(&self);
+    
+    // Open - users can override
+    fn name(&self) -> &str { "unnamed" }
+}
+
+// Only we can add new required sealed methods
+// Users can customize open methods
+```
+
+## When to Seal
+
+| Seal When | Don't Seal When |
+|-----------|-----------------|
+| API stability is critical | You want extension points |
+| Implementation correctness is hard | Users need custom implementations |
+| You'll add methods later | Trait is simple and stable |
+| Safety invariants required | Standard patterns (Iterator, etc.) |
+
+## See Also
+
+- [api-non-exhaustive](./api-non-exhaustive.md) - Related pattern for enums/structs
+- [api-extension-trait](./api-extension-trait.md) - Adding methods to external types
+- [api-typestate](./api-typestate.md) - Compile-time state guarantees

--- a/.agents/skills/rust-skills/rules/api-serde-optional.md
+++ b/.agents/skills/rust-skills/rules/api-serde-optional.md
@@ -1,0 +1,182 @@
+# api-serde-optional
+
+> Make serde a feature flag, not a hard dependency for library crates
+
+## Why It Matters
+
+Not all users of your library need serialization. Making serde a required dependency adds compile time and binary size for everyone. Feature flags let users opt-in to serde support only when needed, following Rust's philosophy of zero-cost abstractions and minimal dependencies.
+
+## Bad
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+
+// lib.rs
+use serde::{Serialize, Deserialize};
+
+// Every user pays for serde, even if they don't need it
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+```
+
+## Good
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
+
+// lib.rs
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Config {
+    pub name: String,
+    pub value: i32,
+}
+
+// Users opt-in:
+// my_crate = { version = "1.0", features = ["serde"] }
+```
+
+## Macro Pattern
+
+```rust
+// Reusable macro for serde derives
+#[cfg(feature = "serde")]
+macro_rules! impl_serde {
+    ($($t:ty),*) => {
+        $(
+            impl serde::Serialize for $t {
+                // ...
+            }
+            impl<'de> serde::Deserialize<'de> for $t {
+                // ...
+            }
+        )*
+    };
+}
+
+#[cfg(not(feature = "serde"))]
+macro_rules! impl_serde {
+    ($($t:ty),*) => {};
+}
+
+// Or use cfg_attr for derived impls
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+```
+
+## Feature Documentation
+
+```rust
+// lib.rs
+
+//! # Features
+//!
+//! - `serde`: Enables `Serialize` and `Deserialize` implementations for all types.
+//!
+//! # Example with serde
+//!
+//! ```toml
+//! [dependencies]
+//! my_crate = { version = "1.0", features = ["serde"] }
+//! ```
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+/// A configuration type.
+/// 
+/// When the `serde` feature is enabled, this type implements
+/// `Serialize` and `Deserialize`.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+pub struct Config {
+    pub name: String,
+}
+```
+
+## Multiple Optional Dependencies
+
+```rust
+// Cargo.toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+rkyv = { version = "0.7", optional = true }
+borsh = { version = "0.10", optional = true }
+
+[features]
+default = []
+serde = ["dep:serde"]
+rkyv = ["dep:rkyv"]
+borsh = ["dep:borsh"]
+
+// lib.rs
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "rkyv", derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshSerialize, borsh::BorshDeserialize))]
+pub struct Message {
+    pub id: u64,
+    pub content: String,
+}
+```
+
+## Testing with Features
+
+```bash
+# Test without serde
+cargo test
+
+# Test with serde
+cargo test --features serde
+
+# Test all feature combinations
+cargo test --all-features
+```
+
+```rust
+// Test serde round-trip when feature enabled
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde_roundtrip() {
+    let config = Config { name: "test".into() };
+    let json = serde_json::to_string(&config).unwrap();
+    let parsed: Config = serde_json::from_str(&json).unwrap();
+    assert_eq!(config, parsed);
+}
+```
+
+## When to Make Serde Required
+
+```rust
+// ✅ Required: Library is about serialization
+// (e.g., json-schema, config-file parser)
+[dependencies]
+serde = "1.0"
+
+// ✅ Required: Domain heavily uses serde
+// (e.g., API client, data format library)
+
+// ❌ Optional: General-purpose utility library
+// ❌ Optional: Math/algorithm library
+// ❌ Optional: Most libraries!
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Library structure
+- [api-common-traits](./api-common-traits.md) - Core trait implementations
+- [lint-deny-correctness](./lint-deny-correctness.md) - Feature testing

--- a/.agents/skills/rust-skills/rules/api-typestate.md
+++ b/.agents/skills/rust-skills/rules/api-typestate.md
@@ -1,0 +1,199 @@
+# api-typestate
+
+> Use typestate pattern to encode state machine invariants in the type system
+
+## Why It Matters
+
+State machines with runtime state checks ("are we connected?", "is the transaction started?") can have invalid transitions. The typestate pattern uses different types for each state, making invalid state transitions compile errors. The compiler enforces your state machine.
+
+## Bad
+
+```rust
+struct Connection {
+    state: ConnectionState,
+    socket: Option<TcpStream>,
+}
+
+enum ConnectionState {
+    Disconnected,
+    Connected,
+    Authenticated,
+}
+
+impl Connection {
+    fn send(&mut self, data: &[u8]) -> Result<(), Error> {
+        // Runtime check - can fail if called in wrong state
+        if self.state != ConnectionState::Authenticated {
+            return Err(Error::NotAuthenticated);
+        }
+        self.socket.as_mut().unwrap().write_all(data)?;
+        Ok(())
+    }
+    
+    fn authenticate(&mut self, password: &str) -> Result<(), Error> {
+        // Runtime check - can fail
+        if self.state != ConnectionState::Connected {
+            return Err(Error::NotConnected);
+        }
+        // ...
+    }
+}
+
+// Bug: forgot to authenticate
+let mut conn = Connection::new();
+conn.connect()?;
+conn.send(b"data")?;  // Runtime error: NotAuthenticated
+```
+
+## Good
+
+```rust
+// Different types for each state
+struct Disconnected;
+struct Connected { socket: TcpStream }
+struct Authenticated { socket: TcpStream, session: Session }
+
+struct Connection<State> {
+    state: State,
+}
+
+impl Connection<Disconnected> {
+    fn new() -> Self {
+        Connection { state: Disconnected }
+    }
+    
+    fn connect(self, addr: &str) -> Result<Connection<Connected>, Error> {
+        let socket = TcpStream::connect(addr)?;
+        Ok(Connection { state: Connected { socket } })
+    }
+}
+
+impl Connection<Connected> {
+    fn authenticate(self, password: &str) -> Result<Connection<Authenticated>, Error> {
+        let session = do_auth(&self.state.socket, password)?;
+        Ok(Connection {
+            state: Authenticated { socket: self.state.socket, session }
+        })
+    }
+}
+
+impl Connection<Authenticated> {
+    fn send(&mut self, data: &[u8]) -> Result<(), Error> {
+        // No runtime check needed - type guarantees we're authenticated
+        self.state.socket.write_all(data)?;
+        Ok(())
+    }
+}
+
+// Bug: forgot to authenticate
+let conn = Connection::new();
+let conn = conn.connect("server:8080")?;
+conn.send(b"data");  // Compile error! send() not available on Connection<Connected>
+
+// Correct usage
+let conn = Connection::new();
+let conn = conn.connect("server:8080")?;
+let mut conn = conn.authenticate("secret")?;
+conn.send(b"data")?;  // Works - type is Connection<Authenticated>
+```
+
+## Builder Typestate
+
+```rust
+// Enforce required fields via typestate
+struct BuilderNoUrl;
+struct BuilderWithUrl { url: String }
+
+struct RequestBuilder<State> {
+    state: State,
+    timeout: Option<Duration>,
+}
+
+impl RequestBuilder<BuilderNoUrl> {
+    fn new() -> Self {
+        RequestBuilder {
+            state: BuilderNoUrl,
+            timeout: None,
+        }
+    }
+    
+    fn url(self, url: &str) -> RequestBuilder<BuilderWithUrl> {
+        RequestBuilder {
+            state: BuilderWithUrl { url: url.to_string() },
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl RequestBuilder<BuilderWithUrl> {
+    fn timeout(mut self, t: Duration) -> Self {
+        self.timeout = Some(t);
+        self
+    }
+    
+    // Only available once URL is set
+    fn build(self) -> Request {
+        Request {
+            url: self.state.url,
+            timeout: self.timeout,
+        }
+    }
+}
+
+// Compile error: build() not available
+let bad = RequestBuilder::new().build();
+
+// Correct: must set URL first
+let good = RequestBuilder::new()
+    .url("https://example.com")
+    .timeout(Duration::from_secs(30))
+    .build();
+```
+
+## Transaction Example
+
+```rust
+struct NotStarted;
+struct InProgress { tx_id: u64 }
+struct Committed;
+
+struct Transaction<State> {
+    conn: Connection,
+    state: State,
+}
+
+impl Transaction<NotStarted> {
+    fn begin(conn: Connection) -> Result<Transaction<InProgress>, Error> {
+        let tx_id = conn.execute("BEGIN")?;
+        Ok(Transaction {
+            conn,
+            state: InProgress { tx_id },
+        })
+    }
+}
+
+impl Transaction<InProgress> {
+    fn execute(&mut self, sql: &str) -> Result<(), Error> {
+        self.conn.execute(sql)
+    }
+    
+    fn commit(self) -> Result<Transaction<Committed>, Error> {
+        self.conn.execute("COMMIT")?;
+        Ok(Transaction {
+            conn: self.conn,
+            state: Committed,
+        })
+    }
+    
+    fn rollback(self) -> Connection {
+        let _ = self.conn.execute("ROLLBACK");
+        self.conn
+    }
+}
+```
+
+## See Also
+
+- [api-builder-pattern](./api-builder-pattern.md) - Basic builder pattern
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven invariants
+- [api-sealed-trait](./api-sealed-trait.md) - Restricting trait implementations

--- a/.agents/skills/rust-skills/rules/async-bounded-channel.md
+++ b/.agents/skills/rust-skills/rules/async-bounded-channel.md
@@ -1,0 +1,175 @@
+# async-bounded-channel
+
+> Use bounded channels to apply backpressure and prevent unbounded memory growth
+
+## Why It Matters
+
+Unbounded channels grow without limit when producers outpace consumers. In production, this leads to memory exhaustion. Bounded channels apply backpressure—producers wait when the channel is full, naturally throttling the system. This prevents OOM and makes resource usage predictable.
+
+## Bad
+
+```rust
+use tokio::sync::mpsc;
+
+// Unbounded channel - can grow forever
+let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
+
+// Fast producer, slow consumer = unbounded memory growth
+tokio::spawn(async move {
+    loop {
+        let msg = generate_message();
+        tx.send(msg).unwrap();  // Never blocks, never fails (until OOM)
+    }
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        slow_process(msg).await;  // Can't keep up
+    }
+});
+// Memory grows unboundedly until crash
+```
+
+## Good
+
+```rust
+use tokio::sync::mpsc;
+
+// Bounded channel - backpressure when full
+let (tx, mut rx) = mpsc::channel::<Message>(100);  // Max 100 items
+
+// Producer waits when channel full
+tokio::spawn(async move {
+    loop {
+        let msg = generate_message();
+        // Blocks if channel is full - natural backpressure
+        tx.send(msg).await.unwrap();
+    }
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        slow_process(msg).await;
+    }
+});
+// Memory usage capped at ~100 messages
+```
+
+## Choosing Buffer Size
+
+```rust
+// Too small: frequent blocking, reduced throughput
+let (tx, rx) = mpsc::channel::<Item>(1);
+
+// Too large: delayed backpressure, memory waste
+let (tx, rx) = mpsc::channel::<Item>(1_000_000);
+
+// Guidelines:
+// - Start with expected burst size
+// - Measure actual usage in production
+// - Err on the smaller side initially
+
+// Small items, high throughput
+let (tx, rx) = mpsc::channel::<u64>(1000);
+
+// Large items, moderate throughput  
+let (tx, rx) = mpsc::channel::<LargeStruct>(100);
+
+// Low latency requirement
+let (tx, rx) = mpsc::channel::<Command>(10);
+```
+
+## Handling Full Channel
+
+```rust
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+let (tx, mut rx) = mpsc::channel::<Message>(100);
+
+// Option 1: Wait indefinitely (default)
+tx.send(msg).await?;
+
+// Option 2: Try send, fail if full
+match tx.try_send(msg) {
+    Ok(()) => println!("Sent"),
+    Err(TrySendError::Full(msg)) => {
+        println!("Channel full, dropping message");
+    }
+    Err(TrySendError::Closed(msg)) => {
+        println!("Receiver dropped");
+    }
+}
+
+// Option 3: Timeout
+match timeout(Duration::from_secs(1), tx.send(msg)).await {
+    Ok(Ok(())) => println!("Sent"),
+    Ok(Err(_)) => println!("Channel closed"),
+    Err(_) => println!("Timeout - channel full for too long"),
+}
+
+// Option 4: send with permit reservation
+let permit = tx.reserve().await?;
+permit.send(msg);  // Guaranteed to succeed
+```
+
+## Channel Types
+
+```rust
+// mpsc: many producers, single consumer
+let (tx, rx) = mpsc::channel::<Message>(100);
+let tx2 = tx.clone();  // Can clone sender
+
+// oneshot: single value, one producer, one consumer
+let (tx, rx) = oneshot::channel::<Response>();
+tx.send(response);  // Can only send once
+
+// broadcast: multiple consumers, each gets all messages
+let (tx, _) = broadcast::channel::<Event>(100);
+let mut rx1 = tx.subscribe();
+let mut rx2 = tx.subscribe();
+
+// watch: single latest value, multiple consumers
+let (tx, rx) = watch::channel::<State>(initial);
+// Receivers see latest value, not all values
+```
+
+## Worker Pool Pattern
+
+```rust
+async fn process_with_workers(items: Vec<Item>) -> Vec<Result> {
+    let (tx, rx) = mpsc::channel(100);
+    let rx = Arc::new(Mutex::new(rx));
+    
+    // Spawn worker pool
+    let workers: Vec<_> = (0..4).map(|_| {
+        let rx = rx.clone();
+        tokio::spawn(async move {
+            loop {
+                let item = {
+                    let mut rx = rx.lock().await;
+                    rx.recv().await
+                };
+                match item {
+                    Some(item) => process(item).await,
+                    None => break,
+                }
+            }
+        })
+    }).collect();
+    
+    // Send items
+    for item in items {
+        tx.send(item).await.unwrap();
+    }
+    drop(tx);  // Signal workers to stop
+    
+    futures::future::join_all(workers).await;
+}
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Multi-producer patterns
+- [async-oneshot-response](./async-oneshot-response.md) - Request-response pattern
+- [async-watch-latest](./async-watch-latest.md) - Latest-value broadcasting

--- a/.agents/skills/rust-skills/rules/async-broadcast-pubsub.md
+++ b/.agents/skills/rust-skills/rules/async-broadcast-pubsub.md
@@ -1,0 +1,185 @@
+# async-broadcast-pubsub
+
+> Use `broadcast` channel for pub/sub where all subscribers receive all messages
+
+## Why It Matters
+
+Unlike `mpsc` where one consumer receives each message, `broadcast` delivers each message to all subscribers. This is ideal for event broadcasting, real-time notifications, or when multiple components need to react to the same events independently.
+
+## Bad
+
+```rust
+use tokio::sync::mpsc;
+
+// mpsc only delivers to ONE consumer
+let (tx, mut rx) = mpsc::channel::<Event>(100);
+
+// Only one of these receives each message!
+let mut rx2 = ???;  // Can't clone receiver
+```
+
+## Good
+
+```rust
+use tokio::sync::broadcast;
+
+// broadcast delivers to ALL subscribers
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// Each subscriber gets ALL messages
+let mut rx1 = tx.subscribe();
+let mut rx2 = tx.subscribe();
+
+tokio::spawn(async move {
+    while let Ok(event) = rx1.recv().await {
+        handle_in_logger(event);
+    }
+});
+
+tokio::spawn(async move {
+    while let Ok(event) = rx2.recv().await {
+        handle_in_metrics(event);
+    }
+});
+
+// Both subscribers receive this
+tx.send(Event::UserLogin { user_id: 42 })?;
+```
+
+## Broadcast Semantics
+
+```rust
+use tokio::sync::broadcast;
+
+let (tx, mut rx1) = broadcast::channel::<i32>(16);
+let mut rx2 = tx.subscribe();
+
+tx.send(1)?;
+tx.send(2)?;
+
+// Both receive all messages
+assert_eq!(rx1.recv().await?, 1);
+assert_eq!(rx1.recv().await?, 2);
+assert_eq!(rx2.recv().await?, 1);
+assert_eq!(rx2.recv().await?, 2);
+```
+
+## Handling Lagging Receivers
+
+```rust
+use tokio::sync::broadcast::{self, error::RecvError};
+
+let (tx, mut rx) = broadcast::channel::<Event>(16);
+
+loop {
+    match rx.recv().await {
+        Ok(event) => {
+            process(event);
+        }
+        Err(RecvError::Lagged(count)) => {
+            // Receiver couldn't keep up, missed `count` messages
+            log::warn!("Missed {} events", count);
+            // Continue receiving new messages
+        }
+        Err(RecvError::Closed) => {
+            break;  // All senders dropped
+        }
+    }
+}
+```
+
+## Event Bus Pattern
+
+```rust
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug)]
+enum AppEvent {
+    UserLoggedIn { user_id: u64 },
+    OrderCreated { order_id: u64 },
+    SystemShutdown,
+}
+
+struct EventBus {
+    tx: broadcast::Sender<AppEvent>,
+}
+
+impl EventBus {
+    fn new() -> Self {
+        let (tx, _) = broadcast::channel(1000);
+        EventBus { tx }
+    }
+    
+    fn publish(&self, event: AppEvent) {
+        // Ignore error if no subscribers
+        let _ = self.tx.send(event);
+    }
+    
+    fn subscribe(&self) -> broadcast::Receiver<AppEvent> {
+        self.tx.subscribe()
+    }
+}
+
+// Usage
+let bus = EventBus::new();
+
+// Logger subscribes
+let mut log_rx = bus.subscribe();
+tokio::spawn(async move {
+    while let Ok(event) = log_rx.recv().await {
+        log::info!("Event: {:?}", event);
+    }
+});
+
+// Metrics subscribes
+let mut metrics_rx = bus.subscribe();
+tokio::spawn(async move {
+    while let Ok(event) = metrics_rx.recv().await {
+        record_metric(&event);
+    }
+});
+
+// Publish events
+bus.publish(AppEvent::UserLoggedIn { user_id: 42 });
+```
+
+## Broadcast vs Watch
+
+```rust
+// broadcast: subscribers get ALL messages
+// Good for: events, logs, notifications
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// watch: subscribers get LATEST value only
+// Good for: config changes, state updates
+let (tx, _) = watch::channel(initial_state);
+
+// If subscriber is slow:
+// - broadcast: they receive old messages (or lag)
+// - watch: they skip to latest (no history)
+```
+
+## Clone Requirement
+
+```rust
+// broadcast requires Clone because message is cloned to each receiver
+use tokio::sync::broadcast;
+
+#[derive(Clone)]  // Required for broadcast
+struct Event {
+    data: String,
+}
+
+let (tx, _) = broadcast::channel::<Event>(100);
+
+// For non-Clone types, wrap in Arc
+use std::sync::Arc;
+
+let (tx, _) = broadcast::channel::<Arc<LargeNonClone>>(100);
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Single-consumer channels
+- [async-watch-latest](./async-watch-latest.md) - Latest-value only
+- [async-bounded-channel](./async-bounded-channel.md) - Buffer sizing

--- a/.agents/skills/rust-skills/rules/async-cancellation-token.md
+++ b/.agents/skills/rust-skills/rules/async-cancellation-token.md
@@ -1,0 +1,203 @@
+# async-cancellation-token
+
+> Use `CancellationToken` for graceful shutdown and task cancellation
+
+## Why It Matters
+
+Dropping a `JoinHandle` doesn't cancel the task—it just detaches it. For graceful shutdown, you need explicit cancellation. `tokio_util::sync::CancellationToken` provides a cooperative cancellation mechanism that tasks can check and respond to, enabling clean resource cleanup.
+
+## Bad
+
+```rust
+// Dropping handle doesn't stop the task
+let handle = tokio::spawn(async {
+    loop {
+        do_work().await;
+    }
+});
+
+drop(handle);  // Task continues running in background!
+
+// Using bool flag - not async-aware
+let running = Arc::new(AtomicBool::new(true));
+
+tokio::spawn({
+    let running = running.clone();
+    async move {
+        while running.load(Ordering::Relaxed) {
+            do_work().await;  // Can't wake up if blocked here
+        }
+    }
+});
+
+running.store(false, Ordering::Relaxed);
+// Task won't stop until current do_work() completes
+```
+
+## Good
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+let token = CancellationToken::new();
+
+let handle = tokio::spawn({
+    let token = token.clone();
+    async move {
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    println!("Shutting down gracefully");
+                    cleanup().await;
+                    break;
+                }
+                _ = do_work() => {
+                    // Work completed
+                }
+            }
+        }
+    }
+});
+
+// Later: trigger cancellation
+token.cancel();
+handle.await?;  // Task completes cleanly
+```
+
+## CancellationToken API
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+// Create token
+let token = CancellationToken::new();
+
+// Clone for sharing (cheap Arc-based clone)
+let token2 = token.clone();
+
+// Check if cancelled (non-blocking)
+if token.is_cancelled() {
+    return;
+}
+
+// Wait for cancellation (async)
+token.cancelled().await;
+
+// Trigger cancellation
+token.cancel();
+
+// Child tokens - cancelled when parent is cancelled
+let child = token.child_token();
+```
+
+## Hierarchical Cancellation
+
+```rust
+async fn run_server(shutdown: CancellationToken) {
+    let listener = TcpListener::bind("0.0.0.0:8080").await?;
+    
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                println!("Server shutting down");
+                break;
+            }
+            result = listener.accept() => {
+                let (socket, _) = result?;
+                // Each connection gets child token
+                let conn_token = shutdown.child_token();
+                tokio::spawn(handle_connection(socket, conn_token));
+            }
+        }
+    }
+    
+    // Child tokens auto-cancelled when we exit
+}
+
+async fn handle_connection(socket: TcpStream, token: CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = token.cancelled() => {
+                // Connection cleanup
+                break;
+            }
+            data = socket.read() => {
+                // Handle data
+            }
+        }
+    }
+}
+```
+
+## Graceful Shutdown Pattern
+
+```rust
+use tokio::signal;
+
+async fn main() -> Result<()> {
+    let shutdown = CancellationToken::new();
+    
+    // Spawn signal handler
+    let shutdown_trigger = shutdown.clone();
+    tokio::spawn(async move {
+        signal::ctrl_c().await.expect("failed to listen for Ctrl+C");
+        println!("Received Ctrl+C, initiating shutdown...");
+        shutdown_trigger.cancel();
+    });
+    
+    // Run application with shutdown token
+    run_app(shutdown).await
+}
+
+async fn run_app(shutdown: CancellationToken) -> Result<()> {
+    let mut tasks = JoinSet::new();
+    
+    tasks.spawn(worker_task(shutdown.child_token()));
+    tasks.spawn(server_task(shutdown.child_token()));
+    
+    // Wait for shutdown or task completion
+    tokio::select! {
+        _ = shutdown.cancelled() => {
+            println!("Shutdown requested, waiting for tasks...");
+        }
+        Some(result) = tasks.join_next() => {
+            // A task completed/failed
+            result??;
+        }
+    }
+    
+    // Wait for remaining tasks with timeout
+    tokio::time::timeout(
+        Duration::from_secs(30),
+        async { while tasks.join_next().await.is_some() {} }
+    ).await.ok();
+    
+    Ok(())
+}
+```
+
+## DropGuard Pattern
+
+```rust
+use tokio_util::sync::CancellationToken;
+
+// Auto-cancel on drop
+let token = CancellationToken::new();
+let guard = token.clone().drop_guard();
+
+tokio::spawn({
+    let token = token.clone();
+    async move {
+        token.cancelled().await;
+        println!("Cancelled!");
+    }
+});
+
+drop(guard);  // Automatically calls token.cancel()
+```
+
+## See Also
+
+- [async-joinset-structured](./async-joinset-structured.md) - Managing multiple tasks
+- [async-select-racing](./async-select-racing.md) - select! for cancellation
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime shutdown

--- a/.agents/skills/rust-skills/rules/async-clone-before-await.md
+++ b/.agents/skills/rust-skills/rules/async-clone-before-await.md
@@ -1,0 +1,171 @@
+# async-clone-before-await
+
+> Clone Arc/Rc data before await points to avoid holding references across suspension
+
+## Why It Matters
+
+References held across `.await` points extend the future's lifetime and can cause borrow checker issues or prevent `Send` bounds. Cloning `Arc`/`Rc` before the await ensures the future only holds owned data, making it `Send` and avoiding lifetime complications.
+
+## Bad
+
+```rust
+use std::sync::Arc;
+
+async fn process(data: Arc<Data>) {
+    // Borrow extends across await - future is not Send
+    let slice = &data.items[..];  // Borrow of Arc contents
+    
+    expensive_async_operation().await;  // Await with active borrow
+    
+    use_slice(slice);  // Still using the borrow
+}
+
+// Error: future cannot be sent between threads safely
+// because `&[Item]` cannot be sent between threads safely
+tokio::spawn(process(data));
+```
+
+## Good
+
+```rust
+use std::sync::Arc;
+
+async fn process(data: Arc<Data>) {
+    // Clone what you need before await
+    let items = data.items.clone();  // Owned Vec
+    
+    expensive_async_operation().await;
+    
+    use_items(&items);  // Using owned data
+}
+
+// Or clone the Arc itself
+async fn share_data(data: Arc<Data>) {
+    let data = data.clone();  // Another Arc handle
+    
+    some_async_work().await;
+    
+    process(&data);  // Safe - we own the Arc
+}
+```
+
+## The Send Problem
+
+```rust
+// Futures must be Send to spawn on multi-threaded runtime
+async fn not_send() {
+    let rc = Rc::new(42);  // Rc is !Send
+    
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    
+    println!("{}", rc);  // rc held across await
+}
+
+tokio::spawn(not_send());  // ERROR: future is not Send
+
+// Fix: use Arc or don't hold across await
+async fn is_send() {
+    let arc = Arc::new(42);  // Arc is Send
+    
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    
+    println!("{}", arc);
+}
+
+tokio::spawn(is_send());  // OK
+```
+
+## Minimizing Clones
+
+```rust
+// Bad: clone everything eagerly
+async fn wasteful(data: Arc<LargeData>) {
+    let data = (*data).clone();  // Clones entire LargeData
+    async_work().await;
+    use_one_field(&data.small_field);
+}
+
+// Good: clone only what you need
+async fn efficient(data: Arc<LargeData>) {
+    let small = data.small_field.clone();  // Clone only needed field
+    async_work().await;
+    use_one_field(&small);
+}
+
+// Good: if you need the whole thing, keep the Arc
+async fn arc_efficient(data: Arc<LargeData>) {
+    let data = data.clone();  // Cheap Arc clone
+    async_work().await;
+    use_data(&data);  // Access through Arc
+}
+```
+
+## Spawn Pattern
+
+```rust
+// Common pattern: clone for spawned task
+let shared = Arc::new(SharedState::new());
+
+for i in 0..10 {
+    let shared = shared.clone();  // Clone before moving into spawn
+    tokio::spawn(async move {
+        // Task owns its Arc clone
+        shared.do_something(i).await;
+    });
+}
+```
+
+## Scope-Based Approach
+
+```rust
+// Limit borrow scope to before await
+async fn scoped(data: Arc<Data>) {
+    // Scope 1: borrow, compute, drop borrow
+    let computed = {
+        let slice = &data.items[..];  // Borrow
+        compute_something(slice)       // Use
+    };  // Borrow ends here
+    
+    // Now safe to await
+    expensive_async_operation().await;
+    
+    use_computed(computed);
+}
+```
+
+## MutexGuard Across Await
+
+```rust
+use tokio::sync::Mutex;
+
+// BAD: holding guard across await
+async fn bad(mutex: Arc<Mutex<Data>>) {
+    let mut guard = mutex.lock().await;
+    guard.value += 1;
+    
+    slow_operation().await;  // Guard held during await!
+    
+    guard.value += 1;
+}
+
+// GOOD: release before await
+async fn good(mutex: Arc<Mutex<Data>>) {
+    {
+        let mut guard = mutex.lock().await;
+        guard.value += 1;
+    }  // Guard released
+    
+    slow_operation().await;
+    
+    {
+        let mut guard = mutex.lock().await;
+        guard.value += 1;
+    }
+}
+```
+
+## See Also
+
+- [async-no-lock-await](./async-no-lock-await.md) - Lock guards across await
+- [own-arc-shared](./own-arc-shared.md) - Arc usage patterns
+- [async-spawn-blocking](./async-spawn-blocking.md) - Blocking in async

--- a/.agents/skills/rust-skills/rules/async-join-parallel.md
+++ b/.agents/skills/rust-skills/rules/async-join-parallel.md
@@ -1,0 +1,158 @@
+# async-join-parallel
+
+> Use `join!` or `try_join!` for concurrent independent futures
+
+## Why It Matters
+
+Awaiting futures sequentially takes the sum of their durations. `join!` runs futures concurrently, taking only as long as the slowest one. For independent operations like multiple API calls or parallel file reads, this can dramatically reduce latency.
+
+## Bad
+
+```rust
+async fn fetch_data() -> (User, Posts, Comments) {
+    // Sequential: 300ms total (100 + 100 + 100)
+    let user = fetch_user().await;        // 100ms
+    let posts = fetch_posts().await;      // 100ms  
+    let comments = fetch_comments().await; // 100ms
+    
+    (user, posts, comments)
+}
+
+async fn read_configs() -> Result<(Config, Settings)> {
+    // Sequential: 20ms + 20ms = 40ms
+    let config = fs::read_to_string("config.toml").await?;
+    let settings = fs::read_to_string("settings.json").await?;
+    
+    Ok((parse_config(&config)?, parse_settings(&settings)?))
+}
+```
+
+## Good
+
+```rust
+use tokio::join;
+
+async fn fetch_data() -> (User, Posts, Comments) {
+    // Concurrent: ~100ms total (max of all three)
+    let (user, posts, comments) = join!(
+        fetch_user(),
+        fetch_posts(),
+        fetch_comments(),
+    );
+    
+    (user, posts, comments)
+}
+
+use tokio::try_join;
+
+async fn read_configs() -> Result<(Config, Settings)> {
+    // Concurrent: ~20ms total
+    let (config_str, settings_str) = try_join!(
+        fs::read_to_string("config.toml"),
+        fs::read_to_string("settings.json"),
+    )?;
+    
+    Ok((parse_config(&config_str)?, parse_settings(&settings_str)?))
+}
+```
+
+## join! vs try_join!
+
+```rust
+// join! - all futures run to completion, returns tuple
+let (a, b, c) = join!(future_a, future_b, future_c);
+
+// try_join! - short-circuits on first error
+let (a, b, c) = try_join!(fallible_a, fallible_b, fallible_c)?;
+// If fallible_b fails, returns Err immediately
+// Other futures may still be running (cancellation is async)
+```
+
+## futures::join_all for Dynamic Collections
+
+```rust
+use futures::future::join_all;
+
+async fn fetch_all_users(ids: &[u64]) -> Vec<User> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    join_all(futures).await
+}
+
+// With fallible futures
+use futures::future::try_join_all;
+
+async fn fetch_all_users(ids: &[u64]) -> Result<Vec<User>> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    try_join_all(futures).await
+}
+```
+
+## Limiting Concurrency
+
+```rust
+use futures::stream::{self, StreamExt};
+
+async fn fetch_with_limit(ids: &[u64]) -> Vec<Result<User>> {
+    stream::iter(ids)
+        .map(|id| fetch_user(*id))
+        .buffer_unordered(10)  // Max 10 concurrent requests
+        .collect()
+        .await
+}
+
+// Or with tokio::sync::Semaphore
+use tokio::sync::Semaphore;
+
+async fn fetch_with_semaphore(ids: &[u64]) -> Vec<User> {
+    let semaphore = Arc::new(Semaphore::new(10));
+    
+    let futures: Vec<_> = ids.iter().map(|id| {
+        let semaphore = semaphore.clone();
+        async move {
+            let _permit = semaphore.acquire().await.unwrap();
+            fetch_user(*id).await
+        }
+    }).collect();
+    
+    join_all(futures).await
+}
+```
+
+## When NOT to Use join!
+
+```rust
+// ❌ Dependent futures - must be sequential
+async fn create_and_populate() -> Result<()> {
+    let db = create_database().await?;   // Must complete first
+    populate_tables(&db).await?;          // Depends on db
+    Ok(())
+}
+
+// ❌ Short-circuiting logic
+async fn find_first() -> Option<Data> {
+    // Want to stop when one succeeds
+    // Use select! instead
+}
+
+// ❌ Shared mutable state
+async fn bad_shared_state() {
+    let counter = Arc::new(Mutex::new(0));
+    // This might work but can cause contention
+    join!(
+        increment(counter.clone()),
+        increment(counter.clone()),
+    );
+}
+```
+
+## See Also
+
+- [async-try-join](./async-try-join.md) - Error handling in concurrent futures
+- [async-select-racing](./async-select-racing.md) - Racing futures
+- [async-joinset-structured](./async-joinset-structured.md) - Dynamic task sets

--- a/.agents/skills/rust-skills/rules/async-joinset-structured.md
+++ b/.agents/skills/rust-skills/rules/async-joinset-structured.md
@@ -1,0 +1,195 @@
+# async-joinset-structured
+
+> Use `JoinSet` for managing dynamic collections of spawned tasks
+
+## Why It Matters
+
+When spawning a variable number of tasks, collecting `JoinHandle`s in a `Vec` and using `join_all` works but lacks flexibility. `JoinSet` provides a better abstraction: add/remove tasks dynamically, get results as they complete, and abort all on drop. It's the idiomatic way to manage task collections.
+
+## Bad
+
+```rust
+// Manual handle management
+let mut handles: Vec<JoinHandle<Result<Data>>> = Vec::new();
+
+for url in urls {
+    handles.push(tokio::spawn(fetch(url)));
+}
+
+// Wait for all, in order (not as they complete)
+let results = futures::future::join_all(handles).await;
+
+// No easy way to cancel all, handle errors progressively, or add more tasks
+```
+
+## Good
+
+```rust
+use tokio::task::JoinSet;
+
+let mut set = JoinSet::new();
+
+for url in urls {
+    set.spawn(fetch(url.clone()));
+}
+
+// Process results as they complete
+while let Some(result) = set.join_next().await {
+    match result {
+        Ok(Ok(data)) => process(data),
+        Ok(Err(e)) => log::error!("Task failed: {}", e),
+        Err(e) => log::error!("Task panicked: {}", e),
+    }
+}
+
+// All tasks done, set is empty
+```
+
+## Dynamic Task Addition
+
+```rust
+use tokio::task::JoinSet;
+
+async fn worker_pool(mut rx: mpsc::Receiver<Task>) {
+    let mut set = JoinSet::new();
+    let max_concurrent = 10;
+    
+    loop {
+        tokio::select! {
+            // Accept new tasks if under limit
+            Some(task) = rx.recv(), if set.len() < max_concurrent => {
+                set.spawn(process_task(task));
+            }
+            
+            // Process completed tasks
+            Some(result) = set.join_next() => {
+                handle_result(result);
+            }
+            
+            // Exit when no tasks and channel closed
+            else => break,
+        }
+    }
+}
+```
+
+## Abort on Drop
+
+```rust
+use tokio::task::JoinSet;
+
+{
+    let mut set = JoinSet::new();
+    set.spawn(long_running_task());
+    set.spawn(another_task());
+    
+    // Early exit
+    return;
+}  // JoinSet dropped here - all tasks are aborted!
+
+// Explicit abort
+let mut set = JoinSet::new();
+set.spawn(task());
+set.abort_all();  // Cancel all tasks
+```
+
+## Error Handling Pattern
+
+```rust
+use tokio::task::JoinSet;
+
+async fn fetch_all(urls: &[String]) -> Vec<Result<Data, Error>> {
+    let mut set = JoinSet::new();
+    let mut results = Vec::new();
+    
+    for url in urls {
+        set.spawn(fetch(url.clone()));
+    }
+    
+    while let Some(join_result) = set.join_next().await {
+        let result = match join_result {
+            Ok(task_result) => task_result,
+            Err(join_error) => {
+                if join_error.is_panic() {
+                    Err(Error::TaskPanicked)
+                } else {
+                    Err(Error::TaskCancelled)
+                }
+            }
+        };
+        results.push(result);
+    }
+    
+    results
+}
+```
+
+## With Cancellation
+
+```rust
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+async fn run_workers(shutdown: CancellationToken) {
+    let mut set = JoinSet::new();
+    
+    for i in 0..4 {
+        let token = shutdown.child_token();
+        set.spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = do_work(i) => {}
+                }
+            }
+        });
+    }
+    
+    // Wait for shutdown
+    shutdown.cancelled().await;
+    
+    // Abort remaining tasks
+    set.abort_all();
+    
+    // Wait for all to finish (drain aborted tasks)
+    while set.join_next().await.is_some() {}
+}
+```
+
+## Spawning with Context
+
+```rust
+use tokio::task::JoinSet;
+
+let mut set: JoinSet<(usize, Result<Data, Error>)> = JoinSet::new();
+
+for (index, url) in urls.iter().enumerate() {
+    let url = url.clone();
+    set.spawn(async move {
+        (index, fetch(&url).await)
+    });
+}
+
+// Results include their index
+while let Some(result) = set.join_next().await {
+    if let Ok((index, data)) = result {
+        results[index] = Some(data);
+    }
+}
+```
+
+## JoinSet vs join_all
+
+| Feature | JoinSet | join_all |
+|---------|---------|----------|
+| Add tasks dynamically | Yes | No |
+| Results as-completed | Yes | No (all at once) |
+| Abort all on drop | Yes | No |
+| Cancel individual | Yes | No |
+| Memory efficient | Yes | Pre-allocates |
+
+## See Also
+
+- [async-join-parallel](./async-join-parallel.md) - Static concurrent futures
+- [async-cancellation-token](./async-cancellation-token.md) - Cancellation patterns
+- [async-try-join](./async-try-join.md) - Error handling in joins

--- a/.agents/skills/rust-skills/rules/async-mpsc-queue.md
+++ b/.agents/skills/rust-skills/rules/async-mpsc-queue.md
@@ -1,0 +1,171 @@
+# async-mpsc-queue
+
+> Use `mpsc` channels for async message queues between tasks
+
+## Why It Matters
+
+`tokio::sync::mpsc` (multi-producer, single-consumer) is the workhorse channel for async Rust. It provides async send/receive, backpressure via bounded capacity, and efficient cloning of senders. It's the default choice for task-to-task communication.
+
+## Bad
+
+```rust
+use std::sync::mpsc;  // Wrong! Blocks the async runtime
+
+let (tx, rx) = std::sync::mpsc::channel();
+
+tokio::spawn(async move {
+    tx.send("hello").unwrap();  // Might block
+});
+
+tokio::spawn(async move {
+    let msg = rx.recv().unwrap();  // BLOCKS the executor thread!
+});
+```
+
+## Good
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<String>(100);
+
+tokio::spawn(async move {
+    tx.send("hello".to_string()).await.unwrap();
+});
+
+tokio::spawn(async move {
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+});
+```
+
+## Sender Cloning
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<Event>(100);
+
+// Multiple producers
+for i in 0..10 {
+    let tx = tx.clone();  // Cheap clone
+    tokio::spawn(async move {
+        tx.send(Event { source: i }).await.unwrap();
+    });
+}
+
+// Drop original sender so channel closes when all clones dropped
+drop(tx);
+
+// Consumer
+while let Some(event) = rx.recv().await {
+    process(event);
+}
+// Loop exits when all senders dropped
+```
+
+## Message Handler Pattern
+
+```rust
+use tokio::sync::mpsc;
+
+enum Command {
+    Get { key: String, reply: oneshot::Sender<Option<Value>> },
+    Set { key: String, value: Value },
+    Delete { key: String },
+}
+
+async fn run_store(mut commands: mpsc::Receiver<Command>) {
+    let mut store = HashMap::new();
+    
+    while let Some(cmd) = commands.recv().await {
+        match cmd {
+            Command::Get { key, reply } => {
+                let _ = reply.send(store.get(&key).cloned());
+            }
+            Command::Set { key, value } => {
+                store.insert(key, value);
+            }
+            Command::Delete { key } => {
+                store.remove(&key);
+            }
+        }
+    }
+}
+
+// Usage
+async fn client(tx: mpsc::Sender<Command>) -> Option<Value> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Command::Get { 
+        key: "foo".to_string(), 
+        reply: reply_tx 
+    }).await.unwrap();
+    
+    reply_rx.await.unwrap()
+}
+```
+
+## Graceful Shutdown
+
+```rust
+async fn worker(mut rx: mpsc::Receiver<Task>, shutdown: CancellationToken) {
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                // Drain remaining messages
+                while let Ok(task) = rx.try_recv() {
+                    process(task).await;
+                }
+                break;
+            }
+            Some(task) = rx.recv() => {
+                process(task).await;
+            }
+            else => break,  // Channel closed
+        }
+    }
+}
+```
+
+## WeakSender for Optional Producers
+
+```rust
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<Message>(100);
+let weak = tx.downgrade();  // Doesn't keep channel alive
+
+tokio::spawn(async move {
+    // Strong sender - keeps channel alive
+    tx.send("from strong".into()).await.unwrap();
+});
+
+tokio::spawn(async move {
+    // Weak sender - may fail if strong senders dropped
+    if let Some(tx) = weak.upgrade() {
+        tx.send("from weak".into()).await.unwrap();
+    }
+});
+```
+
+## Permit Pattern
+
+```rust
+// Reserve slot before preparing message
+let permit = tx.reserve().await?;
+
+// Now we have guaranteed capacity
+let message = expensive_to_create_message();
+permit.send(message);  // Never fails
+
+// Useful when message creation is expensive
+// and you don't want to create it if channel is full
+```
+
+## See Also
+
+- [async-bounded-channel](./async-bounded-channel.md) - Why bounded channels
+- [async-oneshot-response](./async-oneshot-response.md) - Request-response with oneshot
+- [async-broadcast-pubsub](./async-broadcast-pubsub.md) - Multiple consumers

--- a/.agents/skills/rust-skills/rules/async-no-lock-await.md
+++ b/.agents/skills/rust-skills/rules/async-no-lock-await.md
@@ -1,0 +1,156 @@
+# async-no-lock-await
+
+> Never hold `Mutex`/`RwLock` across `.await`
+
+## Why It Matters
+
+Holding a lock across an `.await` point can cause deadlocks and severely hurt performance. The task may be suspended while holding the lock, blocking all other tasks waiting for it - potentially indefinitely.
+
+## Bad
+
+```rust
+use tokio::sync::Mutex;
+
+async fn bad_update(state: &Mutex<State>) {
+    let mut guard = state.lock().await;
+    
+    // BAD: Lock held across await!
+    let data = fetch_from_network().await;
+    
+    guard.value = data;
+}  // Lock finally released
+
+// This can deadlock or starve other tasks
+```
+
+## Good
+
+```rust
+use tokio::sync::Mutex;
+
+async fn good_update(state: &Mutex<State>) {
+    // Fetch data BEFORE taking the lock
+    let data = fetch_from_network().await;
+    
+    // Lock only for the quick update
+    let mut guard = state.lock().await;
+    guard.value = data;
+}  // Lock released immediately
+
+// Alternative: Clone data out, process, then update
+async fn good_update_v2(state: &Mutex<State>) {
+    // Extract what we need
+    let id = {
+        let guard = state.lock().await;
+        guard.id.clone()
+    };  // Lock released!
+    
+    // Do async work without lock
+    let data = fetch_by_id(id).await;
+    
+    // Quick update
+    state.lock().await.value = data;
+}
+```
+
+## The Problem Visualized
+
+```rust
+// Task A:
+let guard = mutex.lock().await;    // Acquires lock
+expensive_io().await;              // Suspended, still holding lock!
+// ... many milliseconds pass ...
+drop(guard);                       // Finally releases
+
+// Task B, C, D:
+let guard = mutex.lock().await;    // All blocked waiting for A!
+```
+
+## Patterns for Extraction
+
+```rust
+use tokio::sync::Mutex;
+
+// Pattern 1: Clone out, process, update
+async fn pattern_clone(state: &Mutex<State>) {
+    let config = state.lock().await.config.clone();
+    let result = process_with_io(&config).await;
+    state.lock().await.result = result;
+}
+
+// Pattern 2: Compute closure, apply
+async fn pattern_closure(state: &Mutex<State>) {
+    let update = compute_update().await;
+    
+    state.lock().await.apply(update);
+}
+
+// Pattern 3: Message passing
+async fn pattern_message(
+    state: &Mutex<State>,
+    tx: mpsc::Sender<Update>,
+) {
+    let update = compute_update().await;
+    tx.send(update).await.unwrap();
+}
+
+// Separate task handles updates
+async fn state_manager(
+    state: Arc<Mutex<State>>,
+    mut rx: mpsc::Receiver<Update>,
+) {
+    while let Some(update) = rx.recv().await {
+        state.lock().await.apply(update);
+    }
+}
+```
+
+## Using RwLock
+
+```rust
+use tokio::sync::RwLock;
+
+async fn read_heavy(state: &RwLock<State>) {
+    // Multiple readers OK, but still don't hold across await
+    let value = {
+        let guard = state.read().await;
+        guard.value.clone()
+    };
+    
+    // Process without lock
+    let result = process(value).await;
+    
+    // Write lock for update
+    state.write().await.result = result;
+}
+```
+
+## std::sync::Mutex vs tokio::sync::Mutex
+
+```rust
+// std::sync::Mutex: Blocks the entire thread
+// - Use for quick, CPU-only operations
+// - NEVER use in async code with await inside
+
+// tokio::sync::Mutex: Async-aware, yields to runtime
+// - Use in async code
+// - Still don't hold across await points!
+
+// std::sync::Mutex in async (quick operation, OK):
+async fn quick_update(state: &std::sync::Mutex<State>) {
+    state.lock().unwrap().counter += 1;  // No await, OK
+}
+
+// tokio::sync::Mutex (must use if lock scope has await):
+async fn must_await_inside(state: &tokio::sync::Mutex<State>) {
+    let mut guard = state.lock().await;
+    // Only if you REALLY need the lock during async op
+    // (usually you don't - redesign instead)
+}
+```
+
+## See Also
+
+- [async-spawn-blocking](async-spawn-blocking.md) - Use spawn_blocking for CPU work
+- [async-clone-before-await](async-clone-before-await.md) - Clone data before await
+- [anti-lock-across-await](anti-lock-across-await.md) - Anti-pattern reference

--- a/.agents/skills/rust-skills/rules/async-oneshot-response.md
+++ b/.agents/skills/rust-skills/rules/async-oneshot-response.md
@@ -1,0 +1,191 @@
+# async-oneshot-response
+
+> Use `oneshot` channel for request-response patterns
+
+## Why It Matters
+
+When one task needs to send a request and wait for exactly one response, `oneshot` is the perfect fit. It's a single-use channel optimized for this pattern—no buffering, no clone overhead. Combined with `mpsc`, it enables clean actor-style message passing.
+
+## Bad
+
+```rust
+// Using mpsc for single response - wasteful
+let (tx, mut rx) = mpsc::channel::<Response>(1);
+send_request().await;
+let response = rx.recv().await.unwrap();
+// Channel persists, could accidentally receive more
+
+// Using shared state - complex
+let result = Arc::new(Mutex::new(None));
+send_request(result.clone()).await;
+while result.lock().await.is_none() {
+    tokio::time::sleep(Duration::from_millis(10)).await;  // Polling!
+}
+```
+
+## Good
+
+```rust
+use tokio::sync::oneshot;
+
+let (tx, rx) = oneshot::channel::<Response>();
+
+// Send request with reply channel
+send_request(Request { data, reply: tx }).await;
+
+// Wait for response
+let response = rx.await?;
+
+// Channel is consumed - can't accidentally reuse
+```
+
+## Request-Response Pattern
+
+```rust
+use tokio::sync::{mpsc, oneshot};
+
+enum Request {
+    Get {
+        key: String,
+        reply: oneshot::Sender<Option<Value>>,
+    },
+    Set {
+        key: String,
+        value: Value,
+        reply: oneshot::Sender<bool>,
+    },
+}
+
+// Service handler
+async fn service(mut rx: mpsc::Receiver<Request>) {
+    let mut store = HashMap::new();
+    
+    while let Some(req) = rx.recv().await {
+        match req {
+            Request::Get { key, reply } => {
+                let value = store.get(&key).cloned();
+                let _ = reply.send(value);  // Ignore if receiver dropped
+            }
+            Request::Set { key, value, reply } => {
+                store.insert(key, value);
+                let _ = reply.send(true);
+            }
+        }
+    }
+}
+
+// Client
+async fn get_value(tx: &mpsc::Sender<Request>, key: &str) -> Option<Value> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Request::Get {
+        key: key.to_string(),
+        reply: reply_tx,
+    }).await.ok()?;
+    
+    reply_rx.await.ok()?
+}
+```
+
+## With Timeout
+
+```rust
+use tokio::time::{timeout, Duration};
+
+async fn request_with_timeout(
+    tx: &mpsc::Sender<Request>,
+    key: &str,
+) -> Result<Value, Error> {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    
+    tx.send(Request::Get {
+        key: key.to_string(),
+        reply: reply_tx,
+    }).await.map_err(|_| Error::ServiceDown)?;
+    
+    timeout(Duration::from_secs(5), reply_rx)
+        .await
+        .map_err(|_| Error::Timeout)?
+        .map_err(|_| Error::ServiceDown)?
+        .ok_or(Error::NotFound)
+}
+```
+
+## Error Handling
+
+```rust
+use tokio::sync::oneshot;
+
+let (tx, rx) = oneshot::channel::<String>();
+
+// Sender dropped without sending
+drop(tx);
+match rx.await {
+    Ok(value) => println!("Got: {}", value),
+    Err(oneshot::error::RecvError { .. }) => {
+        println!("Sender dropped");
+    }
+}
+
+// Receiver dropped before send
+let (tx, rx) = oneshot::channel::<String>();
+drop(rx);
+match tx.send("hello".to_string()) {
+    Ok(()) => println!("Sent"),
+    Err(value) => println!("Receiver dropped, value: {}", value),
+}
+```
+
+## Closed Detection
+
+```rust
+// Check if receiver is still waiting
+let (tx, rx) = oneshot::channel::<i32>();
+
+// In producer
+if tx.is_closed() {
+    println!("Receiver already gone, skip expensive computation");
+} else {
+    let result = expensive_computation();
+    tx.send(result).ok();
+}
+
+// Async wait for close
+let tx_clone = tx.clone();  // Note: can't actually clone, just showing concept
+tokio::select! {
+    _ = tx.closed() => println!("Receiver dropped"),
+    result = compute() => { tx.send(result).ok(); }
+}
+```
+
+## Response Type Wrapper
+
+```rust
+// Standardize request-response pattern
+struct RpcRequest<Req, Res> {
+    request: Req,
+    reply: oneshot::Sender<Res>,
+}
+
+impl<Req, Res> RpcRequest<Req, Res> {
+    fn new(request: Req) -> (Self, oneshot::Receiver<Res>) {
+        let (tx, rx) = oneshot::channel();
+        (RpcRequest { request, reply: tx }, rx)
+    }
+    
+    fn respond(self, response: Res) {
+        let _ = self.reply.send(response);
+    }
+}
+
+// Usage
+let (req, rx) = RpcRequest::new(GetUser { id: 42 });
+tx.send(req).await?;
+let user = rx.await?;
+```
+
+## See Also
+
+- [async-mpsc-queue](./async-mpsc-queue.md) - Pair with oneshot for request-response
+- [async-bounded-channel](./async-bounded-channel.md) - Channel sizing
+- [async-select-racing](./async-select-racing.md) - Timeout patterns

--- a/.agents/skills/rust-skills/rules/async-select-racing.md
+++ b/.agents/skills/rust-skills/rules/async-select-racing.md
@@ -1,0 +1,198 @@
+# async-select-racing
+
+> Use `select!` to race futures and handle the first to complete
+
+## Why It Matters
+
+Sometimes you need the first result from multiple futures—timeout vs operation, cancellation vs work, or competing alternatives. `tokio::select!` lets you race futures and handle whichever completes first, while properly cancelling the others.
+
+## Bad
+
+```rust
+// Can't express "whichever finishes first"
+async fn fetch_with_fallback() -> Data {
+    match fetch_primary().await {
+        Ok(data) => data,
+        Err(_) => fetch_fallback().await.unwrap(),  // Sequential, not racing
+    }
+}
+
+// Manual timeout is error-prone
+async fn fetch_with_timeout() -> Option<Data> {
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > Duration::from_secs(5) {
+            return None;
+        }
+        // How do we check timeout while awaiting?
+    }
+}
+```
+
+## Good
+
+```rust
+use tokio::select;
+
+async fn fetch_with_timeout() -> Result<Data, Error> {
+    select! {
+        result = fetch_data() => result,
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            Err(Error::Timeout)
+        }
+    }
+}
+
+async fn fetch_with_fallback() -> Data {
+    select! {
+        result = fetch_primary() => {
+            match result {
+                Ok(data) => data,
+                Err(_) => fetch_fallback().await.unwrap()
+            }
+        }
+        _ = tokio::time::sleep(Duration::from_secs(1)) => {
+            // Primary too slow, use fallback
+            fetch_fallback().await.unwrap()
+        }
+    }
+}
+```
+
+## select! Syntax
+
+```rust
+select! {
+    // Pattern = future => handler
+    result = async_operation() => {
+        // Handle result
+        println!("Got: {:?}", result);
+    }
+    
+    // Can bind with pattern matching
+    Ok(data) = fallible_operation() => {
+        process(data);
+    }
+    
+    // Conditional branches with if guards
+    msg = channel.recv(), if should_receive => {
+        handle_message(msg);
+    }
+    
+    // else branch for when all futures are disabled
+    else => {
+        println!("All branches disabled");
+    }
+}
+```
+
+## Cancellation Behavior
+
+```rust
+async fn select_example() {
+    select! {
+        _ = operation_a() => {
+            println!("A completed first");
+            // operation_b() is dropped/cancelled
+        }
+        _ = operation_b() => {
+            println!("B completed first");
+            // operation_a() is dropped/cancelled
+        }
+    }
+}
+
+// Futures are cancelled at their next .await point
+// For immediate cancellation, futures must be cancel-safe
+```
+
+## Biased Selection
+
+```rust
+// By default, select! randomly picks when multiple are ready
+// Use biased mode for deterministic priority
+select! {
+    biased;  // Check branches in order
+    
+    msg = high_priority.recv() => handle_high(msg),
+    msg = low_priority.recv() => handle_low(msg),
+}
+
+// Without biased, both channels have equal chance
+// when both have messages ready
+```
+
+## Loop with select!
+
+```rust
+async fn event_loop(
+    mut commands: mpsc::Receiver<Command>,
+    shutdown: CancellationToken,
+) {
+    loop {
+        select! {
+            _ = shutdown.cancelled() => {
+                println!("Shutting down");
+                break;
+            }
+            Some(cmd) = commands.recv() => {
+                process_command(cmd).await;
+            }
+            else => {
+                // commands channel closed
+                break;
+            }
+        }
+    }
+}
+```
+
+## Racing Multiple of Same Type
+
+```rust
+// Race multiple servers for fastest response
+async fn fastest_response(servers: &[String]) -> Result<Response> {
+    let futures = servers.iter()
+        .map(|s| fetch_from(s))
+        .collect::<Vec<_>>();
+    
+    // select! requires static branches, use select_all for dynamic
+    let (result, _index, _remaining) = 
+        futures::future::select_all(futures).await;
+    
+    result
+}
+```
+
+## Common Patterns
+
+```rust
+// Timeout
+select! {
+    result = operation() => result,
+    _ = sleep(Duration::from_secs(5)) => Err(Timeout),
+}
+
+// Cancellation
+select! {
+    result = operation() => result,
+    _ = cancel_token.cancelled() => Err(Cancelled),
+}
+
+// Interval with cancellation
+let mut interval = tokio::time::interval(Duration::from_secs(1));
+loop {
+    select! {
+        _ = shutdown.cancelled() => break,
+        _ = interval.tick() => {
+            do_periodic_work().await;
+        }
+    }
+}
+```
+
+## See Also
+
+- [async-cancellation-token](./async-cancellation-token.md) - Cancellation patterns
+- [async-join-parallel](./async-join-parallel.md) - All futures, not racing
+- [async-bounded-channel](./async-bounded-channel.md) - Channel operations in select

--- a/.agents/skills/rust-skills/rules/async-spawn-blocking.md
+++ b/.agents/skills/rust-skills/rules/async-spawn-blocking.md
@@ -1,0 +1,154 @@
+# async-spawn-blocking
+
+> Use `spawn_blocking` for CPU-intensive work
+
+## Why It Matters
+
+Async runtimes like Tokio use a small number of threads to handle many tasks. CPU-intensive or blocking operations on these threads starve other tasks. `spawn_blocking` moves such work to a dedicated thread pool.
+
+## Bad
+
+```rust
+// BAD: Blocks the async runtime thread
+async fn process_image(data: &[u8]) -> ProcessedImage {
+    // CPU-intensive work on async thread!
+    let resized = resize_image(data);      // Blocks!
+    let compressed = compress(resized);     // Blocks!
+    compressed
+}
+
+// BAD: Synchronous file I/O in async context
+async fn read_large_file(path: &Path) -> Vec<u8> {
+    std::fs::read(path).unwrap()  // Blocks the runtime!
+}
+```
+
+## Good
+
+```rust
+use tokio::task;
+
+// GOOD: Offload CPU work to blocking pool
+async fn process_image(data: Vec<u8>) -> ProcessedImage {
+    task::spawn_blocking(move || {
+        let resized = resize_image(&data);
+        compress(resized)
+    })
+    .await
+    .expect("spawn_blocking failed")
+}
+
+// GOOD: Use async file I/O
+async fn read_large_file(path: &Path) -> tokio::io::Result<Vec<u8>> {
+    tokio::fs::read(path).await
+}
+
+// GOOD: Or spawn_blocking for unavoidable sync I/O
+async fn read_with_sync_lib(path: PathBuf) -> Vec<u8> {
+    task::spawn_blocking(move || {
+        sync_library::read_file(&path)
+    })
+    .await
+    .unwrap()
+}
+```
+
+## What Counts as Blocking
+
+```rust
+// CPU-intensive operations
+- Cryptographic operations (hashing, encryption)
+- Image/video processing
+- Compression/decompression
+- Complex parsing
+- Mathematical computations
+
+// Blocking I/O
+- std::fs operations
+- Synchronous database drivers
+- Synchronous HTTP clients
+- Thread::sleep
+
+// Example thresholds (rough guidelines):
+// < 10µs: OK on async thread
+// 10µs - 1ms: Consider spawn_blocking
+// > 1ms: Definitely spawn_blocking
+```
+
+## Practical Examples
+
+```rust
+// Password hashing (CPU-intensive)
+async fn hash_password(password: String) -> String {
+    task::spawn_blocking(move || {
+        bcrypt::hash(password, bcrypt::DEFAULT_COST).unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+// JSON parsing of large documents
+async fn parse_large_json(data: String) -> serde_json::Value {
+    task::spawn_blocking(move || {
+        serde_json::from_str(&data).unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+// Compression
+async fn compress_data(data: Vec<u8>) -> Vec<u8> {
+    task::spawn_blocking(move || {
+        let mut encoder = flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::default(),
+        );
+        encoder.write_all(&data).unwrap();
+        encoder.finish().unwrap()
+    })
+    .await
+    .unwrap()
+}
+```
+
+## spawn_blocking vs spawn
+
+```rust
+// spawn: Runs async code on runtime threads
+tokio::spawn(async {
+    // Async code here
+    some_async_operation().await;
+});
+
+// spawn_blocking: Runs sync code on blocking thread pool
+tokio::task::spawn_blocking(|| {
+    // Synchronous, possibly CPU-intensive code
+    heavy_computation();
+});
+
+// spawn_blocking returns JoinHandle that can be awaited
+let result = tokio::task::spawn_blocking(|| {
+    expensive_sync_operation()
+}).await?;
+```
+
+## Rayon for Parallel CPU Work
+
+```rust
+// For parallel CPU work, consider Rayon inside spawn_blocking
+async fn parallel_process(items: Vec<Item>) -> Vec<Output> {
+    task::spawn_blocking(move || {
+        use rayon::prelude::*;
+        items.par_iter()
+            .map(|item| cpu_intensive_transform(item))
+            .collect()
+    })
+    .await
+    .unwrap()
+}
+```
+
+## See Also
+
+- [async-tokio-fs](async-tokio-fs.md) - Use tokio::fs for async file I/O
+- [async-no-lock-await](async-no-lock-await.md) - Don't hold locks across await

--- a/.agents/skills/rust-skills/rules/async-tokio-fs.md
+++ b/.agents/skills/rust-skills/rules/async-tokio-fs.md
@@ -1,0 +1,167 @@
+# async-tokio-fs
+
+> Use `tokio::fs` instead of `std::fs` in async code
+
+## Why It Matters
+
+`std::fs` operations are blocking—they stop the current thread until the syscall completes. In async code, this blocks the executor thread, preventing it from running other tasks. `tokio::fs` wraps filesystem operations in `spawn_blocking`, keeping the executor responsive.
+
+## Bad
+
+```rust
+async fn process_files(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let mut contents = Vec::new();
+    
+    for path in paths {
+        // BLOCKS the entire executor thread!
+        let data = std::fs::read_to_string(path)?;
+        contents.push(data);
+    }
+    
+    Ok(contents)
+}
+
+// While reading a file, NO other tasks can run on this thread
+```
+
+## Good
+
+```rust
+use tokio::fs;
+
+async fn process_files(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let mut contents = Vec::new();
+    
+    for path in paths {
+        // Non-blocking: allows other tasks to run
+        let data = fs::read_to_string(path).await?;
+        contents.push(data);
+    }
+    
+    Ok(contents)
+}
+
+// Even better: concurrent reads
+async fn process_files_concurrent(paths: &[PathBuf]) -> Result<Vec<String>> {
+    let futures: Vec<_> = paths.iter()
+        .map(|path| fs::read_to_string(path))
+        .collect();
+    
+    futures::future::try_join_all(futures).await
+}
+```
+
+## tokio::fs API
+
+```rust
+use tokio::fs;
+
+// Reading
+let contents = fs::read_to_string("file.txt").await?;
+let bytes = fs::read("file.bin").await?;
+
+// Writing
+fs::write("output.txt", "contents").await?;
+
+// File operations
+let file = fs::File::open("file.txt").await?;
+let file = fs::File::create("new.txt").await?;
+
+// Directory operations
+fs::create_dir("new_dir").await?;
+fs::create_dir_all("nested/dir/path").await?;
+fs::remove_dir("empty_dir").await?;
+fs::remove_dir_all("dir_with_contents").await?;
+
+// Metadata
+let metadata = fs::metadata("file.txt").await?;
+let canonical = fs::canonicalize("./relative").await?;
+
+// Rename/remove
+fs::rename("old.txt", "new.txt").await?;
+fs::remove_file("file.txt").await?;
+
+// Read directory
+let mut entries = fs::read_dir("some_dir").await?;
+while let Some(entry) = entries.next_entry().await? {
+    println!("{}", entry.path().display());
+}
+```
+
+## Async File I/O
+
+```rust
+use tokio::fs::File;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, AsyncBufReadExt, BufReader};
+
+// Read with buffer
+let mut file = File::open("large.bin").await?;
+let mut buffer = vec![0u8; 4096];
+let bytes_read = file.read(&mut buffer).await?;
+
+// Read all
+let mut contents = Vec::new();
+file.read_to_end(&mut contents).await?;
+
+// Write
+let mut file = File::create("output.bin").await?;
+file.write_all(b"data").await?;
+file.flush().await?;
+
+// Buffered line reading
+let file = File::open("lines.txt").await?;
+let reader = BufReader::new(file);
+let mut lines = reader.lines();
+
+while let Some(line) = lines.next_line().await? {
+    println!("{}", line);
+}
+```
+
+## When std::fs is Acceptable
+
+```rust
+// Startup/initialization (before async runtime)
+fn main() {
+    let config = std::fs::read_to_string("config.toml")
+        .expect("config file required");
+    
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(run_with_config(config));
+}
+
+// Single-threaded current_thread runtime (less impact)
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Still prefer tokio::fs, but impact is lower
+}
+
+// When file operations are rare and quick
+// (e.g., reading small config once per hour)
+```
+
+## Performance Considerations
+
+```rust
+// tokio::fs uses spawn_blocking internally
+// For many small files, the overhead adds up
+
+// Batch operations when possible
+let paths: Vec<_> = entries.iter()
+    .map(|e| e.path())
+    .collect();
+
+let contents = futures::future::try_join_all(
+    paths.iter().map(|p| fs::read_to_string(p))
+).await?;
+
+// For heavy I/O, consider memory-mapped files
+// (requires unsafe or mmap crate)
+```
+
+## See Also
+
+- [async-spawn-blocking](./async-spawn-blocking.md) - How tokio::fs works internally
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime configuration
+- [err-context-chain](./err-context-chain.md) - Adding path context to IO errors

--- a/.agents/skills/rust-skills/rules/async-tokio-runtime.md
+++ b/.agents/skills/rust-skills/rules/async-tokio-runtime.md
@@ -1,0 +1,169 @@
+# async-tokio-runtime
+
+> Configure Tokio runtime appropriately for your workload
+
+## Why It Matters
+
+Tokio's default multi-threaded runtime isn't always optimal. CPU-bound work needs different configuration than IO-bound work. Incorrect configuration leads to poor performance, blocked workers, or resource exhaustion. Understanding runtime options lets you tune for your specific use case.
+
+## Bad
+
+```rust
+// Default runtime for everything - not optimal
+#[tokio::main]
+async fn main() {
+    // CPU-heavy work on async executor starves IO tasks
+    for data in datasets {
+        let result = heavy_computation(data).await;
+    }
+}
+
+// Single-threaded when multi-threaded is needed
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Can't utilize multiple cores for concurrent tasks
+    for _ in 0..1000 {
+        tokio::spawn(async { /* IO work */ });
+    }
+}
+```
+
+## Good
+
+```rust
+// Multi-threaded for concurrent IO (default)
+#[tokio::main]
+async fn main() {
+    // Good for many concurrent network connections
+    let handles: Vec<_> = urls.iter()
+        .map(|url| tokio::spawn(fetch(url.clone())))
+        .collect();
+    
+    futures::future::join_all(handles).await;
+}
+
+// Current-thread for single-threaded scenarios
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // Good for single-connection clients, simpler debugging
+    let client = Client::new();
+    client.run().await;
+}
+
+// Custom configuration
+#[tokio::main(worker_threads = 4)]
+async fn main() {
+    // Limit to 4 worker threads
+}
+
+// Or manual setup for more control
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .thread_name("my-worker")
+        .build()
+        .unwrap();
+    
+    runtime.block_on(async_main());
+}
+```
+
+## Runtime Types
+
+| Runtime | Use Case | Configuration |
+|---------|----------|---------------|
+| Multi-thread | IO-bound, many connections | `#[tokio::main]` (default) |
+| Current-thread | CLI tools, tests, single connection | `flavor = "current_thread"` |
+| Custom | Fine-tuned performance | `Builder::new_*()` |
+
+## Worker Thread Tuning
+
+```rust
+use tokio::runtime::Builder;
+
+// IO-bound: more threads than cores can help
+let io_runtime = Builder::new_multi_thread()
+    .worker_threads(num_cpus::get() * 2)  // IO can benefit from oversubscription
+    .max_blocking_threads(32)              // For spawn_blocking calls
+    .enable_io()
+    .enable_time()
+    .build()?;
+
+// CPU-bound: match core count
+let cpu_runtime = Builder::new_multi_thread()
+    .worker_threads(num_cpus::get())       // No benefit from more than cores
+    .build()?;
+```
+
+## Multiple Runtimes
+
+```rust
+// Separate runtimes for different workloads
+struct App {
+    io_runtime: Runtime,
+    cpu_runtime: Runtime,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            io_runtime: Builder::new_multi_thread()
+                .worker_threads(8)
+                .thread_name("io-worker")
+                .build()
+                .unwrap(),
+            cpu_runtime: Builder::new_multi_thread()
+                .worker_threads(4)
+                .thread_name("cpu-worker")
+                .build()
+                .unwrap(),
+        }
+    }
+    
+    fn spawn_io<F>(&self, future: F) 
+    where F: Future + Send + 'static, F::Output: Send + 'static 
+    {
+        self.io_runtime.spawn(future);
+    }
+    
+    fn spawn_cpu<F>(&self, task: F) 
+    where F: FnOnce() + Send + 'static 
+    {
+        self.cpu_runtime.spawn_blocking(task);
+    }
+}
+```
+
+## Runtime in Tests
+
+```rust
+// Single test runtime
+#[tokio::test]
+async fn test_single() {
+    assert!(true);
+}
+
+// Multi-threaded test
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent() {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move { tx.send(42).unwrap() });
+    assert_eq!(rx.await.unwrap(), 42);
+}
+
+// Custom runtime in test
+#[test]
+fn test_with_custom_runtime() {
+    let rt = Builder::new_current_thread().build().unwrap();
+    rt.block_on(async {
+        // test code
+    });
+}
+```
+
+## See Also
+
+- [async-spawn-blocking](./async-spawn-blocking.md) - Handling blocking code
+- [async-no-lock-await](./async-no-lock-await.md) - Avoiding lock issues
+- [async-joinset-structured](./async-joinset-structured.md) - Managing spawned tasks

--- a/.agents/skills/rust-skills/rules/async-try-join.md
+++ b/.agents/skills/rust-skills/rules/async-try-join.md
@@ -1,0 +1,172 @@
+# async-try-join
+
+> Use `try_join!` for concurrent fallible operations with early return on error
+
+## Why It Matters
+
+When running multiple fallible operations concurrently, `try_join!` returns `Err` as soon as any future fails, without waiting for the others. This provides fail-fast behavior while still running operations in parallel. For many operations, use `futures::future::try_join_all`.
+
+## Bad
+
+```rust
+// Sequential - slow and no early return benefit
+async fn fetch_all() -> Result<(A, B, C)> {
+    let a = fetch_a().await?;  // If this fails, we wait for nothing
+    let b = fetch_b().await?;  // But if this fails, we waited for A
+    let c = fetch_c().await?;
+    Ok((a, b, c))
+}
+
+// join! ignores errors
+async fn fetch_all() -> (Result<A>, Result<B>, Result<C>) {
+    let (a, b, c) = join!(fetch_a(), fetch_b(), fetch_c());
+    // All complete even if first one failed
+    (a, b, c)  // Now we have to handle three Results
+}
+```
+
+## Good
+
+```rust
+use tokio::try_join;
+
+async fn fetch_all() -> Result<(A, B, C)> {
+    // Concurrent AND fail-fast
+    let (a, b, c) = try_join!(
+        fetch_a(),
+        fetch_b(),
+        fetch_c(),
+    )?;
+    
+    Ok((a, b, c))
+}
+
+// For dynamic collections
+use futures::future::try_join_all;
+
+async fn fetch_users(ids: &[u64]) -> Result<Vec<User>> {
+    let futures: Vec<_> = ids.iter()
+        .map(|id| fetch_user(*id))
+        .collect();
+    
+    try_join_all(futures).await
+}
+```
+
+## Error Handling Patterns
+
+```rust
+// Different error types - need common error type
+async fn mixed_operations() -> Result<(A, B), Error> {
+    let (a, b) = try_join!(
+        fetch_a().map_err(Error::from),  // Convert errors
+        fetch_b().map_err(Error::from),
+    )?;
+    Ok((a, b))
+}
+
+// Collect all results, then handle errors
+async fn all_or_nothing(ids: &[u64]) -> Result<Vec<User>> {
+    try_join_all(ids.iter().map(|id| fetch_user(*id))).await
+}
+
+// Collect successes, log failures
+async fn best_effort(ids: &[u64]) -> Vec<User> {
+    let results = futures::future::join_all(
+        ids.iter().map(|id| fetch_user(*id))
+    ).await;
+    
+    results.into_iter()
+        .filter_map(|r| match r {
+            Ok(user) => Some(user),
+            Err(e) => {
+                log::warn!("Failed to fetch user: {}", e);
+                None
+            }
+        })
+        .collect()
+}
+```
+
+## Cancellation Behavior
+
+```rust
+// try_join! cancels remaining futures on error
+async fn with_cancellation() -> Result<()> {
+    // If fetch_a() fails, fetch_b() and fetch_c() are dropped
+    // But "dropped" != "immediately stopped"
+    // They stop at their next .await point
+    
+    try_join!(
+        async {
+            fetch_a().await?;
+            cleanup_a().await;  // May not run if other future fails
+            Ok::<_, Error>(())
+        },
+        async {
+            fetch_b().await?;
+            cleanup_b().await;  // May not run if other future fails
+            Ok::<_, Error>(())
+        },
+    )?;
+    
+    Ok(())
+}
+
+// For guaranteed cleanup, use Drop guards or explicit handling
+```
+
+## With Timeout
+
+```rust
+use tokio::time::{timeout, Duration};
+
+async fn fetch_with_timeout() -> Result<(A, B)> {
+    timeout(
+        Duration::from_secs(10),
+        try_join!(fetch_a(), fetch_b())
+    )
+    .await
+    .map_err(|_| Error::Timeout)?
+}
+
+// Per-operation timeout
+async fn individual_timeouts() -> Result<(A, B)> {
+    try_join!(
+        timeout(Duration::from_secs(5), fetch_a())
+            .map_err(|_| Error::Timeout)
+            .and_then(|r| async { r }),
+        timeout(Duration::from_secs(5), fetch_b())
+            .map_err(|_| Error::Timeout)
+            .and_then(|r| async { r }),
+    )
+}
+```
+
+## try_join! vs FuturesUnordered
+
+```rust
+use futures::stream::{FuturesUnordered, StreamExt};
+
+// try_join!: wait for all, fail fast
+let (a, b, c) = try_join!(fa, fb, fc)?;
+
+// FuturesUnordered: process as they complete
+let mut futures = FuturesUnordered::new();
+futures.push(fetch_a());
+futures.push(fetch_b());
+futures.push(fetch_c());
+
+while let Some(result) = futures.next().await {
+    match result {
+        Ok(data) => process(data),
+        Err(e) => return Err(e),  // Can fail fast manually
+    }
+}
+```
+
+## See Also
+
+- [async-join-parallel](./async-join-parallel.md) - Non-fallible concurrent futures
+- [async-select-racing](./async-select-racing.md) - First-to-complete semantics
+- [err-question-mark](./err-question-mark.md) - Error propagation

--- a/.agents/skills/rust-skills/rules/async-watch-latest.md
+++ b/.agents/skills/rust-skills/rules/async-watch-latest.md
@@ -1,0 +1,189 @@
+# async-watch-latest
+
+> Use `watch` channel for sharing the latest value with multiple observers
+
+## Why It Matters
+
+`watch` is optimized for scenarios where receivers only care about the most recent value, not the history of changes. Unlike `broadcast`, slow receivers don't lag—they simply skip intermediate values. This is perfect for configuration, state, or status that should always reflect the current situation.
+
+## Bad
+
+```rust
+// Using broadcast when only latest value matters
+let (tx, _) = broadcast::channel::<Config>(100);
+
+// Receivers might process stale configs if they're slow
+// And they waste time processing intermediate values
+
+// Using mpsc with buffered stale values
+let (tx, mut rx) = mpsc::channel::<Status>(100);
+// Receiver might process outdated statuses
+```
+
+## Good
+
+```rust
+use tokio::sync::watch;
+
+let (tx, rx) = watch::channel(Config::default());
+
+// Multiple observers
+let rx1 = rx.clone();
+let rx2 = rx.clone();
+
+// Observer 1: waits for changes
+tokio::spawn(async move {
+    let mut rx = rx1;
+    while rx.changed().await.is_ok() {
+        let config = rx.borrow();
+        apply_config(&*config);
+    }
+});
+
+// Observer 2: also sees all changes
+tokio::spawn(async move {
+    let mut rx = rx2;
+    while rx.changed().await.is_ok() {
+        let config = rx.borrow();
+        log_config_change(&*config);
+    }
+});
+
+// Update the value
+tx.send(Config::new())?;
+```
+
+## watch Semantics
+
+```rust
+use tokio::sync::watch;
+
+let (tx, mut rx) = watch::channel("initial");
+
+// Immediate read - no waiting
+assert_eq!(*rx.borrow(), "initial");
+
+// Wait for change
+tx.send("updated")?;
+rx.changed().await?;
+assert_eq!(*rx.borrow(), "updated");
+
+// Multiple rapid updates - receiver sees latest
+tx.send("v1")?;
+tx.send("v2")?;
+tx.send("v3")?;
+rx.changed().await?;
+assert_eq!(*rx.borrow(), "v3");  // Skipped v1, v2
+```
+
+## Configuration Reload Pattern
+
+```rust
+use tokio::sync::watch;
+use std::sync::Arc;
+
+struct AppConfig {
+    log_level: Level,
+    max_connections: usize,
+}
+
+async fn config_watcher(tx: watch::Sender<Arc<AppConfig>>) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        
+        if let Ok(new_config) = reload_config_from_disk() {
+            // Only notifies if value actually changed
+            tx.send_if_modified(|current| {
+                if *current != new_config {
+                    *current = Arc::new(new_config);
+                    true
+                } else {
+                    false
+                }
+            });
+        }
+    }
+}
+
+async fn worker(mut config_rx: watch::Receiver<Arc<AppConfig>>) {
+    loop {
+        tokio::select! {
+            _ = config_rx.changed() => {
+                let config = config_rx.borrow().clone();
+                reconfigure(&config);
+            }
+            _ = do_work() => {}
+        }
+    }
+}
+```
+
+## State Machine Updates
+
+```rust
+#[derive(Clone, PartialEq)]
+enum ConnectionState {
+    Disconnected,
+    Connecting,
+    Connected,
+    Error(String),
+}
+
+struct Connection {
+    state_tx: watch::Sender<ConnectionState>,
+    state_rx: watch::Receiver<ConnectionState>,
+}
+
+impl Connection {
+    async fn wait_connected(&mut self) -> Result<(), Error> {
+        loop {
+            let state = self.state_rx.borrow().clone();
+            match state {
+                ConnectionState::Connected => return Ok(()),
+                ConnectionState::Error(e) => return Err(Error::Connection(e)),
+                _ => {
+                    self.state_rx.changed().await?;
+                }
+            }
+        }
+    }
+}
+```
+
+## Borrow vs Clone
+
+```rust
+use tokio::sync::watch;
+
+let (tx, rx) = watch::channel(vec![1, 2, 3]);
+
+// borrow() returns Ref - must not hold across await
+{
+    let data = rx.borrow();
+    println!("{:?}", *data);
+}  // Ref dropped here
+
+// For use across await, clone the data
+let data = rx.borrow().clone();
+some_async_operation().await;
+use_data(&data);  // Safe
+
+// Or use borrow_and_update() to mark as seen
+let data = rx.borrow_and_update().clone();
+```
+
+## watch vs broadcast vs mpsc
+
+| Feature | watch | broadcast | mpsc |
+|---------|-------|-----------|------|
+| Receivers | Multiple | Multiple | Single |
+| Message delivery | Latest only | All messages | All messages |
+| Slow receiver | Skips to latest | Lags/misses | Backpressure |
+| Clone required | No | Yes | No |
+| Best for | Config, status | Events | Work queues |
+
+## See Also
+
+- [async-broadcast-pubsub](./async-broadcast-pubsub.md) - When history matters
+- [async-mpsc-queue](./async-mpsc-queue.md) - Work queue patterns
+- [async-cancellation-token](./async-cancellation-token.md) - Related pattern

--- a/.agents/skills/rust-skills/rules/doc-all-public.md
+++ b/.agents/skills/rust-skills/rules/doc-all-public.md
@@ -1,0 +1,113 @@
+# doc-all-public
+
+> Document all public items with `///` doc comments
+
+## Why It Matters
+
+Public items define your crate's API contract. Without documentation, users must read source code to understand how to use your library. Well-documented APIs reduce support burden, improve adoption, and serve as the primary reference for users.
+
+Rust's `cargo doc` generates beautiful HTML documentation from doc comments, but only if you write them.
+
+## Bad
+
+```rust
+pub struct Config {
+    pub timeout: Duration,
+    pub retries: u32,
+    pub base_url: String,
+}
+
+pub fn connect(config: Config) -> Result<Connection, Error> {
+    // ...
+}
+
+pub enum Status {
+    Pending,
+    Active,
+    Failed,
+}
+```
+
+## Good
+
+```rust
+/// Configuration for establishing a connection to the service.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::Config;
+/// use std::time::Duration;
+///
+/// let config = Config {
+///     timeout: Duration::from_secs(30),
+///     retries: 3,
+///     base_url: "https://api.example.com".to_string(),
+/// };
+/// ```
+pub struct Config {
+    /// Maximum time to wait for a response before timing out.
+    pub timeout: Duration,
+    
+    /// Number of retry attempts for failed requests.
+    pub retries: u32,
+    
+    /// Base URL for all API requests.
+    pub base_url: String,
+}
+
+/// Establishes a connection using the provided configuration.
+///
+/// # Errors
+///
+/// Returns an error if the connection cannot be established
+/// or if the configuration is invalid.
+pub fn connect(config: Config) -> Result<Connection, Error> {
+    // ...
+}
+
+/// Represents the current status of a job.
+pub enum Status {
+    /// Job is waiting to be processed.
+    Pending,
+    /// Job is currently being processed.
+    Active,
+    /// Job has failed and will not be retried.
+    Failed,
+}
+```
+
+## What to Document
+
+| Item Type | Required Content |
+|-----------|------------------|
+| Structs | Purpose, usage example |
+| Struct fields | What the field represents |
+| Enums | When to use each variant |
+| Enum variants | What state it represents |
+| Functions | What it does, parameters, return value |
+| Traits | Contract and expected behavior |
+| Trait methods | Default implementation behavior |
+| Type aliases | Why the alias exists |
+| Constants | What the value represents |
+
+## Enforcement
+
+Enable the `missing_docs` lint to catch undocumented public items:
+
+```rust
+#![warn(missing_docs)]
+```
+
+Or in `Cargo.toml` for workspace-wide enforcement:
+
+```toml
+[workspace.lints.rust]
+missing_docs = "warn"
+```
+
+## See Also
+
+- [doc-module-inner](./doc-module-inner.md) - Module-level documentation
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [lint-missing-docs](./lint-missing-docs.md) - Enforcing documentation

--- a/.agents/skills/rust-skills/rules/doc-cargo-metadata.md
+++ b/.agents/skills/rust-skills/rules/doc-cargo-metadata.md
@@ -1,0 +1,147 @@
+# doc-cargo-metadata
+
+> Fill `Cargo.toml` metadata for published crates
+
+## Why It Matters
+
+Cargo.toml metadata appears on crates.io, in search results, and helps users evaluate your crate. Missing metadata makes your crate look unprofessional, harder to find, and harder to trust. Complete metadata improves discoverability and adoption.
+
+## Bad
+
+```toml
+[package]
+name = "my-awesome-crate"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# ...
+```
+
+## Good
+
+```toml
+[package]
+name = "my-awesome-crate"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+# Required for crates.io
+description = "A fast, ergonomic HTTP client for Rust"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/username/my-awesome-crate"
+
+# Highly recommended
+documentation = "https://docs.rs/my-awesome-crate"
+readme = "README.md"
+keywords = ["http", "client", "async", "networking"]
+categories = ["network-programming", "web-programming::http-client"]
+authors = ["Your Name <you@example.com>"]
+homepage = "https://my-awesome-crate.dev"
+
+# Optional but helpful
+include = ["src/**/*", "Cargo.toml", "LICENSE*", "README.md"]
+exclude = ["tests/fixtures/*", ".github/*"]
+
+[badges]
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+# ...
+```
+
+## Required Fields for Publishing
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Crate name on crates.io |
+| `version` | Semver version |
+| `license` or `license-file` | SPDX license identifier |
+| `description` | One-line summary (≤256 chars) |
+
+## Recommended Fields
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `repository` | Link to source code | `https://github.com/user/repo` |
+| `documentation` | Link to docs | `https://docs.rs/crate` |
+| `readme` | Path to README | `README.md` |
+| `keywords` | Search terms (max 5) | `["http", "async"]` |
+| `categories` | crates.io categories | `["network-programming"]` |
+| `rust-version` | MSRV | `"1.70"` |
+
+## Keywords Best Practices
+
+```toml
+# Good: specific, searchable terms
+keywords = ["json", "serialization", "serde", "parsing"]
+
+# Bad: too generic or redundant
+keywords = ["rust", "library", "awesome", "fast", "best"]
+```
+
+## Categories
+
+Choose from [crates.io categories](https://crates.io/category_slugs):
+
+```toml
+categories = [
+    "network-programming",
+    "web-programming::http-client",
+    "asynchronous",
+]
+```
+
+## License Patterns
+
+```toml
+# Single license
+license = "MIT"
+
+# Dual license (common in Rust ecosystem)
+license = "MIT OR Apache-2.0"
+
+# Custom license file
+license-file = "LICENSE"
+```
+
+## Include/Exclude
+
+Control what gets published:
+
+```toml
+# Explicit include (whitelist)
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "LICENSE*",
+    "README.md",
+    "CHANGELOG.md",
+]
+
+# Or exclude (blacklist)
+exclude = [
+    "tests/fixtures/large-file.bin",
+    ".github/*",
+    "benches/*",
+]
+```
+
+## Verification
+
+Check your package before publishing:
+
+```bash
+# See what will be included
+cargo package --list
+
+# Check metadata
+cargo publish --dry-run
+```
+
+## See Also
+
+- [doc-module-inner](./doc-module-inner.md) - Crate-level documentation
+- [lint-cargo-metadata](./lint-cargo-metadata.md) - Linting Cargo.toml
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace management

--- a/.agents/skills/rust-skills/rules/doc-errors-section.md
+++ b/.agents/skills/rust-skills/rules/doc-errors-section.md
@@ -1,0 +1,122 @@
+# doc-errors-section
+
+> Include `# Errors` section for fallible functions
+
+## Why It Matters
+
+Functions returning `Result` can fail in specific, documented ways. The `# Errors` section tells users exactly when and why a function might return an error, enabling them to handle failures appropriately without reading source code.
+
+This is especially critical for library code where users cannot easily inspect implementation details.
+
+## Bad
+
+```rust
+/// Opens a file and reads its contents.
+pub fn read_file(path: &Path) -> Result<String, Error> {
+    // Users have no idea what errors to expect
+}
+
+/// Connects to the database.
+pub async fn connect(url: &str) -> Result<Connection, DbError> {
+    // Multiple failure modes, none documented
+}
+```
+
+## Good
+
+```rust
+/// Opens a file and reads its contents as a UTF-8 string.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist ([`Error::NotFound`])
+/// - The process lacks permission to read the file ([`Error::PermissionDenied`])
+/// - The file contains invalid UTF-8 ([`Error::InvalidUtf8`])
+pub fn read_file(path: &Path) -> Result<String, Error> {
+    // ...
+}
+
+/// Establishes a connection to the database.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The URL is malformed ([`DbError::InvalidUrl`])
+/// - The database server is unreachable ([`DbError::ConnectionFailed`])
+/// - Authentication fails ([`DbError::AuthenticationFailed`])
+/// - The connection pool is exhausted ([`DbError::PoolExhausted`])
+pub async fn connect(url: &str) -> Result<Connection, DbError> {
+    // ...
+}
+```
+
+## Error Documentation Patterns
+
+### Simple Single Error
+
+```rust
+/// Parses a string as an integer.
+///
+/// # Errors
+///
+/// Returns [`ParseIntError`] if the string is not a valid integer.
+pub fn parse_int(s: &str) -> Result<i64, ParseIntError> {
+    s.parse()
+}
+```
+
+### Multiple Error Variants
+
+```rust
+/// Sends an HTTP request and returns the response.
+///
+/// # Errors
+///
+/// | Error | Condition |
+/// |-------|-----------|
+/// | [`HttpError::Timeout`] | Request exceeded timeout duration |
+/// | [`HttpError::InvalidUrl`] | URL could not be parsed |
+/// | [`HttpError::ConnectionRefused`] | Server refused connection |
+/// | [`HttpError::TlsError`] | TLS handshake failed |
+pub fn send(request: Request) -> Result<Response, HttpError> {
+    // ...
+}
+```
+
+### Propagated Errors
+
+```rust
+/// Loads configuration from a file.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The configuration file cannot be read (IO error)
+/// - The file contains invalid TOML syntax
+/// - Required fields are missing from the configuration
+///
+/// The underlying error is wrapped with context about which
+/// configuration file failed to load.
+pub fn load_config(path: &Path) -> Result<Config, anyhow::Error> {
+    // ...
+}
+```
+
+## Linking to Error Types
+
+Use intra-doc links to connect error variants to their definitions:
+
+```rust
+/// # Errors
+///
+/// Returns [`ValidationError::TooShort`] if the input is less than
+/// the minimum length, or [`ValidationError::InvalidChars`] if it
+/// contains forbidden characters.
+```
+
+## See Also
+
+- [doc-panics-section](./doc-panics-section.md) - Documenting panics
+- [err-doc-errors](./err-doc-errors.md) - Error documentation patterns
+- [doc-intra-links](./doc-intra-links.md) - Linking to types

--- a/.agents/skills/rust-skills/rules/doc-examples-section.md
+++ b/.agents/skills/rust-skills/rules/doc-examples-section.md
@@ -1,0 +1,161 @@
+# doc-examples-section
+
+> Include `# Examples` with runnable code
+
+## Why It Matters
+
+Examples are the most valuable part of documentation. They show users exactly how to use your API. Rust's doc tests ensure examples stay correct as code evolves.
+
+## Bad
+
+```rust
+/// Parses a string into a Foo.
+pub fn parse(s: &str) -> Result<Foo, Error> {
+    // No examples - users have to guess usage
+}
+
+/// A widget for doing things.
+/// 
+/// This widget is very useful.
+pub struct Widget {
+    // Still no examples
+}
+```
+
+## Good
+
+```rust
+/// Parses a string into a Foo.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::parse;
+///
+/// let foo = parse("hello").unwrap();
+/// assert_eq!(foo.name(), "hello");
+/// ```
+///
+/// Handles empty strings:
+///
+/// ```
+/// use my_crate::parse;
+///
+/// let foo = parse("").unwrap();
+/// assert!(foo.is_empty());
+/// ```
+pub fn parse(s: &str) -> Result<Foo, Error> {
+    // ...
+}
+```
+
+## Use ? Not unwrap()
+
+```rust
+/// Loads configuration from a file.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use my_crate::Config;
+///
+/// let config = Config::load("config.toml")?;
+/// println!("Port: {}", config.port);
+/// # Ok(())
+/// # }
+/// ```
+pub fn load(path: &str) -> Result<Config, Error> {
+    // ...
+}
+```
+
+## Hide Setup Code
+
+```rust
+/// Processes items from a database.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Database, Item};
+/// # fn get_db() -> Database { Database::mock() }
+/// let db = get_db();
+/// let items = db.process_items()?;
+/// assert!(!items.is_empty());
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+pub fn process_items(&self) -> Result<Vec<Item>, Error> {
+    // ...
+}
+```
+
+## Multiple Examples
+
+```rust
+/// Creates a new buffer with the specified capacity.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use my_crate::Buffer;
+///
+/// let buf = Buffer::with_capacity(1024);
+/// assert_eq!(buf.capacity(), 1024);
+/// ```
+///
+/// Zero capacity creates an empty buffer:
+///
+/// ```
+/// use my_crate::Buffer;
+///
+/// let buf = Buffer::with_capacity(0);
+/// assert!(buf.is_empty());
+/// ```
+pub fn with_capacity(cap: usize) -> Self {
+    // ...
+}
+```
+
+## Show Error Cases
+
+```rust
+/// Divides two numbers.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::divide;
+///
+/// assert_eq!(divide(10, 2), Ok(5));
+/// ```
+///
+/// Division by zero returns an error:
+///
+/// ```
+/// use my_crate::{divide, MathError};
+///
+/// assert_eq!(divide(10, 0), Err(MathError::DivisionByZero));
+/// ```
+pub fn divide(a: i32, b: i32) -> Result<i32, MathError> {
+    // ...
+}
+```
+
+## Running Doc Tests
+
+```bash
+# Run all doc tests
+cargo test --doc
+
+# Run doc tests for specific item
+cargo test --doc my_function
+```
+
+## See Also
+
+- [doc-question-mark](doc-question-mark.md) - Use ? in examples
+- [doc-hidden-setup](doc-hidden-setup.md) - Hide setup code with #
+- [doc-errors-section](doc-errors-section.md) - Document error conditions

--- a/.agents/skills/rust-skills/rules/doc-hidden-setup.md
+++ b/.agents/skills/rust-skills/rules/doc-hidden-setup.md
@@ -1,0 +1,149 @@
+# doc-hidden-setup
+
+> Use `# ` prefix to hide example setup code
+
+## Why It Matters
+
+Doc examples often require setup code (imports, struct initialization, mock data) that distracts from the main point. The `# ` prefix hides lines from rendered documentation while keeping them in the compiled test, showing users only the relevant code.
+
+This keeps examples focused and readable while ensuring they still compile and run.
+
+## Bad
+
+```rust
+/// Processes a batch of items.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::{Processor, Config, Item};
+/// use std::sync::Arc;
+/// 
+/// let config = Config {
+///     batch_size: 100,
+///     timeout_ms: 5000,
+///     retry_count: 3,
+/// };
+/// let processor = Processor::new(Arc::new(config));
+/// let items = vec![
+///     Item::new("a"),
+///     Item::new("b"),
+///     Item::new("c"),
+/// ];
+/// 
+/// // This is the actual example - buried after 15 lines of setup
+/// let results = processor.process_batch(&items)?;
+/// assert!(results.all_succeeded());
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+pub fn process_batch(&self, items: &[Item]) -> Result<Results, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Processes a batch of items.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Processor, Config, Item, Error};
+/// # use std::sync::Arc;
+/// # let config = Config { batch_size: 100, timeout_ms: 5000, retry_count: 3 };
+/// # let processor = Processor::new(Arc::new(config));
+/// # let items = vec![Item::new("a"), Item::new("b"), Item::new("c")];
+/// let results = processor.process_batch(&items)?;
+/// assert!(results.all_succeeded());
+/// # Ok::<(), Error>(())
+/// ```
+pub fn process_batch(&self, items: &[Item]) -> Result<Results, Error> {
+    // ...
+}
+```
+
+Users see only:
+
+```rust
+let results = processor.process_batch(&items)?;
+assert!(results.all_succeeded());
+```
+
+## What to Hide
+
+| Hide | Show |
+|------|------|
+| `use` statements | Core API usage |
+| Type definitions | Method calls |
+| Mock/test data setup | Key parameters |
+| Error handling boilerplate | Return value handling |
+| `Ok(())` return | Assertions (sometimes) |
+
+## Pattern: Hiding Multi-Line Setup
+
+```rust
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Client, Request};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let client = Client::builder()
+/// #     .timeout(30)
+/// #     .retry(3)
+/// #     .build()?;
+/// let response = client.send(Request::get("/users"))?;
+/// println!("Status: {}", response.status());
+/// # Ok(())
+/// # }
+/// ```
+```
+
+## Pattern: Showing Setup When Relevant
+
+Sometimes setup IS the point—don't hide it:
+
+```rust
+/// Creates a new client with custom configuration.
+///
+/// # Examples
+///
+/// ```
+/// use my_crate::Client;
+///
+/// // Configuration IS the example - show it
+/// let client = Client::builder()
+///     .base_url("https://api.example.com")
+///     .timeout_secs(30)
+///     .max_retries(3)
+///     .build()?;
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+```
+
+## Pattern: `ignore` and `no_run`
+
+For examples that shouldn't run in tests:
+
+```rust
+/// # Examples
+///
+/// ```no_run
+/// # use my_crate::Server;
+/// // This would actually start a server - don't run in tests
+/// let server = Server::bind("0.0.0.0:8080").await?;
+/// server.run().await?;
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+
+/// ```ignore
+/// // Pseudocode or incomplete example
+/// let magic = do_something_undefined();
+/// ```
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Writing examples
+- [doc-question-mark](./doc-question-mark.md) - Using `?` in examples
+- [test-doctest-examples](./test-doctest-examples.md) - Doctests as tests

--- a/.agents/skills/rust-skills/rules/doc-intra-links.md
+++ b/.agents/skills/rust-skills/rules/doc-intra-links.md
@@ -1,0 +1,138 @@
+# doc-intra-links
+
+> Use intra-doc links to reference types and items
+
+## Why It Matters
+
+Intra-doc links (`[TypeName]`, `[method](Self::method)`) create clickable references in generated documentation. They're verified at doc-build time, catching broken links early. Unlike URL links, they automatically update when items are renamed or moved.
+
+## Bad
+
+```rust
+/// Returns the length of the buffer.
+/// 
+/// See also `capacity()` for the allocated size, and the
+/// `Buffer` struct for more details.
+pub fn len(&self) -> usize {
+    self.data.len()
+}
+
+/// Parses the input using std::str::FromStr trait.
+/// Check the Error enum for possible failures.
+pub fn parse<T: FromStr>(input: &str) -> Result<T, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Returns the length of the buffer.
+/// 
+/// See also [`capacity()`](Self::capacity) for the allocated size, and
+/// [`Buffer`] for more details.
+pub fn len(&self) -> usize {
+    self.data.len()
+}
+
+/// Parses the input using [`FromStr`] trait.
+/// Check [`Error`] for possible failures.
+///
+/// [`FromStr`]: std::str::FromStr
+pub fn parse<T: FromStr>(input: &str) -> Result<T, Error> {
+    // ...
+}
+```
+
+## Link Syntax
+
+| Syntax | Links To | Example |
+|--------|----------|---------|
+| `[Name]` | Item in scope | `[Vec]`, `[Option]` |
+| `[path::Name]` | Fully qualified item | `[std::vec::Vec]` |
+| `[Self::method]` | Method on current type | `[Self::new]` |
+| `[Type::method]` | Method on other type | `[String::new]` |
+| `[Type::CONST]` | Associated constant | `[usize::MAX]` |
+| `[text](path)` | Custom text | `[see here](Self::len)` |
+
+## Common Patterns
+
+### Linking to Self Members
+
+```rust
+impl Buffer {
+    /// Creates an empty buffer.
+    ///
+    /// Use [`with_capacity`](Self::with_capacity) if you know the size.
+    pub fn new() -> Self { /* ... */ }
+    
+    /// Creates a buffer with pre-allocated capacity.
+    ///
+    /// See [`new`](Self::new) for the default constructor.
+    pub fn with_capacity(cap: usize) -> Self { /* ... */ }
+}
+```
+
+### Linking to Trait Methods
+
+```rust
+/// Converts to a string representation.
+///
+/// This is the implementation of [`Display::fmt`](std::fmt::Display::fmt).
+impl Display for MyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // ...
+    }
+}
+```
+
+### Disambiguation
+
+When names conflict, use suffixes:
+
+```rust
+/// See [`foo()`](fn@foo) for the function and [`foo`](mod@foo) for the module.
+
+/// Works with [`Error`](struct@Error) struct or [`Error`](trait@Error) trait.
+```
+
+| Suffix | Item Type |
+|--------|-----------|
+| `fn@` | Function |
+| `mod@` | Module |
+| `struct@` | Struct |
+| `enum@` | Enum |
+| `trait@` | Trait |
+| `type@` | Type alias |
+| `const@` | Constant |
+| `macro@` | Macro |
+
+### Reference-Style Links
+
+For repeated links or long paths:
+
+```rust
+/// Parses using [`serde`] with [`Deserialize`] trait.
+/// Returns a [`Result`] that may contain [`Error`].
+///
+/// [`serde`]: https://serde.rs
+/// [`Deserialize`]: serde::Deserialize
+/// [`Result`]: std::result::Result
+/// [`Error`]: crate::Error
+```
+
+## Verification
+
+Enable link checking in CI:
+
+```bash
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+```
+
+This fails if any intra-doc links are broken.
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documenting public items
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors

--- a/.agents/skills/rust-skills/rules/doc-link-types.md
+++ b/.agents/skills/rust-skills/rules/doc-link-types.md
@@ -1,0 +1,169 @@
+# doc-link-types
+
+> Use intra-doc links to connect related types and functions
+
+## Why It Matters
+
+Intra-doc links (`[`TypeName`]`) create clickable references in generated documentation. They enable navigation between related items, verify that referenced items exist at compile time, and update automatically when items are renamed. Plain text references become stale and unclickable.
+
+## Bad
+
+```rust
+/// Parses input and returns a ParseResult.
+/// 
+/// See also: ParseError for error types.
+/// Uses the Tokenizer internally.
+pub fn parse(input: &str) -> ParseResult {
+    // "ParseResult", "ParseError", "Tokenizer" are not clickable
+    // No verification they exist
+}
+```
+
+## Good
+
+```rust
+/// Parses input and returns a [`ParseResult`].
+///
+/// # Errors
+///
+/// Returns [`ParseError::InvalidSyntax`] if the input contains invalid tokens.
+/// Returns [`ParseError::UnexpectedEof`] if the input ends prematurely.
+///
+/// # Related
+///
+/// - [`Tokenizer`] - The underlying tokenizer used by this parser
+/// - [`parse_file`] - Convenience function for parsing files
+/// - [`ParseOptions`] - Configuration options for parsing
+pub fn parse(input: &str) -> ParseResult {
+    // All links are clickable and verified
+}
+```
+
+## Link Syntax
+
+```rust
+/// Basic link to type in same module
+/// See [`MyType`] for details.
+
+/// Link to method
+/// Use [`MyType::new`] to create instances.
+
+/// Link to associated type
+/// Returns [`Iterator::Item`].
+
+/// Link to module
+/// See the [`parser`] module.
+
+/// Link to external crate type
+/// Works with [`std::collections::HashMap`].
+
+/// Link with custom text
+/// See [the parser][`parse`] for details.
+
+/// Link to module item
+/// See [`crate::utils::helper`].
+
+/// Link to parent module item
+/// See [`super::Parent`].
+```
+
+## Common Patterns
+
+```rust
+/// A configuration builder.
+///
+/// # Example
+///
+/// ```
+/// use my_crate::Config;
+///
+/// let config = Config::builder()
+///     .timeout(30)
+///     .build()?;
+/// ```
+///
+/// # Methods
+///
+/// - [`Config::builder`] - Create a new builder
+/// - [`Config::default`] - Create with defaults
+///
+/// # Related Types
+///
+/// - [`ConfigBuilder`] - The builder returned by [`Config::builder`]
+/// - [`ConfigError`] - Errors that can occur when building
+pub struct Config { ... }
+
+impl Config {
+    /// Creates a new [`ConfigBuilder`].
+    ///
+    /// This is equivalent to [`ConfigBuilder::new`].
+    pub fn builder() -> ConfigBuilder { ... }
+}
+```
+
+## Linking to Trait Items
+
+```rust
+/// Implements [`Iterator`] for lazy evaluation.
+///
+/// The [`Iterator::next`] method advances the cursor.
+/// 
+/// For parallel iteration, see [`rayon::ParallelIterator`].
+pub struct MyIterator { ... }
+
+impl Iterator for MyIterator {
+    /// Advances and returns the next value.
+    ///
+    /// See also [`Iterator::nth`] for skipping elements.
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+```
+
+## Broken Link Detection
+
+```bash
+# Catch broken intra-doc links
+RUSTDOCFLAGS="-D warnings" cargo doc
+
+# Or in CI
+cargo doc --no-deps 2>&1 | grep "warning: unresolved link"
+```
+
+```toml
+# Cargo.toml - deny broken links
+[lints.rustdoc]
+broken_intra_doc_links = "deny"
+```
+
+## Module-Level Documentation
+
+```rust
+//! # Parser Module
+//!
+//! This module provides parsing utilities.
+//!
+//! ## Main Types
+//!
+//! - [`Parser`] - The main parser struct
+//! - [`Token`] - Tokens produced by tokenization
+//! - [`Ast`] - The abstract syntax tree
+//!
+//! ## Functions
+//!
+//! - [`parse`] - Parse a string
+//! - [`parse_file`] - Parse a file
+//!
+//! ## Errors
+//!
+//! All functions return [`ParseError`] on failure.
+
+pub struct Parser { ... }
+pub enum Token { ... }
+pub struct Ast { ... }
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Code examples in docs
+- [err-doc-errors](./err-doc-errors.md) - Documenting errors
+- [lint-deny-correctness](./lint-deny-correctness.md) - Lint settings

--- a/.agents/skills/rust-skills/rules/doc-module-inner.md
+++ b/.agents/skills/rust-skills/rules/doc-module-inner.md
@@ -1,0 +1,116 @@
+# doc-module-inner
+
+> Use `//!` for module-level documentation
+
+## Why It Matters
+
+Inner doc comments (`//!`) document the module itself, not the next item. They appear at the top of module files and describe the module's purpose, contents, and usage patterns. This helps users understand what a module provides before diving into individual items.
+
+Module docs are the first thing users see in `cargo doc` when navigating to a module.
+
+## Bad
+
+```rust
+// This module handles authentication
+// It provides JWT and session-based auth
+
+mod auth;
+
+pub use auth::*;
+```
+
+```rust
+// auth.rs
+/// Authentication utilities  // Wrong: this documents nothing useful
+use std::collections::HashMap;
+
+pub struct Session { /* ... */ }
+```
+
+## Good
+
+```rust
+//! Authentication and authorization utilities.
+//!
+//! This module provides multiple authentication strategies:
+//!
+//! - [`JwtAuth`] - JSON Web Token based authentication
+//! - [`SessionAuth`] - Cookie-based session authentication
+//! - [`ApiKeyAuth`] - API key authentication for services
+//!
+//! # Examples
+//!
+//! ```
+//! use my_crate::auth::{JwtAuth, Authenticator};
+//!
+//! let auth = JwtAuth::new("secret-key");
+//! let token = auth.generate_token(&user)?;
+//! ```
+//!
+//! # Feature Flags
+//!
+//! - `jwt` - Enables JWT authentication (enabled by default)
+//! - `sessions` - Enables session-based authentication
+
+use std::collections::HashMap;
+
+pub struct Session { /* ... */ }
+```
+
+## Where to Use Inner Docs
+
+| Location | Purpose |
+|----------|---------|
+| `lib.rs` | Crate-level documentation (appears on crate root) |
+| `mod.rs` | Module documentation for directory modules |
+| `module.rs` | Module documentation for single-file modules |
+
+## Crate Root Example
+
+```rust
+//! # My Awesome Crate
+//!
+//! `my_crate` provides utilities for handling complex workflows.
+//!
+//! ## Quick Start
+//!
+//! ```rust
+//! use my_crate::prelude::*;
+//!
+//! let workflow = Workflow::builder()
+//!     .add_step(Step::new("fetch"))
+//!     .add_step(Step::new("process"))
+//!     .build();
+//! ```
+//!
+//! ## Modules
+//!
+//! - [`workflow`] - Core workflow engine
+//! - [`steps`] - Built-in workflow steps
+//! - [`prelude`] - Common imports
+//!
+//! ## Feature Flags
+//!
+//! | Feature | Description |
+//! |---------|-------------|
+//! | `async` | Async workflow execution |
+//! | `serde` | Serialization support |
+
+pub mod workflow;
+pub mod steps;
+pub mod prelude;
+```
+
+## Key Sections for Module Docs
+
+1. **Brief description** - One-line summary
+2. **Overview** - What the module provides
+3. **Examples** - How to use it
+4. **Feature flags** - Optional functionality
+5. **See Also** - Related modules
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documenting public items
+- [doc-examples-section](./doc-examples-section.md) - Adding examples
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Crate metadata

--- a/.agents/skills/rust-skills/rules/doc-panics-section.md
+++ b/.agents/skills/rust-skills/rules/doc-panics-section.md
@@ -1,0 +1,128 @@
+# doc-panics-section
+
+> Include `# Panics` section for functions that can panic
+
+## Why It Matters
+
+Panics are exceptional conditions that crash the program (or unwind the stack). Users need to know when a function might panic so they can ensure preconditions are met or avoid the function in contexts where panics are unacceptable (e.g., `no_std`, embedded, FFI).
+
+If a function can panic, document exactly when.
+
+## Bad
+
+```rust
+/// Returns the element at the given index.
+pub fn get(index: usize) -> &T {
+    &self.data[index]  // Panics if out of bounds - not documented!
+}
+
+/// Divides two numbers.
+pub fn divide(a: i32, b: i32) -> i32 {
+    a / b  // Panics on division by zero - not documented!
+}
+```
+
+## Good
+
+```rust
+/// Returns the element at the given index.
+///
+/// # Panics
+///
+/// Panics if `index` is out of bounds (i.e., `index >= self.len()`).
+///
+/// # Examples
+///
+/// ```
+/// let v = vec![1, 2, 3];
+/// assert_eq!(v.get(1), &2);
+/// ```
+pub fn get(&self, index: usize) -> &T {
+    &self.data[index]
+}
+
+/// Divides two numbers.
+///
+/// # Panics
+///
+/// Panics if `divisor` is zero.
+///
+/// For a non-panicking version, use [`checked_divide`].
+pub fn divide(dividend: i32, divisor: i32) -> i32 {
+    dividend / divisor
+}
+
+/// Divides two numbers, returning `None` if the divisor is zero.
+pub fn checked_divide(dividend: i32, divisor: i32) -> Option<i32> {
+    if divisor == 0 {
+        None
+    } else {
+        Some(dividend / divisor)
+    }
+}
+```
+
+## Common Panic Conditions
+
+| Operation | Panic Condition |
+|-----------|-----------------|
+| Index access `[i]` | Index out of bounds |
+| Division `/`, `%` | Division by zero |
+| `.unwrap()` | `None` or `Err` value |
+| `.expect()` | `None` or `Err` value |
+| `slice::split_at(mid)` | `mid > len` |
+| `Vec::remove(i)` | `i >= len` |
+| Overflow (debug) | Integer overflow |
+
+## Pattern: Panic vs Return Error
+
+Document why you chose to panic vs return `Result`:
+
+```rust
+/// Creates a new buffer with the given capacity.
+///
+/// # Panics
+///
+/// Panics if `capacity` is zero. A buffer must have at least
+/// one byte of capacity.
+///
+/// This panics rather than returning an error because a zero-capacity
+/// buffer represents a programming error, not a runtime condition.
+pub fn new(capacity: usize) -> Self {
+    assert!(capacity > 0, "capacity must be non-zero");
+    // ...
+}
+```
+
+## Pattern: Debug-Only Panics
+
+```rust
+/// Adds an item to the collection.
+///
+/// # Panics
+///
+/// In debug builds, panics if the collection is at capacity.
+/// In release builds, this is a no-op when at capacity.
+pub fn push(&mut self, item: T) {
+    debug_assert!(self.len < self.capacity, "collection at capacity");
+    // ...
+}
+```
+
+## Provide Non-Panicking Alternatives
+
+When documenting a panicking function, point to safe alternatives:
+
+```rust
+/// # Panics
+///
+/// Panics if the index is out of bounds.
+///
+/// For a non-panicking version, use [`get`] which returns `Option<&T>`.
+```
+
+## See Also
+
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors
+- [doc-safety-section](./doc-safety-section.md) - Documenting unsafe
+- [err-result-over-panic](./err-result-over-panic.md) - Preferring Result

--- a/.agents/skills/rust-skills/rules/doc-question-mark.md
+++ b/.agents/skills/rust-skills/rules/doc-question-mark.md
@@ -1,0 +1,136 @@
+# doc-question-mark
+
+> Use `?` in examples, not `.unwrap()`
+
+## Why It Matters
+
+Doc examples should model best practices. Using `.unwrap()` teaches users to ignore errors, while `?` demonstrates proper error propagation. Examples with `?` also fail the doctest if an error occurs, catching bugs in documentation.
+
+Rust doctests wrap examples in a function that returns `Result<(), E>` by default when you use `?`, making this pattern easy to adopt.
+
+## Bad
+
+```rust
+/// Reads a configuration file.
+///
+/// # Examples
+///
+/// ```
+/// let config = Config::from_file("config.toml").unwrap();
+/// println!("{:?}", config.database_url);
+/// ```
+pub fn from_file(path: &str) -> Result<Config, Error> {
+    // ...
+}
+
+/// Fetches data from the API.
+///
+/// # Examples
+///
+/// ```
+/// let client = Client::new();
+/// let response = client.get("https://api.example.com").unwrap();
+/// let data: Data = response.json().unwrap();
+/// ```
+pub async fn get(&self, url: &str) -> Result<Response, Error> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Reads a configuration file.
+///
+/// # Examples
+///
+/// ```
+/// # use my_crate::{Config, Error};
+/// # fn main() -> Result<(), Error> {
+/// let config = Config::from_file("config.toml")?;
+/// println!("{:?}", config.database_url);
+/// # Ok(())
+/// # }
+/// ```
+pub fn from_file(path: &str) -> Result<Config, Error> {
+    // ...
+}
+
+/// Fetches data from the API.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use my_crate::{Client, Data, Error};
+/// # async fn example() -> Result<(), Error> {
+/// let client = Client::new();
+/// let response = client.get("https://api.example.com").await?;
+/// let data: Data = response.json().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn get(&self, url: &str) -> Result<Response, Error> {
+    // ...
+}
+```
+
+## Doctest Wrapper Pattern
+
+Rust wraps doc examples in a function. You can make this explicit:
+
+```rust
+/// # Examples
+///
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let value = parse_config("key=value")?;
+/// assert_eq!(value.key, "value");
+/// # Ok(())
+/// # }
+/// ```
+```
+
+Or use the implicit wrapper (Rust 2021+):
+
+```rust
+/// # Examples
+///
+/// ```
+/// # use my_crate::parse_config;
+/// let value = parse_config("key=value")?;
+/// assert_eq!(value.key, "value");
+/// # Ok::<(), my_crate::Error>(())
+/// ```
+```
+
+## When to Use `.unwrap()`
+
+There are specific cases where `.unwrap()` is acceptable in examples:
+
+```rust
+/// # Examples
+///
+/// ```
+/// // Static regex that is known at compile time to be valid
+/// let re = Regex::new(r"^\d{4}-\d{2}-\d{2}$").unwrap();
+///
+/// // Parsing a literal that cannot fail
+/// let n: i32 = "42".parse().unwrap();
+/// ```
+```
+
+But still prefer `?` when demonstrating error handling patterns.
+
+## Comparison
+
+| Pattern | Behavior on Error | Teaches |
+|---------|-------------------|---------|
+| `.unwrap()` | Panics with generic message | Bad habits |
+| `.expect()` | Panics with custom message | Slightly better |
+| `?` | Propagates error, test fails | Best practices |
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Writing examples
+- [doc-hidden-setup](./doc-hidden-setup.md) - Hiding setup code
+- [err-question-mark](./err-question-mark.md) - Error propagation

--- a/.agents/skills/rust-skills/rules/doc-safety-section.md
+++ b/.agents/skills/rust-skills/rules/doc-safety-section.md
@@ -1,0 +1,131 @@
+# doc-safety-section
+
+> Include `# Safety` section for unsafe functions
+
+## Why It Matters
+
+Unsafe functions require callers to uphold invariants that the compiler cannot verify. The `# Safety` section documents exactly what the caller must guarantee for the function to be sound. Without this, users cannot safely call the function.
+
+This is not optional—it's a requirement for sound unsafe code.
+
+## Bad
+
+```rust
+/// Reads a value from a raw pointer.
+pub unsafe fn read_ptr<T>(ptr: *const T) -> T {
+    // What guarantees must the caller provide? Unknown!
+    ptr.read()
+}
+
+/// Creates a string from raw parts.
+pub unsafe fn string_from_raw(ptr: *mut u8, len: usize, cap: usize) -> String {
+    String::from_raw_parts(ptr, len, cap)
+}
+```
+
+## Good
+
+```rust
+/// Reads a value from a raw pointer.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+/// - `ptr` is valid for reads of `size_of::<T>()` bytes
+/// - `ptr` is properly aligned for type `T`
+/// - `ptr` points to a properly initialized value of type `T`
+/// - The memory referenced by `ptr` is not mutated during this call
+pub unsafe fn read_ptr<T>(ptr: *const T) -> T {
+    ptr.read()
+}
+
+/// Creates a `String` from raw parts.
+///
+/// # Safety
+///
+/// The caller must guarantee that:
+/// - `ptr` was allocated by the same allocator that `String` uses
+/// - `len` is less than or equal to `cap`
+/// - The first `len` bytes at `ptr` are valid UTF-8
+/// - `cap` is the capacity that `ptr` was allocated with
+/// - No other code will use `ptr` after this call (ownership is transferred)
+///
+/// Violating these requirements leads to undefined behavior including
+/// memory corruption, use-after-free, or invalid UTF-8 in strings.
+pub unsafe fn string_from_raw(ptr: *mut u8, len: usize, cap: usize) -> String {
+    String::from_raw_parts(ptr, len, cap)
+}
+```
+
+## Key Elements of Safety Documentation
+
+| Element | Description |
+|---------|-------------|
+| **Preconditions** | What must be true before calling |
+| **Pointer validity** | Alignment, null-ness, lifetime |
+| **Memory ownership** | Who owns what, transfer semantics |
+| **Invariants** | Type invariants that must hold |
+| **Consequences** | What happens if violated |
+
+## Pattern: Unsafe Trait Implementations
+
+```rust
+/// A type that can be safely zeroed.
+///
+/// # Safety
+///
+/// Implementing this trait guarantees that:
+/// - All bit patterns of zeros represent a valid value of this type
+/// - The type has no padding bytes that could leak data
+/// - The type contains no references or pointers
+pub unsafe trait Zeroable {
+    fn zeroed() -> Self;
+}
+
+// SAFETY: u32 is a primitive integer type where all zero bits
+// represent a valid value (0).
+unsafe impl Zeroable for u32 {
+    fn zeroed() -> Self {
+        0
+    }
+}
+```
+
+## Pattern: Unsafe Blocks in Safe Functions
+
+When a safe function contains unsafe blocks, document the invariants:
+
+```rust
+/// Returns a reference to the element at the given index.
+///
+/// Returns `None` if the index is out of bounds.
+pub fn get(&self, index: usize) -> Option<&T> {
+    if index < self.len {
+        // SAFETY: We just verified that index < len, so this
+        // access is within bounds.
+        Some(unsafe { self.data.get_unchecked(index) })
+    } else {
+        None
+    }
+}
+```
+
+## Common Safety Requirements
+
+```rust
+/// # Safety
+///
+/// - Pointer must be non-null
+/// - Pointer must be aligned to `align_of::<T>()`
+/// - Pointer must be valid for reads/writes of `size_of::<T>()` bytes
+/// - Pointer must point to an initialized value of `T`
+/// - The referenced memory must not be accessed through any other pointer
+///   for the duration of the returned reference
+/// - The total size must not exceed `isize::MAX`
+```
+
+## See Also
+
+- [doc-panics-section](./doc-panics-section.md) - Documenting panics
+- [lint-unsafe-doc](./lint-unsafe-doc.md) - Enforcing unsafe documentation
+- [doc-errors-section](./doc-errors-section.md) - Documenting errors

--- a/.agents/skills/rust-skills/rules/err-anyhow-app.md
+++ b/.agents/skills/rust-skills/rules/err-anyhow-app.md
@@ -1,0 +1,179 @@
+# err-anyhow-app
+
+> Use `anyhow` for application error handling
+
+## Why It Matters
+
+Applications often don't need typed errors - they just need to report what went wrong with good context. `anyhow` provides easy error handling with context chaining, backtraces, and conversion from any error type.
+
+## Bad
+
+```rust
+// Tedious type management
+fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
+    let path = find_config()?;  // Returns FindError
+    let content = std::fs::read_to_string(&path)?;  // Returns io::Error
+    let config: Config = toml::from_str(&content)?;  // Returns toml::Error
+    validate(&config)?;  // Returns ValidationError
+    Ok(config)
+}
+
+// No context - hard to debug
+fn process() -> Result<(), Box<dyn std::error::Error>> {
+    let data = fetch()?;  // Which fetch failed?
+    transform(data)?;     // What was being transformed?
+    save()?;              // Where was it saving to?
+    Ok(())
+}
+```
+
+## Good
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_config() -> Result<Config> {
+    let path = find_config()
+        .context("failed to locate config file")?;
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read config from {}", path.display()))?;
+    
+    let config: Config = toml::from_str(&content)
+        .context("failed to parse config as TOML")?;
+    
+    validate(&config)
+        .context("config validation failed")?;
+    
+    Ok(config)
+}
+
+// Error message: "config validation failed: field 'port' must be > 0"
+// Full chain preserved for debugging
+```
+
+## Key Features
+
+```rust
+use anyhow::{anyhow, bail, ensure, Context, Result};
+
+fn example() -> Result<()> {
+    // Create ad-hoc errors
+    let err = anyhow!("something went wrong");
+    
+    // Early return with error
+    bail!("aborting due to {}", reason);
+    
+    // Assert with error
+    ensure!(condition, "condition was false");
+    
+    // Add context to any error
+    risky_operation()
+        .context("risky operation failed")?;
+    
+    // Dynamic context
+    fetch(url)
+        .with_context(|| format!("failed to fetch {}", url))?;
+    
+    Ok(())
+}
+```
+
+## Main Function Pattern
+
+```rust
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+
+// Or with custom exit handling
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);  // Pretty-print with causes
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    // Application logic
+    Ok(())
+}
+```
+
+## Error Display Formats
+
+```rust
+use anyhow::Result;
+
+fn show_error(err: anyhow::Error) {
+    // Just the top-level message
+    println!("{}", err);
+    // "config validation failed"
+    
+    // With cause chain (# alternate format)
+    println!("{:#}", err);
+    // "config validation failed: field 'port' must be > 0"
+    
+    // Debug format with backtrace
+    println!("{:?}", err);
+    // Full backtrace if RUST_BACKTRACE=1
+    
+    // Iterate through cause chain
+    for cause in err.chain() {
+        println!("Caused by: {}", cause);
+    }
+}
+```
+
+## Combining with thiserror
+
+```rust
+// In your library crate - typed errors
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("rate limited")]
+    RateLimited,
+    #[error("not found: {0}")]
+    NotFound(String),
+}
+
+// In your application - anyhow for handling
+use anyhow::{Context, Result};
+
+fn fetch_user(id: u64) -> Result<User> {
+    api::get_user(id)
+        .with_context(|| format!("failed to fetch user {}", id))
+}
+
+// Can still downcast if needed
+fn handle_error(err: anyhow::Error) {
+    if let Some(api_err) = err.downcast_ref::<ApiError>() {
+        match api_err {
+            ApiError::RateLimited => wait_and_retry(),
+            ApiError::NotFound(id) => log_missing(id),
+        }
+    }
+}
+```
+
+## When to Use Which
+
+| Situation | Use |
+|-----------|-----|
+| Library public API | `thiserror` |
+| Application code | `anyhow` |
+| CLI tools | `anyhow` |
+| Internal library code | Either |
+| Need to match error variants | `thiserror` |
+| Just need to report errors | `anyhow` |
+
+## See Also
+
+- [err-thiserror-lib](err-thiserror-lib.md) - Use thiserror for libraries
+- [err-context-chain](err-context-chain.md) - Add context to errors

--- a/.agents/skills/rust-skills/rules/err-context-chain.md
+++ b/.agents/skills/rust-skills/rules/err-context-chain.md
@@ -1,0 +1,144 @@
+# err-context-chain
+
+> Add context with `.context()` or `.with_context()`
+
+## Why It Matters
+
+Raw errors often lack information about what operation failed. Adding context creates an error chain that tells the full story: what you were trying to do, and why it failed.
+
+## Bad
+
+```rust
+// Raw error - no context
+fn load_user(id: u64) -> Result<User, Error> {
+    let path = format!("users/{}.json", id);
+    let content = std::fs::read_to_string(&path)?;
+    Ok(serde_json::from_str(&content)?)
+}
+
+// Error message: "No such file or directory (os error 2)"
+// Which file? What were we doing?
+```
+
+## Good
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let path = format!("users/{}.json", id);
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read user file: {}", path))?;
+    
+    let user: User = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse user {} JSON", id))?;
+    
+    Ok(user)
+}
+
+// Error: "failed to parse user 42 JSON"
+// Caused by: "expected ':' at line 5 column 12"
+```
+
+## context() vs with_context()
+
+```rust
+// context() - static string (slight allocation)
+fs::read_to_string(path)
+    .context("failed to read config")?;
+
+// with_context() - lazy evaluation (only allocates on error)
+fs::read_to_string(path)
+    .with_context(|| format!("failed to read {}", path))?;
+
+// Use with_context() when:
+// - Message includes runtime data (format!)
+// - Computing the message is expensive
+// - Error path is cold (most of the time)
+```
+
+## Building Context Chains
+
+```rust
+fn process_order(order_id: u64) -> Result<()> {
+    let order = fetch_order(order_id)
+        .with_context(|| format!("failed to fetch order {}", order_id))?;
+    
+    let user = load_user(order.user_id)
+        .with_context(|| format!("failed to load user for order {}", order_id))?;
+    
+    let payment = process_payment(&order, &user)
+        .context("payment processing failed")?;
+    
+    ship_order(&order, &payment)
+        .context("shipping failed")?;
+    
+    Ok(())
+}
+
+// Full error chain:
+// "shipping failed"
+// Caused by: "carrier API returned 503"
+// Caused by: "connection refused"
+```
+
+## Displaying Error Chains
+
+```rust
+fn main() {
+    if let Err(e) = run() {
+        // Just top-level message
+        eprintln!("Error: {}", e);
+        
+        // Full chain with alternate format
+        eprintln!("Error: {:#}", e);
+        
+        // Debug format (includes backtrace if enabled)
+        eprintln!("Error: {:?}", e);
+        
+        // Iterate through chain
+        for (i, cause) in e.chain().enumerate() {
+            eprintln!("  {}: {}", i, cause);
+        }
+    }
+}
+```
+
+## With thiserror
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AppError {
+    #[error("failed to load config from {path}")]
+    ConfigLoad {
+        path: String,
+        #[source]
+        cause: std::io::Error,
+    },
+    
+    #[error("failed to connect to database")]
+    Database {
+        #[source]
+        cause: sqlx::Error,
+    },
+}
+
+// Usage
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| AppError::ConfigLoad {
+            path: path.to_string(),
+            cause: e,
+        })?;
+    // ...
+}
+```
+
+## See Also
+
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications
+- [err-source-chain](err-source-chain.md) - Use #[source] to chain errors
+- [err-question-mark](err-question-mark.md) - Use ? for propagation

--- a/.agents/skills/rust-skills/rules/err-custom-type.md
+++ b/.agents/skills/rust-skills/rules/err-custom-type.md
@@ -1,0 +1,152 @@
+# err-custom-type
+
+> Define custom error types for domain-specific failures
+
+## Why It Matters
+
+Generic errors like `String`, `Box<dyn Error>`, or catch-all enums obscure what can actually go wrong. Custom error types document failure modes in the type system, enable pattern matching for specific handling, and provide clear API contracts. They make your code self-documenting and help callers handle errors appropriately.
+
+## Bad
+
+```rust
+// Generic string errors - no structure
+fn validate_user(user: &User) -> Result<(), String> {
+    if user.name.is_empty() {
+        return Err("Name is empty".to_string());
+    }
+    if user.age > 150 {
+        return Err("Age is invalid".to_string());
+    }
+    Ok(())
+}
+
+// Caller can't match on specific errors
+match validate_user(&user) {
+    Ok(()) => save(user),
+    Err(msg) => {
+        // Can only do string comparison - fragile!
+        if msg.contains("Name") {
+            prompt_for_name()
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ValidationError {
+    #[error("name cannot be empty")]
+    EmptyName,
+    
+    #[error("name exceeds maximum length of {max} characters")]
+    NameTooLong { max: usize, actual: usize },
+    
+    #[error("invalid age {0}: must be between 0 and 150")]
+    InvalidAge(u8),
+    
+    #[error("email format is invalid: {0}")]
+    InvalidEmail(String),
+}
+
+fn validate_user(user: &User) -> Result<(), ValidationError> {
+    if user.name.is_empty() {
+        return Err(ValidationError::EmptyName);
+    }
+    if user.name.len() > 100 {
+        return Err(ValidationError::NameTooLong { 
+            max: 100, 
+            actual: user.name.len() 
+        });
+    }
+    if user.age > 150 {
+        return Err(ValidationError::InvalidAge(user.age));
+    }
+    Ok(())
+}
+
+// Caller can match specifically
+match validate_user(&user) {
+    Ok(()) => save(user),
+    Err(ValidationError::EmptyName) => prompt_for_name(),
+    Err(ValidationError::InvalidAge(age)) => {
+        show_error(&format!("Please enter a valid age (you entered {})", age))
+    }
+    Err(e) => show_error(&e.to_string()),
+}
+```
+
+## Error Type Design Guidelines
+
+```rust
+// 1. Group related errors in domain-specific enums
+#[derive(Error, Debug)]
+pub enum AuthError {
+    #[error("invalid credentials")]
+    InvalidCredentials,
+    #[error("account locked after {attempts} failed attempts")]
+    AccountLocked { attempts: u32 },
+    #[error("token expired")]
+    TokenExpired,
+}
+
+#[derive(Error, Debug)]
+pub enum PaymentError {
+    #[error("insufficient funds: need {required}, have {available}")]
+    InsufficientFunds { required: Decimal, available: Decimal },
+    #[error("card declined: {reason}")]
+    CardDeclined { reason: String },
+}
+
+// 2. Include relevant data for error handling/display
+#[derive(Error, Debug)]
+pub enum FileError {
+    #[error("file not found: {path}")]
+    NotFound { path: PathBuf },
+    #[error("permission denied for {path}")]
+    PermissionDenied { path: PathBuf },
+}
+
+// 3. Consider #[non_exhaustive] for public APIs
+#[derive(Error, Debug)]
+#[non_exhaustive]  // Allows adding variants without breaking changes
+pub enum ApiError {
+    #[error("rate limited")]
+    RateLimited,
+    #[error("not found")]
+    NotFound,
+}
+```
+
+## When to Use What
+
+| Error Pattern | Use Case |
+|---------------|----------|
+| Custom enum | Library with specific failure modes |
+| `thiserror` | Libraries needing `std::error::Error` |
+| `anyhow::Error` | Applications, prototypes |
+| Struct with source | Single error type with wrapped cause |
+
+## Struct-Based Errors
+
+For single error types with rich context:
+
+```rust
+#[derive(Error, Debug)]
+#[error("query failed for table '{table}' with filter '{filter}'")]
+pub struct QueryError {
+    pub table: String,
+    pub filter: String,
+    #[source]
+    pub source: DatabaseError,
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - thiserror for error definitions
+- [err-anyhow-app](./err-anyhow-app.md) - When to use anyhow instead
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums

--- a/.agents/skills/rust-skills/rules/err-doc-errors.md
+++ b/.agents/skills/rust-skills/rules/err-doc-errors.md
@@ -1,0 +1,145 @@
+# err-doc-errors
+
+> Document error conditions with `# Errors` section in doc comments
+
+## Why It Matters
+
+Users of your API need to know what can go wrong and why. The `# Errors` documentation section is the standard Rust convention for describing when a function returns `Err`. Good error documentation helps callers handle errors appropriately and understand the contract of your API.
+
+## Bad
+
+```rust
+/// Loads a configuration from the specified path.
+pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    // No documentation of error conditions
+    // Caller must read source code to understand what can fail
+}
+
+/// Parses and validates the input string.
+/// 
+/// Returns the parsed value.  // What about errors?
+pub fn parse_input(input: &str) -> Result<Value, ParseError> {
+    // ...
+}
+```
+
+## Good
+
+```rust
+/// Loads a configuration from the specified path.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file at `path` does not exist or cannot be read
+/// - The file contents are not valid TOML
+/// - Required configuration keys are missing
+/// - Configuration values are out of valid ranges
+///
+/// # Examples
+///
+/// ```
+/// # use mylib::{load_config, ConfigError};
+/// # fn main() -> Result<(), ConfigError> {
+/// let config = load_config("app.toml")?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    // ...
+}
+
+/// Parses and validates the input string as a positive integer.
+///
+/// # Errors
+///
+/// Returns [`ParseError::Empty`] if the input is empty.
+/// Returns [`ParseError::InvalidFormat`] if the input contains non-digit characters.
+/// Returns [`ParseError::Overflow`] if the value exceeds `i64::MAX`.
+/// Returns [`ParseError::NotPositive`] if the value is zero or negative.
+pub fn parse_positive_int(input: &str) -> Result<i64, ParseError> {
+    // ...
+}
+```
+
+## Linking to Error Variants
+
+```rust
+/// Attempts to connect to the database.
+///
+/// # Errors
+///
+/// This function will return an error if:
+///
+/// - [`DbError::ConnectionFailed`] - The database server is unreachable
+/// - [`DbError::AuthenticationFailed`] - Invalid credentials
+/// - [`DbError::Timeout`] - Connection attempt exceeded timeout
+/// - [`DbError::TlsError`] - TLS handshake failed
+///
+/// See [`DbError`] for more details on each variant.
+pub fn connect(config: &DbConfig) -> Result<Connection, DbError> {
+    // ...
+}
+```
+
+## Panic vs Error Documentation
+
+```rust
+/// Divides two numbers.
+///
+/// # Errors
+///
+/// Returns [`MathError::DivisionByZero`] if `divisor` is zero.
+///
+/// # Panics
+///
+/// Panics if called from a non-main thread (debug builds only).
+pub fn divide(dividend: i64, divisor: i64) -> Result<i64, MathError> {
+    // ...
+}
+```
+
+## Error Section Format Options
+
+```rust
+// Style 1: Bullet list (good for multiple conditions)
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist
+/// - The file cannot be read
+/// - The content is invalid UTF-8
+
+// Style 2: Returns statements (good for mapping to variants)
+/// # Errors
+///
+/// Returns [`Error::NotFound`] if the item doesn't exist.
+/// Returns [`Error::PermissionDenied`] if access is forbidden.
+
+// Style 3: Prose (good for complex conditions)
+/// # Errors
+///
+/// This function returns an error when the input fails validation.
+/// Validation includes checking that all required fields are present,
+/// that numeric fields are within allowed ranges, and that string
+/// fields match their expected formats.
+```
+
+## Clippy Lint
+
+```toml
+# Cargo.toml - require error documentation
+[lints.clippy]
+missing_errors_doc = "warn"
+```
+
+```rust
+// This will warn without # Errors section
+pub fn might_fail() -> Result<(), Error> { Ok(()) }
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Examples in documentation
+- [err-thiserror-lib](./err-thiserror-lib.md) - Defining error types
+- [api-must-use](./api-must-use.md) - Marking Results as must_use

--- a/.agents/skills/rust-skills/rules/err-expect-bugs-only.md
+++ b/.agents/skills/rust-skills/rules/err-expect-bugs-only.md
@@ -1,0 +1,133 @@
+# err-expect-bugs-only
+
+> Use `expect()` only for invariants that indicate bugs, not user errors
+
+## Why It Matters
+
+`expect()` is better than `unwrap()` because it provides context, but it still panics. Reserve it for situations where failure indicates a bug in your code—a violated invariant, not a user error or external failure. The message should explain why the invariant should hold, helping future developers understand and fix the bug.
+
+## Bad
+
+```rust
+// User input can legitimately fail - don't expect
+fn parse_user_input(input: &str) -> Config {
+    serde_json::from_str(input)
+        .expect("Invalid JSON")  // User error, not a bug!
+}
+
+// Network can fail - don't expect
+fn fetch_data(url: &str) -> Data {
+    reqwest::get(url)
+        .expect("Network request failed")  // External failure!
+        .json()
+        .expect("Invalid response")
+}
+
+// File might not exist - don't expect
+fn load_config() -> Config {
+    let content = fs::read_to_string("config.json")
+        .expect("Config file missing");  // Environment issue!
+}
+```
+
+## Good
+
+```rust
+// Invariant: after insert, key exists
+fn cache_and_get(&mut self, key: String, value: Value) -> &Value {
+    self.cache.insert(key.clone(), value);
+    self.cache.get(&key)
+        .expect("BUG: key must exist immediately after insert")
+}
+
+// Invariant: regex is compile-time constant
+fn create_parser() -> Regex {
+    Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+        .expect("BUG: date regex is invalid - this is a compile-time constant")
+}
+
+// Invariant: already validated
+fn process_validated(data: ValidatedData) -> Result<Output, ProcessError> {
+    let value = data.required_field
+        .expect("BUG: ValidatedData guarantees required_field is Some");
+    // ...
+}
+
+// Invariant: type system guarantees
+fn get_first<T>(vec: Vec<T>) -> T 
+where 
+    Vec<T>: NonEmpty,  // Hypothetical trait
+{
+    vec.into_iter().next()
+        .expect("BUG: NonEmpty Vec cannot be empty")
+}
+```
+
+## expect() Message Guidelines
+
+Messages should:
+1. Start with "BUG:" or similar to indicate it's an invariant
+2. Explain WHY the invariant should hold
+3. Help developers fix the issue
+
+```rust
+// ❌ Bad messages
+.expect("failed")                    // No context
+.expect("should not be None")        // Doesn't explain why
+.expect("Invalid state")             // Vague
+
+// ✅ Good messages
+.expect("BUG: HashMap entry exists after insert")
+.expect("BUG: validated input must parse - validation is broken")
+.expect("BUG: static regex compilation failed - regex syntax error in source")
+```
+
+## Pattern: Validate Once, expect() After
+
+```rust
+struct ValidatedEmail(String);
+
+impl ValidatedEmail {
+    pub fn new(email: &str) -> Result<Self, EmailError> {
+        // Validation happens here, returns Result
+        if !is_valid_email(email) {
+            return Err(EmailError::Invalid);
+        }
+        Ok(ValidatedEmail(email.to_string()))
+    }
+    
+    pub fn domain(&self) -> &str {
+        // After validation, expect() is fine
+        self.0.split('@').nth(1)
+            .expect("BUG: ValidatedEmail must contain @")
+    }
+}
+```
+
+## Alternatives When expect() Is Wrong
+
+```rust
+// Don't: expect on user data
+let port: u16 = input.parse().expect("Invalid port");
+
+// Do: Return Result
+let port: u16 = input.parse().map_err(|_| ConfigError::InvalidPort)?;
+
+// Do: Provide default
+let port: u16 = input.parse().unwrap_or(8080);
+
+// Do: Handle explicitly
+let port: u16 = match input.parse() {
+    Ok(p) => p,
+    Err(_) => {
+        log::warn!("Invalid port '{}', using default", input);
+        8080
+    }
+};
+```
+
+## See Also
+
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoiding unwrap in production
+- [err-result-over-panic](./err-result-over-panic.md) - When to return Result
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Type-driven validation

--- a/.agents/skills/rust-skills/rules/err-from-impl.md
+++ b/.agents/skills/rust-skills/rules/err-from-impl.md
@@ -1,0 +1,152 @@
+# err-from-impl
+
+> Implement `From<E>` for error conversions to enable `?` operator
+
+## Why It Matters
+
+The `?` operator automatically converts errors using `From` trait. By implementing `From<SourceError> for YourError`, you enable seamless error propagation without explicit `.map_err()` calls. This makes error handling code cleaner and ensures consistent error wrapping throughout your codebase.
+
+## Bad
+
+```rust
+#[derive(Debug)]
+enum AppError {
+    Io(std::io::Error),
+    Parse(serde_json::Error),
+    Database(diesel::result::Error),
+}
+
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| AppError::Io(e))?;  // Manual conversion everywhere
+    
+    let config: Config = serde_json::from_str(&content)
+        .map_err(|e| AppError::Parse(e))?;  // Repeated boilerplate
+    
+    save_to_db(&config)
+        .map_err(|e| AppError::Database(e))?;  // Gets tedious
+    
+    Ok(config)
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug)]
+enum AppError {
+    Io(std::io::Error),
+    Parse(serde_json::Error),
+    Database(diesel::result::Error),
+}
+
+// Implement From for each source error type
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> Self {
+        AppError::Io(err)
+    }
+}
+
+impl From<serde_json::Error> for AppError {
+    fn from(err: serde_json::Error) -> Self {
+        AppError::Parse(err)
+    }
+}
+
+impl From<diesel::result::Error> for AppError {
+    fn from(err: diesel::result::Error) -> Self {
+        AppError::Database(err)
+    }
+}
+
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)?;  // Auto-converts
+    let config: Config = serde_json::from_str(&content)?;  // Clean!
+    save_to_db(&config)?;
+    Ok(config)
+}
+```
+
+## Use thiserror for Automatic From
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum AppError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),  // Auto-generates From impl
+    
+    #[error("Parse error: {0}")]
+    Parse(#[from] serde_json::Error),  // #[from] does the work
+    
+    #[error("Database error: {0}")]
+    Database(#[from] diesel::result::Error),
+}
+
+// Now ? just works
+fn load_config(path: &str) -> Result<Config, AppError> {
+    let content = std::fs::read_to_string(path)?;
+    let config: Config = serde_json::from_str(&content)?;
+    save_to_db(&config)?;
+    Ok(config)
+}
+```
+
+## From with Context
+
+Sometimes you need to add context during conversion:
+
+```rust
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config from '{path}': {source}")]
+    ReadFailed {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+// Can't use #[from] when you need extra context
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|source| ConfigError::ReadFailed {
+            path: path.to_string(),
+            source,
+        })?;
+    // ...
+}
+
+// Or use anyhow for ad-hoc context
+use anyhow::{Context, Result};
+
+fn load_config(path: &str) -> Result<Config> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config from '{}'", path))?;
+    // ...
+}
+```
+
+## Blanket From Implementations
+
+Be careful with blanket implementations:
+
+```rust
+// ❌ Too broad - conflicts with other From impls
+impl<E: std::error::Error> From<E> for AppError {
+    fn from(err: E) -> Self {
+        AppError::Other(err.to_string())
+    }
+}
+
+// ✅ Specific implementations
+impl From<std::io::Error> for AppError { ... }
+impl From<ParseIntError> for AppError { ... }
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Using thiserror for libraries
+- [err-source-chain](./err-source-chain.md) - Preserving error chains
+- [err-question-mark](./err-question-mark.md) - The ? operator

--- a/.agents/skills/rust-skills/rules/err-lowercase-msg.md
+++ b/.agents/skills/rust-skills/rules/err-lowercase-msg.md
@@ -1,0 +1,124 @@
+# err-lowercase-msg
+
+> Start error messages lowercase, no trailing punctuation
+
+## Why It Matters
+
+Error messages are often chained, logged, or displayed with additional context. Consistent formatting—lowercase start, no trailing period—allows clean composition: "failed to load config: invalid JSON: unexpected token". Mixed case and punctuation create awkward output: "Failed to load config.: Invalid JSON.: Unexpected token.".
+
+## Bad
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file.")]  // Capital F, trailing period
+    ReadFailed(#[from] std::io::Error),
+    
+    #[error("Invalid JSON format!")]  // Capital I, exclamation
+    ParseFailed(#[from] serde_json::Error),
+    
+    #[error("The requested key was not found")]  // Reads like a sentence
+    KeyNotFound(String),
+}
+
+// Chained output: "Config load error: Failed to read config file.: No such file"
+// Awkward capitalization and punctuation
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("failed to read config file")]  // lowercase, no period
+    ReadFailed(#[from] std::io::Error),
+    
+    #[error("invalid JSON format")]  // lowercase, no period
+    ParseFailed(#[from] serde_json::Error),
+    
+    #[error("key not found: {0}")]  // lowercase, data at end
+    KeyNotFound(String),
+}
+
+// Chained output: "config load error: failed to read config file: no such file"
+// Clean, consistent
+```
+
+## Rust Standard Library Convention
+
+The standard library follows this convention:
+
+```rust
+// std::io::Error messages
+"entity not found"
+"permission denied"
+"connection refused"
+
+// std::num::ParseIntError
+"invalid digit found in string"
+
+// std::str::Utf8Error  
+"invalid utf-8 sequence"
+```
+
+## Formatting Guidelines
+
+| Do | Don't |
+|----|-------|
+| `"failed to parse config"` | `"Failed to parse config."` |
+| `"invalid input: expected number"` | `"Invalid input - expected a number!"` |
+| `"connection timed out after {0}s"` | `"Connection Timed Out After {0} seconds."` |
+| `"key '{0}' not found"` | `"Key Not Found: {0}"` |
+
+## Context Addition Pattern
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let data = fetch(id)
+        .with_context(|| format!("failed to fetch user {}", id))?;
+    
+    parse_user(data)
+        .with_context(|| "failed to parse user data")?
+}
+
+// Output: "failed to fetch user 42: connection refused"
+// All lowercase, clean chain
+```
+
+## Display vs Debug
+
+```rust
+#[derive(Error, Debug)]
+#[error("invalid configuration")]  // Display: for users/logs
+pub struct ConfigError {
+    path: PathBuf,
+    source: io::Error,
+}
+
+// Debug output (for developers) can have more detail
+// Display output (for users) should be clean
+```
+
+## When to Use Capitals
+
+```rust
+// Proper nouns / acronyms keep their case
+#[error("invalid JSON syntax")]     // JSON is an acronym
+#[error("OAuth token expired")]     // OAuth is a proper noun
+#[error("HTTP request failed")]     // HTTP is an acronym
+
+// Error codes can be uppercase
+#[error("error code E0001: invalid input")]
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Error definition with thiserror
+- [err-context-chain](./err-context-chain.md) - Adding context to errors
+- [doc-examples-section](./doc-examples-section.md) - Documentation conventions

--- a/.agents/skills/rust-skills/rules/err-no-unwrap-prod.md
+++ b/.agents/skills/rust-skills/rules/err-no-unwrap-prod.md
@@ -1,0 +1,115 @@
+# err-no-unwrap-prod
+
+> Avoid `unwrap()` in production code; use `?`, `expect()`, or handle errors
+
+## Why It Matters
+
+`unwrap()` panics on `None` or `Err` without any context about what went wrong. In production, this creates cryptic crash messages that are hard to debug. Either propagate errors with `?`, use `expect()` with a message explaining the invariant, or handle the error explicitly.
+
+## Bad
+
+```rust
+fn process_request(req: Request) -> Response {
+    let user_id = req.headers.get("X-User-Id").unwrap();  // Why did it fail?
+    let user = database.find_user(user_id).unwrap();       // Which operation?
+    let data = user.preferences.get("theme").unwrap();     // No context
+    
+    Response::new(data)
+}
+
+// Crash message: "called `Option::unwrap()` on a `None` value"
+// Where? Why? No idea.
+```
+
+## Good
+
+```rust
+// Option 1: Propagate with ?
+fn process_request(req: Request) -> Result<Response, AppError> {
+    let user_id = req.headers
+        .get("X-User-Id")
+        .ok_or(AppError::MissingHeader("X-User-Id"))?;
+    
+    let user = database.find_user(user_id)?;
+    
+    let data = user.preferences
+        .get("theme")
+        .ok_or(AppError::MissingPreference("theme"))?;
+    
+    Ok(Response::new(data))
+}
+
+// Option 2: expect() for invariants (not user input)
+fn get_config_value(&self, key: &str) -> &str {
+    self.config
+        .get(key)
+        .expect("BUG: required config key missing after validation")
+}
+
+// Option 3: Provide defaults
+fn get_theme(user: &User) -> &str {
+    user.preferences
+        .get("theme")
+        .unwrap_or(&"default")
+}
+
+// Option 4: Match for complex handling
+fn process_optional(value: Option<Data>) -> ProcessedData {
+    match value {
+        Some(data) => process(data),
+        None => {
+            log::warn!("No data provided, using fallback");
+            ProcessedData::default()
+        }
+    }
+}
+```
+
+## `expect()` vs `unwrap()`
+
+```rust
+// Bad: no context
+let port = config.get("port").unwrap();
+
+// Better: explains the invariant
+let port = config.get("port")
+    .expect("config must contain 'port' after validation");
+
+// Best: propagate if it's not truly an invariant
+let port = config.get("port")
+    .ok_or_else(|| ConfigError::MissingKey("port"))?;
+```
+
+## Alternatives to unwrap()
+
+| Situation | Use Instead |
+|-----------|-------------|
+| Can propagate error | `?` operator |
+| Has sensible default | `unwrap_or()`, `unwrap_or_default()` |
+| Default requires computation | `unwrap_or_else(\|\| ...)` |
+| Internal invariant | `expect("explanation")` |
+| Need to handle both cases | `match` or `if let` |
+
+## Clippy Lints
+
+```toml
+# Cargo.toml
+[lints.clippy]
+unwrap_used = "warn"      # Warn on unwrap()
+expect_used = "warn"       # Also warn on expect() (stricter)
+```
+
+```rust
+// Allow in specific places where it's justified
+#[allow(clippy::unwrap_used)]
+fn definitely_safe() {
+    // Unwrap is safe here because...
+    let x = Some(5).unwrap();
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Return Result instead of panicking
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When expect() is appropriate
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - Patterns for avoiding unwrap

--- a/.agents/skills/rust-skills/rules/err-question-mark.md
+++ b/.agents/skills/rust-skills/rules/err-question-mark.md
@@ -1,0 +1,151 @@
+# err-question-mark
+
+> Use `?` operator for clean propagation
+
+## Why It Matters
+
+The `?` operator is Rust's idiomatic way to propagate errors. It's concise, readable, and automatically converts between compatible error types using `From`. It replaces verbose `match` or `unwrap()` calls.
+
+## Bad
+
+```rust
+// Verbose match-based error handling
+fn load_config() -> Result<Config, Error> {
+    let content = match std::fs::read_to_string("config.toml") {
+        Ok(c) => c,
+        Err(e) => return Err(Error::Io(e)),
+    };
+    
+    let config = match toml::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => return Err(Error::Parse(e)),
+    };
+    
+    Ok(config)
+}
+
+// Or worse - using unwrap
+fn load_config_bad() -> Config {
+    let content = std::fs::read_to_string("config.toml").unwrap();
+    toml::from_str(&content).unwrap()
+}
+```
+
+## Good
+
+```rust
+fn load_config() -> Result<Config, Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    let config = toml::from_str(&content)?;
+    Ok(config)
+}
+
+// Even more concise
+fn load_config() -> Result<Config, Error> {
+    Ok(toml::from_str(&std::fs::read_to_string("config.toml")?)?)
+}
+```
+
+## How ? Works
+
+```rust
+// This:
+let x = expr?;
+
+// Expands roughly to:
+let x = match expr {
+    Ok(val) => val,
+    Err(err) => return Err(From::from(err)),
+};
+```
+
+## Combining with Context
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_user(id: u64) -> Result<User> {
+    let path = format!("users/{}.json", id);
+    
+    let content = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read user file: {}", path))?;
+    
+    let user: User = serde_json::from_str(&content)
+        .context("failed to parse user JSON")?;
+    
+    Ok(user)
+}
+```
+
+## ? with Option
+
+```rust
+fn get_first_word(text: &str) -> Option<&str> {
+    let first_line = text.lines().next()?;
+    let first_word = first_line.split_whitespace().next()?;
+    Some(first_word)
+}
+
+// Convert Option to Result
+fn get_required_config(key: &str) -> Result<String, Error> {
+    config.get(key)
+        .cloned()
+        .ok_or_else(|| Error::MissingConfig(key.to_string()))
+}
+```
+
+## Error Type Conversion
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum MyError {
+    #[error("io error")]
+    Io(#[from] std::io::Error),  // Auto From impl
+    
+    #[error("parse error")]
+    Parse(#[from] serde_json::Error),  // Auto From impl
+}
+
+fn process() -> Result<(), MyError> {
+    // ? automatically converts io::Error to MyError via From
+    let content = std::fs::read_to_string("file.txt")?;
+    
+    // ? automatically converts serde_json::Error to MyError
+    let data: Data = serde_json::from_str(&content)?;
+    
+    Ok(())
+}
+```
+
+## In main()
+
+```rust
+// Option 1: Return Result from main
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+
+// Option 2: Handle in main, exit on error
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let config = load_config()?;
+    run_app(config)?;
+    Ok(())
+}
+```
+
+## See Also
+
+- [err-context-chain](err-context-chain.md) - Add context with .context()
+- [err-from-impl](err-from-impl.md) - Use #[from] for automatic conversion
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications

--- a/.agents/skills/rust-skills/rules/err-result-over-panic.md
+++ b/.agents/skills/rust-skills/rules/err-result-over-panic.md
@@ -1,0 +1,130 @@
+# err-result-over-panic
+
+> Return `Result<T, E>` instead of panicking for recoverable errors
+
+## Why It Matters
+
+Panics unwind the stack and crash the thread (or program). They're unrecoverable from the caller's perspective. `Result<T, E>` gives callers the ability to decide how to handle errors—retry, fallback, propagate, or log. Libraries should almost never panic; applications should minimize panics to truly unrecoverable situations.
+
+## Bad
+
+```rust
+fn parse_config(path: &str) -> Config {
+    let content = std::fs::read_to_string(path)
+        .expect("Failed to read config");  // Crashes on missing file
+    
+    serde_json::from_str(&content)
+        .expect("Invalid config format")   // Crashes on bad JSON
+}
+
+fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 {
+        panic!("Division by zero!");  // Crashes the program
+    }
+    a / b
+}
+```
+
+Caller has no chance to recover or provide a fallback.
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Invalid config format: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+fn parse_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)?;
+    let config = serde_json::from_str(&content)?;
+    Ok(config)
+}
+
+fn divide(a: i32, b: i32) -> Result<i32, &'static str> {
+    if b == 0 {
+        return Err("Division by zero");
+    }
+    Ok(a / b)
+}
+
+// Caller decides how to handle
+match parse_config("app.json") {
+    Ok(config) => run_app(config),
+    Err(e) => {
+        eprintln!("Using default config: {}", e);
+        run_app(Config::default())
+    }
+}
+```
+
+## When Panic IS Appropriate
+
+```rust
+// 1. Bug in the program (invariant violation)
+fn get_cached_value(&self, key: &str) -> &Value {
+    self.cache.get(key).expect("BUG: key was verified to exist")
+}
+
+// 2. Setup/initialization that can't reasonably fail
+fn main() {
+    let config = Config::load().expect("Failed to load required config");
+    // Can't run without config, panic is reasonable
+}
+
+// 3. Tests
+#[test]
+fn test_parse() {
+    let result = parse("valid input").unwrap(); // unwrap OK in tests
+    assert_eq!(result, expected);
+}
+
+// 4. Examples and prototypes
+fn main() {
+    // Quick prototype, panic is fine
+    let data = fetch_data().unwrap();
+}
+```
+
+## Panic vs Result Decision Guide
+
+| Situation | Use |
+|-----------|-----|
+| File not found | `Result` |
+| Network error | `Result` |
+| Invalid user input | `Result` |
+| Parse error | `Result` |
+| Index out of bounds (from user data) | `Result` |
+| Index out of bounds (internal bug) | Panic |
+| Violated internal invariant | Panic |
+| Unimplemented code path | Panic (`unimplemented!()`) |
+| Impossible state reached | Panic (`unreachable!()`) |
+
+## Library vs Application
+
+```rust
+// Library: NEVER panic on user input
+pub fn parse(input: &str) -> Result<Ast, ParseError> {
+    // Always return Result
+}
+
+// Application: Can panic at top level for critical failures
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Fatal error: {}", e);
+        std::process::exit(1);
+    }
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Define error types for libraries
+- [err-anyhow-app](./err-anyhow-app.md) - Ergonomic errors for applications
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Avoid unwrap in production code
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - When unwrap is acceptable

--- a/.agents/skills/rust-skills/rules/err-source-chain.md
+++ b/.agents/skills/rust-skills/rules/err-source-chain.md
@@ -1,0 +1,155 @@
+# err-source-chain
+
+> Preserve error chains with `#[source]` or `source()` method
+
+## Why It Matters
+
+Errors often have underlying causes. Preserving the error chain (via `source()` method) allows logging frameworks and error reporters to show the full context: "config parse failed → JSON syntax error at line 5 → unexpected token". Without chaining, you lose valuable debugging information.
+
+## Bad
+
+```rust
+#[derive(Debug)]
+enum ConfigError {
+    ParseFailed(String),  // Lost the original serde_json::Error
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| ConfigError::ParseFailed(e.to_string()))?;  // Chain lost!
+    
+    serde_json::from_str(&content)
+        .map_err(|e| ConfigError::ParseFailed(e.to_string()))?  // No source
+}
+
+// Error output: "Parse failed: invalid type: ..."
+// Missing: which file? what line? what was the parent error?
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum ConfigError {
+    #[error("Failed to read config file '{path}'")]
+    ReadFailed {
+        path: String,
+        #[source]  // Preserves the error chain
+        source: std::io::Error,
+    },
+    
+    #[error("Failed to parse config file '{path}'")]
+    ParseFailed {
+        path: String,
+        #[source]  // Original parse error preserved
+        source: serde_json::Error,
+    },
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|source| ConfigError::ReadFailed {
+            path: path.to_string(),
+            source,  // Chain preserved
+        })?;
+    
+    serde_json::from_str(&content)
+        .map_err(|source| ConfigError::ParseFailed {
+            path: path.to_string(),
+            source,
+        })
+}
+```
+
+## Manual source() Implementation
+
+```rust
+use std::error::Error;
+
+#[derive(Debug)]
+struct MyError {
+    message: String,
+    source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for MyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as &(dyn Error + 'static))
+    }
+}
+```
+
+## Walking the Error Chain
+
+```rust
+fn print_error_chain(error: &dyn std::error::Error) {
+    eprintln!("Error: {}", error);
+    
+    let mut source = error.source();
+    while let Some(err) = source {
+        eprintln!("Caused by: {}", err);
+        source = err.source();
+    }
+}
+
+// With anyhow, use {:?} for full chain
+let result: anyhow::Result<()> = do_something();
+if let Err(e) = result {
+    eprintln!("{:?}", e);  // Prints full chain with backtraces
+}
+```
+
+## anyhow Context
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_config(path: &str) -> Result<Config> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read '{}'", path))?;
+    
+    let config: Config = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse '{}'", path))?;
+    
+    Ok(config)
+}
+
+// Output:
+// Error: Failed to parse 'config.json'
+// Caused by: expected `:` at line 5 column 10
+```
+
+## #[from] vs #[source]
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum MyError {
+    // #[from] = implements From + sets source
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+    
+    // #[source] = only sets source (no From impl)
+    #[error("Parse error in file '{path}'")]
+    Parse {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - thiserror for error definitions
+- [err-context-chain](./err-context-chain.md) - Adding context to errors
+- [err-from-impl](./err-from-impl.md) - From implementations for ?

--- a/.agents/skills/rust-skills/rules/err-thiserror-lib.md
+++ b/.agents/skills/rust-skills/rules/err-thiserror-lib.md
@@ -1,0 +1,171 @@
+# err-thiserror-lib
+
+> Use `thiserror` for library error types
+
+## Why It Matters
+
+Libraries should expose typed, matchable errors so users can handle specific error conditions. `thiserror` generates `Error` trait implementations with minimal boilerplate, creating ergonomic error types that are easy to match against.
+
+## Bad
+
+```rust
+// String errors - not matchable
+fn parse(input: &str) -> Result<Data, String> {
+    Err("parse error".to_string())
+}
+
+// Box<dyn Error> - not matchable
+fn load(path: &Path) -> Result<Data, Box<dyn std::error::Error>> {
+    Err(Box::new(std::io::Error::new(std::io::ErrorKind::NotFound, "file not found")))
+}
+
+// Manual implementation - verbose
+#[derive(Debug)]
+enum MyError {
+    Io(std::io::Error),
+    Parse(String),
+}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MyError::Io(e) => write!(f, "io error: {}", e),
+            MyError::Parse(s) => write!(f, "parse error: {}", s),
+        }
+    }
+}
+
+impl std::error::Error for MyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            MyError::Io(e) => Some(e),
+            MyError::Parse(_) => None,
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("invalid syntax at line {line}: {message}")]
+    Syntax { line: usize, message: String },
+    
+    #[error("unexpected end of file")]
+    UnexpectedEof,
+    
+    #[error("invalid utf-8 encoding")]
+    Utf8(#[from] std::str::Utf8Error),
+    
+    #[error("io error reading input")]
+    Io(#[from] std::io::Error),
+}
+
+// Usage
+fn parse(input: &str) -> Result<Ast, ParseError> {
+    if input.is_empty() {
+        return Err(ParseError::UnexpectedEof);
+    }
+    // ...
+}
+
+// Users can match specific errors
+match parse(input) {
+    Ok(ast) => process(ast),
+    Err(ParseError::Syntax { line, message }) => {
+        eprintln!("Syntax error on line {}: {}", line, message);
+    }
+    Err(ParseError::UnexpectedEof) => {
+        eprintln!("File ended unexpectedly");
+    }
+    Err(e) => eprintln!("Error: {}", e),
+}
+```
+
+## Key Attributes
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MyError {
+    // Simple message
+    #[error("operation failed")]
+    Failed,
+    
+    // Interpolated fields
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
+    
+    // Named fields
+    #[error("connection to {host}:{port} failed")]
+    Connection { host: String, port: u16 },
+    
+    // Automatic From impl with #[from]
+    #[error("database error")]
+    Database(#[from] sqlx::Error),
+    
+    // Source without From (manual conversion needed)
+    #[error("validation failed")]
+    Validation {
+        #[source]
+        cause: ValidationError,
+        field: String,
+    },
+    
+    // Transparent - delegates Display and source to inner
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+```
+
+## Error Chaining
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("failed to read config file")]
+    Read(#[source] std::io::Error),
+    
+    #[error("failed to parse config")]
+    Parse(#[source] toml::de::Error),
+    
+    #[error("invalid config value for '{key}'")]
+    InvalidValue {
+        key: String,
+        #[source]
+        cause: ValueError,
+    },
+}
+
+// Error chain is preserved
+fn load_config(path: &Path) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(ConfigError::Read)?;
+    
+    let config: Config = toml::from_str(&content)
+        .map_err(ConfigError::Parse)?;
+    
+    Ok(config)
+}
+```
+
+## Library vs Application
+
+| Context | Crate | Why |
+|---------|-------|-----|
+| Library | `thiserror` | Typed errors users can match |
+| Application | `anyhow` | Easy error handling with context |
+| Both | `thiserror` for public API, `anyhow` internally | Best of both |
+
+## See Also
+
+- [err-anyhow-app](err-anyhow-app.md) - Use anyhow for applications
+- [err-from-impl](err-from-impl.md) - Use #[from] for automatic conversion
+- [err-source-chain](err-source-chain.md) - Use #[source] to chain errors

--- a/.agents/skills/rust-skills/rules/lint-cargo-metadata.md
+++ b/.agents/skills/rust-skills/rules/lint-cargo-metadata.md
@@ -1,0 +1,138 @@
+# lint-cargo-metadata
+
+> Enable clippy::cargo for published crates
+
+## Why It Matters
+
+The `clippy::cargo` lint group checks Cargo.toml for issues that affect publishing and dependency management. For crates intended for crates.io, these checks help ensure a professional, well-configured package.
+
+## Configuration
+
+```toml
+# Cargo.toml
+[lints.clippy]
+cargo = "warn"
+```
+
+Or in code:
+
+```rust
+#![warn(clippy::cargo)]
+```
+
+## What It Catches
+
+### Missing Metadata
+
+```toml
+# WARN: missing package.description
+# WARN: missing package.license or package.license-file
+# WARN: missing package.repository
+[package]
+name = "my-crate"
+version = "0.1.0"
+```
+
+### Dependency Issues
+
+```toml
+# WARN: feature used but not defined
+# WARN: dependency version not specified
+[dependencies]
+serde = "*"  # Bad: any version
+tokio = { git = "..." }  # WARN for published crates
+```
+
+### Feature Issues
+
+```toml
+# WARN: negative_feature_names
+[features]
+no-std = []  # Should be: std = [] (opt-out vs opt-in)
+
+# WARN: redundant_feature_names
+[features]
+default = ["feature-a"]
+feature-a = []  # Feature name matches crate name
+```
+
+## Notable Lints
+
+| Lint | Issue |
+|------|-------|
+| `cargo_common_metadata` | Missing description/license/repository |
+| `multiple_crate_versions` | Same crate at different versions |
+| `negative_feature_names` | Features like `no-std` instead of `std` |
+| `redundant_feature_names` | Feature same as crate name |
+| `wildcard_dependencies` | Using `*` for version |
+
+## Complete Cargo.toml
+
+```toml
+[package]
+name = "my-crate"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+
+# Required for cargo lint satisfaction
+description = "A short description of what this crate does"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/user/my-crate"
+
+# Recommended
+documentation = "https://docs.rs/my-crate"
+readme = "README.md"
+keywords = ["keyword1", "keyword2"]
+categories = ["category-slug"]
+
+[dependencies]
+# Specific versions, not wildcards
+serde = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+
+[features]
+default = ["std"]
+std = []  # Opt-out, not no-std opt-in
+
+[lints.clippy]
+cargo = "warn"
+```
+
+## Multiple Crate Versions
+
+```
+# WARN: multiple versions of `syn` in dependency tree
+# syn v1.0.109
+# syn v2.0.48
+```
+
+Fix by updating dependencies or using `[patch]`:
+
+```toml
+[patch.crates-io]
+old-dep = { git = "...", branch = "syn-2" }
+```
+
+## When to Disable
+
+For internal/unpublished crates:
+
+```toml
+[lints.clippy]
+cargo = "allow"  # Not publishing, metadata not needed
+```
+
+Or selectively:
+
+```toml
+[lints.clippy]
+cargo = "warn"
+multiple_crate_versions = "allow"  # Acceptable in this project
+```
+
+## See Also
+
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Cargo.toml metadata
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace dependencies
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints

--- a/.agents/skills/rust-skills/rules/lint-deny-correctness.md
+++ b/.agents/skills/rust-skills/rules/lint-deny-correctness.md
@@ -1,0 +1,107 @@
+# lint-deny-correctness
+
+> `#![deny(clippy::correctness)]`
+
+## Why It Matters
+
+Clippy's correctness lints catch code that is outright wrong - logic errors, undefined behavior, or code that doesn't do what you think. These should always be errors, not warnings.
+
+## Setup
+
+```rust
+// At the top of lib.rs or main.rs
+#![deny(clippy::correctness)]
+
+// Or in Cargo.toml for workspace-wide
+[lints.clippy]
+correctness = "deny"
+```
+
+## What It Catches
+
+```rust
+// Infinite loop (iter::repeat without take)
+for x in std::iter::repeat(1) {  // ERROR: infinite iterator
+    println!("{}", x);
+}
+
+// Comparison to NaN (always false)
+if x == f64::NAN {  // ERROR: NaN != NaN always
+    // This never executes
+}
+
+// Use after free patterns
+let r;
+{
+    let x = 5;
+    r = &x;  // ERROR: x dropped here
+}
+println!("{}", r);
+
+// Wrong equality check
+if x = 5 {  // ERROR: assignment in condition (should be ==)
+}
+
+// Useless comparisons
+if x >= 0 && x < 0 {  // ERROR: impossible condition
+}
+```
+
+## Important Correctness Lints
+
+```rust
+// approx_constant - using imprecise PI, E values
+let pi = 3.14;  // Use std::f64::consts::PI
+
+// invalid_regex - regex that won't compile
+let re = Regex::new("[");  // Invalid regex
+
+// iter_next_loop - using .next() in for loop incorrectly
+for x in iter.next() {  // Should be: for x in iter
+
+// never_loop - loop that never actually loops
+loop {
+    break;  // Always breaks immediately
+}
+
+// nonsensical_open_options - impossible file options
+File::options().read(false).write(false).open("f");
+
+// unit_cmp - comparing unit type ()
+if foo() == bar() { }  // Both return (), always true
+```
+
+## Full Recommended Lints
+
+```rust
+#![deny(clippy::correctness)]
+#![warn(clippy::suspicious)]
+#![warn(clippy::style)]
+#![warn(clippy::complexity)]
+#![warn(clippy::perf)]
+
+// For published crates
+#![warn(missing_docs)]
+#![warn(clippy::cargo)]
+```
+
+## Running Clippy
+
+```bash
+# Basic check
+cargo clippy
+
+# With all warnings as errors
+cargo clippy -- -D warnings
+
+# Check specific lint category
+cargo clippy -- -W clippy::correctness
+
+# In CI (fail on warnings)
+cargo clippy -- -D warnings -D clippy::correctness
+```
+
+## See Also
+
+- [lint-warn-suspicious](lint-warn-suspicious.md) - Warn on suspicious code
+- [lint-warn-perf](lint-warn-perf.md) - Warn on performance issues

--- a/.agents/skills/rust-skills/rules/lint-missing-docs.md
+++ b/.agents/skills/rust-skills/rules/lint-missing-docs.md
@@ -1,0 +1,154 @@
+# lint-missing-docs
+
+> Warn on missing documentation for public items
+
+## Why It Matters
+
+The `missing_docs` lint ensures all public API items are documented. For libraries, documentation IS the user interface. Missing docs mean users can't understand your API without reading source code.
+
+## Configuration
+
+```rust
+// In lib.rs
+#![warn(missing_docs)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.rust]
+missing_docs = "warn"
+```
+
+For strict enforcement:
+
+```rust
+#![deny(missing_docs)]
+```
+
+## What It Catches
+
+```rust
+#![warn(missing_docs)]
+
+pub struct User {  // WARN: missing documentation for a struct
+    pub name: String,  // WARN: missing documentation for a field
+    pub age: u32,      // WARN: missing documentation for a field
+}
+
+pub fn process() { }  // WARN: missing documentation for a function
+
+pub trait Handler {  // WARN: missing documentation for a trait
+    fn handle(&self);  // WARN: missing documentation for a method
+}
+```
+
+## Good
+
+```rust
+#![warn(missing_docs)]
+
+//! User management module.
+
+/// Represents a registered user in the system.
+pub struct User {
+    /// The user's display name.
+    pub name: String,
+    /// The user's age in years.
+    pub age: u32,
+}
+
+/// Processes pending user requests.
+///
+/// # Examples
+///
+/// ```
+/// process();
+/// ```
+pub fn process() { }
+
+/// Handler trait for request processing.
+pub trait Handler {
+    /// Handle an incoming request.
+    fn handle(&self);
+}
+```
+
+## Private Items
+
+`missing_docs` only applies to `pub` items. Private items don't trigger warnings:
+
+```rust
+#![warn(missing_docs)]
+
+struct Internal { }  // No warning - private
+
+pub struct Public { }  // WARN - public, needs docs
+```
+
+## Allow for Specific Items
+
+```rust
+#![warn(missing_docs)]
+
+/// Documented module.
+pub mod api {
+    /// Documented struct.
+    pub struct Config { }
+    
+    #[allow(missing_docs)]
+    pub mod internal {
+        // Internal API, docs not required
+        pub struct Helper { }
+    }
+}
+```
+
+## Gradual Adoption
+
+For existing codebases, start with `warn` and fix incrementally:
+
+```rust
+// Phase 1: Warn, fix critical items
+#![warn(missing_docs)]
+
+// Phase 2: After cleanup, deny
+#![deny(missing_docs)]
+```
+
+## Combining with doc Attributes
+
+```rust
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(rustdoc::private_intra_doc_links)]
+```
+
+## Workspace Configuration
+
+```toml
+# In workspace Cargo.toml
+[workspace.lints.rust]
+missing_docs = "warn"
+
+# Member crates inherit
+[lints]
+workspace = true
+```
+
+## What to Document
+
+| Item | Doc Focus |
+|------|-----------|
+| Structs | Purpose, usage example |
+| Struct fields | What it represents |
+| Enums | When to use each variant |
+| Functions | What it does, params, return |
+| Traits | Contract and expectations |
+| Modules | What the module provides |
+
+## See Also
+
+- [doc-all-public](./doc-all-public.md) - Documentation patterns
+- [lint-unsafe-doc](./lint-unsafe-doc.md) - Unsafe documentation
+- [doc-examples-section](./doc-examples-section.md) - Adding examples

--- a/.agents/skills/rust-skills/rules/lint-pedantic-selective.md
+++ b/.agents/skills/rust-skills/rules/lint-pedantic-selective.md
@@ -1,0 +1,118 @@
+# lint-pedantic-selective
+
+> Enable clippy::pedantic selectively
+
+## Why It Matters
+
+The `clippy::pedantic` group contains opinionated lints that aren't universally applicable. Enabling it wholesale produces noise; selectively enabling useful pedantic lints improves code quality without false positives.
+
+## Bad
+
+```rust
+// Too noisy - will fight you constantly
+#![warn(clippy::pedantic)]
+```
+
+## Good
+
+```toml
+# Cargo.toml - cherry-pick useful pedantic lints
+[lints.clippy]
+# Enable pedantic as baseline
+pedantic = "warn"
+
+# Disable noisy ones
+missing_errors_doc = "allow"      # Document errors separately
+missing_panics_doc = "allow"      # Document panics separately
+module_name_repetitions = "allow" # Allow Foo::FooError pattern
+too_many_lines = "allow"          # Function length varies
+must_use_candidate = "allow"      # Too many suggestions
+```
+
+## Recommended Pedantic Lints
+
+| Lint | Why Enable |
+|------|-----------|
+| `doc_markdown` | Catch unmarked code in docs |
+| `match_wildcard_for_single_variants` | Explicit variant matching |
+| `semicolon_if_nothing_returned` | Consistent semicolons |
+| `string_add_assign` | Use `+=` for string concatenation |
+| `unnested_or_patterns` | Simplify match patterns |
+| `unused_self` | Catch methods that should be functions |
+| `used_underscore_binding` | Warn on using `_var` |
+| `wildcard_imports` | Avoid glob imports |
+
+## Often Disabled
+
+| Lint | Why Disable |
+|------|-------------|
+| `missing_errors_doc` | Handle with `#[doc]` policy |
+| `missing_panics_doc` | Handle with `#[doc]` policy |
+| `module_name_repetitions` | Sometimes intentional |
+| `must_use_candidate` | Too aggressive |
+| `too_many_lines` | Arbitrary threshold |
+| `struct_excessive_bools` | Valid for config structs |
+
+## Full Configuration
+
+```toml
+# Cargo.toml
+[lints.clippy]
+# Start with pedantic
+pedantic = "warn"
+
+# Keep these
+doc_markdown = "warn"
+match_wildcard_for_single_variants = "warn"
+semicolon_if_nothing_returned = "warn"
+unused_self = "warn"
+wildcard_imports = "warn"
+
+# Disable these
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+must_use_candidate = "allow"
+too_many_lines = "allow"
+similar_names = "allow"
+struct_excessive_bools = "allow"
+```
+
+## Alternative: Explicit Opt-in
+
+```toml
+# Only enable specific lints, not the group
+[lints.clippy]
+# From pedantic, only these:
+doc_markdown = "warn"
+semicolon_if_nothing_returned = "warn"
+unused_self = "warn"
+wildcard_imports = "warn"
+```
+
+## Module-Level Overrides
+
+```rust
+// Allow specific lint for a module
+#![allow(clippy::module_name_repetitions)]
+
+// Or for specific items
+#[allow(clippy::too_many_arguments)]
+fn complex_function(/* many args */) { }
+```
+
+## Team Consensus
+
+Pedantic lints are style choices. Agree as a team:
+
+1. Enable `pedantic` as baseline
+2. Run `cargo clippy` on codebase
+3. Discuss each warning category
+4. Disable ones that don't fit your style
+5. Document decisions in `clippy.toml`
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints

--- a/.agents/skills/rust-skills/rules/lint-rustfmt-check.md
+++ b/.agents/skills/rust-skills/rules/lint-rustfmt-check.md
@@ -1,0 +1,157 @@
+# lint-rustfmt-check
+
+> Run cargo fmt --check in CI
+
+## Why It Matters
+
+Consistent formatting eliminates style debates and makes diffs cleaner. Running `cargo fmt --check` in CI ensures all code follows the same format. This catches formatting issues before merge, not after.
+
+## CI Configuration
+
+### GitHub Actions
+
+```yaml
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+```
+
+### GitLab CI
+
+```yaml
+fmt:
+  image: rust:latest
+  script:
+    - rustup component add rustfmt
+    - cargo fmt --all --check
+```
+
+### Pre-commit Hook
+
+```bash
+#!/bin/sh
+# .git/hooks/pre-commit
+cargo fmt --all --check
+```
+
+## Configuration
+
+Create `rustfmt.toml` for custom settings:
+
+```toml
+# rustfmt.toml
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Max"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+```
+
+## Common Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_width` | 100 | Maximum line width |
+| `tab_spaces` | 4 | Spaces per indent |
+| `edition` | "2015" | Rust edition |
+| `use_small_heuristics` | "Default" | Layout heuristics |
+| `imports_granularity` | "Preserve" | Import grouping |
+| `group_imports` | "Preserve" | Import ordering |
+
+## Running Locally
+
+```bash
+# Check formatting (doesn't modify files)
+cargo fmt --all --check
+
+# Apply formatting
+cargo fmt --all
+
+# Format specific file
+cargo fmt -- src/main.rs
+
+# Check with verbose output
+cargo fmt --all --check -- --verbose
+```
+
+## Workspace Formatting
+
+```bash
+# Format all workspace members
+cargo fmt --all
+
+# Format specific package
+cargo fmt -p my-package
+```
+
+## Ignoring Files
+
+In `rustfmt.toml`:
+
+```toml
+# Skip generated files
+ignore = [
+    "src/generated/*",
+    "build.rs",
+]
+```
+
+Or in code:
+
+```rust
+#[rustfmt::skip]
+mod generated_code;
+
+#[rustfmt::skip]
+const MATRIX: [[i32; 4]; 4] = [
+    [1, 0, 0, 0],
+    [0, 1, 0, 0],
+    [0, 0, 1, 0],
+    [0, 0, 0, 1],
+];
+```
+
+## Nightly Features
+
+Some options require nightly:
+
+```toml
+# rustfmt.toml (nightly only)
+unstable_features = true
+imports_granularity = "Crate"
+wrap_comments = true
+format_code_in_doc_comments = true
+```
+
+```bash
+# Use nightly rustfmt
+cargo +nightly fmt
+```
+
+## IDE Integration
+
+Most IDEs format on save. Configure to use project `rustfmt.toml`:
+
+```json
+// VS Code settings.json
+{
+  "rust-analyzer.rustfmt.extraArgs": ["--config-path", "./rustfmt.toml"]
+}
+```
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style lints
+- [lint-pedantic-selective](./lint-pedantic-selective.md) - Pedantic lints
+- [name-funcs-snake](./name-funcs-snake.md) - Naming conventions

--- a/.agents/skills/rust-skills/rules/lint-unsafe-doc.md
+++ b/.agents/skills/rust-skills/rules/lint-unsafe-doc.md
@@ -1,0 +1,133 @@
+# lint-unsafe-doc
+
+> Require documentation for unsafe blocks
+
+## Why It Matters
+
+The `undocumented_unsafe_blocks` lint ensures every unsafe block has a `// SAFETY:` comment explaining why the operation is sound. Unsafe code is the source of most memory safety bugs—documenting invariants catches mistakes and helps reviewers.
+
+## Configuration
+
+```rust
+#![warn(clippy::undocumented_unsafe_blocks)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"
+```
+
+For strict enforcement:
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+```
+
+## Bad
+
+```rust
+pub fn read_data(ptr: *const u8, len: usize) -> &[u8] {
+    unsafe {
+        std::slice::from_raw_parts(ptr, len)  // WARN: undocumented
+    }
+}
+
+impl Buffer {
+    pub fn get_unchecked(&self, index: usize) -> &u8 {
+        unsafe { self.data.get_unchecked(index) }  // WARN
+    }
+}
+```
+
+## Good
+
+```rust
+pub fn read_data(ptr: *const u8, len: usize) -> &[u8] {
+    // SAFETY: Caller guarantees:
+    // - ptr is valid for reads of len bytes
+    // - ptr is properly aligned for u8
+    // - the memory is initialized
+    // - no mutable references exist to this memory
+    unsafe {
+        std::slice::from_raw_parts(ptr, len)
+    }
+}
+
+impl Buffer {
+    pub fn get_unchecked(&self, index: usize) -> &u8 {
+        debug_assert!(index < self.len(), "index out of bounds");
+        // SAFETY: We verified index < len in debug builds.
+        // Callers must ensure index is within bounds.
+        unsafe { self.data.get_unchecked(index) }
+    }
+}
+```
+
+## SAFETY Comment Format
+
+```rust
+// SAFETY: <explanation of why this is sound>
+unsafe {
+    // ...
+}
+```
+
+The comment should explain:
+1. **What invariants are upheld** - preconditions that make this safe
+2. **Why the invariants hold** - how you know they're satisfied
+3. **What could go wrong** - if invariants are violated
+
+## Examples by Category
+
+### Pointer Operations
+
+```rust
+// SAFETY: ptr was obtained from Box::into_raw, so it's valid
+// and properly aligned. We're taking back ownership.
+let boxed = unsafe { Box::from_raw(ptr) };
+```
+
+### Unchecked Operations
+
+```rust
+// SAFETY: We just checked that i < self.len() above.
+// The bounds check cannot be elided by the optimizer
+// because len() is not inlined.
+unsafe { self.data.get_unchecked(i) }
+```
+
+### FFI Calls
+
+```rust
+// SAFETY: libc::getenv is safe to call with a null-terminated
+// string. We ensure null termination with CString::new.
+// The returned pointer is valid for the lifetime of the environment.
+let value = unsafe { libc::getenv(key.as_ptr()) };
+```
+
+### Trait Implementations
+
+```rust
+// SAFETY: MyType contains no pointers or interior mutability,
+// and all bit patterns are valid MyType values.
+unsafe impl Send for MyType {}
+unsafe impl Sync for MyType {}
+```
+
+## Related Lints
+
+```toml
+[lints.clippy]
+undocumented_unsafe_blocks = "warn"
+# Also consider:
+multiple_unsafe_ops_per_block = "warn"  # One operation per block
+```
+
+## See Also
+
+- [doc-safety-section](./doc-safety-section.md) - `# Safety` in docs
+- [lint-deny-correctness](./lint-deny-correctness.md) - Correctness lints
+- [type-repr-transparent](./type-repr-transparent.md) - FFI safety

--- a/.agents/skills/rust-skills/rules/lint-warn-complexity.md
+++ b/.agents/skills/rust-skills/rules/lint-warn-complexity.md
@@ -1,0 +1,131 @@
+# lint-warn-complexity
+
+> Enable clippy::complexity for simpler code
+
+## Why It Matters
+
+The `clippy::complexity` lint group identifies unnecessarily complex code that can be simplified. Complex code is harder to read, maintain, and often hides bugs. Clippy suggests cleaner alternatives.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::complexity)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+complexity = "warn"
+```
+
+## What It Catches
+
+### Unnecessary Complexity
+
+```rust
+// WARN: Overly complex boolean expression
+if !(x == 0) { }  // Use: if x != 0 { }
+
+// WARN: Manual implementation of Option::map
+match option {
+    Some(x) => Some(x + 1),
+    None => None,
+}  // Use: option.map(|x| x + 1)
+
+// WARN: Unnecessary filter before count
+iter.filter(|x| predicate(x)).count()  // Could simplify if only counting
+```
+
+### Redundant Operations
+
+```rust
+// WARN: Redundant allocation
+let s = format!("literal");  // Use: "literal".to_string() or just "literal"
+
+// WARN: Unnecessarily complicated match
+match result {
+    Ok(ok) => Ok(ok),
+    Err(err) => Err(err),
+}  // Just use: result
+
+// WARN: Box::new in return position
+fn make_error() -> Box<dyn Error> {
+    Box::new(MyError)  // Could use: MyError.into()
+}
+```
+
+### Overly Verbose Code
+
+```rust
+// WARN: bind_instead_of_map
+option.and_then(|x| Some(x + 1))  // Use: option.map(|x| x + 1)
+
+// WARN: clone_on_copy
+let y = x.clone();  // Where x is Copy type, just use: let y = x;
+
+// WARN: useless_let_if_seq
+let result;
+if condition {
+    result = 1;
+} else {
+    result = 2;
+}
+// Use: let result = if condition { 1 } else { 2 };
+```
+
+## Notable Lints in This Group
+
+| Lint | Simplification |
+|------|---------------|
+| `bind_instead_of_map` | Use `map` instead of `and_then(Some(...))` |
+| `bool_comparison` | `if x == true` → `if x` |
+| `clone_on_copy` | Remove `.clone()` for Copy types |
+| `filter_next` | Use `.find()` instead |
+| `option_map_unit_fn` | Use `if let` instead |
+| `search_is_some` | Use `.any()` or `.contains()` |
+| `unnecessary_cast` | Remove redundant casts |
+| `useless_conversion` | Remove `.into()` when types match |
+
+## Examples
+
+```rust
+// Before (complexity warnings)
+fn find_positive(nums: &[i32]) -> Option<i32> {
+    let filtered: Vec<_> = nums.iter()
+        .cloned()
+        .filter(|x| *x > 0)
+        .collect();
+    if filtered.len() == 0 {
+        None
+    } else {
+        Some(filtered[0])
+    }
+}
+
+// After (simplified)
+fn find_positive(nums: &[i32]) -> Option<i32> {
+    nums.iter()
+        .copied()
+        .find(|&x| x > 0)
+}
+```
+
+## Cognitive Load
+
+Complex code isn't just longer—it's harder to understand:
+
+```rust
+// High cognitive load
+let value = if x.is_some() { x.unwrap() } else { y.unwrap_or(z) };
+
+// Lower cognitive load
+let value = x.unwrap_or_else(|| y.unwrap_or(z));
+```
+
+## See Also
+
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-perf](./lint-warn-perf.md) - Performance warnings
+- [lint-pedantic-selective](./lint-pedantic-selective.md) - Pedantic lints

--- a/.agents/skills/rust-skills/rules/lint-warn-perf.md
+++ b/.agents/skills/rust-skills/rules/lint-warn-perf.md
@@ -1,0 +1,136 @@
+# lint-warn-perf
+
+> Enable clippy::perf for performance improvements
+
+## Why It Matters
+
+The `clippy::perf` lint group catches performance anti-patterns—inefficient allocations, unnecessary copies, suboptimal API usage. While not all performance issues are critical, avoiding obvious inefficiencies is good practice.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::perf)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+perf = "warn"
+```
+
+## What It Catches
+
+### Unnecessary Allocations
+
+```rust
+// WARN: Unnecessary to_string before into
+fn take_string(s: impl Into<String>) { }
+take_string("hello".to_string());  // Just use: "hello"
+
+// WARN: Box::new in return with deref coercion
+fn make_trait() -> Box<dyn Trait> {
+    Box::new(concrete)  // Could use Into
+}
+
+// WARN: Unnecessary vec! for iteration
+for x in vec![1, 2, 3] { }  // Use array: [1, 2, 3]
+```
+
+### Inefficient Operations
+
+```rust
+// WARN: Single-character string patterns
+s.starts_with("x")  // Use char: 'x'
+s.contains("a")     // Use char: 'a'
+
+// WARN: iter().nth(0) instead of first()
+iter.nth(0)  // Use: iter.first() or iter.next()
+
+// WARN: Manual saturating arithmetic
+if x > i32::MAX - y { i32::MAX } else { x + y }
+// Use: x.saturating_add(y)
+```
+
+### Collection Inefficiencies
+
+```rust
+// WARN: extend with a single element
+vec.extend(std::iter::once(item));  // Use: vec.push(item)
+
+// WARN: Inefficient to_vec
+slice.iter().cloned().collect::<Vec<_>>()  // Use: slice.to_vec()
+
+// WARN: Manual string concatenation
+let s = format!("{}{}", a, b);  // When both are &str, use: a.to_owned() + b
+```
+
+## Notable Lints in This Group
+
+| Lint | Improvement |
+|------|-------------|
+| `box_collection` | Use `Vec<T>` not `Box<Vec<T>>` |
+| `iter_nth` | Use `.get(n)` or `.next()` |
+| `large_enum_variant` | Box large variants |
+| `manual_memcpy` | Use slice copy methods |
+| `redundant_allocation` | Remove double boxing |
+| `single_char_pattern` | Use `char` not `&str` |
+| `slow_vector_initialization` | Use `vec![0; n]` |
+| `unnecessary_to_owned` | Remove redundant `.to_owned()` |
+
+## Examples
+
+```rust
+// Before (perf warnings)
+fn process(input: &str) -> String {
+    let parts: Vec<_> = input.split(",").collect();
+    let mut result = String::new();
+    for part in parts.iter() {
+        if part.starts_with(" ") {
+            result = result + &part.trim().to_string();
+        }
+    }
+    result
+}
+
+// After (optimized)
+fn process(input: &str) -> String {
+    input.split(',')
+        .filter(|part| part.starts_with(' '))
+        .map(str::trim)
+        .collect()
+}
+```
+
+## Allocation Patterns
+
+```rust
+// Unnecessary allocation
+let vec: Vec<i32> = vec![];  // Creates capacity
+let vec: Vec<i32> = Vec::new();  // No allocation
+
+// Pre-allocation
+let mut vec = Vec::with_capacity(100);  // One allocation
+for i in 0..100 {
+    vec.push(i);  // No reallocation
+}
+```
+
+## String Patterns
+
+```rust
+// Slow: str pattern
+s.contains("x");
+s.find("y");
+
+// Fast: char pattern
+s.contains('x');
+s.find('y');
+```
+
+## See Also
+
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimizing

--- a/.agents/skills/rust-skills/rules/lint-warn-style.md
+++ b/.agents/skills/rust-skills/rules/lint-warn-style.md
@@ -1,0 +1,135 @@
+# lint-warn-style
+
+> Enable clippy::style for idiomatic code
+
+## Why It Matters
+
+The `clippy::style` lint group enforces idiomatic Rust patterns. While not bugs, style violations make code harder to read and maintain. Consistent style helps teams work together and makes code easier to review.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::style)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+style = "warn"
+```
+
+## What It Catches
+
+### Redundant Code
+
+```rust
+// WARN: Redundant clone on Copy type
+let x = 5;
+let y = x.clone();  // Just use: let y = x;
+
+// WARN: Redundant closure
+iter.map(|x| foo(x))  // Just use: iter.map(foo)
+
+// WARN: Redundant pattern matching
+match result {
+    Ok(x) => Ok(x),
+    Err(e) => Err(e),
+}  // Just return result
+```
+
+### Non-Idiomatic Patterns
+
+```rust
+// WARN: Should use if let
+match option {
+    Some(x) => do_something(x),
+    None => {},
+}
+// Better: if let Some(x) = option { do_something(x) }
+
+// WARN: Should use or_else
+let value = if option.is_some() {
+    option.unwrap()
+} else {
+    default()
+};
+// Better: option.unwrap_or_else(default)
+
+// WARN: Collapsible if statements
+if condition1 {
+    if condition2 {
+        do_something();
+    }
+}
+// Better: if condition1 && condition2 { do_something() }
+```
+
+### Naming Issues
+
+```rust
+// WARN: Function should not start with 'is_' returning non-bool
+fn is_valid() -> i32 { 0 }  // Misleading name
+
+// WARN: Method should not be named 'new' without returning Self
+impl Foo {
+    fn new() -> Bar { Bar }  // Confusing
+}
+```
+
+## Notable Lints in This Group
+
+| Lint | Better Pattern |
+|------|---------------|
+| `len_zero` | Use `is_empty()` instead of `len() == 0` |
+| `redundant_field_names` | Use shorthand `{ x }` not `{ x: x }` |
+| `unused_unit` | Remove `-> ()` and trailing `()` |
+| `collapsible_if` | Combine nested ifs with `&&` |
+| `single_match` | Use `if let` instead |
+| `match_like_matches_macro` | Use `matches!()` macro |
+| `needless_return` | Remove explicit `return` at end |
+| `question_mark` | Use `?` instead of `match` |
+
+## Examples
+
+```rust
+// Before (style warnings)
+fn process(data: Vec<i32>) -> Option<i32> {
+    if data.len() == 0 {
+        return None;
+    }
+    let first = match data.first() {
+        Some(x) => x,
+        None => return None,
+    };
+    return Some(*first);
+}
+
+// After (idiomatic)
+fn process(data: Vec<i32>) -> Option<i32> {
+    if data.is_empty() {
+        return None;
+    }
+    let first = data.first()?;
+    Some(*first)
+}
+```
+
+## Selective Allowance
+
+Some style lints may conflict with team preferences:
+
+```rust
+// If your team prefers explicit returns
+#[allow(clippy::needless_return)]
+fn explicit_return() -> i32 {
+    return 42;
+}
+```
+
+## See Also
+
+- [lint-warn-suspicious](./lint-warn-suspicious.md) - Suspicious patterns
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings
+- [lint-rustfmt-check](./lint-rustfmt-check.md) - Formatting checks

--- a/.agents/skills/rust-skills/rules/lint-warn-suspicious.md
+++ b/.agents/skills/rust-skills/rules/lint-warn-suspicious.md
@@ -1,0 +1,122 @@
+# lint-warn-suspicious
+
+> Enable clippy::suspicious for likely bugs
+
+## Why It Matters
+
+The `clippy::suspicious` lint group catches code patterns that are syntactically valid but almost always wrong. These are potential bugs that deserve investigation. Enabling this group as a warning helps catch mistakes early.
+
+## Configuration
+
+```rust
+// In lib.rs or main.rs
+#![warn(clippy::suspicious)]
+```
+
+Or in `Cargo.toml`:
+
+```toml
+[lints.clippy]
+suspicious = "warn"
+```
+
+Or in `clippy.toml`:
+
+```toml
+warn = ["clippy::suspicious"]
+```
+
+## What It Catches
+
+### Suspicious Arithmetic
+
+```rust
+// WARN: Suspicious use of + in a << expression
+let bits = 1 << 4 + 1;  // Probably meant (1 << 4) + 1 or 1 << (4 + 1)
+
+// WARN: Suspicious use of | in a + expression
+let value = x | 1 + y;  // Probably meant (x | 1) + y or x | (1 + y)
+```
+
+### Suspicious Comparisons
+
+```rust
+// WARN: Almost swapped operands in a comparison
+if 5 < x && x < 3 { }  // Impossible condition
+
+// WARN: Suspicious assignment in a condition
+if (x = 5) { }  // Probably meant x == 5
+```
+
+### Suspicious Method Calls
+
+```rust
+// WARN: Suspicious map usage
+let _: Vec<_> = vec.iter().map(|x| { 
+    println!("{}", x);  // Side effect in map
+    x
+}).collect();  // Use for_each instead
+
+// WARN: Suspicious string formatting
+let s = format!("{}", format!("{}", x));  // Redundant nested format
+```
+
+### Suspicious Casts
+
+```rust
+// WARN: Suspicious use of not on a bool
+let inverted = !x as i32;  // Did you mean (!x) as i32 or !(x as i32)?
+
+// WARN: Cast of float to int may lose precision
+let n = 3.14_f64 as i32;  // May want .round() first
+```
+
+## Notable Lints in This Group
+
+| Lint | Description |
+|------|-------------|
+| `suspicious_arithmetic_impl` | Unusual operator in arithmetic trait |
+| `suspicious_assignment_formatting` | Looks like typo in assignment |
+| `suspicious_else_formatting` | Else on wrong line |
+| `suspicious_map` | Map with side effects |
+| `suspicious_op_assign_impl` | Unusual op-assign implementation |
+| `suspicious_splitn` | splitn that can't produce n parts |
+| `suspicious_unary_op_formatting` | Confusing unary operator spacing |
+
+## Example Catches
+
+```rust
+// Caught: Suspicious double negation
+let value = --x;  // In Rust, this is -(-x), not pre-decrement
+
+// Caught: Suspicious modulo
+let remainder = x % 1;  // Always 0 for integers
+
+// Caught: Suspicious else formatting
+if condition {
+    do_something();
+}
+else {  // Weird formatting, might be a mistake
+    do_other();
+}
+```
+
+## When to Allow
+
+Rarely. If you need to suppress, document why:
+
+```rust
+#[allow(clippy::suspicious_arithmetic_impl)]
+impl Mul for Matrix {
+    // Custom matrix multiplication using + for reduction step
+    fn mul(self, rhs: Self) -> Self::Output {
+        // ...
+    }
+}
+```
+
+## See Also
+
+- [lint-deny-correctness](./lint-deny-correctness.md) - Deny definite bugs
+- [lint-warn-style](./lint-warn-style.md) - Style warnings
+- [lint-warn-complexity](./lint-warn-complexity.md) - Complexity warnings

--- a/.agents/skills/rust-skills/rules/lint-workspace-lints.md
+++ b/.agents/skills/rust-skills/rules/lint-workspace-lints.md
@@ -1,0 +1,172 @@
+# lint-workspace-lints
+
+> Configure lints at workspace level for consistent enforcement
+
+## Why It Matters
+
+Without centralized lint configuration, each crate develops its own standards (or none). Workspace-level lints (Rust 1.74+) ensure consistent code quality across all crates. Denied lints catch issues in CI before they reach production.
+
+## Bad
+
+```toml
+# crate-a/Cargo.toml - strict
+[lints.clippy]
+unwrap_used = "deny"
+
+# crate-b/Cargo.toml - lenient
+# No lint config
+
+# crate-c/Cargo.toml - different
+[lints.clippy]
+unwrap_used = "warn"
+
+# Inconsistent enforcement, some issues slip through
+```
+
+## Good
+
+```toml
+# Root Cargo.toml
+[workspace.lints.rust]
+unsafe_code = "deny"
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+# Correctness
+unwrap_used = "deny"
+expect_used = "warn"
+panic = "deny"
+
+# Style
+needless_pass_by_value = "warn"
+redundant_clone = "warn"
+
+# Complexity
+cognitive_complexity = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+
+# crate-a/Cargo.toml
+[lints]
+workspace = true
+
+# crate-b/Cargo.toml
+[lints]
+workspace = true
+```
+
+## Recommended Lint Configuration
+
+```toml
+# Root Cargo.toml
+[workspace.lints.rust]
+# Safety
+unsafe_code = "deny"
+missing_debug_implementations = "warn"
+
+# Quality
+unused_results = "warn"
+unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# === Correctness (deny) ===
+correctness = { level = "deny", priority = -1 }
+
+# === Suspicious (deny) ===
+suspicious = { level = "deny", priority = -1 }
+
+# === Style (warn) ===
+style = { level = "warn", priority = -1 }
+
+# === Complexity (warn) ===
+complexity = { level = "warn", priority = -1 }
+
+# === Perf (warn) ===
+perf = { level = "warn", priority = -1 }
+
+# === Pedantic (selective) ===
+# Not all pedantic lints are useful
+doc_markdown = "warn"
+needless_pass_by_value = "warn"
+redundant_closure_for_method_calls = "warn"
+semicolon_if_nothing_returned = "warn"
+
+# === Nursery (selective) ===
+cognitive_complexity = "warn"
+useless_let_if_seq = "warn"
+
+# === Restriction (selective) ===
+unwrap_used = "deny"
+expect_used = "warn"
+dbg_macro = "warn"
+print_stdout = "warn"  # Use logging instead
+todo = "warn"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "warn"
+```
+
+## Per-Crate Overrides
+
+```toml
+# crate-with-binary/Cargo.toml
+[lints]
+workspace = true
+
+# Binary entry point can use unwrap
+[lints.clippy]
+unwrap_used = "allow"
+
+# test-utils/Cargo.toml
+[lints]
+workspace = true
+
+# Test utilities can print
+[lints.clippy]
+print_stdout = "allow"
+```
+
+## CI Integration
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      
+      - name: Rustdoc
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+```
+
+## Lint Categories
+
+```toml
+# Category-level configuration
+[workspace.lints.clippy]
+# All lints in category at once
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+style = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Then override specific lints (higher priority)
+missing_errors_doc = "allow"  # Override pedantic
+```
+
+## See Also
+
+- [lint-deny-correctness](./lint-deny-correctness.md) - Critical lints
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace configuration
+- [anti-unwrap-abuse](./anti-unwrap-abuse.md) - unwrap lints

--- a/.agents/skills/rust-skills/rules/mem-arena-allocator.md
+++ b/.agents/skills/rust-skills/rules/mem-arena-allocator.md
@@ -1,0 +1,168 @@
+# mem-arena-allocator
+
+> Use arena allocators for batch allocations
+
+## Why It Matters
+
+Arena allocators (bump allocators) allocate memory from a contiguous region, making allocation extremely fast (just bump a pointer). All allocations are freed at once when the arena is dropped. Perfect for request-scoped or parse-tree allocations.
+
+## Bad
+
+```rust
+// Many small allocations during parsing
+fn parse(input: &str) -> Vec<Node> {
+    let mut nodes = Vec::new();
+    for token in tokenize(input) {
+        nodes.push(Box::new(Node::new(token)));  // Heap alloc per node!
+    }
+    nodes
+}
+
+// Per-request allocations add up
+fn handle_request(req: Request) -> Response {
+    let headers = parse_headers(&req);      // Allocates
+    let body = parse_body(&req);            // Allocates
+    let response = generate_response();     // Allocates
+    // All freed individually at end
+    response
+}
+```
+
+## Good
+
+```rust
+use bumpalo::Bump;
+
+// All nodes allocated from same arena
+fn parse<'a>(input: &str, arena: &'a Bump) -> Vec<&'a Node> {
+    let mut nodes = Vec::new();
+    for token in tokenize(input) {
+        let node = arena.alloc(Node::new(token));  // Fast bump!
+        nodes.push(node);
+    }
+    nodes
+}  // Arena freed all at once
+
+// Per-request arena
+fn handle_request(req: Request) -> Response {
+    let arena = Bump::new();
+    
+    let headers = parse_headers(&req, &arena);
+    let body = parse_body(&req, &arena);
+    let response = generate_response(&arena);
+    
+    // Convert to owned response before arena drops
+    response.to_owned()
+}  // All request memory freed instantly
+```
+
+## Thread-Local Scratch Arena Pattern
+
+```rust
+use bumpalo::Bump;
+use std::cell::RefCell;
+
+thread_local! {
+    static SCRATCH: RefCell<Bump> = RefCell::new(Bump::with_capacity(4 * 1024));
+}
+
+fn with_scratch<T>(f: impl FnOnce(&Bump) -> T) -> T {
+    SCRATCH.with(|scratch| {
+        let arena = scratch.borrow();
+        let result = f(&arena);
+        result
+    })
+}
+
+fn reset_scratch() {
+    SCRATCH.with(|scratch| {
+        scratch.borrow_mut().reset();
+    });
+}
+
+// Usage
+fn process_batch(items: &[Item]) -> Vec<Output> {
+    with_scratch(|arena| {
+        let temp_data: Vec<&TempData> = items
+            .iter()
+            .map(|item| arena.alloc(compute_temp(item)))
+            .collect();
+        
+        // Use temp_data...
+        let result = finalize(&temp_data);
+        
+        reset_scratch();  // Reuse arena memory
+        result
+    })
+}
+```
+
+## Evidence from ROC Compiler
+
+```rust
+// https://github.com/roc-lang/roc/blob/main/crates/compiler/solve/src/to_var.rs
+std::thread_local! {
+    static SCRATCHPAD: RefCell<Option<bumpalo::Bump>> = 
+        RefCell::new(Some(bumpalo::Bump::with_capacity(4 * 1024)));
+}
+
+fn take_scratchpad() -> bumpalo::Bump {
+    SCRATCHPAD.with(|f| f.take().unwrap())
+}
+
+fn put_scratchpad(scratchpad: bumpalo::Bump) {
+    SCRATCHPAD.with(|f| {
+        f.replace(Some(scratchpad));
+    });
+}
+```
+
+## Bumpalo Collections
+
+```rust
+use bumpalo::Bump;
+use bumpalo::collections::{Vec, String};
+
+fn process<'a>(arena: &'a Bump, input: &str) -> Vec<'a, String<'a>> {
+    let mut results = Vec::new_in(arena);
+    
+    for word in input.split_whitespace() {
+        let mut s = String::new_in(arena);
+        s.push_str(word);
+        s.push_str("_processed");
+        results.push(s);
+    }
+    
+    results  // All allocated in arena
+}
+```
+
+## When to Use Arenas
+
+| Situation | Use Arena? |
+|-----------|-----------|
+| Parsing (AST nodes) | Yes |
+| Request handling | Yes |
+| Batch processing | Yes |
+| Long-lived data | No |
+| Data escaping scope | No (or copy out) |
+| Simple programs | Overkill |
+
+## Performance Impact
+
+```rust
+// Benchmarks from production systems:
+// - Individual allocations: ~25-50ns each
+// - Arena bump: ~1-2ns each (20-50x faster)
+// - Arena reset: O(1) regardless of allocation count
+
+// Memory overhead:
+// - Arena wastes some memory (unused capacity)
+// - But eliminates per-allocation metadata overhead
+```
+
+## See Also
+
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate when size is known
+- [mem-reuse-collections](mem-reuse-collections.md) - Reuse collections with clear()
+- [opt-profile-first](perf-profile-first.md) - Profile to verify benefit

--- a/.agents/skills/rust-skills/rules/mem-arrayvec.md
+++ b/.agents/skills/rust-skills/rules/mem-arrayvec.md
@@ -1,0 +1,142 @@
+# mem-arrayvec
+
+> Use `ArrayVec<T, N>` for fixed-capacity collections that never heap-allocate
+
+## Why It Matters
+
+`ArrayVec` from the `arrayvec` crate provides Vec-like API with a compile-time maximum capacity, storing all elements inline on the stack. Unlike `SmallVec` which can spill to heap, `ArrayVec` guarantees no heap allocation—if you exceed capacity, it returns an error or panics. This is ideal for embedded systems, real-time code, or when you have a hard upper bound.
+
+## Bad
+
+```rust
+// Vec always heap-allocates, even for small collections
+fn parse_options(input: &str) -> Vec<Option> {
+    let mut options = Vec::new();  // Heap allocation
+    for part in input.split(',').take(8) {  // Know we never exceed 8
+        options.push(parse_option(part));
+    }
+    options
+}
+
+// Or SmallVec when you truly can't exceed capacity
+use smallvec::SmallVec;
+fn get_flags() -> SmallVec<[Flag; 4]> {
+    // SmallVec CAN heap-allocate if pushed beyond 4
+    // That might be unexpected in no-alloc contexts
+}
+```
+
+## Good
+
+```rust
+use arrayvec::ArrayVec;
+
+// Guaranteed no heap allocation
+fn parse_options(input: &str) -> ArrayVec<Option, 8> {
+    let mut options = ArrayVec::new();
+    for part in input.split(',') {
+        if options.try_push(parse_option(part)).is_err() {
+            break;  // Capacity reached, stop
+        }
+    }
+    options
+}
+
+// For embedded/no_std contexts
+#[no_std]
+fn collect_readings() -> ArrayVec<SensorReading, 16> {
+    let mut readings = ArrayVec::new();
+    for sensor in SENSORS.iter() {
+        readings.push(sensor.read());  // Panics if > 16
+    }
+    readings
+}
+```
+
+## ArrayVec vs SmallVec vs Vec
+
+| Type | Stack | Heap | Use When |
+|------|-------|------|----------|
+| `Vec<T>` | Never | Always | Unknown size, may grow indefinitely |
+| `SmallVec<[T; N]>` | Up to N | Beyond N | Usually small, occasionally large |
+| `ArrayVec<T, N>` | Always | Never | Hard limit, no heap allowed |
+
+## API Patterns
+
+```rust
+use arrayvec::ArrayVec;
+
+let mut arr: ArrayVec<i32, 4> = ArrayVec::new();
+
+// Push with potential panic (like Vec)
+arr.push(1);
+arr.push(2);
+
+// Safe push - returns Err if full
+match arr.try_push(3) {
+    Ok(()) => println!("Added"),
+    Err(err) => println!("Full, couldn't add {}", err.element()),
+}
+
+// Check capacity
+assert!(arr.len() < arr.capacity());
+
+// Remaining capacity
+let remaining = arr.remaining_capacity();
+
+// Is it full?
+if arr.is_full() {
+    arr.pop();
+}
+
+// From iterator with limit
+let arr: ArrayVec<_, 10> = (0..100)
+    .filter(|x| x % 2 == 0)
+    .take(10)  // Important: don't exceed capacity
+    .collect();
+```
+
+## ArrayString for Stack Strings
+
+```rust
+use arrayvec::ArrayString;
+
+// Stack-allocated string with max capacity
+let mut s: ArrayString<64> = ArrayString::new();
+s.push_str("Hello, ");
+s.push_str("world!");
+
+// No heap allocation for small strings
+fn format_code(code: u32) -> ArrayString<16> {
+    let mut s = ArrayString::new();
+    write!(&mut s, "CODE-{:04}", code).unwrap();
+    s
+}
+```
+
+## When NOT to Use ArrayVec
+
+```rust
+// ❌ When size varies widely
+fn parse_json_array(json: &str) -> ArrayVec<Value, ???> {
+    // What capacity? JSON arrays can be any size
+}
+
+// ❌ When capacity is very large
+let big: ArrayVec<u8, 1_000_000> = ArrayVec::new();  // 1MB on stack = bad
+
+// ✅ Use SmallVec or Vec instead for these cases
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+arrayvec = "0.7"
+```
+
+## See Also
+
+- [mem-smallvec](./mem-smallvec.md) - When heap fallback is acceptable
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating Vec capacity
+- [own-move-large](./own-move-large.md) - Large stack types considerations

--- a/.agents/skills/rust-skills/rules/mem-assert-type-size.md
+++ b/.agents/skills/rust-skills/rules/mem-assert-type-size.md
@@ -1,0 +1,168 @@
+# mem-assert-type-size
+
+> Use static assertions to guard against accidental type size growth
+
+## Why It Matters
+
+Adding a field to a frequently-instantiated struct can silently bloat memory usage. Static size assertions catch this at compile time, making size changes intentional rather than accidental. This is especially important for types stored in large collections or passed frequently by value.
+
+## Bad
+
+```rust
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+}
+
+// Later, someone adds a field without realizing the impact
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+    metadata: String,  // Silently adds 24 bytes!
+}
+
+// 10 million events now use 240MB more memory
+// No warning, no review trigger
+```
+
+## Good
+
+```rust
+struct Event {
+    timestamp: u64,
+    kind: EventKind,
+    payload: [u8; 32],
+}
+
+// Static assertion - breaks compile if size changes
+const _: () = assert!(std::mem::size_of::<Event>() == 48);
+
+// Or with static_assertions crate
+use static_assertions::assert_eq_size;
+assert_eq_size!(Event, [u8; 48]);
+
+// Now adding metadata triggers compile error:
+// error: assertion failed: std::mem::size_of::<Event>() == 48
+```
+
+## static_assertions Crate
+
+```rust
+use static_assertions::{assert_eq_size, const_assert};
+
+struct Critical {
+    id: u64,
+    flags: u32,
+    data: [u8; 16],
+}
+
+// Exact size assertion
+assert_eq_size!(Critical, [u8; 32]);
+
+// Maximum size assertion
+const_assert!(std::mem::size_of::<Critical>() <= 64);
+
+// Alignment assertion
+const_assert!(std::mem::align_of::<Critical>() == 8);
+
+// Compare sizes
+assert_eq_size!(Critical, [u64; 4]);
+```
+
+## Built-in Const Assertions
+
+```rust
+// No external crate needed (Rust 1.57+)
+struct Packet {
+    header: u32,
+    payload: [u8; 60],
+}
+
+const _: () = assert!(
+    std::mem::size_of::<Packet>() == 64,
+    "Packet must be exactly 64 bytes for protocol compliance"
+);
+
+// Compile error shows custom message if assertion fails
+```
+
+## Documenting Size Constraints
+
+```rust
+/// Network protocol packet header.
+/// 
+/// # Size
+/// 
+/// This struct is guaranteed to be exactly 32 bytes to match
+/// the network protocol specification. Any changes to fields
+/// must maintain this size constraint.
+#[repr(C)]  // Predictable layout for FFI
+struct Header {
+    version: u16,
+    flags: u16,
+    length: u32,
+    checksum: u64,
+    reserved: [u8; 16],
+}
+
+const _: () = assert!(std::mem::size_of::<Header>() == 32);
+```
+
+## Testing Size Stability
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn critical_types_have_expected_sizes() {
+        // Document expected sizes in tests too
+        assert_eq!(std::mem::size_of::<Event>(), 48);
+        assert_eq!(std::mem::size_of::<Message>(), 64);
+        assert_eq!(std::mem::size_of::<Header>(), 32);
+    }
+    
+    #[test]
+    fn cache_line_aligned() {
+        // Verify cache-friendly sizing
+        assert!(std::mem::size_of::<HotData>() <= 64);
+    }
+}
+```
+
+## When to Assert
+
+```rust
+// ✅ Types stored in large collections
+struct Node { /* ... */ }
+const _: () = assert!(std::mem::size_of::<Node>() <= 64);
+
+// ✅ Types used in FFI / binary protocols
+#[repr(C)]
+struct WireFormat { /* ... */ }
+const _: () = assert!(std::mem::size_of::<WireFormat>() == 256);
+
+// ✅ Performance-critical types
+struct HotPath { /* ... */ }
+const _: () = assert!(std::mem::size_of::<HotPath>() <= 128);
+
+// ❌ Skip for rarely-instantiated types
+struct AppConfig { /* many fields */ }
+// Size doesn't matter, only one instance
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+static_assertions = "1.1"
+```
+
+## See Also
+
+- [mem-smaller-integers](./mem-smaller-integers.md) - Choosing appropriate integer sizes
+- [mem-box-large-variant](./mem-box-large-variant.md) - Managing enum variant sizes
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache line considerations

--- a/.agents/skills/rust-skills/rules/mem-avoid-format.md
+++ b/.agents/skills/rust-skills/rules/mem-avoid-format.md
@@ -1,0 +1,147 @@
+# mem-avoid-format
+
+> Avoid `format!()` when string literals work
+
+## Why It Matters
+
+`format!()` always allocates a new String, even for constant text. In hot paths, these allocations add up. Use string literals, `write!()`, or pre-allocated buffers instead.
+
+## Bad
+
+```rust
+// Allocates every time, even for static text
+fn get_error_message() -> String {
+    format!("An error occurred")  // Unnecessary allocation!
+}
+
+// Allocates in a loop
+for item in items {
+    log::info!("{}", format!("Processing item: {}", item));  // Double work!
+}
+
+// format! in hot path
+fn classify(n: i32) -> String {
+    if n > 0 {
+        format!("positive")  // Allocates!
+    } else if n < 0 {
+        format!("negative")  // Allocates!
+    } else {
+        format!("zero")      // Allocates!
+    }
+}
+```
+
+## Good
+
+```rust
+// Return &'static str for constants
+fn get_error_message() -> &'static str {
+    "An error occurred"  // No allocation
+}
+
+// Use format args directly
+for item in items {
+    log::info!("Processing item: {}", item);  // No intermediate String
+}
+
+// Return Cow for mixed static/dynamic
+use std::borrow::Cow;
+
+fn classify(n: i32) -> Cow<'static, str> {
+    if n > 0 {
+        Cow::Borrowed("positive")  // No allocation
+    } else if n < 0 {
+        Cow::Borrowed("negative")  // No allocation
+    } else {
+        Cow::Borrowed("zero")      // No allocation
+    }
+}
+
+// Or just &'static str if always static
+fn classify_str(n: i32) -> &'static str {
+    if n > 0 { "positive" }
+    else if n < 0 { "negative" }
+    else { "zero" }
+}
+```
+
+## Use write!() for Output
+
+```rust
+use std::io::Write;
+
+// Bad: Allocate then write
+fn bad_log(writer: &mut impl Write, msg: &str, code: u32) {
+    let formatted = format!("[ERROR {}] {}", code, msg);  // Allocation!
+    writer.write_all(formatted.as_bytes()).unwrap();
+}
+
+// Good: Write directly
+fn good_log(writer: &mut impl Write, msg: &str, code: u32) {
+    write!(writer, "[ERROR {}] {}", code, msg).unwrap();  // No allocation!
+}
+```
+
+## Pre-allocate for Multiple Appends
+
+```rust
+// Bad: Multiple allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result = format!("{}{}\n", result, part);  // Allocates each iteration!
+    }
+    result
+}
+
+// Good: Pre-allocate
+fn build_message(parts: &[&str]) -> String {
+    let total_len: usize = parts.iter().map(|p| p.len() + 1).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(part);
+        result.push('\n');
+    }
+    result
+}
+
+// Good: Use join
+fn build_message(parts: &[&str]) -> String {
+    parts.join("\n")
+}
+```
+
+## CompactString for Small Strings
+
+```rust
+use compact_str::CompactString;
+
+// Stack-allocated for strings <= 24 bytes
+fn format_code(code: u32) -> CompactString {
+    compact_str::format_compact!("ERR-{:04}", code)
+    // Stack-allocated if result is small enough
+}
+```
+
+## When format!() Is Fine
+
+```rust
+// Rare/cold paths - clarity over micro-optimization
+fn log_startup_message() {
+    println!("{}", format!("Starting {} v{}", APP_NAME, VERSION));
+}
+
+// When you need an owned String anyway
+fn create_user_greeting(name: &str) -> String {
+    format!("Hello, {}!", name)  // Need owned String
+}
+
+// Error messages (already on error path)
+return Err(format!("Invalid value: {}", value).into());
+```
+
+## See Also
+
+- [mem-write-over-format](mem-write-over-format.md) - Use write!() instead of format!()
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate strings
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for mixed static/dynamic

--- a/.agents/skills/rust-skills/rules/mem-box-large-variant.md
+++ b/.agents/skills/rust-skills/rules/mem-box-large-variant.md
@@ -1,0 +1,158 @@
+# mem-box-large-variant
+
+> Box large enum variants to reduce overall enum size
+
+## Why It Matters
+
+An enum's size is determined by its largest variant. If one variant contains a large struct while others are small, every instance of the enum pays for the largest variant's size. Boxing the large variant puts that data on the heap, keeping the enum itself small. This can significantly reduce memory usage and improve cache performance.
+
+## Bad
+
+```rust
+enum Message {
+    Quit,                              // 0 bytes of data
+    Move { x: i32, y: i32 },          // 8 bytes
+    Text(String),                      // 24 bytes
+    Image { 
+        data: [u8; 1024],             // 1024 bytes - forces entire enum to ~1032 bytes!
+        width: u32, 
+        height: u32 
+    },
+}
+
+// Every Message is ~1032 bytes, even Quit and Move
+let messages: Vec<Message> = vec![
+    Message::Quit,  // Wastes ~1032 bytes
+    Message::Quit,  // Wastes ~1032 bytes
+    Message::Move { x: 0, y: 0 },  // Wastes ~1024 bytes
+];
+```
+
+## Good
+
+```rust
+struct ImageData {
+    data: [u8; 1024],
+    width: u32,
+    height: u32,
+}
+
+enum Message {
+    Quit,
+    Move { x: i32, y: i32 },
+    Text(String),
+    Image(Box<ImageData>),  // Now just 8 bytes (pointer)
+}
+
+// Message is now ~32 bytes (String variant is largest)
+let messages: Vec<Message> = vec![
+    Message::Quit,  // Uses ~32 bytes
+    Message::Quit,  // Uses ~32 bytes  
+    Message::Move { x: 0, y: 0 },  // Uses ~32 bytes
+];
+```
+
+## Check Enum Sizes
+
+```rust
+use std::mem::size_of;
+
+// Before boxing
+enum BadEvent {
+    Click { x: u32, y: u32 },           // 8 bytes
+    KeyPress(char),                      // 4 bytes
+    LargeData([u8; 256]),               // 256 bytes
+}
+println!("BadEvent: {} bytes", size_of::<BadEvent>());  // ~264 bytes
+
+// After boxing
+enum GoodEvent {
+    Click { x: u32, y: u32 },
+    KeyPress(char),
+    LargeData(Box<[u8; 256]>),          // 8 bytes (pointer)
+}
+println!("GoodEvent: {} bytes", size_of::<GoodEvent>());  // ~16 bytes
+```
+
+## Clippy Lint
+
+```toml
+[lints.clippy]
+large_enum_variant = "warn"  # Warns when variants differ significantly
+```
+
+```rust
+// Clippy will suggest:
+// warning: large size difference between variants
+// help: consider boxing the large fields to reduce the total size
+```
+
+## When to Box
+
+| Largest Variant | Other Variants | Action |
+|-----------------|----------------|--------|
+| < 64 bytes | Similar size | Don't box |
+| > 128 bytes | Much smaller | Box the large variant |
+| > 256 bytes | Any | Definitely box |
+
+## Recursive Types Require Boxing
+
+```rust
+// Won't compile - infinite size
+enum List {
+    Cons(i32, List),
+    Nil,
+}
+
+// Must box recursive variant
+enum List {
+    Cons(i32, Box<List>),  // Now finite size
+    Nil,
+}
+
+// Same for ASTs
+enum Expr {
+    Number(i64),
+    BinOp {
+        op: Op,
+        left: Box<Expr>,   // Recursive - must box
+        right: Box<Expr>,
+    },
+}
+```
+
+## Pattern Matching with Boxed Variants
+
+```rust
+enum Event {
+    Small(u32),
+    Large(Box<LargeData>),
+}
+
+fn handle(event: Event) {
+    match event {
+        Event::Small(n) => println!("Small: {}", n),
+        Event::Large(data) => {
+            // data is Box<LargeData>, dereference to access
+            println!("Large: {} bytes", data.size);
+        }
+    }
+}
+
+// Or match on reference
+fn handle_ref(event: &Event) {
+    match event {
+        Event::Small(n) => println!("Small: {}", n),
+        Event::Large(data) => {
+            // data is &Box<LargeData>, auto-derefs
+            println!("Large: {} bytes", data.size);
+        }
+    }
+}
+```
+
+## See Also
+
+- [own-move-large](./own-move-large.md) - Boxing large types for cheap moves
+- [mem-smallvec](./mem-smallvec.md) - Alternative for inline small collections
+- [lint-deny-correctness](./lint-deny-correctness.md) - Enabling clippy lints

--- a/.agents/skills/rust-skills/rules/mem-boxed-slice.md
+++ b/.agents/skills/rust-skills/rules/mem-boxed-slice.md
@@ -1,0 +1,139 @@
+# mem-boxed-slice
+
+> Use `Box<[T]>` instead of `Vec<T>` for fixed-size heap data
+
+## Why It Matters
+
+`Vec<T>` stores three words: pointer, length, and capacity. When you know a collection won't grow, `Box<[T]>` stores only pointer and length (2 words), saving 8 bytes per instance. More importantly, it communicates intent: "this data is fixed-size." For large numbers of fixed collections, this adds up.
+
+## Bad
+
+```rust
+struct Document {
+    // Vec signals "might grow" but we never push after creation
+    paragraphs: Vec<Paragraph>,  // 24 bytes: ptr + len + capacity
+}
+
+fn load_document(data: &[u8]) -> Document {
+    let paragraphs: Vec<Paragraph> = parse_paragraphs(data);
+    // paragraphs has capacity >= len, wasting the capacity field
+    Document { paragraphs }
+}
+```
+
+## Good
+
+```rust
+struct Document {
+    // Box<[T]> signals "fixed size" - clear intent
+    paragraphs: Box<[Paragraph]>,  // 16 bytes: ptr + len (as fat pointer)
+}
+
+fn load_document(data: &[u8]) -> Document {
+    let paragraphs: Vec<Paragraph> = parse_paragraphs(data);
+    Document { 
+        paragraphs: paragraphs.into_boxed_slice()  // Shrinks + converts
+    }
+}
+```
+
+## Memory Layout
+
+```rust
+use std::mem::size_of;
+
+// Vec: 24 bytes on 64-bit
+assert_eq!(size_of::<Vec<u8>>(), 24);  // ptr(8) + len(8) + cap(8)
+
+// Box<[T]>: 16 bytes (fat pointer)
+assert_eq!(size_of::<Box<[u8]>>(), 16);  // ptr(8) + len(8)
+
+// Savings per instance: 8 bytes
+// For 1 million instances: 8 MB saved
+```
+
+## Conversion Patterns
+
+```rust
+// Vec to Box<[T]>
+let vec: Vec<i32> = vec![1, 2, 3, 4, 5];
+let boxed: Box<[i32]> = vec.into_boxed_slice();
+
+// Box<[T]> back to Vec (if you need to grow)
+let vec_again: Vec<i32> = boxed.into_vec();
+
+// From iterator
+let boxed: Box<[i32]> = (0..100).collect::<Vec<_>>().into_boxed_slice();
+
+// Shrink Vec first if it has excess capacity
+let mut vec = Vec::with_capacity(1000);
+vec.extend(0..10);
+vec.shrink_to_fit();  // Reduce capacity to length
+let boxed = vec.into_boxed_slice();  // Now no wasted allocation
+```
+
+## When to Use What
+
+| Type | Use When |
+|------|----------|
+| `Vec<T>` | Collection may grow/shrink |
+| `Box<[T]>` | Fixed-size, heap-allocated, many instances |
+| `[T; N]` | Fixed-size, stack-allocated, size known at compile time |
+| `&[T]` | Borrowed view, don't need ownership |
+
+## Box<str> for Immutable Strings
+
+Same principle applies to strings:
+
+```rust
+use std::mem::size_of;
+
+// String: 24 bytes (like Vec<u8>)
+assert_eq!(size_of::<String>(), 24);
+
+// Box<str>: 16 bytes
+assert_eq!(size_of::<Box<str>>(), 16);
+
+// For immutable strings
+struct Name {
+    value: Box<str>,  // Saves 8 bytes vs String
+}
+
+impl Name {
+    fn new(s: &str) -> Self {
+        Name { value: s.into() }  // &str -> Box<str>
+    }
+}
+
+// Or from String
+let s = String::from("hello");
+let boxed: Box<str> = s.into_boxed_str();
+```
+
+## Real-World Example
+
+```rust
+// Cache with millions of entries
+struct Cache {
+    // 8 bytes saved per entry adds up
+    entries: HashMap<Key, Box<[u8]>>,
+}
+
+impl Cache {
+    fn insert(&mut self, key: Key, data: Vec<u8>) {
+        // Convert to boxed slice for storage
+        self.entries.insert(key, data.into_boxed_slice());
+    }
+    
+    fn get(&self, key: &Key) -> Option<&[u8]> {
+        // Returns regular slice reference
+        self.entries.get(key).map(|b| b.as_ref())
+    }
+}
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating when size is known
+- [own-slice-over-vec](./own-slice-over-vec.md) - Using slices in function parameters
+- [mem-compact-string](./mem-compact-string.md) - Compact string alternatives

--- a/.agents/skills/rust-skills/rules/mem-clone-from.md
+++ b/.agents/skills/rust-skills/rules/mem-clone-from.md
@@ -1,0 +1,147 @@
+# mem-clone-from
+
+> Use `clone_from()` to reuse allocations when repeatedly cloning
+
+## Why It Matters
+
+`x = y.clone()` drops x's allocation and creates a new one from y. `x.clone_from(&y)` reuses x's existing allocation if possible, avoiding the allocation overhead. For repeatedly cloning into the same variable (loops, buffers), this can significantly reduce allocator pressure.
+
+## Bad
+
+```rust
+let mut buffer = String::with_capacity(1024);
+
+for source in sources {
+    buffer = source.clone();  // Drops old allocation, allocates new
+    process(&buffer);
+}
+
+// Each iteration:
+// 1. Drops buffer's 1024-byte allocation
+// 2. Allocates new memory for source.clone()
+// Allocator thrashing!
+```
+
+## Good
+
+```rust
+let mut buffer = String::with_capacity(1024);
+
+for source in sources {
+    buffer.clone_from(source);  // Reuses allocation if capacity sufficient
+    process(&buffer);
+}
+
+// If source.len() <= 1024, no allocation happens
+// Just copies bytes into existing buffer
+```
+
+## How clone_from Works
+
+```rust
+impl Clone for String {
+    fn clone(&self) -> Self {
+        // Always allocates new memory
+        String::from(self.as_str())
+    }
+    
+    fn clone_from(&mut self, source: &Self) {
+        // Reuse existing capacity if possible
+        self.clear();
+        self.push_str(source);  // Only reallocates if capacity insufficient
+    }
+}
+```
+
+## Types That Benefit
+
+```rust
+// String - reuses capacity
+let mut s = String::with_capacity(100);
+s.clone_from(&other_string);
+
+// Vec<T> - reuses capacity
+let mut v: Vec<u8> = Vec::with_capacity(1000);
+v.clone_from(&other_vec);
+
+// HashMap - reuses buckets
+let mut map = HashMap::with_capacity(100);
+map.clone_from(&other_map);
+
+// PathBuf - reuses capacity
+let mut path = PathBuf::with_capacity(256);
+path.clone_from(&other_path);
+```
+
+## Benchmarking the Difference
+
+```rust
+use criterion::{black_box, criterion_group, Criterion};
+
+fn bench_clone_patterns(c: &mut Criterion) {
+    let source = "x".repeat(1000);
+    
+    c.bench_function("clone assignment", |b| {
+        let mut buffer = String::new();
+        b.iter(|| {
+            buffer = black_box(&source).clone();
+        });
+    });
+    
+    c.bench_function("clone_from", |b| {
+        let mut buffer = String::with_capacity(1000);
+        b.iter(|| {
+            buffer.clone_from(black_box(&source));
+        });
+    });
+}
+// clone_from is typically 2-3x faster for this pattern
+```
+
+## Custom Implementations
+
+When implementing Clone for your types:
+
+```rust
+#[derive(Debug)]
+struct Buffer {
+    data: Vec<u8>,
+    metadata: Metadata,
+}
+
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Buffer {
+            data: self.data.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+    
+    // Optimize clone_from to reuse vec capacity
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);  // Reuses allocation
+        self.metadata = source.metadata.clone();
+    }
+}
+```
+
+## When NOT Needed
+
+```rust
+// Single clone - no benefit
+let copy = original.clone();  // Can't reuse, no prior allocation
+
+// Small Copy types - no allocation anyway
+let x: i32 = y;  // Not even Clone, just Copy
+
+// Immutable context
+fn process(data: &String) {
+    // Can't use clone_from - would need &mut self
+}
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating capacity
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing collection allocations
+- [own-clone-explicit](./own-clone-explicit.md) - When Clone is appropriate

--- a/.agents/skills/rust-skills/rules/mem-compact-string.md
+++ b/.agents/skills/rust-skills/rules/mem-compact-string.md
@@ -1,0 +1,149 @@
+# mem-compact-string
+
+> Use compact string types for memory-constrained string storage
+
+## Why It Matters
+
+Standard `String` is 24 bytes (pointer + length + capacity). For applications storing millions of short strings, this overhead dominates. Compact string libraries like `compact_str`, `smartstring`, or `ecow` store small strings inline (no heap allocation) and use optimized layouts for larger strings.
+
+## Bad
+
+```rust
+struct User {
+    id: u64,
+    // Most usernames are < 24 chars, but String is always 24 bytes + heap
+    username: String,
+    email: String,
+}
+
+// 1 million users = 24 bytes * 2 * 1M = 48MB just for String metadata
+// Plus all the heap allocations for actual content
+```
+
+## Good
+
+```rust
+use compact_str::CompactString;
+
+struct User {
+    id: u64,
+    // CompactString: 24 bytes, but strings ≤ 24 chars are inline (no heap)
+    username: CompactString,
+    email: CompactString,
+}
+
+// Most usernames fit inline = zero heap allocations
+// Same memory footprint as String but way fewer allocations
+```
+
+## Compact String Libraries
+
+### compact_str
+
+```rust
+use compact_str::CompactString;
+
+// Inline storage for strings ≤ 24 bytes
+let small: CompactString = "hello".into();  // No heap allocation
+
+// Automatic heap fallback for larger strings
+let large: CompactString = "x".repeat(100).into();
+
+// String-like API
+let mut s = CompactString::new("hello");
+s.push_str(" world");
+assert_eq!(s.as_str(), "hello world");
+
+// Format macro
+use compact_str::format_compact;
+let s = format_compact!("value: {}", 42);
+```
+
+### smartstring
+
+```rust
+use smartstring::{SmartString, LazyCompact};
+
+// Default is LazyCompact: 24 bytes inline capacity
+let s: SmartString<LazyCompact> = "short string".into();
+
+// Compact mode: 23 bytes inline on 64-bit
+use smartstring::Compact;
+let s: SmartString<Compact> = "hello".into();
+```
+
+### ecow (copy-on-write)
+
+```rust
+use ecow::EcoString;
+
+// Clone is O(1) - shares underlying data
+let s1: EcoString = "shared data".into();
+let s2 = s1.clone();  // Cheap, shares allocation
+
+// Copy-on-write: only allocates on mutation
+let mut s3 = s1.clone();
+s3.push_str(" modified");  // Now allocates
+```
+
+## Memory Comparison
+
+```rust
+use std::mem::size_of;
+
+// All 24 bytes, but different inline capacities
+assert_eq!(size_of::<String>(), 24);
+assert_eq!(size_of::<compact_str::CompactString>(), 24);
+assert_eq!(size_of::<smartstring::SmartString>(), 24);
+assert_eq!(size_of::<ecow::EcoString>(), 16);  // Even smaller!
+```
+
+## Inline Capacity
+
+| Type | Size | Inline Capacity |
+|------|------|-----------------|
+| `String` | 24 | 0 (always heap) |
+| `CompactString` | 24 | 24 bytes |
+| `SmartString<LazyCompact>` | 24 | 23 bytes |
+| `EcoString` | 16 | 15 bytes |
+
+## When to Use
+
+```rust
+// ✅ Good: Many short strings in memory
+struct Dictionary {
+    words: Vec<CompactString>,  // Millions of short words
+}
+
+// ✅ Good: Frequently cloned strings
+struct Template {
+    parts: Vec<EcoString>,  // O(1) clone
+}
+
+// ❌ Don't: Hot path string manipulation
+fn transform(s: &str) -> String {
+    // Standard String is optimized for manipulation
+    s.to_uppercase()
+}
+
+// ❌ Don't: API boundaries (prefer &str or String for interop)
+pub fn public_api(input: CompactString) { }  // Forces dependency
+pub fn public_api(input: impl Into<String>) { }  // Better
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+compact_str = "0.7"
+# or
+smartstring = "1.0"
+# or
+ecow = "0.2"
+```
+
+## See Also
+
+- [mem-boxed-slice](./mem-boxed-slice.md) - Box<str> for immutable strings
+- [own-cow-conditional](./own-cow-conditional.md) - Cow<str> for borrow-or-own
+- [mem-smallvec](./mem-smallvec.md) - Similar concept for Vec

--- a/.agents/skills/rust-skills/rules/mem-reuse-collections.md
+++ b/.agents/skills/rust-skills/rules/mem-reuse-collections.md
@@ -1,0 +1,174 @@
+# mem-reuse-collections
+
+> Clear and reuse collections instead of creating new ones in loops
+
+## Why It Matters
+
+Creating new `Vec`, `String`, or `HashMap` instances in hot loops generates significant allocator pressure. Clearing a collection and reusing it keeps the existing capacity, avoiding repeated allocation/deallocation cycles. This is especially impactful for frequently-executed code paths.
+
+## Bad
+
+```rust
+fn process_batches(batches: &[Batch]) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for batch in batches {
+        let mut temp = Vec::new();  // Allocates every iteration
+        
+        for item in &batch.items {
+            temp.push(transform(item));
+        }
+        
+        results.push(aggregate(&temp));
+        // temp dropped here, deallocation
+    }
+    
+    results
+}
+
+fn format_lines(items: &[Item]) -> String {
+    let mut output = String::new();
+    
+    for item in items {
+        let line = format!("{}: {}", item.name, item.value);  // Allocates
+        output.push_str(&line);
+        output.push('\n');
+    }
+    
+    output
+}
+```
+
+## Good
+
+```rust
+fn process_batches(batches: &[Batch]) -> Vec<Result> {
+    let mut results = Vec::with_capacity(batches.len());
+    let mut temp = Vec::new();  // Allocate once outside loop
+    
+    for batch in batches {
+        temp.clear();  // Reuse allocation, just reset length
+        
+        for item in &batch.items {
+            temp.push(transform(item));
+        }
+        
+        results.push(aggregate(&temp));
+        // temp keeps its capacity for next iteration
+    }
+    
+    results
+}
+
+fn format_lines(items: &[Item]) -> String {
+    use std::fmt::Write;
+    
+    let mut output = String::new();
+    let mut line = String::new();  // Reusable buffer
+    
+    for item in items {
+        line.clear();
+        write!(&mut line, "{}: {}", item.name, item.value).unwrap();
+        output.push_str(&line);
+        output.push('\n');
+    }
+    
+    output
+}
+```
+
+## Clear vs Drain vs New
+
+```rust
+let mut vec = vec![1, 2, 3, 4, 5];
+
+// clear(): keeps capacity, O(n) for Drop types
+vec.clear();
+assert_eq!(vec.len(), 0);
+assert!(vec.capacity() >= 5);
+
+// drain(): returns iterator, clears after iteration
+let drained: Vec<_> = vec.drain(..).collect();
+
+// truncate(): keeps first n elements
+vec.truncate(2);
+
+// Creating new: loses all capacity
+vec = Vec::new();  // Capacity gone
+```
+
+## HashMap Reuse
+
+```rust
+use std::collections::HashMap;
+
+fn count_words_per_line(lines: &[&str]) -> Vec<HashMap<String, usize>> {
+    let mut results = Vec::with_capacity(lines.len());
+    let mut counts = HashMap::new();  // Reuse across iterations
+    
+    for line in lines {
+        counts.clear();  // Keeps bucket allocation
+        
+        for word in line.split_whitespace() {
+            *counts.entry(word.to_string()).or_insert(0) += 1;
+        }
+        
+        results.push(counts.clone());
+    }
+    
+    results
+}
+```
+
+## BufWriter Pattern
+
+```rust
+use std::io::{BufWriter, Write};
+
+fn write_many_records(records: &[Record], mut output: impl Write) -> std::io::Result<()> {
+    // BufWriter reuses its internal buffer
+    let mut writer = BufWriter::with_capacity(8192, &mut output);
+    let mut line = String::with_capacity(256);  // Reusable formatting buffer
+    
+    for record in records {
+        line.clear();
+        format_record(record, &mut line);
+        writer.write_all(line.as_bytes())?;
+        writer.write_all(b"\n")?;
+    }
+    
+    writer.flush()
+}
+```
+
+## When to Create Fresh
+
+```rust
+// When ownership transfer is needed
+fn produce_results() -> Vec<Vec<Item>> {
+    let mut results = Vec::new();
+    
+    for batch in batches {
+        let processed: Vec<Item> = batch.process();  // Ownership transferred
+        results.push(processed);  // Moved into results
+    }
+    
+    results  // Each inner Vec is independent
+}
+
+// When thread safety requires it
+std::thread::scope(|s| {
+    for _ in 0..4 {
+        s.spawn(|| {
+            let local_buffer = Vec::new();  // Thread-local, can't share
+            // ...
+        });
+    }
+});
+```
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating capacity
+- [mem-clone-from](./mem-clone-from.md) - Reusing allocations when cloning
+- [mem-write-over-format](./mem-write-over-format.md) - Avoiding format! allocations

--- a/.agents/skills/rust-skills/rules/mem-smaller-integers.md
+++ b/.agents/skills/rust-skills/rules/mem-smaller-integers.md
@@ -1,0 +1,159 @@
+# mem-smaller-integers
+
+> Use appropriately-sized integers to reduce memory footprint
+
+## Why It Matters
+
+Using `i64` when `i16` suffices wastes 6 bytes per value. In arrays, vectors, and structs with millions of instances, this waste compounds dramatically. Choosing the smallest integer type that fits your domain reduces memory usage and improves cache utilization.
+
+## Bad
+
+```rust
+struct Pixel {
+    r: u64,  // Color channels 0-255 = 8 bits needed
+    g: u64,  // Using 64 bits = 8x waste
+    b: u64,
+    a: u64,
+}
+// Size: 32 bytes per pixel
+
+struct HttpStatus {
+    code: i32,      // HTTP codes 100-599 = 10 bits needed
+    version: i32,   // HTTP 1.0, 1.1, 2, 3 = 2 bits needed
+}
+// Size: 8 bytes per status
+
+struct GeoPoint {
+    lat: f64,   // -90 to 90
+    lon: f64,   // -180 to 180
+}
+// Often f32 precision is sufficient for display
+```
+
+## Good
+
+```rust
+struct Pixel {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+// Size: 4 bytes per pixel (8x smaller!)
+
+struct HttpStatus {
+    code: u16,      // 100-599 fits in u16
+    version: u8,    // 1, 2, 3 fits in u8
+}
+// Size: 3 bytes (+ 1 padding = 4 bytes)
+
+struct GeoPoint {
+    lat: f32,   // ~7 decimal digits precision
+    lon: f32,   // Sufficient for most geo applications
+}
+// Size: 8 bytes vs 16 bytes
+```
+
+## Integer Size Reference
+
+| Type | Range | Use For |
+|------|-------|---------|
+| `u8` | 0 to 255 | Bytes, small counts, flags |
+| `i8` | -128 to 127 | Small signed values |
+| `u16` | 0 to 65,535 | Port numbers, small indices |
+| `i16` | -32,768 to 32,767 | Audio samples |
+| `u32` | 0 to 4 billion | Array indices, timestamps (seconds) |
+| `i32` | ±2 billion | General integers, file offsets |
+| `u64` | 0 to 18 quintillion | Large counts, nanosecond timestamps |
+| `usize` | Platform-dependent | Array indexing (required by Rust) |
+
+## Struct Packing
+
+```rust
+use std::mem::size_of;
+
+// Poor ordering - 24 bytes due to padding
+struct Wasteful {
+    a: u8,    // 1 byte + 7 padding
+    b: u64,   // 8 bytes
+    c: u8,    // 1 byte + 7 padding
+}
+assert_eq!(size_of::<Wasteful>(), 24);
+
+// Better ordering - 16 bytes
+struct Efficient {
+    b: u64,   // 8 bytes (aligned)
+    a: u8,    // 1 byte
+    c: u8,    // 1 byte + 6 padding
+}
+assert_eq!(size_of::<Efficient>(), 16);
+
+// Even better with smaller types - 10 bytes
+struct Compact {
+    b: u32,   // 4 bytes (if u32 suffices)
+    a: u8,    // 1 byte
+    c: u8,    // 1 byte
+}
+assert_eq!(size_of::<Compact>(), 8);  // With padding
+```
+
+## Conversion Safety
+
+```rust
+// Safe: always succeeds (widening)
+let small: u8 = 42;
+let big: u32 = small.into();
+
+// Fallible: may overflow (narrowing)
+let big: u32 = 1000;
+let small: u8 = big.try_into().expect("value out of range");
+
+// Or use checked conversion
+if let Ok(small) = u8::try_from(big) {
+    use_small(small);
+} else {
+    handle_overflow();
+}
+```
+
+## Bitflags for Boolean Sets
+
+```rust
+use bitflags::bitflags;
+
+// Instead of 8 separate bool fields (8 bytes minimum)
+bitflags! {
+    struct Permissions: u8 {
+        const READ    = 0b0000_0001;
+        const WRITE   = 0b0000_0010;
+        const EXECUTE = 0b0000_0100;
+        const DELETE  = 0b0000_1000;
+    }
+}
+// All 8 flags in 1 byte!
+
+let perms = Permissions::READ | Permissions::WRITE;
+if perms.contains(Permissions::READ) {
+    // ...
+}
+```
+
+## NonZero Types for Option Optimization
+
+```rust
+use std::num::NonZeroU64;
+
+// Option<u64> = 16 bytes (no null pointer optimization)
+assert_eq!(size_of::<Option<u64>>(), 16);
+
+// Option<NonZeroU64> = 8 bytes (0 represents None)
+assert_eq!(size_of::<Option<NonZeroU64>>(), 8);
+
+let id: Option<NonZeroU64> = NonZeroU64::new(42);
+```
+
+## See Also
+
+- [mem-box-large-variant](./mem-box-large-variant.md) - Optimizing enum sizes
+- [mem-assert-type-size](./mem-assert-type-size.md) - Compile-time size checks
+- [type-newtype-ids](./type-newtype-ids.md) - Type safety for integer IDs

--- a/.agents/skills/rust-skills/rules/mem-smallvec.md
+++ b/.agents/skills/rust-skills/rules/mem-smallvec.md
@@ -1,0 +1,138 @@
+# mem-smallvec
+
+> Use `SmallVec` for usually-small collections
+
+## Why It Matters
+
+`SmallVec<[T; N]>` stores up to N elements inline (on the stack), only allocating on the heap when the size exceeds N. This eliminates heap allocations for the common case while still allowing growth when needed.
+
+## Bad
+
+```rust
+// Always heap-allocates, even for 1-2 elements
+fn get_path_components(path: &str) -> Vec<&str> {
+    path.split('/').collect()  // Usually 2-4 components
+}
+
+// Always heap-allocates for error list
+fn validate(input: &Input) -> Vec<ValidationError> {
+    let mut errors = Vec::new();  // Usually 0-3 errors
+    // validation logic...
+    errors
+}
+```
+
+## Good
+
+```rust
+use smallvec::{smallvec, SmallVec};
+
+// Stack-allocated for typical paths (1-8 components)
+fn get_path_components(path: &str) -> SmallVec<[&str; 8]> {
+    path.split('/').collect()
+}
+
+// Stack-allocated for typical error counts
+fn validate(input: &Input) -> SmallVec<[ValidationError; 4]> {
+    let mut errors = SmallVec::new();
+    // validation logic...
+    errors
+}
+
+// Using smallvec! macro
+let v: SmallVec<[i32; 4]> = smallvec![1, 2, 3];
+```
+
+## Choosing Capacity N
+
+```rust
+// Measure your actual data distribution!
+// Guidelines:
+
+// Path components: 4-8 (most paths are shallow)
+type PathParts<'a> = SmallVec<[&'a str; 8]>;
+
+// Function arguments: 4-8 (most functions have few args)  
+type Args = SmallVec<[Arg; 8]>;
+
+// AST children: 2-4 (binary ops, if/else, etc.)
+type Children = SmallVec<[Node; 4]>;
+
+// Error accumulation: 2-4 (most inputs have few errors)
+type Errors = SmallVec<[Error; 4]>;
+
+// Attribute lists: 4-8 (most items have few attributes)
+type Attrs = SmallVec<[Attribute; 8]>;
+```
+
+## Evidence from rust-analyzer
+
+```rust
+// https://github.com/rust-lang/rust/blob/main/compiler/rustc_expand/src/base.rs
+macro_rules! make_stmts_default {
+    ($me:expr) => {
+        $me.make_expr().map(|e| {
+            smallvec![ast::Stmt {
+                id: ast::DUMMY_NODE_ID,
+                span: e.span,
+                kind: ast::StmtKind::Expr(e),
+            }]
+        })
+    }
+}
+```
+
+## Trade-offs
+
+```rust
+// SmallVec is slightly larger than Vec
+use std::mem::size_of;
+// Vec<i32>: 24 bytes (ptr + len + cap)
+// SmallVec<[i32; 4]>: 32 bytes (inline storage + len + discriminant)
+
+// SmallVec has branching overhead on every operation
+// (must check if inline or heap)
+
+// Profile to verify benefit!
+```
+
+## When to Use SmallVec vs Alternatives
+
+| Situation | Use |
+|-----------|-----|
+| Usually small, sometimes large | `SmallVec<[T; N]>` |
+| Always small, fixed max | `ArrayVec<T, N>` |
+| Rarely grows past initial | `Vec::with_capacity` |
+| No `unsafe` allowed | `TinyVec` |
+| Often empty | `ThinVec` |
+
+## ArrayVec Alternative
+
+```rust
+use arrayvec::ArrayVec;
+
+// Fixed maximum capacity, never heap allocates
+// Panics if you exceed capacity
+fn parse_rgb(s: &str) -> ArrayVec<u8, 3> {
+    let mut components = ArrayVec::new();
+    for part in s.split(',').take(3) {
+        components.push(part.parse().unwrap());
+    }
+    components
+}
+```
+
+## TinyVec (No Unsafe)
+
+```rust
+use tinyvec::{tiny_vec, TinyVec};
+
+// Same concept as SmallVec but 100% safe code
+let v: TinyVec<[i32; 4]> = tiny_vec![1, 2, 3];
+```
+
+## See Also
+
+- [mem-arrayvec](mem-arrayvec.md) - Use ArrayVec for fixed-max collections
+- [mem-with-capacity](mem-with-capacity.md) - Pre-allocate when size is known
+- [mem-thinvec](mem-thinvec.md) - Use ThinVec for often-empty vectors

--- a/.agents/skills/rust-skills/rules/mem-thinvec.md
+++ b/.agents/skills/rust-skills/rules/mem-thinvec.md
@@ -1,0 +1,142 @@
+# mem-thinvec
+
+> Use `ThinVec<T>` for nullable collections with minimal overhead
+
+## Why It Matters
+
+Standard `Vec<T>` is 24 bytes even when empty. `ThinVec` from Mozilla's `thin_vec` crate uses a single pointer (8 bytes), storing length and capacity inline with the heap allocation. For Option<Vec<T>> patterns or structs with many optional vecs, this significantly reduces memory overhead.
+
+## Bad
+
+```rust
+struct TreeNode {
+    value: i32,
+    // Each node pays 24 bytes for children, even leaves
+    children: Vec<TreeNode>,  // Most nodes are leaves with empty Vec
+}
+
+// Or using Option<Vec<T>>
+struct SparseData {
+    // Option<Vec> = 24 bytes (Vec is never null-pointer optimized)
+    tags: Option<Vec<String>>,
+    metadata: Option<Vec<Metadata>>,
+    // 48 bytes for usually-None fields
+}
+```
+
+## Good
+
+```rust
+use thin_vec::ThinVec;
+
+struct TreeNode {
+    value: i32,
+    // Empty ThinVec is just a null pointer - 8 bytes
+    children: ThinVec<TreeNode>,
+}
+
+struct SparseData {
+    // ThinVec empty = 8 bytes each
+    tags: ThinVec<String>,
+    metadata: ThinVec<Metadata>,
+    // 16 bytes vs 48 bytes
+}
+```
+
+## Memory Layout
+
+```rust
+use std::mem::size_of;
+
+// Standard Vec: always 24 bytes
+assert_eq!(size_of::<Vec<u8>>(), 24);
+assert_eq!(size_of::<Option<Vec<u8>>>(), 24);  // No NPO benefit
+
+// ThinVec: 8 bytes (one pointer)
+use thin_vec::ThinVec;
+assert_eq!(size_of::<ThinVec<u8>>(), 8);
+assert_eq!(size_of::<Option<ThinVec<u8>>>(), 8);  // Option is free!
+```
+
+## ThinVec vs Vec
+
+| Feature | `Vec<T>` | `ThinVec<T>` |
+|---------|----------|--------------|
+| Size (empty) | 24 bytes | 8 bytes |
+| Size (non-empty) | 24 bytes | 8 bytes (header on heap) |
+| Option<T> optimization | No | Yes |
+| Cache locality | Better (len/cap on stack) | Worse (len/cap on heap) |
+| Iteration speed | Faster | Slightly slower |
+| API compatibility | Full | Vec-like |
+
+## When to Use ThinVec
+
+```rust
+// ✅ Good: Many instances, often empty
+struct SparseGraph {
+    nodes: Vec<Node>,
+    // Most edges lists are empty or small
+    edges: Vec<ThinVec<EdgeId>>,  // Saves 16 bytes per node
+}
+
+// ✅ Good: Nullable collection field
+struct Document {
+    content: String,
+    attachments: ThinVec<Attachment>,  // Often empty
+}
+
+// ❌ Avoid: Hot loops, performance-critical iteration
+fn process_hot_path(data: &ThinVec<Item>) {
+    // Every length check goes through pointer indirection
+    for item in data {  // Vec would be faster here
+        process(item);
+    }
+}
+
+// ❌ Avoid: Few instances
+fn main() {
+    let single_vec: ThinVec<i32> = ThinVec::new();
+    // Saving 16 bytes once is meaningless
+}
+```
+
+## API Compatibility
+
+```rust
+use thin_vec::{ThinVec, thin_vec};
+
+// Constructor macro
+let v: ThinVec<i32> = thin_vec![1, 2, 3];
+
+// Familiar Vec-like API
+let mut v = ThinVec::new();
+v.push(1);
+v.push(2);
+v.extend([3, 4, 5]);
+v.pop();
+
+// Iteration
+for item in &v {
+    println!("{}", item);
+}
+
+// Slicing
+let slice: &[i32] = &v[..];
+
+// Conversion
+let vec: Vec<i32> = v.into();
+let thin: ThinVec<i32> = vec.into();
+```
+
+## Cargo.toml
+
+```toml
+[dependencies]
+thin-vec = "0.2"
+```
+
+## See Also
+
+- [mem-smallvec](./mem-smallvec.md) - Stack-allocated small vecs
+- [mem-boxed-slice](./mem-boxed-slice.md) - Fixed-size heap slices
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation strategies

--- a/.agents/skills/rust-skills/rules/mem-with-capacity.md
+++ b/.agents/skills/rust-skills/rules/mem-with-capacity.md
@@ -1,0 +1,156 @@
+# mem-with-capacity
+
+> Use `with_capacity()` when size is known
+
+## Why It Matters
+
+When you know (or can estimate) the final size of a collection, pre-allocating avoids multiple reallocations as it grows. Each reallocation copies all existing elements, so avoiding them can dramatically improve performance.
+
+## Bad
+
+```rust
+// Vec starts at capacity 0, reallocates at 4, 8, 16, 32...
+let mut results = Vec::new();
+for i in 0..1000 {
+    results.push(process(i));  // ~10 reallocations!
+}
+
+// String grows similarly
+let mut output = String::new();
+for word in words {
+    output.push_str(word);
+    output.push(' ');
+}
+
+// HashMap default capacity is small
+let mut map = HashMap::new();
+for (k, v) in pairs {  // Many reallocations
+    map.insert(k, v);
+}
+```
+
+## Good
+
+```rust
+// Pre-allocate exact size
+let mut results = Vec::with_capacity(1000);
+for i in 0..1000 {
+    results.push(process(i));  // Zero reallocations!
+}
+
+// Or use collect with size hint (iterator provides capacity)
+let results: Vec<_> = (0..1000).map(process).collect();
+
+// Pre-allocate string
+let estimated_len = words.iter().map(|w| w.len() + 1).sum();
+let mut output = String::with_capacity(estimated_len);
+for word in words {
+    output.push_str(word);
+    output.push(' ');
+}
+
+// Pre-allocate HashMap
+let mut map = HashMap::with_capacity(pairs.len());
+for (k, v) in pairs {
+    map.insert(k, v);
+}
+```
+
+## Collection Capacity Methods
+
+```rust
+// Vec
+let mut v = Vec::with_capacity(100);
+v.reserve(50);        // Ensure at least 50 more slots
+v.reserve_exact(50);  // Ensure exactly 50 more (no extra)
+v.shrink_to_fit();    // Release unused capacity
+
+// String
+let mut s = String::with_capacity(100);
+s.reserve(50);
+
+// HashMap / HashSet
+let mut m = HashMap::with_capacity(100);
+m.reserve(50);
+
+// VecDeque
+let mut d = VecDeque::with_capacity(100);
+```
+
+## Estimating Capacity
+
+```rust
+// From iterator length
+fn collect_results(items: &[Item]) -> Vec<Output> {
+    let mut results = Vec::with_capacity(items.len());
+    for item in items {
+        results.push(process(item));
+    }
+    results
+}
+
+// From filter estimate (if ~10% pass filter)
+fn filter_valid(items: &[Item]) -> Vec<&Item> {
+    let mut valid = Vec::with_capacity(items.len() / 10);
+    for item in items {
+        if item.is_valid() {
+            valid.push(item);
+        }
+    }
+    valid
+}
+
+// String from parts
+fn join_with_sep(parts: &[&str], sep: &str) -> String {
+    let total_len: usize = parts.iter().map(|p| p.len()).sum();
+    let sep_len = if parts.is_empty() { 0 } else { sep.len() * (parts.len() - 1) };
+    
+    let mut result = String::with_capacity(total_len + sep_len);
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            result.push_str(sep);
+        }
+        result.push_str(part);
+    }
+    result
+}
+```
+
+## Evidence from Production Code
+
+From fd (file finder):
+```rust
+// https://github.com/sharkdp/fd/blob/master/src/walk.rs
+struct ReceiverBuffer<'a, W> {
+    buffer: Vec<DirEntry>,
+    // ...
+}
+
+impl<'a, W: Write> ReceiverBuffer<'a, W> {
+    fn new(...) -> Self {
+        Self {
+            buffer: Vec::with_capacity(MAX_BUFFER_LENGTH),
+            // ...
+        }
+    }
+}
+```
+
+## When to Skip
+
+```rust
+// Unknown size, small expected
+let mut small: Vec<i32> = Vec::new();  // OK for small collections
+
+// Using collect() with good size_hint
+let v: Vec<_> = iter.collect();  // collect() uses size_hint
+
+// Capacity overhead exceeds benefit
+let mut rarely_used = Vec::new();  // OK if rarely grown
+```
+
+## See Also
+
+- [mem-reuse-collections](mem-reuse-collections.md) - Reuse collections with clear()
+- [mem-smallvec](mem-smallvec.md) - Use SmallVec for usually-small collections
+- [perf-extend-batch](perf-extend-batch.md) - Use extend() for batch insertions

--- a/.agents/skills/rust-skills/rules/mem-write-over-format.md
+++ b/.agents/skills/rust-skills/rules/mem-write-over-format.md
@@ -1,0 +1,172 @@
+# mem-write-over-format
+
+> Use `write!()` into existing buffers instead of `format!()` allocations
+
+## Why It Matters
+
+`format!()` always allocates a new `String`. In hot paths or loops, these allocations add up. `write!()` writes directly into an existing buffer, reusing its capacity. For high-frequency formatting operations, this can eliminate significant allocator overhead.
+
+## Bad
+
+```rust
+fn log_event(event: &Event, output: &mut Vec<u8>) {
+    // format! allocates a new String every call
+    let line = format!(
+        "[{}] {}: {}\n",
+        event.timestamp,
+        event.level,
+        event.message
+    );
+    output.extend_from_slice(line.as_bytes());
+}
+
+fn build_response(items: &[Item]) -> String {
+    let mut result = String::new();
+    
+    for item in items {
+        // format! allocates for each item
+        result.push_str(&format!("{}: {}\n", item.name, item.value));
+    }
+    
+    result
+}
+```
+
+## Good
+
+```rust
+use std::fmt::Write;
+
+fn log_event(event: &Event, output: &mut Vec<u8>) {
+    use std::io::Write;
+    // write! to Vec<u8> directly, no intermediate allocation
+    write!(
+        output,
+        "[{}] {}: {}\n",
+        event.timestamp,
+        event.level,
+        event.message
+    ).unwrap();
+}
+
+fn build_response(items: &[Item]) -> String {
+    use std::fmt::Write;
+    
+    let mut result = String::with_capacity(items.len() * 64);
+    
+    for item in items {
+        // write! into existing String, reuses capacity
+        write!(&mut result, "{}: {}\n", item.name, item.value).unwrap();
+    }
+    
+    result
+}
+```
+
+## Write Trait Varieties
+
+```rust
+// std::fmt::Write - for String, &mut String
+use std::fmt::Write as FmtWrite;
+let mut s = String::new();
+write!(&mut s, "Hello {}", 42).unwrap();
+
+// std::io::Write - for Vec<u8>, File, TcpStream, etc.
+use std::io::Write as IoWrite;
+let mut v: Vec<u8> = Vec::new();
+write!(&mut v, "Hello {}", 42).unwrap();
+
+// Both can fail in principle, but String/Vec never fail
+// Still need .unwrap() due to Result return type
+```
+
+## Reusable Formatting Buffer
+
+```rust
+use std::fmt::Write;
+
+struct Formatter {
+    buffer: String,
+}
+
+impl Formatter {
+    fn new() -> Self {
+        Self { buffer: String::with_capacity(1024) }
+    }
+    
+    fn format_event(&mut self, event: &Event) -> &str {
+        self.buffer.clear();  // Reuse allocation
+        write!(
+            &mut self.buffer, 
+            "[{}] {}",
+            event.timestamp, 
+            event.message
+        ).unwrap();
+        &self.buffer
+    }
+}
+
+// Usage
+let mut formatter = Formatter::new();
+for event in events {
+    let formatted = formatter.format_event(event);
+    send_log(formatted);
+}
+```
+
+## writeln! for Lines
+
+```rust
+use std::fmt::Write;
+
+let mut output = String::new();
+
+// writeln! adds newline automatically
+writeln!(&mut output, "Line 1: {}", value1).unwrap();
+writeln!(&mut output, "Line 2: {}", value2).unwrap();
+
+// Equivalent to
+write!(&mut output, "Line 1: {}\n", value1).unwrap();
+```
+
+## When format! Is Fine
+
+```rust
+// One-time formatting, not in loop
+let message = format!("Starting server on port {}", port);
+log::info!("{}", message);
+
+// Return value (can't return reference to local buffer)
+fn describe(item: &Item) -> String {
+    format!("{}: {}", item.name, item.value)  // Must allocate
+}
+
+// Debug/error paths (not hot)
+if condition {
+    panic!("Unexpected: {}", format!("details: {:?}", debug_info));
+}
+```
+
+## Benchmark Difference
+
+```rust
+// format! in loop: ~500ns per iteration (allocation heavy)
+for i in 0..1000 {
+    let s = format!("item-{}", i);
+    process(&s);
+}
+
+// write! with reuse: ~50ns per iteration (no allocation)
+let mut buf = String::with_capacity(32);
+for i in 0..1000 {
+    buf.clear();
+    write!(&mut buf, "item-{}", i).unwrap();
+    process(&buf);
+}
+```
+
+## See Also
+
+- [mem-avoid-format](./mem-avoid-format.md) - General format! avoidance patterns
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing buffers in loops
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocating string capacity

--- a/.agents/skills/rust-skills/rules/mem-zero-copy.md
+++ b/.agents/skills/rust-skills/rules/mem-zero-copy.md
@@ -1,0 +1,164 @@
+# mem-zero-copy
+
+> Use zero-copy patterns with slices and `Bytes`
+
+## Why It Matters
+
+Zero-copy means working with data without copying it. Instead of allocating new memory and copying bytes, you work with references to the original data. This dramatically reduces memory usage and improves performance, especially for large data.
+
+## Bad
+
+```rust
+// Copies every line into a new String
+fn get_lines(data: &str) -> Vec<String> {
+    data.lines()
+        .map(|line| line.to_string())  // Allocates!
+        .collect()
+}
+
+// Copies the entire buffer
+fn process_packet(buffer: &[u8]) -> Vec<u8> {
+    let header = buffer[0..16].to_vec();  // Copy!
+    let body = buffer[16..].to_vec();      // Copy!
+    // Process...
+    [header, body].concat()  // Another copy!
+}
+```
+
+## Good
+
+```rust
+// Zero-copy: returns references to original data
+fn get_lines(data: &str) -> Vec<&str> {
+    data.lines().collect()  // Just pointers!
+}
+
+// Zero-copy with slices
+fn process_packet(buffer: &[u8]) -> (&[u8], &[u8]) {
+    let header = &buffer[0..16];  // Just a pointer + length
+    let body = &buffer[16..];     // Just a pointer + length
+    (header, body)
+}
+```
+
+## Using bytes::Bytes
+
+```rust
+use bytes::Bytes;
+
+// Bytes provides zero-copy slicing with reference counting
+let data = Bytes::from("hello world");
+
+// Slicing doesn't copy - just increments refcount
+let hello = data.slice(0..5);   // Zero-copy!
+let world = data.slice(6..11); // Zero-copy!
+
+// Both hello and world share the underlying allocation
+// Memory is freed when all references are dropped
+```
+
+## Real-World Pattern from Deno
+
+```rust
+// https://github.com/denoland/deno/blob/main/ext/http/lib.rs
+fn method_to_cow(method: &http::Method) -> Cow<'static, str> {
+    match *method {
+        Method::GET => Cow::Borrowed("GET"),      // Zero-copy
+        Method::POST => Cow::Borrowed("POST"),    // Zero-copy
+        Method::PUT => Cow::Borrowed("PUT"),      // Zero-copy
+        _ => Cow::Owned(method.to_string()),      // Only copies for rare methods
+    }
+}
+```
+
+## Zero-Copy Parsing
+
+```rust
+// Bad: Copies each parsed field
+struct ParsedBad {
+    name: String,
+    value: String,
+}
+
+fn parse_bad(input: &str) -> ParsedBad {
+    let (name, value) = input.split_once('=').unwrap();
+    ParsedBad {
+        name: name.to_string(),   // Copy!
+        value: value.to_string(), // Copy!
+    }
+}
+
+// Good: References into original string
+struct Parsed<'a> {
+    name: &'a str,
+    value: &'a str,
+}
+
+fn parse_good(input: &str) -> Parsed<'_> {
+    let (name, value) = input.split_once('=').unwrap();
+    Parsed { name, value }  // Zero-copy!
+}
+```
+
+## Combining with Cow
+
+```rust
+use std::borrow::Cow;
+
+// Zero-copy when possible, copy when needed
+fn normalize<'a>(input: &'a str) -> Cow<'a, str> {
+    if input.contains('\t') {
+        // Must copy to modify
+        Cow::Owned(input.replace('\t', "    "))
+    } else {
+        // Zero-copy reference
+        Cow::Borrowed(input)
+    }
+}
+```
+
+## memchr for Fast Searching
+
+```rust
+use memchr::memchr;
+
+// Fast byte search using SIMD
+fn find_newline(data: &[u8]) -> Option<usize> {
+    memchr(b'\n', data)  // SIMD-accelerated, no allocation
+}
+
+// Find all occurrences
+use memchr::memchr_iter;
+
+fn count_newlines(data: &[u8]) -> usize {
+    memchr_iter(b'\n', data).count()
+}
+```
+
+## When Zero-Copy Isn't Possible
+
+```rust
+// Need to modify data - must copy
+fn uppercase(s: &str) -> String {
+    s.to_uppercase()  // Creates new String
+}
+
+// Need data to outlive source
+fn store_for_later(s: &str) -> String {
+    s.to_string()  // Must copy for ownership
+}
+
+// Cross-thread transfer (without Arc)
+fn send_to_thread(data: &[u8]) {
+    let owned = data.to_vec();  // Must copy
+    std::thread::spawn(move || {
+        process(&owned);
+    });
+}
+```
+
+## See Also
+
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for conditional ownership
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning
+- [mem-arena-allocator](mem-arena-allocator.md) - Arena allocators for batch operations

--- a/.agents/skills/rust-skills/rules/name-acronym-word.md
+++ b/.agents/skills/rust-skills/rules/name-acronym-word.md
@@ -1,0 +1,99 @@
+# name-acronym-word
+
+> Treat acronyms as words in identifiers: `HttpServer`, not `HTTPServer`
+
+## Why It Matters
+
+When acronyms are written in ALL CAPS within identifiers, word boundaries become unclear: is `HTTPSHandler` "HTTPS Handler" or "HTTP SHandler"? Treating acronyms as words (`HttpsHandler`) maintains clear word boundaries and follows Rust convention. The standard library uses this consistently.
+
+## Bad
+
+```rust
+// ALL CAPS acronyms - unclear word boundaries
+struct HTTPServer { ... }      // HTTP + Server or H + TTP + Server?
+struct TCPIPConnection { ... } // TCP + IP? Or other splits?
+struct JSONParser { ... }
+struct XMLHTTPRequest { ... }  // Very confusing
+
+fn parseJSON(input: &str) { ... }
+fn connectTCP(addr: &str) { ... }
+```
+
+## Good
+
+```rust
+// Acronyms as words - clear boundaries
+struct HttpServer { ... }      // Http + Server
+struct TcpIpConnection { ... } // Tcp + Ip + Connection
+struct JsonParser { ... }
+struct XmlHttpRequest { ... }
+
+fn parse_json(input: &str) { ... }
+fn connect_tcp(addr: &str) { ... }
+
+// More examples
+struct Uuid { ... }            // Not UUID
+struct Uri { ... }             // Not URI
+struct Url { ... }             // Not URL
+struct Html { ... }            // Not HTML
+struct Css { ... }             // Not CSS
+struct Api { ... }             // Not API
+```
+
+## Standard Library Examples
+
+```rust
+// std uses acronyms as words
+std::net::TcpStream            // Not TCPStream
+std::net::TcpListener          // Not TCPListener
+std::net::UdpSocket            // Not UDPSocket
+std::net::IpAddr               // Not IPAddr
+std::io::IoError               // Not IOError (though Io is acceptable too)
+```
+
+## Two-Letter Acronyms
+
+```rust
+// Two-letter acronyms can go either way
+struct Io { ... }    // or IO - both acceptable
+struct Id { ... }    // or ID - both acceptable
+
+// Preference: treat as word for consistency
+struct IoHandler { ... }     // Preferred
+struct IdGenerator { ... }   // Preferred
+```
+
+## In snake_case
+
+```rust
+// Acronyms become lowercase in snake_case
+fn parse_json() { ... }
+fn connect_tcp() { ... }
+fn generate_uuid() { ... }
+fn fetch_http() { ... }
+fn encode_url() { ... }
+
+// Variables
+let json_response = fetch_json();
+let tcp_connection = connect_tcp();
+let user_id = generate_uuid();
+```
+
+## Mixed Cases
+
+```rust
+// When acronym is part of compound
+struct HttpsConnection { ... }   // Https (not HTTPS)
+struct Utf8String { ... }        // Utf8 (not UTF8)
+struct Base64Encoder { ... }     // Base64 as word
+
+// Multiple acronyms
+struct JsonApiClient { ... }     // Json + Api + Client
+struct RestApiHandler { ... }    // Rest + Api + Handler
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming conventions
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming conventions
+- [name-consts-screaming](./name-consts-screaming.md) - Constant naming

--- a/.agents/skills/rust-skills/rules/name-as-free.md
+++ b/.agents/skills/rust-skills/rules/name-as-free.md
@@ -1,0 +1,104 @@
+# name-as-free
+
+> `as_` prefix: free reference conversion
+
+## Why It Matters
+
+Consistent naming helps users understand API cost. `as_` prefix signals a free (O(1), no allocation) conversion that returns a reference. This convention is used throughout the standard library.
+
+## The Convention
+
+| Prefix | Cost | Ownership | Example |
+|--------|------|-----------|---------|
+| `as_` | Free | `&T -> &U` | `str::as_bytes()` |
+| `to_` | Expensive | `&T -> U` | `str::to_lowercase()` |
+| `into_` | Variable | `T -> U` | `String::into_bytes()` |
+
+## Examples
+
+```rust
+impl MyString {
+    // as_ - free reference conversion
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+    
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl Wrapper<T> {
+    // as_ - returns reference to inner
+    pub fn as_inner(&self) -> &T {
+        &self.inner
+    }
+    
+    pub fn as_inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// String
+let s = String::from("hello");
+let bytes: &[u8] = s.as_bytes();    // Free, returns &[u8]
+let str_ref: &str = s.as_str();     // Free, returns &str
+
+// Vec
+let v = vec![1, 2, 3];
+let slice: &[i32] = v.as_slice();   // Free, returns &[i32]
+
+// Path
+let p = PathBuf::from("/home");
+let path: &Path = p.as_path();      // Free, returns &Path
+
+// OsString
+let os = OsString::from("hello");
+let os_str: &OsStr = os.as_os_str(); // Free, returns &OsStr
+```
+
+## Bad
+
+```rust
+impl MyType {
+    // BAD: as_ but allocates
+    pub fn as_string(&self) -> String {
+        format!("{}", self.value)  // Allocates! Should be to_string()
+    }
+    
+    // BAD: as_ but expensive
+    pub fn as_processed(&self) -> &ProcessedData {
+        // Actually does expensive computation
+    }
+}
+```
+
+## Good
+
+```rust
+impl MyType {
+    // GOOD: Free reference
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+    
+    // GOOD: to_ signals allocation
+    pub fn to_string(&self) -> String {
+        format!("{}", self.value)
+    }
+    
+    // GOOD: into_ signals ownership transfer
+    pub fn into_inner(self) -> Inner {
+        self.inner
+    }
+}
+```
+
+## See Also
+
+- [name-to-expensive](name-to-expensive.md) - `to_` prefix for expensive conversions
+- [name-into-ownership](name-into-ownership.md) - `into_` prefix for ownership transfer

--- a/.agents/skills/rust-skills/rules/name-consts-screaming.md
+++ b/.agents/skills/rust-skills/rules/name-consts-screaming.md
@@ -1,0 +1,94 @@
+# name-consts-screaming
+
+> Use `SCREAMING_SNAKE_CASE` for constants and statics
+
+## Why It Matters
+
+Constants and statics are special—they're known at compile time and have program-wide lifetime. `SCREAMING_SNAKE_CASE` makes them visually distinct from runtime variables. This convention is enforced by the compiler and universally expected.
+
+## Bad
+
+```rust
+// lowercase/camelCase constants - compiler warns
+const maxConnections: u32 = 100;  // warning
+const default_timeout: u64 = 30;  // warning
+static globalCounter: AtomicU64 = AtomicU64::new(0);  // warning
+```
+
+## Good
+
+```rust
+// SCREAMING_SNAKE_CASE for constants
+const MAX_CONNECTIONS: u32 = 100;
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+const BUFFER_SIZE: usize = 4096;
+
+// SCREAMING_SNAKE_CASE for statics
+static GLOBAL_COUNTER: AtomicU64 = AtomicU64::new(0);
+static CONFIG: OnceLock<Config> = OnceLock::new();
+
+// Type-level constants in impl blocks
+impl Buffer {
+    const INITIAL_CAPACITY: usize = 1024;
+    const MAX_CAPACITY: usize = 1024 * 1024;
+}
+```
+
+## Associated Constants
+
+```rust
+trait Limit {
+    const MAX: usize;
+    const MIN: usize;
+}
+
+impl Limit for SmallBuffer {
+    const MAX: usize = 256;
+    const MIN: usize = 16;
+}
+
+// Generic associated constants
+struct Container<T> {
+    data: Vec<T>,
+}
+
+impl<T> Container<T> {
+    const EMPTY: Self = Self { data: Vec::new() };
+}
+```
+
+## Environment and Config
+
+```rust
+// Environment variable names
+const ENV_DATABASE_URL: &str = "DATABASE_URL";
+const ENV_LOG_LEVEL: &str = "LOG_LEVEL";
+
+// Configuration keys
+const CONFIG_TIMEOUT_SECONDS: &str = "timeout_seconds";
+const CONFIG_MAX_RETRIES: &str = "max_retries";
+```
+
+## Lazy Static / OnceLock
+
+```rust
+use std::sync::OnceLock;
+
+// Global configuration
+static CONFIG: OnceLock<AppConfig> = OnceLock::new();
+
+// Compiled regex
+static EMAIL_REGEX: OnceLock<Regex> = OnceLock::new();
+
+fn get_email_regex() -> &'static Regex {
+    EMAIL_REGEX.get_or_init(|| {
+        Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap()
+    })
+}
+```
+
+## See Also
+
+- [name-funcs-snake](./name-funcs-snake.md) - Function/variable naming
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [type-newtype-ids](./type-newtype-ids.md) - Type-safe constants

--- a/.agents/skills/rust-skills/rules/name-crate-no-rs.md
+++ b/.agents/skills/rust-skills/rules/name-crate-no-rs.md
@@ -1,0 +1,78 @@
+# name-crate-no-rs
+
+> Don't suffix crate names with `-rs` or `-rust`
+
+## Why It Matters
+
+Adding `-rs` or `-rust` to crate names is redundant—you're already on crates.io, it's obviously Rust. These suffixes waste characters, clutter the namespace, and can make crate names harder to type. The Rust community discourages this pattern.
+
+## Bad
+
+```toml
+# Cargo.toml
+[package]
+name = "json-parser-rs"    # Redundant -rs
+name = "my-lib-rust"       # Redundant -rust
+name = "http-client-rs"    # We know it's Rust
+name = "rust-sqlite"       # rust- prefix equally bad
+```
+
+## Good
+
+```toml
+# Cargo.toml
+[package]
+name = "json-parser"
+name = "my-lib"
+name = "http-client"
+name = "sqlite-wrapper"
+
+# Real crate examples (no -rs):
+# serde (not serde-rs)
+# tokio (not tokio-rs)
+# reqwest (not reqwest-rs)
+# clap (not clap-rs)
+```
+
+## When Context Is Needed
+
+```toml
+# If you're porting a library from another language:
+name = "python-ast"        # Describes what it's for, not what it's written in
+
+# If you're providing bindings:
+name = "openssl"           # The Rust crate IS the Rust interface
+
+# Platform-specific:
+name = "windows-sys"       # Platform, not language
+```
+
+## Repository Naming
+
+```
+# GitHub repos don't need -rs either
+github.com/user/my-library      # Good
+github.com/user/my-library-rs   # Unnecessary
+
+# Though some do for disambiguation from other language versions
+github.com/rust-lang/rust       # The rust repo itself uses "rust"
+```
+
+## Exceptions
+
+```toml
+# Rare cases where disambiguation matters:
+# - If there's a widely-known non-Rust project with the same name
+# - Official Rust project repositories (rust-lang org)
+
+# But even then, consider alternatives:
+name = "fancy-lib"           # Instead of fancy-rs
+name = "better-json"         # Instead of json-rust
+name = "my-serde-impl"       # Instead of serde-rs-fork
+```
+
+## See Also
+
+- [proj-workspace-deps](./proj-workspace-deps.md) - Cargo configuration
+- [doc-cargo-metadata](./doc-cargo-metadata.md) - Package metadata
+- [name-funcs-snake](./name-funcs-snake.md) - Naming conventions

--- a/.agents/skills/rust-skills/rules/name-funcs-snake.md
+++ b/.agents/skills/rust-skills/rules/name-funcs-snake.md
@@ -1,0 +1,76 @@
+# name-funcs-snake
+
+> Use `snake_case` for functions, methods, variables, and modules
+
+## Why It Matters
+
+Rust uses `snake_case` for "value-level" names—functions, methods, variables, modules. This convention is enforced by the compiler and distinguishes runtime entities from types. Consistent naming makes code scannable and predictable.
+
+## Bad
+
+```rust
+// CamelCase functions - compiler warns
+fn calculateTotal() -> f64 { ... }  // warning: function `calculateTotal` should have a snake case name
+fn getUserName() -> String { ... }  // warning
+
+// Inconsistent naming
+fn get_user() -> User { ... }
+fn fetchOrder() -> Order { ... }  // Mixed conventions
+```
+
+## Good
+
+```rust
+// snake_case for functions
+fn calculate_total() -> f64 { ... }
+fn get_user_name() -> String { ... }
+fn fetch_order() -> Order { ... }
+
+// snake_case for methods
+impl User {
+    fn full_name(&self) -> String { ... }
+    fn is_active(&self) -> bool { ... }
+    fn set_email(&mut self, email: &str) { ... }
+}
+
+// snake_case for variables
+let user_count = 42;
+let max_connections = 100;
+let is_valid = true;
+
+// snake_case for modules
+mod user_service;
+mod http_client;
+mod json_parser;
+```
+
+## Acronyms in snake_case
+
+```rust
+// Lowercase acronyms in snake_case
+fn parse_json() -> Json { ... }   // Not parse_JSON
+fn connect_tcp() -> TcpStream { ... }   // Not connect_TCP
+fn generate_uuid() -> Uuid { ... }      // Not generate_UUID
+
+let http_response = fetch();
+let json_data = parse();
+```
+
+## Local Variables
+
+```rust
+fn process_data(input_data: &[u8]) -> Result<Output, Error> {
+    let raw_bytes = input_data;
+    let decoded_string = decode(raw_bytes)?;
+    let parsed_value = parse(&decoded_string)?;
+    let final_result = transform(parsed_value)?;
+    
+    Ok(final_result)
+}
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [name-consts-screaming](./name-consts-screaming.md) - Constant naming
+- [name-lifetime-short](./name-lifetime-short.md) - Lifetime naming

--- a/.agents/skills/rust-skills/rules/name-into-ownership.md
+++ b/.agents/skills/rust-skills/rules/name-into-ownership.md
@@ -1,0 +1,123 @@
+# name-into-ownership
+
+> Use `into_` prefix for ownership-consuming conversions
+
+## Why It Matters
+
+The `into_` prefix signals "this method consumes self and returns something else." The original value is moved and no longer usable. This ownership transfer is usually cheap (no allocation), but the caller loses access to the original. Clear naming prevents "use after move" confusion.
+
+## Bad
+
+```rust
+impl Wrapper {
+    // Misleading: doesn't indicate ownership transfer
+    fn get_inner(self) -> Inner {  
+        self.inner
+    }
+    
+    // Misleading: suggests borrowing
+    fn as_inner(self) -> Inner {  // Takes self by value!
+        self.inner
+    }
+}
+```
+
+## Good
+
+```rust
+impl Wrapper {
+    // into_ clearly shows ownership transfer
+    fn into_inner(self) -> Inner {
+        self.inner
+    }
+}
+
+// Usage is clear
+let wrapper = Wrapper::new(inner);
+let inner = wrapper.into_inner();  // wrapper is consumed
+// wrapper.foo();  // Error: use of moved value
+```
+
+## Standard Library Examples
+
+```rust
+// All consume self and return owned data
+let string: String = "hello".to_string();
+let bytes: Vec<u8> = string.into_bytes();  // String consumed
+
+let path = PathBuf::from("/foo");
+let os_string: OsString = path.into_os_string();  // PathBuf consumed
+
+let boxed: Box<[i32]> = vec![1, 2, 3].into_boxed_slice();  // Vec consumed
+
+let vec: Vec<u8> = boxed.into_vec();  // Box consumed
+```
+
+## into_iter() Pattern
+
+```rust
+let vec = vec![1, 2, 3];
+
+// into_iter consumes the collection
+for item in vec.into_iter() {  // or just: for item in vec
+    // item is i32, not &i32
+}
+// vec is consumed, can't use anymore
+
+// Contrast with iter() which borrows
+let vec = vec![1, 2, 3];
+for item in vec.iter() {
+    // item is &i32
+}
+// vec still usable
+```
+
+## IntoIterator Trait
+
+```rust
+impl IntoIterator for MyCollection {
+    type Item = Element;
+    type IntoIter = std::vec::IntoIter<Element>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.into_iter()  // Consumes self
+    }
+}
+```
+
+## Conversion Prefix Summary
+
+```rust
+struct Buffer {
+    data: Vec<u8>,
+    name: String,
+}
+
+impl Buffer {
+    // as_ : free borrow, returns reference
+    fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+    
+    // to_ : allocates, creates new value
+    fn to_vec(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+    
+    // into_ : consumes self, usually cheap
+    fn into_inner(self) -> Vec<u8> {
+        self.data
+    }
+    
+    // into_ : can destructure into parts
+    fn into_parts(self) -> (Vec<u8>, String) {
+        (self.data, self.name)
+    }
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Borrowing conversions
+- [name-to-expensive](./name-to-expensive.md) - Allocating conversions
+- [api-from-not-into](./api-from-not-into.md) - From trait implementation

--- a/.agents/skills/rust-skills/rules/name-is-has-bool.md
+++ b/.agents/skills/rust-skills/rules/name-is-has-bool.md
@@ -1,0 +1,127 @@
+# name-is-has-bool
+
+> Use `is_`, `has_`, `can_`, `should_` prefixes for boolean-returning methods
+
+## Why It Matters
+
+Boolean methods answer yes/no questions. Prefixes like `is_`, `has_`, `can_` make the question explicit, so code reads naturally: `if user.is_active()`, `if buffer.has_remaining()`. Without prefixes, boolean methods are ambiguous and require reading documentation.
+
+## Bad
+
+```rust
+impl User {
+    // Unclear: does this check or set?
+    fn active(&self) -> bool { ... }
+    
+    // Unclear: does this delete or check?
+    fn deleted(&self) -> bool { ... }
+    
+    // Unclear return type
+    fn admin(&self) -> bool { ... }
+}
+
+// Reading code is confusing
+if user.active() { ... }  // Is this checking or activating?
+```
+
+## Good
+
+```rust
+impl User {
+    // Clear: answers "is the user active?"
+    fn is_active(&self) -> bool { ... }
+    
+    // Clear: answers "is the user deleted?"
+    fn is_deleted(&self) -> bool { ... }
+    
+    // Clear: answers "is the user an admin?"
+    fn is_admin(&self) -> bool { ... }
+    
+    // Clear: answers "does the user have permission X?"
+    fn has_permission(&self, perm: Permission) -> bool { ... }
+    
+    // Clear: answers "can the user edit?"
+    fn can_edit(&self) -> bool { ... }
+}
+
+// Reads naturally
+if user.is_active() && user.has_permission(Permission::Write) {
+    // ...
+}
+```
+
+## Common Prefixes
+
+| Prefix | Use For | Example |
+|--------|---------|---------|
+| `is_` | State/property check | `is_empty()`, `is_valid()`, `is_some()` |
+| `has_` | Possession/containment | `has_key()`, `has_children()`, `has_remaining()` |
+| `can_` | Capability/permission | `can_read()`, `can_write()`, `can_execute()` |
+| `should_` | Recommendation/policy | `should_retry()`, `should_cache()` |
+| `needs_` | Requirement | `needs_update()`, `needs_auth()` |
+| `will_` | Future action | `will_block()`, `will_overflow()` |
+
+## Standard Library Examples
+
+```rust
+// is_ prefix
+vec.is_empty()
+option.is_some()
+option.is_none()
+result.is_ok()
+result.is_err()
+char.is_alphabetic()
+str.is_ascii()
+path.is_file()
+path.is_dir()
+
+// has_ prefix (less common in std)
+iterator.has_next()  // conceptual
+
+// Checking methods
+str.contains("foo")      // Not is_ because takes argument
+str.starts_with("bar")   // Descriptive verb phrase
+str.ends_with("baz")
+```
+
+## Negation
+
+```rust
+// Prefer positive form with caller negation
+if !user.is_active() { ... }
+
+// Rather than negative method
+if user.is_inactive() { ... }  // Avoid double negatives: !is_inactive()
+
+// Exception: when negative is the common case
+fn is_empty(&self) -> bool { ... }     // Checking for empty is common
+fn is_not_empty(&self) -> bool { ... } // Rarely needed, use !is_empty()
+```
+
+## Boolean Fields
+
+```rust
+struct Config {
+    // Field names can omit prefix
+    enabled: bool,
+    verbose: bool,
+    debug: bool,
+}
+
+impl Config {
+    // But methods should have prefix
+    fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+    
+    fn is_verbose(&self) -> bool {
+        self.verbose
+    }
+}
+```
+
+## See Also
+
+- [name-no-get-prefix](./name-no-get-prefix.md) - Getter naming
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming
+- [api-must-use](./api-must-use.md) - Boolean functions should be checked

--- a/.agents/skills/rust-skills/rules/name-iter-convention.md
+++ b/.agents/skills/rust-skills/rules/name-iter-convention.md
@@ -1,0 +1,129 @@
+# name-iter-convention
+
+> Use iter/iter_mut/into_iter for iterator methods
+
+## Why It Matters
+
+Rust has a standard convention for iterator method names that signals ownership semantics. Following this convention makes APIs predictable and enables the `for item in collection` syntax to work correctly.
+
+## The Three Iterator Methods
+
+| Method | Returns | Ownership |
+|--------|---------|-----------|
+| `iter()` | `impl Iterator<Item = &T>` | Borrows collection |
+| `iter_mut()` | `impl Iterator<Item = &mut T>` | Mutably borrows |
+| `into_iter()` | `impl Iterator<Item = T>` | Consumes collection |
+
+## Implementation
+
+```rust
+struct MyCollection<T> {
+    items: Vec<T>,
+}
+
+impl<T> MyCollection<T> {
+    /// Returns an iterator over references.
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    /// Returns an iterator over mutable references.
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.items.iter_mut()
+    }
+}
+
+// IntoIterator trait for into_iter()
+impl<T> IntoIterator for MyCollection<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+// Also implement for references
+impl<'a, T> IntoIterator for &'a MyCollection<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MyCollection<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter_mut()
+    }
+}
+```
+
+## Usage
+
+```rust
+let collection = MyCollection { items: vec![1, 2, 3] };
+
+// Explicit methods
+for x in collection.iter() { }     // Borrows
+for x in collection.iter_mut() { } // Mutably borrows
+
+// IntoIterator enables for loop syntax
+for x in &collection { }      // Calls (&collection).into_iter()
+for x in &mut collection { }  // Calls (&mut collection).into_iter()
+for x in collection { }       // Consumes, calls collection.into_iter()
+```
+
+## Bad
+
+```rust
+impl MyCollection<T> {
+    // Non-standard names
+    fn elements(&self) -> impl Iterator<Item = &T> { }      // Should be iter()
+    fn get_items(&self) -> impl Iterator<Item = &T> { }     // Should be iter()
+    fn iterate(&self) -> impl Iterator<Item = &T> { }       // Should be iter()
+    fn as_iter(&self) -> impl Iterator<Item = &T> { }       // Should be iter()
+}
+```
+
+## Additional Iterator Methods
+
+```rust
+impl MyCollection<T> {
+    // Filter by predicate
+    fn iter_valid(&self) -> impl Iterator<Item = &T> {
+        self.iter().filter(|x| x.is_valid())
+    }
+    
+    // Specific slice
+    fn iter_range(&self, start: usize, end: usize) -> impl Iterator<Item = &T> {
+        self.items[start..end].iter()
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// Vec, slice, arrays
+vec.iter()      // &T
+vec.iter_mut()  // &mut T
+vec.into_iter() // T
+
+// HashMap
+map.iter()      // (&K, &V)
+map.iter_mut()  // (&K, &mut V)
+map.into_iter() // (K, V)
+map.keys()      // &K
+map.values()    // &V
+```
+
+## See Also
+
+- [name-iter-type-match](./name-iter-type-match.md) - Iterator type naming
+- [name-iter-method](./name-iter-method.md) - Iterator method names
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators

--- a/.agents/skills/rust-skills/rules/name-iter-method.md
+++ b/.agents/skills/rust-skills/rules/name-iter-method.md
@@ -1,0 +1,131 @@
+# name-iter-method
+
+> Name iterator methods `iter()`, `iter_mut()`, and `into_iter()` consistently
+
+## Why It Matters
+
+Rust has a strong convention for iterator method names. Following these conventions makes your types work predictably with `for` loops and iterator adapters. Users expect `iter()` for shared references, `iter_mut()` for mutable references, and `into_iter()` for owned iteration.
+
+## Bad
+
+```rust
+struct Collection<T> {
+    items: Vec<T>,
+}
+
+impl<T> Collection<T> {
+    // Non-standard names - confusing
+    fn elements(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    fn get_iterator(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    fn to_iter(self) -> impl Iterator<Item = T> {
+        self.items.into_iter()
+    }
+}
+```
+
+## Good
+
+```rust
+struct Collection<T> {
+    items: Vec<T>,
+}
+
+impl<T> Collection<T> {
+    /// Returns an iterator over references.
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+    
+    /// Returns an iterator over mutable references.
+    fn iter_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.items.iter_mut()
+    }
+}
+
+// Implement IntoIterator for for-loop support
+impl<T> IntoIterator for Collection<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Collection<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Collection<T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+    
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter_mut()
+    }
+}
+```
+
+## Iterator Convention Summary
+
+| Method | Receiver | Yields | Use Case |
+|--------|----------|--------|----------|
+| `iter()` | `&self` | `&T` | Read-only iteration |
+| `iter_mut()` | `&mut self` | `&mut T` | In-place modification |
+| `into_iter()` | `self` | `T` | Consuming iteration |
+
+## For Loop Integration
+
+```rust
+let col = Collection { items: vec![1, 2, 3] };
+
+// These all work with proper IntoIterator impls
+for item in &col {           // Calls (&col).into_iter() -> iter()
+    println!("{}", item);    // &i32
+}
+
+for item in &mut col {       // Calls (&mut col).into_iter() -> iter_mut()
+    *item += 1;              // &mut i32
+}
+
+for item in col {            // Calls col.into_iter()
+    process(item);           // i32, consumes col
+}
+```
+
+## Additional Iterator Methods
+
+```rust
+impl<T> Collection<T> {
+    // Domain-specific iterators follow similar patterns
+    
+    /// Iterates over keys (for map-like structures).
+    fn keys(&self) -> impl Iterator<Item = &K> { ... }
+    
+    /// Iterates over values.
+    fn values(&self) -> impl Iterator<Item = &V> { ... }
+    
+    /// Iterates over mutable values.
+    fn values_mut(&mut self) -> impl Iterator<Item = &mut V> { ... }
+    
+    /// Drains elements, leaving container empty.
+    fn drain(&mut self) -> impl Iterator<Item = T> { ... }
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Conversion naming conventions
+- [api-extension-trait](./api-extension-trait.md) - Iterator extensions
+- [api-common-traits](./api-common-traits.md) - Standard trait implementations

--- a/.agents/skills/rust-skills/rules/name-iter-type-match.md
+++ b/.agents/skills/rust-skills/rules/name-iter-type-match.md
@@ -1,0 +1,142 @@
+# name-iter-type-match
+
+> Name iterator types after their source method
+
+## Why It Matters
+
+Iterator types should match the method that creates them. `iter()` returns `Iter`, `into_iter()` returns `IntoIter`, `keys()` returns `Keys`. This naming pattern is established by the standard library and makes types predictable.
+
+## Standard Library Pattern
+
+```rust
+// Vec
+impl<T> Vec<T> {
+    fn iter(&self) -> Iter<'_, T> { }       // Returns Iter
+    fn iter_mut(&mut self) -> IterMut<'_, T> { }  // Returns IterMut
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type IntoIter = IntoIter<T>;  // Returns IntoIter
+}
+
+// HashMap
+impl<K, V> HashMap<K, V> {
+    fn iter(&self) -> Iter<'_, K, V> { }
+    fn keys(&self) -> Keys<'_, K, V> { }    // Returns Keys
+    fn values(&self) -> Values<'_, K, V> { }  // Returns Values
+    fn drain(&mut self) -> Drain<'_, K, V> { }  // Returns Drain
+}
+```
+
+## Implementation
+
+```rust
+mod my_collection {
+    pub struct MyCollection<T> {
+        items: Vec<T>,
+    }
+    
+    // Iterator types in same module
+    pub struct Iter<'a, T> {
+        inner: std::slice::Iter<'a, T>,
+    }
+    
+    pub struct IterMut<'a, T> {
+        inner: std::slice::IterMut<'a, T>,
+    }
+    
+    pub struct IntoIter<T> {
+        inner: std::vec::IntoIter<T>,
+    }
+    
+    impl<T> MyCollection<T> {
+        pub fn iter(&self) -> Iter<'_, T> {
+            Iter { inner: self.items.iter() }
+        }
+        
+        pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+            IterMut { inner: self.items.iter_mut() }
+        }
+    }
+    
+    impl<T> IntoIterator for MyCollection<T> {
+        type Item = T;
+        type IntoIter = IntoIter<T>;
+        
+        fn into_iter(self) -> IntoIter<T> {
+            IntoIter { inner: self.items.into_iter() }
+        }
+    }
+    
+    // Implement Iterator for each type
+    impl<'a, T> Iterator for Iter<'a, T> {
+        type Item = &'a T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+    
+    impl<'a, T> Iterator for IterMut<'a, T> {
+        type Item = &'a mut T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+    
+    impl<T> Iterator for IntoIter<T> {
+        type Item = T;
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+    }
+}
+```
+
+## Naming Convention
+
+| Method | Iterator Type |
+|--------|---------------|
+| `iter()` | `Iter` |
+| `iter_mut()` | `IterMut` |
+| `into_iter()` | `IntoIter` |
+| `keys()` | `Keys` |
+| `values()` | `Values` |
+| `values_mut()` | `ValuesMut` |
+| `drain()` | `Drain` |
+| `chunks()` | `Chunks` |
+| `windows()` | `Windows` |
+
+## Custom Iterator Methods
+
+```rust
+impl Graph {
+    // Method name -> Type name
+    fn nodes(&self) -> Nodes<'_> { }        // Custom: Nodes
+    fn edges(&self) -> Edges<'_> { }        // Custom: Edges
+    fn neighbors(&self, node: NodeId) -> Neighbors<'_> { }  // Custom: Neighbors
+}
+
+pub struct Nodes<'a> { /* ... */ }
+pub struct Edges<'a> { /* ... */ }
+pub struct Neighbors<'a> { /* ... */ }
+```
+
+## Bad
+
+```rust
+// Mismatched names
+impl MyCollection<T> {
+    fn iter(&self) -> MyCollectionIterator<'_, T> { }  // Should be Iter
+    fn keys(&self) -> KeyIterator<'_, K> { }           // Should be Keys
+}
+
+// Generic names that don't match method
+pub struct Iterator<T>;  // Conflicts with std::iter::Iterator
+pub struct I<T>;         // Too cryptic
+```
+
+## See Also
+
+- [name-iter-convention](./name-iter-convention.md) - iter/iter_mut/into_iter
+- [name-iter-method](./name-iter-method.md) - Iterator method names
+- [api-common-traits](./api-common-traits.md) - Implementing common traits

--- a/.agents/skills/rust-skills/rules/name-lifetime-short.md
+++ b/.agents/skills/rust-skills/rules/name-lifetime-short.md
@@ -1,0 +1,86 @@
+# name-lifetime-short
+
+> Use short, conventional lifetime names: `'a`, `'b`, `'de`, `'src`
+
+## Why It Matters
+
+Lifetime parameters are ubiquitous in Rust signatures. Short names like `'a` keep signatures readable. For domain-specific lifetimes, descriptive but short names like `'src` or `'de` communicate intent without clutter. The Rust community has established conventions that aid recognition.
+
+## Bad
+
+```rust
+// Overly verbose lifetimes
+fn parse<'input_lifetime, 'output_lifetime>(
+    input: &'input_lifetime str
+) -> Result<&'output_lifetime str, Error> { ... }
+
+// Meaningless long names
+struct Parser<'parser_instance_lifetime> {
+    source: &'parser_instance_lifetime str,
+}
+```
+
+## Good
+
+```rust
+// Standard short lifetimes
+fn parse<'a>(input: &'a str) -> Result<&'a str, Error> { ... }
+
+struct Parser<'a> {
+    source: &'a str,
+}
+
+// Multiple lifetimes: 'a, 'b, 'c
+fn merge<'a, 'b>(first: &'a str, second: &'b str) -> String { ... }
+
+// Descriptive when clarity helps
+fn deserialize<'de>(input: &'de [u8]) -> Result<Value<'de>, Error> { ... }
+```
+
+## Common Lifetime Conventions
+
+| Lifetime | Convention | Example |
+|----------|------------|---------|
+| `'a` | Generic, first lifetime | `fn foo<'a>(x: &'a str)` |
+| `'b` | Generic, second lifetime | `fn bar<'a, 'b>(x: &'a T, y: &'b U)` |
+| `'de` | Deserialization | serde's `Deserialize<'de>` |
+| `'src` | Source code/input | `struct Lexer<'src>` |
+| `'ctx` | Context | `struct Query<'ctx>` |
+| `'input` | Input data | `struct Parser<'input>` |
+| `'static` | Static lifetime | `&'static str` |
+
+## Elision Preferred
+
+```rust
+// Let elision work when possible
+fn first_word(s: &str) -> &str {  // Not fn first_word<'a>(s: &'a str) -> &'a str
+    s.split_whitespace().next().unwrap_or("")
+}
+
+impl User {
+    fn name(&self) -> &str {  // Elision handles this
+        &self.name
+    }
+}
+```
+
+## Serde Convention
+
+```rust
+use serde::{Deserialize, Serialize};
+
+// 'de is the standard serde lifetime for borrowed data
+#[derive(Deserialize)]
+struct Request<'de> {
+    #[serde(borrow)]
+    name: &'de str,
+    #[serde(borrow)]
+    tags: Vec<&'de str>,
+}
+```
+
+## See Also
+
+- [own-lifetime-elision](./own-lifetime-elision.md) - When to omit lifetimes
+- [name-type-param-single](./name-type-param-single.md) - Type parameter naming
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Borrowing patterns

--- a/.agents/skills/rust-skills/rules/name-no-get-prefix.md
+++ b/.agents/skills/rust-skills/rules/name-no-get-prefix.md
@@ -1,0 +1,154 @@
+# name-no-get-prefix
+
+> Omit get_ prefix for simple getters
+
+## Why It Matters
+
+Rust convention omits the `get_` prefix for simple field access. Methods like `len()`, `name()`, `value()` are cleaner than `get_len()`, `get_name()`, `get_value()`. This follows the principle of making the common case concise.
+
+The `get` prefix is reserved for methods that DO something beyond simple field access.
+
+## Bad
+
+```rust
+struct User {
+    name: String,
+    age: u32,
+}
+
+impl User {
+    fn get_name(&self) -> &str {      // Verbose
+        &self.name
+    }
+    
+    fn get_age(&self) -> u32 {         // Verbose
+        self.age
+    }
+    
+    fn get_is_adult(&self) -> bool {   // Doubly verbose
+        self.age >= 18
+    }
+}
+
+let name = user.get_name();
+let age = user.get_age();
+```
+
+## Good
+
+```rust
+struct User {
+    name: String,
+    age: u32,
+}
+
+impl User {
+    fn name(&self) -> &str {           // Clean
+        &self.name
+    }
+    
+    fn age(&self) -> u32 {             // Clean
+        self.age
+    }
+    
+    fn is_adult(&self) -> bool {       // Boolean uses is_ prefix
+        self.age >= 18
+    }
+}
+
+let name = user.name();
+let age = user.age();
+```
+
+## When get_ IS Appropriate
+
+Use `get` when the method does more than simple access:
+
+```rust
+impl HashMap<K, V> {
+    // Returns Option - not just field access
+    fn get(&self, key: &K) -> Option<&V> { }
+    
+    // Mutable variant
+    fn get_mut(&mut self, key: &K) -> Option<&mut V> { }
+}
+
+impl Vec<T> {
+    // Returns Option - bounds checked
+    fn get(&self, index: usize) -> Option<&T> { }
+}
+
+impl Context {
+    // Does computation/lookup, not just field access
+    fn get_config(&self) -> Config {
+        self.configs.get(&self.current_env).cloned().unwrap_or_default()
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// No get_ prefix
+String::len()
+Vec::len()
+Vec::capacity()
+Vec::is_empty()
+Path::file_name()
+Option::is_some()
+Result::is_ok()
+
+// With get - returns Option or does lookup
+Vec::get(index)
+HashMap::get(key)
+BTreeMap::get(key)
+```
+
+## Pattern: Getter/Setter Pairs
+
+```rust
+impl Config {
+    // Getter: no prefix
+    fn timeout(&self) -> Duration {
+        self.timeout
+    }
+    
+    // Setter: use set_ prefix
+    fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+}
+```
+
+## Pattern: Builder Methods
+
+```rust
+impl ConfigBuilder {
+    // Builder methods: no get_, no set_
+    fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+    
+    fn retries(mut self, retries: u32) -> Self {
+        self.retries = retries;
+        self
+    }
+}
+```
+
+## Decision Guide
+
+| Pattern | Naming |
+|---------|--------|
+| Simple field access | `name()`, `value()`, `len()` |
+| Boolean property | `is_valid()`, `has_items()` |
+| Fallible access | `get()`, `get_mut()` |
+| Setter | `set_name()`, `set_value()` |
+| Builder | `name()`, `value()` (consuming self) |
+
+## See Also
+
+- [name-is-has-bool](./name-is-has-bool.md) - Boolean naming
+- [name-is-has-bool](./name-is-has-bool.md) - Boolean naming
+- [api-builder-pattern](./api-builder-pattern.md) - Builder pattern

--- a/.agents/skills/rust-skills/rules/name-to-expensive.md
+++ b/.agents/skills/rust-skills/rules/name-to-expensive.md
@@ -1,0 +1,118 @@
+# name-to-expensive
+
+> Use `to_` prefix for expensive conversions that allocate or compute
+
+## Why It Matters
+
+The `to_` prefix signals "this conversion has a cost"—typically allocation, cloning, or computation. Callers know to consider caching the result or avoiding repeated calls. This contrasts with `as_` (free reference conversion) and `into_` (ownership transfer).
+
+## Bad
+
+```rust
+impl Name {
+    // Misleading: suggests expensive operation
+    fn as_uppercase(&self) -> String {
+        self.0.to_uppercase()  // Allocates!
+    }
+    
+    // Misleading: suggests cheap reference
+    fn get_string(&self) -> String {
+        self.0.clone()  // Allocates!
+    }
+}
+```
+
+## Good
+
+```rust
+impl Name {
+    // to_ = allocates/computes
+    fn to_uppercase(&self) -> String {
+        self.0.to_uppercase()
+    }
+    
+    // to_ = creates new value
+    fn to_string(&self) -> String {
+        self.0.clone()
+    }
+    
+    // as_ = free reference (cheap)
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// to_ methods - all allocate or compute
+let s: String = slice.to_vec();           // Allocates Vec
+let s: String = "hello".to_string();      // Allocates String
+let s: String = "HELLO".to_lowercase();   // Allocates new String
+let s: String = path.to_string_lossy().into_owned();  // May allocate
+
+// Contrast with as_ methods - all are free
+let slice: &[u8] = s.as_bytes();          // Just reinterpret
+let str_ref: &str = string.as_str();      // Just reference
+let path: &Path = Path::new("foo");       // Just reference
+```
+
+## Conversion Method Prefixes
+
+| Prefix | Cost | Ownership | Example |
+|--------|------|-----------|---------|
+| `as_` | Free (O(1)) | Borrows `&T` | `as_str()`, `as_bytes()` |
+| `to_` | Allocates/Computes | Creates new | `to_string()`, `to_vec()` |
+| `into_` | Usually free | Takes ownership | `into_inner()`, `into_vec()` |
+
+## Custom Types
+
+```rust
+struct Email(String);
+
+impl Email {
+    // Cheap: just returns reference
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+    
+    // Expensive: allocates
+    fn to_lowercase(&self) -> Email {
+        Email(self.0.to_lowercase())
+    }
+    
+    // Expensive: allocates
+    fn to_display_format(&self) -> String {
+        format!("<{}>", self.0)
+    }
+    
+    // Ownership transfer: usually cheap
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+```
+
+## to_owned() Pattern
+
+```rust
+// to_owned() for getting owned version of borrowed data
+let borrowed: &str = "hello";
+let owned: String = borrowed.to_owned();  // Allocates
+
+let borrowed: &[i32] = &[1, 2, 3];
+let owned: Vec<i32> = borrowed.to_owned();  // Allocates
+
+// ToOwned trait
+trait ToOwned {
+    type Owned;
+    fn to_owned(&self) -> Self::Owned;
+}
+```
+
+## See Also
+
+- [name-as-free](./name-as-free.md) - Free reference conversions
+- [name-into-ownership](./name-into-ownership.md) - Ownership transfer
+- [own-cow-conditional](./own-cow-conditional.md) - Avoiding unnecessary allocations

--- a/.agents/skills/rust-skills/rules/name-type-param-single.md
+++ b/.agents/skills/rust-skills/rules/name-type-param-single.md
@@ -1,0 +1,92 @@
+# name-type-param-single
+
+> Use single uppercase letters for type parameters: `T`, `E`, `K`, `V`
+
+## Why It Matters
+
+Generic type parameters conventionally use single uppercase letters. This keeps signatures concise and follows established conventions that readers instantly recognize. `T` for "type", `E` for "error", `K` for "key", `V` for "value" are universal in Rust.
+
+## Bad
+
+```rust
+// Verbose type parameters
+struct Container<ElementType> {
+    items: Vec<ElementType>,
+}
+
+fn process<InputType, OutputType>(input: InputType) -> OutputType { ... }
+
+// Lowercase - looks like lifetime
+struct Wrapper<t> { ... }  // Confusing
+```
+
+## Good
+
+```rust
+// Single uppercase letters
+struct Container<T> {
+    items: Vec<T>,
+}
+
+fn process<I, O>(input: I) -> O { ... }
+
+// Standard conventions
+struct HashMap<K, V> { ... }     // K=Key, V=Value
+enum Result<T, E> { ... }         // T=Type, E=Error
+enum Option<T> { ... }            // T=Type
+struct Ref<'a, T> { ... }        // Lifetime + Type
+```
+
+## Standard Type Parameter Names
+
+| Parameter | Meaning | Example |
+|-----------|---------|---------|
+| `T` | Type (generic) | `Vec<T>` |
+| `E` | Error | `Result<T, E>` |
+| `K` | Key | `HashMap<K, V>` |
+| `V` | Value | `HashMap<K, V>` |
+| `I` | Input / Item | `Iterator<Item = I>` |
+| `O` | Output | `Fn(I) -> O` |
+| `R` | Return / Result | `fn() -> R` |
+| `S` | State | `StateMachine<S>` |
+| `A` | Allocator | `Vec<T, A>` |
+| `F` | Function | `map<F>(f: F)` |
+
+## Multiple Type Parameters
+
+```rust
+// Use related letters
+fn transform<I, O, E>(input: I) -> Result<O, E>
+where
+    I: Input,
+    O: Output,
+    E: Error,
+{ ... }
+
+// Or sequential: T, U, V
+fn combine<T, U, V>(a: T, b: U) -> V { ... }
+
+// Descriptive only when many parameters need clarity
+struct Query<Db, Row, Err> { ... }
+```
+
+## Trait Bounds
+
+```rust
+// Keep type params short, move complexity to where clause
+fn process<T, E>(value: T) -> Result<T, E>
+where
+    T: Clone + Debug + Send + Sync,
+    E: Error + From<IoError>,
+{ ... }
+
+// Not inline
+fn process<T: Clone + Debug + Send + Sync, E: Error + From<IoError>>(value: T) -> Result<T, E>
+// Too long!
+```
+
+## See Also
+
+- [name-lifetime-short](./name-lifetime-short.md) - Lifetime parameter naming
+- [name-types-camel](./name-types-camel.md) - Concrete type naming
+- [type-generic-bounds](./type-generic-bounds.md) - Trait bounds

--- a/.agents/skills/rust-skills/rules/name-types-camel.md
+++ b/.agents/skills/rust-skills/rules/name-types-camel.md
@@ -1,0 +1,65 @@
+# name-types-camel
+
+> Use `UpperCamelCase` for types, traits, and enum names
+
+## Why It Matters
+
+Rust's naming conventions are enforced by the compiler and linter. Consistent naming makes code immediately recognizable—you know `HttpClient` is a type, `send_request` is a function. Violating conventions triggers warnings and makes code harder to read.
+
+## Bad
+
+```rust
+// Lowercase types - compiler warns
+struct http_client { ... }  // warning: type `http_client` should have an upper camel case name
+trait serializable { ... }  // warning
+enum response_type { ... }  // warning
+
+// Screaming case for types
+struct HTTP_CLIENT { ... }  // Not idiomatic
+```
+
+## Good
+
+```rust
+// UpperCamelCase for all types
+struct HttpClient { ... }
+trait Serializable { ... }
+enum ResponseType { ... }
+
+// Compound words
+struct TcpConnection { ... }
+struct IoError { ... }
+struct FileReader { ... }
+
+// Generic types
+struct HashMap<K, V> { ... }
+struct Result<T, E> { ... }
+```
+
+## Acronyms
+
+```rust
+// Treat acronyms as words (capitalize first letter only)
+struct HttpServer { ... }      // Not HTTPServer
+struct JsonParser { ... }      // Not JSONParser
+struct Uuid { ... }            // Not UUID
+struct TcpStream { ... }       // Not TCPStream
+
+// Exception: Two-letter acronyms can be all caps
+struct IOError { ... }         // Acceptable
+struct IoError { ... }         // Also acceptable (preferred)
+```
+
+## Type Aliases
+
+```rust
+// Type aliases also use UpperCamelCase
+type Result<T> = std::result::Result<T, Error>;
+type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+```
+
+## See Also
+
+- [name-variants-camel](./name-variants-camel.md) - Enum variant naming
+- [name-funcs-snake](./name-funcs-snake.md) - Function naming
+- [name-acronym-word](./name-acronym-word.md) - Acronym handling

--- a/.agents/skills/rust-skills/rules/name-variants-camel.md
+++ b/.agents/skills/rust-skills/rules/name-variants-camel.md
@@ -1,0 +1,101 @@
+# name-variants-camel
+
+> Use `UpperCamelCase` for enum variants
+
+## Why It Matters
+
+Enum variants follow the same naming convention as types—`UpperCamelCase`. This distinguishes them from fields, variables, and functions. The compiler warns on violations, and consistent naming helps readers instantly recognize variant names.
+
+## Bad
+
+```rust
+enum Status {
+    pending,       // warning: variant `pending` should have an upper camel case name
+    in_progress,   // warning
+    COMPLETED,     // Not idiomatic
+}
+
+enum Color {
+    RED,           // Screaming case - not Rust style
+    GREEN,
+    BLUE,
+}
+```
+
+## Good
+
+```rust
+enum Status {
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+enum Color {
+    Red,
+    Green,
+    Blue,
+    Custom(u8, u8, u8),
+}
+
+enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+}
+```
+
+## Variants with Data
+
+```rust
+enum Message {
+    // Unit variant
+    Quit,
+    
+    // Tuple variant
+    Move(i32, i32),
+    
+    // Struct variant
+    Write { text: String },
+    
+    // Named fields
+    ChangeColor {
+        red: u8,
+        green: u8,
+        blue: u8,
+    },
+}
+```
+
+## Variant Naming Tips
+
+```rust
+// Be specific
+enum Error {
+    NotFound,           // Good: specific
+    PermissionDenied,   // Good: specific
+    Error,              // Bad: vague
+}
+
+// Avoid redundant type name in variant
+enum ConnectionState {
+    Connected,          // Good
+    Disconnected,       // Good
+    ConnectionError,    // Bad: redundant "Connection"
+}
+
+// Use None/Some pattern for Option-like enums
+enum MaybeValue<T> {
+    Some(T),
+    None,
+}
+```
+
+## See Also
+
+- [name-types-camel](./name-types-camel.md) - Type naming
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums
+- [type-enum-states](./type-enum-states.md) - State machine enums

--- a/.agents/skills/rust-skills/rules/opt-bounds-check.md
+++ b/.agents/skills/rust-skills/rules/opt-bounds-check.md
@@ -1,0 +1,161 @@
+# opt-bounds-check
+
+> Use iterators and patterns that eliminate bounds checks in hot paths
+
+## Why It Matters
+
+Rust's safety guarantees require bounds checking on array/slice indexing. In tight loops, these checks can cause measurable overhead (branch mispredictions, preventing vectorization). Patterns like iterators, `get_unchecked`, and index splitting can eliminate these checks while maintaining safety.
+
+## Bad
+
+```rust
+fn sum_products(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len() {
+        sum += a[i] * b[i];  // Two bounds checks per iteration
+    }
+    sum
+}
+
+fn apply_filter(data: &mut [u8], kernel: &[u8; 3]) {
+    for i in 1..data.len() - 1 {
+        // Three bounds checks per iteration
+        data[i] = (data[i - 1] + data[i] + data[i + 1]) / 3;
+    }
+}
+```
+
+## Good
+
+```rust
+fn sum_products(a: &[f64], b: &[f64]) -> f64 {
+    // Iterator zips - no bounds checks, vectorizes well
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+fn apply_filter(data: &mut [u8]) {
+    // Windows pattern - no bounds checks
+    for window in data.windows(3) {
+        // window[0], window[1], window[2] are all valid
+    }
+    
+    // Or use chunks
+    for chunk in data.chunks_exact(4) {
+        process_simd(chunk);
+    }
+}
+```
+
+## Iterator Patterns
+
+```rust
+// All of these avoid bounds checks:
+
+// zip - parallel iteration
+for (a, b) in xs.iter().zip(ys.iter()) { ... }
+
+// enumerate - index + value  
+for (i, x) in data.iter().enumerate() { ... }
+
+// windows - sliding window
+for window in data.windows(3) { ... }
+
+// chunks - fixed-size groups
+for chunk in data.chunks(4) { ... }
+for chunk in data.chunks_exact(4) { ... }  // Guarantees exact size
+
+// split_at - divide slice
+let (left, right) = data.split_at(mid);
+```
+
+## Split for Parallel Access
+
+```rust
+fn parallel_sum(data: &[i32]) -> i32 {
+    // Split into independent chunks
+    let (left, right) = data.split_at(data.len() / 2);
+    
+    // Process chunks without bounds checks
+    let sum_left: i32 = left.iter().sum();
+    let sum_right: i32 = right.iter().sum();
+    
+    sum_left + sum_right
+}
+```
+
+## get_unchecked for Proven Safety
+
+```rust
+fn matrix_multiply(a: &[f64], b: &[f64], c: &mut [f64], n: usize) {
+    assert!(a.len() >= n * n);
+    assert!(b.len() >= n * n);
+    assert!(c.len() >= n * n);
+    
+    for i in 0..n {
+        for j in 0..n {
+            let mut sum = 0.0;
+            for k in 0..n {
+                // SAFETY: bounds verified by asserts above
+                unsafe {
+                    sum += a.get_unchecked(i * n + k) 
+                         * b.get_unchecked(k * n + j);
+                }
+            }
+            // SAFETY: bounds verified by asserts above
+            unsafe {
+                *c.get_unchecked_mut(i * n + j) = sum;
+            }
+        }
+    }
+}
+```
+
+## Slice Patterns
+
+```rust
+fn process_header(data: &[u8]) -> Option<Header> {
+    // Slice pattern - single length check, no per-field checks
+    let [a, b, c, d, rest @ ..] = data else {
+        return None;
+    };
+    
+    Some(Header {
+        magic: *a,
+        version: *b,
+        flags: u16::from_le_bytes([*c, *d]),
+        payload: rest,
+    })
+}
+```
+
+## Verify Bounds Check Elimination
+
+```bash
+# Check generated assembly
+cargo asm --release my_crate::hot_function
+
+# Look for 'cmp' and 'ja'/'jbe' instructions near array access
+# If eliminated, you'll see direct memory access
+```
+
+## When to Accept Bounds Checks
+
+```rust
+// Random access patterns - checks unavoidable
+fn random_lookup(data: &[u8], indices: &[usize]) -> Vec<u8> {
+    indices.iter()
+        .filter_map(|&i| data.get(i).copied())  // Checked, but necessary
+        .collect()
+}
+
+// Infrequent access - overhead negligible
+fn get_config(&self, key: &str) -> Option<&Value> {
+    self.config.get(key)  // Fine, not hot path
+}
+```
+
+## See Also
+
+- [opt-simd-portable](./opt-simd-portable.md) - SIMD requires unchecked access
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache-efficient patterns
+- [perf-profile-first](./perf-profile-first.md) - Identify actual hot paths

--- a/.agents/skills/rust-skills/rules/opt-cache-friendly.md
+++ b/.agents/skills/rust-skills/rules/opt-cache-friendly.md
@@ -1,0 +1,187 @@
+# opt-cache-friendly
+
+> Organize data for cache-efficient access patterns
+
+## Why It Matters
+
+Cache misses are expensive—a L3 cache miss costs ~100+ cycles vs ~4 cycles for L1 hit. Data layout and access patterns determine cache efficiency. Arrays of structs (AoS) vs structs of arrays (SoA), memory locality, and access patterns can make order-of-magnitude performance differences.
+
+## Bad
+
+```rust
+// Array of Structs (AoS) - poor cache use when accessing one field
+struct Particle {
+    position: [f32; 3],  // 12 bytes
+    velocity: [f32; 3],  // 12 bytes
+    mass: f32,           // 4 bytes
+    id: u64,             // 8 bytes
+    flags: u8,           // 1 byte + padding
+    // Total: 40 bytes per particle
+}
+
+fn update_positions(particles: &mut [Particle], dt: f32) {
+    for p in particles {
+        // Access position and velocity - 24 bytes
+        // But loads 40-byte struct per particle
+        // 16 bytes wasted per cache line load
+        p.position[0] += p.velocity[0] * dt;
+        p.position[1] += p.velocity[1] * dt;
+        p.position[2] += p.velocity[2] * dt;
+    }
+}
+```
+
+## Good
+
+```rust
+// Struct of Arrays (SoA) - cache-efficient for field access
+struct Particles {
+    positions_x: Vec<f32>,
+    positions_y: Vec<f32>,
+    positions_z: Vec<f32>,
+    velocities_x: Vec<f32>,
+    velocities_y: Vec<f32>,
+    velocities_z: Vec<f32>,
+    masses: Vec<f32>,
+    ids: Vec<u64>,
+    flags: Vec<u8>,
+}
+
+fn update_positions(p: &mut Particles, dt: f32) {
+    // Access contiguous memory - perfect cache utilization
+    for (px, vx) in p.positions_x.iter_mut().zip(&p.velocities_x) {
+        *px += vx * dt;
+    }
+    for (py, vy) in p.positions_y.iter_mut().zip(&p.velocities_y) {
+        *py += vy * dt;
+    }
+    for (pz, vz) in p.positions_z.iter_mut().zip(&p.velocities_z) {
+        *pz += vz * dt;
+    }
+}
+```
+
+## Hot/Cold Splitting
+
+```rust
+// Separate frequently and rarely accessed fields
+struct EntityHot {
+    position: [f32; 3],
+    velocity: [f32; 3],
+    // Hot data - accessed every frame
+}
+
+struct EntityCold {
+    name: String,
+    creation_time: Instant,
+    metadata: HashMap<String, Value>,
+    // Cold data - rarely accessed
+}
+
+struct Entities {
+    hot: Vec<EntityHot>,
+    cold: Vec<EntityCold>,
+}
+
+// Hot loop touches only hot data
+fn update(entities: &mut Entities, dt: f32) {
+    for e in &mut entities.hot {
+        e.position[0] += e.velocity[0] * dt;
+        // Cold data stays out of cache
+    }
+}
+```
+
+## Prefetching
+
+```rust
+// Process in cache-line-sized chunks
+const CACHE_LINE: usize = 64;
+
+fn process_with_prefetch(data: &mut [u8]) {
+    for chunk in data.chunks_mut(CACHE_LINE) {
+        // Prefetch next chunk while processing current
+        // (automatic in many cases, manual for complex patterns)
+        process_chunk(chunk);
+    }
+}
+
+// Matrix multiplication - block for cache
+fn matmul_blocked(a: &[f64], b: &[f64], c: &mut [f64], n: usize) {
+    const BLOCK: usize = 32;  // Fits in L1 cache
+    
+    for i0 in (0..n).step_by(BLOCK) {
+        for j0 in (0..n).step_by(BLOCK) {
+            for k0 in (0..n).step_by(BLOCK) {
+                // Process BLOCK x BLOCK tile
+                for i in i0..min(i0 + BLOCK, n) {
+                    for j in j0..min(j0 + BLOCK, n) {
+                        // Inner loop operates on cached data
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+## Avoid Pointer Chasing
+
+```rust
+// Bad: linked list - random memory access
+struct Node {
+    value: i32,
+    next: Option<Box<Node>>,
+}
+
+fn sum_linked(head: &Node) -> i32 {
+    // Each node is a cache miss
+}
+
+// Good: contiguous vector
+fn sum_vector(data: &[i32]) -> i32 {
+    data.iter().sum()  // Sequential access, prefetcher happy
+}
+
+// Good: if graph needed, use indices
+struct Graph {
+    values: Vec<i32>,
+    edges: Vec<usize>,  // Indices into values
+}
+```
+
+## Memory Layout Attributes
+
+```rust
+// Ensure cache-line alignment
+#[repr(C, align(64))]
+struct CacheAligned {
+    data: [u8; 64],
+}
+
+// Prevent false sharing in concurrent code
+#[repr(C, align(64))]
+struct PaddedCounter {
+    value: AtomicU64,
+    _pad: [u8; 56],
+}
+```
+
+## Measuring Cache Performance
+
+```bash
+# Linux perf
+perf stat -e cache-references,cache-misses ./my_program
+
+# Detailed cache analysis
+perf stat -e L1-dcache-loads,L1-dcache-load-misses,LLC-loads,LLC-load-misses ./my_program
+
+# Cachegrind
+valgrind --tool=cachegrind ./my_program
+```
+
+## See Also
+
+- [mem-smaller-integers](./mem-smaller-integers.md) - Smaller data fits more in cache
+- [mem-box-large-variant](./mem-box-large-variant.md) - Keep enum sizes small
+- [opt-bounds-check](./opt-bounds-check.md) - Sequential access patterns

--- a/.agents/skills/rust-skills/rules/opt-codegen-units.md
+++ b/.agents/skills/rust-skills/rules/opt-codegen-units.md
@@ -1,0 +1,142 @@
+# opt-codegen-units
+
+> Set `codegen-units = 1` for maximum optimization in release builds
+
+## Why It Matters
+
+By default, Cargo splits code into multiple codegen units for parallel compilation. This speeds up builds but prevents some cross-unit optimizations. Setting `codegen-units = 1` allows LLVM to optimize across the entire crate, potentially improving runtime performance by 5-20% at the cost of slower builds.
+
+## Bad
+
+```toml
+# Cargo.toml - default settings
+[profile.release]
+# codegen-units defaults to 16
+# Fast to compile, but misses optimization opportunities
+```
+
+## Good
+
+```toml
+# Cargo.toml - optimized for runtime performance
+[profile.release]
+codegen-units = 1  # Single unit = better optimization
+lto = true         # Link-time optimization
+opt-level = 3      # Maximum optimization
+```
+
+## What codegen-units Affects
+
+| Codegen Units | Compile Time | Runtime Performance | Memory Use |
+|---------------|--------------|---------------------|------------|
+| 16 (default)  | Faster       | Baseline            | Lower      |
+| 4-8           | Moderate     | Slightly better     | Moderate   |
+| 1             | Slower       | Best                | Higher     |
+
+## How It Works
+
+```rust
+// With codegen-units = 16:
+// - Crate split into 16 independent compilation units
+// - Compiled in parallel
+// - Limited visibility between units for optimization
+
+// With codegen-units = 1:
+// - Entire crate in single unit
+// - LLVM sees all code at once
+// - Can inline across module boundaries
+// - Better dead code elimination
+// - Better constant propagation
+```
+
+## Full Release Profile
+
+```toml
+[profile.release]
+# Maximum runtime performance
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"      # Smaller binary, slight perf gain
+strip = true         # Smaller binary
+
+[profile.release-with-debug]
+# Performance with debugging ability
+inherits = "release"
+debug = true         # Keep debug symbols
+strip = false
+
+[profile.bench]
+# For benchmarking
+inherits = "release"
+```
+
+## Build Time Trade-offs
+
+```bash
+# Default release build (fast compile)
+cargo build --release
+# Time: ~30s
+
+# Optimized release build (slow compile, fast runtime)
+# With codegen-units = 1, lto = "fat"
+cargo build --release
+# Time: ~2-5min, but potentially 10-20% faster binary
+```
+
+## Per-Profile Configuration
+
+```toml
+# Fast debug builds
+[profile.dev]
+codegen-units = 256  # Maximum parallelism
+
+# Fast CI builds
+[profile.ci]
+inherits = "release"
+codegen-units = 16   # Balance compile time vs runtime
+lto = "thin"         # Faster than "fat"
+
+# Production release
+[profile.production]
+inherits = "release"
+codegen-units = 1
+lto = "fat"
+```
+
+## When to Use What
+
+```rust
+// codegen-units = 16 (default)
+// - Development builds
+// - CI where compile time matters
+// - When runtime performance isn't critical
+
+// codegen-units = 1
+// - Production deployments
+// - Performance-critical applications
+// - Final releases
+// - Benchmarking
+```
+
+## Measuring Impact
+
+```bash
+# Build with different settings
+cargo build --release
+
+# Benchmark
+cargo bench
+
+# Compare binary sizes
+ls -lh target/release/my_binary
+
+# Profile runtime
+perf stat ./target/release/my_binary
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - Link-time optimization
+- [opt-pgo-profile](./opt-pgo-profile.md) - Profile-guided optimization
+- [opt-target-cpu](./opt-target-cpu.md) - CPU-specific optimization

--- a/.agents/skills/rust-skills/rules/opt-cold-unlikely.md
+++ b/.agents/skills/rust-skills/rules/opt-cold-unlikely.md
@@ -1,0 +1,152 @@
+# opt-cold-unlikely
+
+> Mark unlikely code paths with `#[cold]` to help compiler optimization
+
+## Why It Matters
+
+The `#[cold]` attribute tells the compiler that a function is rarely called. The compiler uses this to optimize code layout—keeping cold code away from hot code improves instruction cache utilization. Combined with branch layout optimization, this can measurably improve performance.
+
+## Bad
+
+```rust
+// All branches treated equally
+fn validate(input: &str) -> Result<Data, ValidationError> {
+    if input.is_empty() {
+        return Err(ValidationError::Empty);  // Rare
+    }
+    
+    if input.len() > 1000 {
+        return Err(ValidationError::TooLong);  // Rare  
+    }
+    
+    if !input.is_ascii() {
+        return Err(ValidationError::NonAscii);  // Rare
+    }
+    
+    // This is the common case
+    Ok(parse_data(input))
+}
+```
+
+## Good
+
+```rust
+fn validate(input: &str) -> Result<Data, ValidationError> {
+    if input.is_empty() {
+        return cold_empty_error();
+    }
+    
+    if input.len() > 1000 {
+        return cold_too_long_error();
+    }
+    
+    if !input.is_ascii() {
+        return cold_non_ascii_error();
+    }
+    
+    Ok(parse_data(input))
+}
+
+#[cold]
+fn cold_empty_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::Empty)
+}
+
+#[cold]
+fn cold_too_long_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::TooLong)
+}
+
+#[cold]
+fn cold_non_ascii_error() -> Result<Data, ValidationError> {
+    Err(ValidationError::NonAscii)
+}
+```
+
+## What #[cold] Does
+
+1. **Code placement**: Cold functions are placed in separate code sections, away from hot code
+2. **Branch prediction**: Compiler generates branch hints favoring the non-cold path
+3. **Inlining decisions**: Cold functions are not inlined into hot paths
+4. **Optimization budget**: Compiler spends less effort optimizing cold code
+
+## Common Cold Patterns
+
+```rust
+// Error handling
+#[cold]
+fn handle_error<E: std::fmt::Display>(e: E) -> ! {
+    eprintln!("Fatal error: {}", e);
+    std::process::exit(1);
+}
+
+// Logging rare events
+#[cold]
+fn log_rare_event(event: &Event) {
+    log::warn!("Rare event occurred: {:?}", event);
+}
+
+// Fallback paths
+#[cold]
+fn slow_fallback(data: &Data) -> Output {
+    // This path should rarely be taken
+    compute_slowly(data)
+}
+
+// Panic handlers
+#[cold]
+fn panic_invalid_state(state: &State) -> ! {
+    panic!("Invalid state: {:?}", state);
+}
+```
+
+## Assertions and Invariants
+
+```rust
+fn get_unchecked(&self, index: usize) -> &T {
+    if index >= self.len {
+        cold_bounds_panic(index, self.len);
+    }
+    unsafe { &*self.ptr.add(index) }
+}
+
+#[cold]
+#[inline(never)]
+fn cold_bounds_panic(index: usize, len: usize) -> ! {
+    panic!("index out of bounds: the len is {} but the index is {}", len, index);
+}
+```
+
+## Combining with #[inline(never)]
+
+```rust
+// Usually combine both for maximum effect
+#[cold]
+#[inline(never)]
+fn error_path() -> Error {
+    // Complex error construction stays out of hot code
+    Error {
+        backtrace: Backtrace::capture(),
+        context: gather_context(),
+    }
+}
+```
+
+## Measuring Impact
+
+```rust
+// Check code layout with objdump
+// objdump -d target/release/binary | less
+
+// Look for .cold sections
+// nm target/release/binary | grep cold
+
+// Profile to verify improvement
+// perf stat -e cache-misses,cache-references ./binary
+```
+
+## See Also
+
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Combining with inline(never)
+- [opt-likely-hint](./opt-likely-hint.md) - Branch prediction hints
+- [err-result-over-panic](./err-result-over-panic.md) - Error handling

--- a/.agents/skills/rust-skills/rules/opt-inline-always-rare.md
+++ b/.agents/skills/rust-skills/rules/opt-inline-always-rare.md
@@ -1,0 +1,141 @@
+# opt-inline-always-rare
+
+> Use `#[inline(always)]` sparingly—only for critical hot paths proven by profiling
+
+## Why It Matters
+
+`#[inline(always)]` forces the compiler to inline a function regardless of heuristics. Overuse increases binary size, hurts instruction cache, and can slow down code. The compiler is usually smarter about inlining than humans. Reserve this for measured hot paths where benchmarks prove a benefit.
+
+## Bad
+
+```rust
+// Annotating everything - trusting intuition over data
+#[inline(always)]
+pub fn get_name(&self) -> &str {
+    &self.name
+}
+
+#[inline(always)]
+pub fn calculate_tax(amount: f64) -> f64 {
+    amount * 0.1
+}
+
+#[inline(always)]
+fn helper(x: i32) -> i32 {
+    x + 1
+}
+
+// Result: bloated binary, poor cache utilization
+```
+
+## Good
+
+```rust
+// Let compiler decide for most functions
+pub fn get_name(&self) -> &str {
+    &self.name
+}
+
+pub fn calculate_tax(amount: f64) -> f64 {
+    amount * 0.1
+}
+
+// Only force inline for proven hot paths
+impl Hasher for MyHasher {
+    // Hasher::write is called millions of times in tight loops
+    // Profiling showed 15% improvement from forced inlining
+    #[inline(always)]
+    fn write(&mut self, bytes: &[u8]) {
+        // Very small, very hot
+        self.state = self.state.wrapping_add(bytes.len() as u64);
+    }
+}
+```
+
+## When #[inline(always)] Helps
+
+```rust
+// ✅ Tiny functions in hot inner loops
+#[inline(always)]
+fn fast_hash(a: u64, b: u64) -> u64 {
+    a.wrapping_mul(b).wrapping_add(a)
+}
+
+// ✅ Generic functions that benefit from monomorphization
+#[inline(always)]
+fn swap<T>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b);
+}
+
+// ✅ Iterator adapters and closures
+#[inline(always)]
+fn apply<T, F: Fn(T) -> T>(f: F, x: T) -> T {
+    f(x)
+}
+
+// ✅ SIMD/vectorization helpers
+#[inline(always)]
+fn add_simd(a: &[f32], b: &[f32], out: &mut [f32]) {
+    // ...
+}
+```
+
+## Inline Variants
+
+```rust
+// #[inline] - hint to inline, compiler may ignore
+#[inline]
+fn suggested_inline(x: i32) -> i32 { x + 1 }
+
+// #[inline(always)] - force inline (almost always)
+#[inline(always)]
+fn force_inline(x: i32) -> i32 { x + 1 }
+
+// #[inline(never)] - prevent inlining (for profiling, code size)
+#[inline(never)]
+fn no_inline(x: i32) -> i32 { x + 1 }
+
+// No annotation - compiler decides based on heuristics
+fn compiler_decides(x: i32) -> i32 { x + 1 }
+```
+
+## Measuring Inline Impact
+
+```rust
+// Use criterion to benchmark
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_with_inline(c: &mut Criterion) {
+    c.bench_function("hot_path_inline", |b| {
+        b.iter(|| hot_loop())
+    });
+}
+
+// Compare binary sizes
+// cargo bloat --release --crates
+
+// Check if function was inlined
+// cargo asm --rust my_crate::hot_function
+```
+
+## Generic Functions
+
+```rust
+// Generic functions across crate boundaries often need #[inline]
+// Because the generic code is compiled in the calling crate
+
+// In library crate:
+#[inline]  // Allow inlining in downstream crates
+pub fn generic_function<T: Display>(x: T) {
+    println!("{}", x);
+}
+
+// Without #[inline], the generic function can't be inlined
+// across crate boundaries even if beneficial
+```
+
+## See Also
+
+- [opt-inline-small](./opt-inline-small.md) - Regular inline for small functions
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Preventing inlining
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimizing

--- a/.agents/skills/rust-skills/rules/opt-inline-never-cold.md
+++ b/.agents/skills/rust-skills/rules/opt-inline-never-cold.md
@@ -1,0 +1,181 @@
+# opt-inline-never-cold
+
+> Use `#[inline(never)]` and `#[cold]` for error paths and rarely-executed code
+
+## Why It Matters
+
+Inlining error handling code into hot paths wastes instruction cache space and can prevent other optimizations. `#[inline(never)]` keeps cold code out of the hot path. `#[cold]` tells the compiler this branch is unlikely, enabling better branch prediction hints and code layout.
+
+## Bad
+
+```rust
+fn process_data(data: &[u8]) -> Result<Output, Error> {
+    if data.is_empty() {
+        // Error path inlined into hot function
+        return Err(Error::Empty {
+            context: format!("Expected data, got empty slice"),
+            suggestions: vec!["Check input", "Validate before calling"],
+        });
+    }
+    
+    // Hot path - now polluted with error construction code
+    do_processing(data)
+}
+```
+
+## Good
+
+```rust
+fn process_data(data: &[u8]) -> Result<Output, Error> {
+    if data.is_empty() {
+        return Err(empty_data_error());  // Cold path stays small
+    }
+    
+    do_processing(data)
+}
+
+#[cold]
+#[inline(never)]
+fn empty_data_error() -> Error {
+    Error::Empty {
+        context: format!("Expected data, got empty slice"),
+        suggestions: vec!["Check input", "Validate before calling"],
+    }
+}
+```
+
+## #[cold] for Unlikely Branches
+
+```rust
+fn parse_value(input: &str) -> Result<i32, ParseError> {
+    match input.parse() {
+        Ok(n) => Ok(n),
+        Err(e) => cold_parse_error(input, e),
+    }
+}
+
+#[cold]
+fn cold_parse_error(input: &str, e: std::num::ParseIntError) -> Result<i32, ParseError> {
+    Err(ParseError {
+        input: input.to_string(),
+        source: e,
+    })
+}
+```
+
+## Panic Paths
+
+```rust
+fn get_index(&self, idx: usize) -> &T {
+    if idx >= self.len {
+        cold_out_of_bounds(idx, self.len);
+    }
+    unsafe { self.ptr.add(idx).as_ref().unwrap() }
+}
+
+#[cold]
+#[inline(never)]
+fn cold_out_of_bounds(idx: usize, len: usize) -> ! {
+    panic!("index {} out of bounds for length {}", idx, len);
+}
+```
+
+## Error Construction Functions
+
+```rust
+// Keep error construction out of hot path
+impl MyError {
+    #[cold]
+    pub fn io_error(source: std::io::Error, path: &Path) -> Self {
+        MyError::Io {
+            source,
+            path: path.to_path_buf(),
+            context: get_context(),
+        }
+    }
+    
+    #[cold]
+    pub fn validation_error(msg: &str, field: &str) -> Self {
+        MyError::Validation {
+            message: msg.to_string(),
+            field: field.to_string(),
+        }
+    }
+}
+
+fn read_config(path: &Path) -> Result<Config, MyError> {
+    std::fs::read_to_string(path)
+        .map_err(|e| MyError::io_error(e, path))?
+        .parse()
+        .map_err(|e| MyError::parse_error(e))
+}
+```
+
+## likely/unlikely Hints
+
+```rust
+// Nightly: intrinsics for branch hints
+#![feature(core_intrinsics)]
+use std::intrinsics::{likely, unlikely};
+
+fn process(data: Option<&Data>) -> Result<Output, Error> {
+    if unlikely(data.is_none()) {
+        return cold_none_error();
+    }
+    
+    let data = data.unwrap();
+    
+    if likely(data.is_valid()) {
+        fast_process(data)
+    } else {
+        slow_validate_and_process(data)
+    }
+}
+
+// Stable alternative: structure code so hot path is "fall through"
+fn process(data: Option<&Data>) -> Result<Output, Error> {
+    let data = match data {
+        Some(d) => d,
+        None => return cold_none_error(),  // Early return = unlikely hint
+    };
+    
+    // Compiler assumes code after early returns is "hot"
+    fast_process(data)
+}
+```
+
+## Pattern: Extract Cold Code
+
+```rust
+// Before: cold code inline
+fn hot_function(x: i32) -> i32 {
+    if x < 0 {
+        log::error!("Negative value: {}", x);
+        eprintln!("Debug info: {:?}", std::backtrace::Backtrace::capture());
+        return 0;
+    }
+    x * 2
+}
+
+// After: cold code extracted
+fn hot_function(x: i32) -> i32 {
+    if x < 0 {
+        return handle_negative(x);
+    }
+    x * 2
+}
+
+#[cold]
+#[inline(never)]
+fn handle_negative(x: i32) -> i32 {
+    log::error!("Negative value: {}", x);
+    eprintln!("Debug info: {:?}", std::backtrace::Backtrace::capture());
+    0
+}
+```
+
+## See Also
+
+- [opt-inline-small](./opt-inline-small.md) - Inlining for hot code
+- [opt-inline-always-rare](./opt-inline-always-rare.md) - Forced inlining
+- [err-result-over-panic](./err-result-over-panic.md) - Error handling patterns

--- a/.agents/skills/rust-skills/rules/opt-inline-small.md
+++ b/.agents/skills/rust-skills/rules/opt-inline-small.md
@@ -1,0 +1,160 @@
+# opt-inline-small
+
+> Use `#[inline]` for small hot functions
+
+## Why It Matters
+
+Function call overhead (stack frame setup, register saves, jumps) can dominate small functions. Inlining eliminates this overhead and enables further optimizations by the compiler. The compiler often inlines automatically, but hints help for cross-crate calls.
+
+## Bad
+
+```rust
+// Small hot function without inline hint
+// May not be inlined across crate boundaries
+fn is_ascii_digit(b: u8) -> bool {
+    b >= b'0' && b <= b'9'
+}
+
+// Called millions of times
+for byte in data {
+    if is_ascii_digit(*byte) {  // Function call overhead
+        count += 1;
+    }
+}
+```
+
+## Good
+
+```rust
+#[inline]
+fn is_ascii_digit(b: u8) -> bool {
+    b >= b'0' && b <= b'9'
+}
+
+// Now the compiler will inline this
+for byte in data {
+    if is_ascii_digit(*byte) {  // Inlined, no call overhead
+        count += 1;
+    }
+}
+```
+
+## Inline Attributes
+
+```rust
+// No attribute - compiler decides (usually good for same-crate)
+fn auto_decide() { }
+
+// Suggest inlining - helps cross-crate
+#[inline]
+fn suggest_inline() { }
+
+// Strongly suggest inlining - almost always inlined
+#[inline(always)]
+fn force_inline() { }
+
+// Strongly suggest NOT inlining - for large/cold code
+#[inline(never)]
+fn prevent_inline() { }
+```
+
+## When to Use Each
+
+```rust
+// #[inline] - Small functions, especially in libraries
+#[inline]
+pub fn len(&self) -> usize {
+    self.inner.len()
+}
+
+// #[inline(always)] - Critical hot path, verified by profiling
+#[inline(always)]
+fn hot_inner_loop_helper(x: u32) -> u32 {
+    x.wrapping_mul(0x9E3779B9)
+}
+
+// #[inline(never)] - Error handlers, cold paths
+#[inline(never)]
+fn handle_error(err: Error) -> ! {
+    eprintln!("Fatal: {}", err);
+    std::process::exit(1);
+}
+
+// No attribute - large functions, infrequent calls
+fn complex_processing(data: &mut Data) {
+    // Many lines of code...
+}
+```
+
+## Evidence from ripgrep
+
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/printer/src/standard.rs
+
+#[inline(always)]
+fn write_prelude(
+    &self,
+    absolute_byte_offset: u64,
+    line_number: Option<u64>,
+    column: Option<u64>,
+) -> io::Result<()> {
+    // Hot path in printing matches
+}
+
+#[inline(always)]
+fn write_line(&self, line: &[u8]) -> io::Result<()> {
+    // Called for every line
+}
+```
+
+## Generic Functions
+
+```rust
+// Generic functions are already candidates for per-monomorphization inlining
+// But #[inline] helps ensure it across crates
+
+#[inline]
+pub fn min<T: Ord>(a: T, b: T) -> T {
+    if a < b { a } else { b }
+}
+```
+
+## Cautions
+
+```rust
+// DON'T inline large functions - hurts instruction cache
+#[inline(always)]  // BAD for large function
+fn large_complex_function(data: &mut [u8]) {
+    // 100+ lines of code
+    // Inlining bloats every call site
+}
+
+// DON'T assume inlining always helps - measure!
+// Sometimes the compiler makes better decisions
+
+// Inlining is non-transitive
+#[inline]
+fn outer() {
+    inner();  // inner() also needs #[inline] to be inlined together
+}
+
+fn inner() { }  // Won't be inlined at outer's call sites
+```
+
+## Verifying Inlining
+
+```bash
+# Check if function was inlined using Cachegrind
+# Non-inlined functions show entry/exit counts
+
+# Or examine assembly
+cargo rustc --release -- --emit=asm
+# Look for call instructions vs inlined code
+```
+
+## See Also
+
+- [opt-inline-always-rare](opt-inline-always-rare.md) - Use #[inline(always)] sparingly
+- [opt-inline-never-cold](opt-inline-never-cold.md) - Use #[inline(never)] for cold paths
+- [opt-cold-unlikely](opt-cold-unlikely.md) - Use #[cold] for unlikely paths
+- [opt-lto-release](opt-lto-release.md) - LTO enables cross-crate inlining

--- a/.agents/skills/rust-skills/rules/opt-likely-hint.md
+++ b/.agents/skills/rust-skills/rules/opt-likely-hint.md
@@ -1,0 +1,171 @@
+# opt-likely-hint
+
+> Use code structure to hint at likely branches; use intrinsics on nightly
+
+## Why It Matters
+
+Modern CPUs predict branches to speculatively execute code. Mispredictions cause pipeline stalls (10-20 cycles). Helping the compiler understand which branches are likely allows it to generate optimal code layout and branch hints, improving performance in hot paths.
+
+## Stable Rust: Code Structure Hints
+
+```rust
+// Pattern 1: Early returns for unlikely cases
+fn process(data: Option<&Data>) -> i32 {
+    // Compiler assumes early return is "unlikely"
+    let data = match data {
+        None => return 0,  // Unlikely
+        Some(d) => d,
+    };
+    
+    // Hot path continues here
+    complex_processing(data)
+}
+
+// Pattern 2: if-else ordering
+fn calculate(x: i32) -> i32 {
+    if x >= 0 {
+        // Put likely case in "if" branch
+        x * 2
+    } else {
+        // Unlikely case in "else"
+        handle_negative(x)
+    }
+}
+
+// Pattern 3: Cold function extraction
+fn hot_path(data: &[u8]) -> Result<(), Error> {
+    if data.is_empty() {
+        return cold_empty_error();  // Extracted = unlikely
+    }
+    
+    process_fast(data)
+}
+
+#[cold]
+fn cold_empty_error() -> Result<(), Error> {
+    Err(Error::EmptyInput)
+}
+```
+
+## Nightly: Intrinsics
+
+```rust
+#![feature(core_intrinsics)]
+use std::intrinsics::{likely, unlikely};
+
+fn process(data: &Data) -> i32 {
+    if unlikely(data.is_corrupted()) {
+        return handle_corruption(data);
+    }
+    
+    if likely(data.is_cached()) {
+        return fast_cached_path(data);
+    }
+    
+    slow_uncached_path(data)
+}
+```
+
+## Boolean Likely Wrapper (Nightly)
+
+```rust
+#![feature(core_intrinsics)]
+
+#[inline(always)]
+fn likely(b: bool) -> bool {
+    std::intrinsics::likely(b)
+}
+
+#[inline(always)]
+fn unlikely(b: bool) -> bool {
+    std::intrinsics::unlikely(b)
+}
+
+// Usage
+if likely(x > 0) {
+    hot_path(x)
+} else {
+    cold_path(x)
+}
+```
+
+## Stable: likely-stable Crate
+
+```rust
+use likely_stable::{likely, unlikely};
+
+fn check(value: i32) -> bool {
+    if unlikely(value < 0) {
+        handle_negative()
+    } else if likely(value < 1000) {
+        handle_common()
+    } else {
+        handle_large()
+    }
+}
+```
+
+## Loop Optimization
+
+```rust
+fn search(data: &[i32], target: i32) -> Option<usize> {
+    for (i, &item) in data.iter().enumerate() {
+        // Assume most iterations DON'T find the target
+        if unlikely(item == target) {
+            return Some(i);
+        }
+    }
+    None
+}
+
+// Alternative: structure for likely case
+fn search_common(data: &[i32], target: i32) -> Option<usize> {
+    // If target is usually found
+    for (i, &item) in data.iter().enumerate() {
+        if likely(item == target) {
+            return Some(i);
+        }
+    }
+    None
+}
+```
+
+## Match Arm Ordering
+
+```rust
+// Put most common variants first
+fn process_message(msg: Message) {
+    match msg {
+        // Most common - listed first
+        Message::Data(d) => handle_data(d),
+        Message::Heartbeat => (), // Second most common
+        
+        // Rare cases last
+        Message::Error(e) => handle_error(e),
+        Message::Shutdown => shutdown(),
+    }
+}
+```
+
+## Benchmark-Driven Hints
+
+```rust
+// Profile first to know which branches are actually likely!
+fn speculative(x: i32) -> i32 {
+    // DON'T GUESS - measure with profiling
+    // perf record / perf report
+    // cargo flamegraph
+    
+    if x > threshold {  // Is this actually common?
+        path_a(x)
+    } else {
+        path_b(x)
+    }
+}
+```
+
+## See Also
+
+- [opt-cold-unlikely](./opt-cold-unlikely.md) - #[cold] for unlikely functions
+- [opt-inline-never-cold](./opt-inline-never-cold.md) - Keeping cold code separate
+- [perf-profile-first](./perf-profile-first.md) - Profile to know what's likely

--- a/.agents/skills/rust-skills/rules/opt-lto-release.md
+++ b/.agents/skills/rust-skills/rules/opt-lto-release.md
@@ -1,0 +1,130 @@
+# opt-lto-release
+
+> Enable LTO in release builds
+
+## Why It Matters
+
+Link-Time Optimization (LTO) enables optimizations across crate boundaries that aren't possible during normal compilation. This includes cross-crate inlining, dead code elimination, and devirtualization. Typically provides 5-20% performance improvement.
+
+## Bad
+
+```toml
+# Cargo.toml - default release profile
+[profile.release]
+opt-level = 3
+# No LTO = missed optimization opportunities
+```
+
+## Good
+
+```toml
+# Cargo.toml - optimized release profile
+[profile.release]
+opt-level = 3
+lto = "fat"          # Maximum optimization
+codegen-units = 1    # Better optimization (single codegen unit)
+panic = "abort"      # Smaller binary, no unwind tables
+strip = true         # Remove symbols for smaller binary
+```
+
+## LTO Options Explained
+
+```toml
+# No LTO (default)
+lto = false
+
+# Thin LTO - fast compilation, most benefits
+lto = "thin"
+
+# Fat LTO - slowest compilation, maximum optimization
+lto = "fat"
+# Equivalent to:
+lto = true
+
+# Thin-local - LTO within each crate only
+lto = "off"
+```
+
+## Trade-offs
+
+| Setting | Compile Time | Binary Size | Performance |
+|---------|--------------|-------------|-------------|
+| `lto = false` | Fast | Larger | Baseline |
+| `lto = "thin"` | Medium | Smaller | +5-15% |
+| `lto = "fat"` | Slow | Smallest | +10-20% |
+
+## Evidence from Production
+
+```toml
+# From Anchor (Solana framework)
+# https://github.com/solana-foundation/anchor/blob/master/cli/src/rust_template.rs
+[profile.release]
+overflow-checks = true
+lto = "fat"
+codegen-units = 1
+
+# From sol-trade-sdk
+# https://github.com/0xfnzero/sol-trade-sdk
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+```
+
+## Complete Optimized Profile
+
+```toml
+[profile.release]
+opt-level = 3        # Maximum optimization
+lto = "fat"          # Link-time optimization
+codegen-units = 1    # Single codegen unit for better optimization
+panic = "abort"      # Remove panic unwinding code
+strip = true         # Strip symbols
+debug = false        # No debug info
+
+# For benchmarking (need some debug info for profiling)
+[profile.bench]
+inherits = "release"
+debug = true
+strip = false
+
+# Fast dev builds with optimized dependencies
+[profile.dev]
+opt-level = 0
+debug = true
+
+[profile.dev.package."*"]
+opt-level = 3        # Optimize dependencies even in dev
+```
+
+## When to Use Each
+
+| Situation | LTO Setting |
+|-----------|-------------|
+| Development | `false` (fast compiles) |
+| CI builds | `"thin"` (balance) |
+| Release binaries | `"fat"` (max perf) |
+| Libraries (crates.io) | `false` (users choose) |
+
+## Measuring Impact
+
+```bash
+# Build without LTO
+cargo build --release
+hyperfine ./target/release/myapp
+
+# Build with LTO
+# (after adding lto = "fat" to Cargo.toml)
+cargo build --release
+hyperfine ./target/release/myapp
+
+# Compare binary sizes
+ls -la target/release/myapp
+```
+
+## See Also
+
+- [opt-codegen-units](opt-codegen-units.md) - Use codegen-units = 1
+- [opt-pgo-profile](opt-pgo-profile.md) - Profile-guided optimization
+- [perf-release-profile](perf-release-profile.md) - Full release profile settings

--- a/.agents/skills/rust-skills/rules/opt-pgo-profile.md
+++ b/.agents/skills/rust-skills/rules/opt-pgo-profile.md
@@ -1,0 +1,167 @@
+# opt-pgo-profile
+
+> Use Profile-Guided Optimization (PGO) for maximum performance
+
+## Why It Matters
+
+PGO uses real runtime behavior to guide compiler optimization decisions. By profiling actual workloads, the compiler learns which code paths are hot, optimizing them aggressively while deprioritizing cold paths. This can yield 10-30% performance improvements beyond standard optimizations.
+
+## The PGO Process
+
+1. **Instrument**: Build with profiling instrumentation
+2. **Profile**: Run representative workloads
+3. **Optimize**: Rebuild using collected profile data
+
+## Step-by-Step
+
+```bash
+# Step 1: Build instrumented binary
+RUSTFLAGS="-Cprofile-generate=/tmp/pgo-data" \
+    cargo build --release
+
+# Step 2: Run representative workloads
+./target/release/my_app < test_data_1.txt
+./target/release/my_app < test_data_2.txt
+./target/release/my_app < typical_workload.txt
+
+# Step 3: Merge profile data
+llvm-profdata merge -o /tmp/pgo-data/merged.profdata /tmp/pgo-data
+
+# Step 4: Build optimized binary using profile
+RUSTFLAGS="-Cprofile-use=/tmp/pgo-data/merged.profdata" \
+    cargo build --release
+```
+
+## Cargo Configuration
+
+```toml
+# Cargo.toml
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+
+# PGO flags set via RUSTFLAGS environment variable
+```
+
+## Build Script
+
+```bash
+#!/bin/bash
+set -e
+
+PGO_DIR=/tmp/pgo-$(date +%s)
+
+# Clean
+cargo clean
+
+# Instrumented build
+echo "Building instrumented binary..."
+RUSTFLAGS="-Cprofile-generate=$PGO_DIR" cargo build --release
+
+# Run workloads
+echo "Collecting profile data..."
+./target/release/my_app --benchmark-mode
+./target/release/my_app < test_fixtures/typical.txt
+./target/release/my_app < test_fixtures/stress.txt
+
+# Merge profiles
+echo "Merging profile data..."
+llvm-profdata merge -o $PGO_DIR/merged.profdata $PGO_DIR
+
+# Optimized build
+echo "Building optimized binary..."
+RUSTFLAGS="-Cprofile-use=$PGO_DIR/merged.profdata" cargo build --release
+
+echo "Done! Optimized binary at target/release/my_app"
+```
+
+## Representative Workloads
+
+```rust
+// Create benchmarks that match real usage patterns
+
+// Good: actual data samples
+fn profile_workload() {
+    for file in real_customer_data_samples() {
+        process_file(&file);
+    }
+}
+
+// Good: synthetic but realistic
+fn profile_synthetic() {
+    for _ in 0..10000 {
+        let data = generate_realistic_data();
+        process(&data);
+    }
+}
+
+// Bad: artificial microbenchmarks
+fn profile_bad() {
+    for _ in 0..1000000 {
+        small_operation();  // Doesn't reflect real hot paths
+    }
+}
+```
+
+## BOLT Post-Link Optimization
+
+For even more gains, combine PGO with BOLT:
+
+```bash
+# After PGO build, apply BOLT
+llvm-bolt target/release/my_app \
+    -o target/release/my_app.bolt \
+    -data=perf.data \
+    -reorder-blocks=ext-tsp \
+    -reorder-functions=hfsort
+
+# BOLT can add another 5-15% on top of PGO
+```
+
+## CI/CD Integration
+
+```yaml
+# GitHub Actions example
+jobs:
+  pgo-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install LLVM tools
+        run: sudo apt-get install llvm
+      
+      - name: Instrumented build
+        run: RUSTFLAGS="-Cprofile-generate=/tmp/pgo" cargo build --release
+      
+      - name: Run profiling workloads
+        run: ./scripts/run_profiling_workloads.sh
+      
+      - name: Merge profiles
+        run: llvm-profdata merge -o /tmp/pgo/merged.profdata /tmp/pgo
+      
+      - name: Optimized build
+        run: RUSTFLAGS="-Cprofile-use=/tmp/pgo/merged.profdata" cargo build --release
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimized-binary
+          path: target/release/my_app
+```
+
+## When to Use PGO
+
+| Use PGO | Skip PGO |
+|---------|----------|
+| Production deployments | Development builds |
+| Performance-critical apps | Libraries (users can PGO) |
+| Stable workload patterns | Highly variable workloads |
+| Sufficient profiling data | Quick iteration cycles |
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - LTO works well with PGO
+- [opt-codegen-units](./opt-codegen-units.md) - Single codegen unit for PGO
+- [perf-profile-first](./perf-profile-first.md) - Profiling basics

--- a/.agents/skills/rust-skills/rules/opt-simd-portable.md
+++ b/.agents/skills/rust-skills/rules/opt-simd-portable.md
@@ -1,0 +1,144 @@
+# opt-simd-portable
+
+> Use portable SIMD for vectorized operations across architectures
+
+## Why It Matters
+
+SIMD (Single Instruction, Multiple Data) processes multiple values per instruction—4x, 8x, or more speedup for suitable algorithms. Rust's portable SIMD (nightly) and crates like `wide` provide cross-platform vectorization without architecture-specific intrinsics. For stable Rust, let LLVM auto-vectorize or use platform-specific crates.
+
+## Autovectorization (Stable)
+
+```rust
+// LLVM often vectorizes simple patterns automatically
+fn sum(data: &[f32]) -> f32 {
+    data.iter().sum()  // May vectorize to SIMD
+}
+
+fn add_arrays(a: &[f32], b: &[f32], out: &mut [f32]) {
+    for ((x, y), o) in a.iter().zip(b).zip(out.iter_mut()) {
+        *o = x + y;  // Often vectorizes
+    }
+}
+
+// Help autovectorization:
+// 1. Use iterators over indexing
+// 2. Avoid early exits in loops
+// 3. Use chunks_exact for aligned access
+```
+
+## Portable SIMD (Nightly)
+
+```rust
+#![feature(portable_simd)]
+use std::simd::*;
+
+fn sum_simd(data: &[f32]) -> f32 {
+    let (prefix, middle, suffix) = data.as_simd::<8>();
+    
+    // Handle unaligned prefix
+    let mut sum = prefix.iter().sum::<f32>();
+    
+    // SIMD loop - 8 floats at a time
+    let mut simd_sum = f32x8::splat(0.0);
+    for chunk in middle {
+        simd_sum += *chunk;
+    }
+    sum += simd_sum.reduce_sum();
+    
+    // Handle unaligned suffix
+    sum += suffix.iter().sum::<f32>();
+    
+    sum
+}
+
+fn dot_product(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len());
+    
+    let (a_pre, a_mid, a_suf) = a.as_simd::<8>();
+    let (b_pre, b_mid, b_suf) = b.as_simd::<8>();
+    
+    let scalar: f32 = a_pre.iter().zip(b_pre).map(|(x, y)| x * y).sum();
+    
+    let mut simd_sum = f32x8::splat(0.0);
+    for (av, bv) in a_mid.iter().zip(b_mid) {
+        simd_sum += *av * *bv;
+    }
+    
+    let suffix: f32 = a_suf.iter().zip(b_suf).map(|(x, y)| x * y).sum();
+    
+    scalar + simd_sum.reduce_sum() + suffix
+}
+```
+
+## wide Crate (Stable)
+
+```rust
+use wide::*;
+
+fn process_simd(data: &mut [f32]) {
+    // Process 8 floats at a time
+    for chunk in data.chunks_exact_mut(8) {
+        let v = f32x8::from(chunk);
+        let result = v * f32x8::splat(2.0) + f32x8::splat(1.0);
+        chunk.copy_from_slice(&result.to_array());
+    }
+}
+
+fn blend_images(a: &[u8], b: &[u8], alpha: f32, out: &mut [u8]) {
+    let alpha_v = f32x8::splat(alpha);
+    let one_minus = f32x8::splat(1.0 - alpha);
+    
+    for ((a_chunk, b_chunk), out_chunk) in 
+        a.chunks_exact(8).zip(b.chunks_exact(8)).zip(out.chunks_exact_mut(8)) 
+    {
+        let av = f32x8::from([
+            a_chunk[0] as f32, a_chunk[1] as f32, /* ... */
+        ]);
+        let bv = f32x8::from([
+            b_chunk[0] as f32, b_chunk[1] as f32, /* ... */
+        ]);
+        
+        let result = av * one_minus + bv * alpha_v;
+        // Convert back to u8...
+    }
+}
+```
+
+## Platform-Specific (When Needed)
+
+```rust
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn sum_avx2(data: &[f32]) -> f32 {
+    let mut sum = _mm256_setzero_ps();
+    
+    for chunk in data.chunks_exact(8) {
+        let v = _mm256_loadu_ps(chunk.as_ptr());
+        sum = _mm256_add_ps(sum, v);
+    }
+    
+    // Horizontal sum
+    let high = _mm256_extractf128_ps(sum, 1);
+    let low = _mm256_castps256_ps128(sum);
+    let sum128 = _mm_add_ps(high, low);
+    // ... continue reduction
+}
+```
+
+## Choosing an Approach
+
+| Approach | Stability | Portability | Control |
+|----------|-----------|-------------|---------|
+| Autovectorization | Stable | Excellent | Low |
+| `wide` crate | Stable | Good | Medium |
+| Portable SIMD | Nightly | Excellent | High |
+| Intrinsics | Stable | None | Maximum |
+
+## See Also
+
+- [opt-target-cpu](./opt-target-cpu.md) - Enable SIMD features
+- [opt-bounds-check](./opt-bounds-check.md) - Unchecked access for SIMD
+- [perf-profile-first](./perf-profile-first.md) - Identify vectorization opportunities

--- a/.agents/skills/rust-skills/rules/opt-target-cpu.md
+++ b/.agents/skills/rust-skills/rules/opt-target-cpu.md
@@ -1,0 +1,154 @@
+# opt-target-cpu
+
+> Use `target-cpu=native` for maximum performance on known deployment targets
+
+## Why It Matters
+
+By default, Rust compiles for a generic x86-64 baseline (roughly Sandy Bridge era). Modern CPUs have SIMD extensions (AVX2, AVX-512), improved instructions, and micro-architectural optimizations that go unused. `target-cpu=native` enables all features of your current CPU, potentially unlocking significant speedups.
+
+## Bad
+
+```toml
+# Cargo.toml - compiles for generic x86-64
+[profile.release]
+# No target-cpu specified
+# Binary works everywhere but uses only SSE2
+```
+
+## Good
+
+```toml
+# .cargo/config.toml - for known deployment target
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
+# Or specific CPU for cross-compilation
+# rustflags = ["-C", "target-cpu=skylake"]
+```
+
+## Via Environment
+
+```bash
+# Build with native optimizations
+RUSTFLAGS="-C target-cpu=native" cargo build --release
+
+# Check what features are enabled
+rustc --print cfg -C target-cpu=native | grep target_feature
+```
+
+## Common Target CPUs
+
+```bash
+# x86-64 targets
+target-cpu=native          # Current machine
+target-cpu=x86-64          # Baseline (SSE2)
+target-cpu=x86-64-v2       # SSE4.2, POPCNT
+target-cpu=x86-64-v3       # AVX2, BMI2
+target-cpu=x86-64-v4       # AVX-512
+
+# Intel specific
+target-cpu=skylake         # 6th gen Core
+target-cpu=alderlake       # 12th gen Core
+
+# AMD specific
+target-cpu=znver3          # Zen 3
+target-cpu=znver4          # Zen 4
+
+# ARM
+target-cpu=apple-m1        # Apple Silicon
+target-cpu=neoverse-n1     # AWS Graviton2
+```
+
+## Feature Detection at Runtime
+
+```rust
+// For portable binaries that use native features when available
+#[cfg(target_arch = "x86_64")]
+fn process_fast(data: &[u8]) -> u64 {
+    if is_x86_feature_detected!("avx2") {
+        unsafe { process_avx2(data) }
+    } else if is_x86_feature_detected!("sse4.2") {
+        unsafe { process_sse42(data) }
+    } else {
+        process_generic(data)
+    }
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn process_avx2(data: &[u8]) -> u64 {
+    // AVX2 optimized implementation
+}
+```
+
+## Multi-Architecture Builds
+
+```bash
+# Build multiple binaries
+RUSTFLAGS="-C target-cpu=x86-64" cargo build --release
+mv target/release/app target/release/app-generic
+
+RUSTFLAGS="-C target-cpu=x86-64-v3" cargo build --release
+mv target/release/app target/release/app-avx2
+
+# Select at runtime
+if supports_avx2; then
+    ./app-avx2
+else
+    ./app-generic
+fi
+```
+
+## Cargo Configuration
+
+```toml
+# .cargo/config.toml
+
+# Native builds for development
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=native"]
+
+# AWS deployment (Graviton2)
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=neoverse-n1"]
+
+# Intel server deployment
+[target.x86_64-unknown-linux-gnu.deployment]
+rustflags = ["-C", "target-cpu=skylake-avx512"]
+```
+
+## What Changes
+
+```rust
+// With AVX2 enabled:
+// - 256-bit SIMD operations
+// - Better autovectorization
+// - FMA (fused multiply-add)
+// - BMI (bit manipulation)
+
+// Example: sum of squares
+fn sum_squares(data: &[f64]) -> f64 {
+    data.iter().map(|x| x * x).sum()
+}
+// Generic: scalar loop
+// AVX2: processes 4 f64s per iteration
+```
+
+## Checking Enabled Features
+
+```bash
+# What's enabled for native?
+rustc --print cfg -C target-cpu=native | grep feature
+
+# Compare generic vs native
+rustc --print cfg -C target-cpu=x86-64 | grep feature
+rustc --print cfg -C target-cpu=native | grep feature
+
+# View generated assembly
+cargo asm --rust --release my_crate::hot_function
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - Combine with LTO
+- [opt-simd-portable](./opt-simd-portable.md) - Portable SIMD
+- [opt-codegen-units](./opt-codegen-units.md) - Single codegen unit

--- a/.agents/skills/rust-skills/rules/own-arc-shared.md
+++ b/.agents/skills/rust-skills/rules/own-arc-shared.md
@@ -1,0 +1,141 @@
+# own-arc-shared
+
+> Use `Arc<T>` for thread-safe shared ownership
+
+## Why It Matters
+
+`Arc` (Atomic Reference Counted) provides shared ownership across threads. Unlike `Rc`, its reference count is updated atomically, making it safe for concurrent access. Use it when multiple threads need to read the same data.
+
+## Bad
+
+```rust
+use std::rc::Rc;
+use std::thread;
+
+let data = Rc::new(vec![1, 2, 3]);
+let data_clone = Rc::clone(&data);
+
+// ERROR: Rc cannot be sent between threads safely
+thread::spawn(move || {
+    println!("{:?}", data_clone);
+});
+```
+
+## Good
+
+```rust
+use std::sync::Arc;
+use std::thread;
+
+let data = Arc::new(vec![1, 2, 3]);
+let data_clone = Arc::clone(&data);
+
+thread::spawn(move || {
+    println!("{:?}", data_clone);  // Safe!
+});
+
+println!("{:?}", data);  // Original still accessible
+```
+
+## Arc with Mutex for Mutable Shared State
+
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+let counter = Arc::new(Mutex::new(0));
+let mut handles = vec![];
+
+for _ in 0..10 {
+    let counter = Arc::clone(&counter);
+    let handle = thread::spawn(move || {
+        let mut num = counter.lock().unwrap();
+        *num += 1;
+    });
+    handles.push(handle);
+}
+
+for handle in handles {
+    handle.join().unwrap();
+}
+
+println!("Result: {}", *counter.lock().unwrap());
+```
+
+## Arc vs Rc Decision Tree
+
+```
+Need shared ownership?
+├── No → Use owned value or references
+└── Yes → Will it cross thread boundaries?
+    ├── No → Use Rc<T> (cheaper, no atomic ops)
+    └── Yes → Use Arc<T>
+        └── Need mutation?
+            ├── No → Arc<T> is enough
+            └── Yes → Arc<Mutex<T>> or Arc<RwLock<T>>
+```
+
+## Common Patterns
+
+```rust
+use std::sync::Arc;
+
+// Shared configuration (read-only)
+struct AppConfig {
+    database_url: String,
+    max_connections: u32,
+}
+
+fn setup_workers(config: Arc<AppConfig>) {
+    for i in 0..4 {
+        let config = Arc::clone(&config);
+        std::thread::spawn(move || {
+            println!("Worker {} using db: {}", i, config.database_url);
+        });
+    }
+}
+
+// Shared cache with interior mutability
+use std::sync::RwLock;
+use std::collections::HashMap;
+
+type Cache = Arc<RwLock<HashMap<String, String>>>;
+
+fn get_cached(cache: &Cache, key: &str) -> Option<String> {
+    cache.read().unwrap().get(key).cloned()
+}
+
+fn set_cached(cache: &Cache, key: String, value: String) {
+    cache.write().unwrap().insert(key, value);
+}
+```
+
+## Performance Considerations
+
+```rust
+// Arc::clone is cheap - just increments atomic counter
+let a = Arc::new(large_data);
+let b = Arc::clone(&a);  // Fast! No data copied
+
+// But atomic operations have overhead vs Rc
+// Use Rc in single-threaded contexts for better performance
+
+// Avoid cloning Arc in hot loops if possible
+// Bad:
+for item in items {
+    let arc = Arc::clone(&shared);  // Atomic op each iteration
+    process(arc, item);
+}
+
+// Better: Clone once outside loop if possible
+let arc = Arc::clone(&shared);
+for item in items {
+    process(&arc, item);  // Pass reference
+}
+```
+
+## See Also
+
+- [own-rc-single-thread](own-rc-single-thread.md) - Use Rc for single-threaded sharing
+- [own-mutex-interior](own-mutex-interior.md) - Use Mutex for interior mutability
+- [async-clone-before-await](async-clone-before-await.md) - Clone Arc before await points

--- a/.agents/skills/rust-skills/rules/own-borrow-over-clone.md
+++ b/.agents/skills/rust-skills/rules/own-borrow-over-clone.md
@@ -1,0 +1,95 @@
+# own-borrow-over-clone
+
+> Prefer `&T` borrowing over `.clone()`
+
+## Why It Matters
+
+Cloning allocates new memory and copies data, while borrowing is free. Unnecessary clones can significantly impact performance, especially in hot paths or with large data structures.
+
+## Bad
+
+```rust
+fn process(data: &String) {
+    let local = data.clone();  // Unnecessary allocation!
+    println!("{}", local);
+}
+
+fn count_words(text: &String) -> usize {
+    let owned = text.clone();  // Why clone just to read?
+    owned.split_whitespace().count()
+}
+
+// Clone in a loop - multiplied cost
+fn process_all(items: &[String]) {
+    for item in items {
+        let copy = item.clone();  // N allocations!
+        handle(&copy);
+    }
+}
+```
+
+## Good
+
+```rust
+fn process(data: &str) {  // Accept &str, more flexible
+    println!("{}", data);  // No allocation needed
+}
+
+fn count_words(text: &str) -> usize {
+    text.split_whitespace().count()  // Just borrow
+}
+
+// Borrow in a loop - zero allocations
+fn process_all(items: &[String]) {
+    for item in items {
+        handle(item);  // Pass reference
+    }
+}
+```
+
+## When Clone Is Acceptable
+
+```rust
+// 1. Need owned data for storage
+struct Cache {
+    data: HashMap<String, String>,
+}
+
+impl Cache {
+    fn insert(&mut self, key: &str, value: &str) {
+        // Clone needed - we're storing owned data
+        self.data.insert(key.to_string(), value.to_string());
+    }
+}
+
+// 2. Need to send across threads
+fn spawn_worker(data: &Config) {
+    let owned = data.clone();  // Clone needed for 'static
+    std::thread::spawn(move || {
+        use_config(owned);
+    });
+}
+
+// 3. Copy types (no heap allocation)
+let x: i32 = 42;
+let y = x;  // Copy, not clone - this is fine
+```
+
+## Evidence
+
+From ripgrep's codebase - uses `Cow` to avoid clones:
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/globset/src/pathutil.rs
+pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
+    match *path {
+        Cow::Borrowed(path) => Cow::Borrowed(&path[last_slash..]),
+        Cow::Owned(ref path) => Cow::Owned(path.clone()),
+    }
+}
+```
+
+## See Also
+
+- [own-slice-over-vec](own-slice-over-vec.md) - Accept slices instead of references to collections
+- [own-cow-conditional](own-cow-conditional.md) - Use Cow for conditional ownership
+- [mem-clone-from](mem-clone-from.md) - Reuse allocations when cloning

--- a/.agents/skills/rust-skills/rules/own-clone-explicit.md
+++ b/.agents/skills/rust-skills/rules/own-clone-explicit.md
@@ -1,0 +1,135 @@
+# own-clone-explicit
+
+> Use explicit `Clone` for types where copying has meaningful cost
+
+## Why It Matters
+
+Unlike `Copy` which is implicit and "free," `Clone` requires an explicit `.clone()` call, signaling that duplication has a cost. This makes heap allocations and deep copies visible in code, helping developers reason about performance. Types with heap data (`String`, `Vec`, `Box`) should implement `Clone` but not `Copy`.
+
+## Bad
+
+```rust
+// Hiding expensive operations
+fn process_data(data: Vec<u32>) -> Vec<u32> {
+    let backup = data; // Moved, not copied - but unclear at call site
+    transform(backup)
+}
+
+let my_data = vec![1, 2, 3, 4, 5];
+let result = process_data(my_data);
+// my_data is moved - surprise if you expected it to still exist
+```
+
+## Good
+
+```rust
+fn process_data(data: Vec<u32>) -> Vec<u32> {
+    let backup = data; 
+    transform(backup)
+}
+
+let my_data = vec![1, 2, 3, 4, 5];
+let result = process_data(my_data.clone()); // Explicit: "I know this allocates"
+// my_data still available
+
+// Or better - take reference if you don't need ownership
+fn process_data_ref(data: &[u32]) -> Vec<u32> {
+    transform(data)
+}
+let result = process_data_ref(&my_data); // No clone needed
+```
+
+## Custom Clone Implementation
+
+For types with mixed cheap/expensive fields, implement `Clone` manually:
+
+```rust
+#[derive(Debug)]
+struct Document {
+    id: u64,              // Cheap to copy
+    content: String,      // Expensive to clone
+    metadata: Metadata,   // Moderate cost
+}
+
+impl Clone for Document {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            content: self.content.clone(),
+            metadata: self.metadata.clone(),
+        }
+    }
+    
+    // Optimization: reuse existing allocations
+    fn clone_from(&mut self, source: &Self) {
+        self.id = source.id;
+        self.content.clone_from(&source.content); // Reuses capacity
+        self.metadata.clone_from(&source.metadata);
+    }
+}
+```
+
+## clone_from Optimization
+
+`clone_from` can reuse existing allocations:
+
+```rust
+let mut buffer = String::with_capacity(1000);
+
+// Bad: drops old allocation, creates new one
+buffer = source.clone();
+
+// Good: reuses existing capacity if sufficient
+buffer.clone_from(&source);
+```
+
+## Derive vs Manual Clone
+
+```rust
+// Derive when all fields need cloning
+#[derive(Clone)]
+struct Simple {
+    data: Vec<u8>,
+    name: String,
+}
+
+// Manual when you need special behavior
+struct CachedValue {
+    value: i32,
+    cache: RefCell<Option<ExpensiveComputation>>,
+}
+
+impl Clone for CachedValue {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value,
+            cache: RefCell::new(None), // Don't clone cache, let it rebuild
+        }
+    }
+}
+```
+
+## When to Avoid Clone
+
+```rust
+// Instead of cloning, consider:
+
+// 1. References
+fn process(data: &MyType) { } // Borrow instead of clone
+
+// 2. Cow for conditional cloning
+fn process(data: Cow<'_, str>) { } // Clone only if mutation needed
+
+// 3. Arc for shared ownership
+let shared = Arc::new(expensive_data);
+let handle = shared.clone(); // Cheap: just increments counter
+
+// 4. Passing by value when caller is done with it
+fn consume(data: MyType) { } // Caller moves, no clone
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - When implicit Copy is appropriate
+- [own-cow-conditional](./own-cow-conditional.md) - Avoiding clones with Cow
+- [mem-clone-from](./mem-clone-from.md) - Optimizing repeated clones

--- a/.agents/skills/rust-skills/rules/own-copy-small.md
+++ b/.agents/skills/rust-skills/rules/own-copy-small.md
@@ -1,0 +1,124 @@
+# own-copy-small
+
+> Implement `Copy` for small, simple types
+
+## Why It Matters
+
+Types that implement `Copy` are implicitly duplicated on assignment instead of moved. This eliminates the need for explicit `.clone()` calls and makes the code more ergonomic. For small types (generally ≤16 bytes), copying is as fast or faster than moving a pointer.
+
+## Bad
+
+```rust
+// Small type without Copy - requires explicit clone
+#[derive(Clone, Debug)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn distance(p1: Point, p2: Point) -> f64 {
+    ((p2.x - p1.x).powi(2) + (p2.y - p1.y).powi(2)).sqrt()
+}
+
+let origin = Point { x: 0.0, y: 0.0 };
+let target = Point { x: 3.0, y: 4.0 };
+
+let d1 = distance(origin.clone(), target.clone()); // Tedious
+let d2 = distance(origin.clone(), target.clone()); // Every use needs clone
+// origin and target still usable but verbose
+```
+
+## Good
+
+```rust
+// Small type with Copy - implicit duplication
+#[derive(Clone, Copy, Debug)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+fn distance(p1: Point, p2: Point) -> f64 {
+    ((p2.x - p1.x).powi(2) + (p2.y - p1.y).powi(2)).sqrt()
+}
+
+let origin = Point { x: 0.0, y: 0.0 };
+let target = Point { x: 3.0, y: 4.0 };
+
+let d1 = distance(origin, target); // Implicitly copied
+let d2 = distance(origin, target); // Still works!
+// origin and target remain valid
+```
+
+## Copy Requirements
+
+A type can implement `Copy` only if:
+1. All fields implement `Copy`
+2. No custom `Drop` implementation
+3. No heap-allocated data (`String`, `Vec`, `Box`, etc.)
+
+```rust
+// ✅ Can be Copy
+#[derive(Clone, Copy)]
+struct Color {
+    r: u8,
+    g: u8,
+    b: u8,
+    a: u8,
+}
+
+// ❌ Cannot be Copy - contains String
+#[derive(Clone)]
+struct Person {
+    name: String,  // String is not Copy
+    age: u32,
+}
+
+// ❌ Cannot be Copy - has Drop
+struct FileHandle {
+    fd: i32,
+}
+impl Drop for FileHandle {
+    fn drop(&mut self) { /* close file */ }
+}
+```
+
+## Size Guidelines
+
+| Size | Recommendation |
+|------|----------------|
+| ≤ 16 bytes | Implement `Copy` |
+| 17-64 bytes | Consider `Copy`, benchmark if critical |
+| > 64 bytes | Probably don't, prefer references |
+
+```rust
+use std::mem::size_of;
+
+#[derive(Clone, Copy)]
+struct SmallId(u64); // 8 bytes ✅
+
+#[derive(Clone, Copy)]
+struct Rect { x: f32, y: f32, w: f32, h: f32 } // 16 bytes ✅
+
+#[derive(Clone)] // No Copy - 72 bytes
+struct Transform {
+    matrix: [[f64; 3]; 3], // 72 bytes, too large
+}
+```
+
+## Common Copy Types
+
+Standard library types that are `Copy`:
+- All primitives: `i32`, `f64`, `bool`, `char`, etc.
+- References: `&T`, `&mut T`
+- Raw pointers: `*const T`, `*mut T`
+- Function pointers: `fn(T) -> U`
+- Tuples of `Copy` types: `(i32, f64)`
+- Arrays of `Copy` types: `[u8; 32]`
+- `Option<T>` where `T: Copy`
+- `PhantomData<T>`
+
+## See Also
+
+- [own-clone-explicit](./own-clone-explicit.md) - When Clone without Copy is appropriate
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern often uses Copy

--- a/.agents/skills/rust-skills/rules/own-cow-conditional.md
+++ b/.agents/skills/rust-skills/rules/own-cow-conditional.md
@@ -1,0 +1,135 @@
+# own-cow-conditional
+
+> Use `Cow<'a, T>` for conditional ownership
+
+## Why It Matters
+
+`Cow` (Clone-on-Write) lets you avoid allocations when you *might* need to own data but usually don't. It holds either a borrowed reference or an owned value, cloning only when mutation is needed.
+
+## Bad
+
+```rust
+// Always allocates, even when input doesn't need modification
+fn normalize_path(path: &str) -> String {
+    if path.contains("//") {
+        path.replace("//", "/")  // Allocation needed
+    } else {
+        path.to_string()  // Unnecessary allocation!
+    }
+}
+
+// Always clones the error message
+fn format_error(code: u32) -> String {
+    match code {
+        404 => "Not Found".to_string(),      // Unnecessary!
+        500 => "Internal Error".to_string(), // Unnecessary!
+        _ => format!("Error {}", code),      // This one needs allocation
+    }
+}
+```
+
+## Good
+
+```rust
+use std::borrow::Cow;
+
+// Only allocates when needed
+fn normalize_path(path: &str) -> Cow<'_, str> {
+    if path.contains("//") {
+        Cow::Owned(path.replace("//", "/"))  // Allocate
+    } else {
+        Cow::Borrowed(path)  // Zero-cost borrow
+    }
+}
+
+// Static strings stay borrowed
+fn format_error(code: u32) -> Cow<'static, str> {
+    match code {
+        404 => Cow::Borrowed("Not Found"),      // No allocation
+        500 => Cow::Borrowed("Internal Error"), // No allocation
+        _ => Cow::Owned(format!("Error {}", code)), // Allocate only for unknown
+    }
+}
+```
+
+## Real-World Example from ripgrep
+
+```rust
+// https://github.com/BurntSushi/ripgrep/blob/master/crates/globset/src/pathutil.rs
+pub(crate) fn file_name<'a>(path: &Cow<'a, [u8]>) -> Option<Cow<'a, [u8]>> {
+    let last_slash = path.rfind_byte(b'/').map(|i| i + 1).unwrap_or(0);
+    match *path {
+        Cow::Borrowed(path) => Some(Cow::Borrowed(&path[last_slash..])),
+        Cow::Owned(ref path) => {
+            let mut path = path.clone();
+            path.drain_bytes(..last_slash);
+            Some(Cow::Owned(path))
+        }
+    }
+}
+```
+
+## Clone-on-Write Pattern
+
+```rust
+use std::borrow::Cow;
+
+fn process_text(text: Cow<'_, str>) -> Cow<'_, str> {
+    if text.contains("bad_word") {
+        // to_mut() clones if borrowed, returns &mut if owned
+        let mut owned = text.into_owned();
+        owned = owned.replace("bad_word", "***");
+        Cow::Owned(owned)
+    } else {
+        text  // Pass through unchanged
+    }
+}
+
+// Usage
+let borrowed: Cow<str> = Cow::Borrowed("hello world");
+let result = process_text(borrowed);  // No allocation!
+
+let with_bad: Cow<str> = Cow::Borrowed("hello bad_word");
+let result = process_text(with_bad);  // Allocates only here
+```
+
+## Cow with Collections
+
+```rust
+use std::borrow::Cow;
+
+// Mixed borrowed/owned in a collection
+fn collect_errors<'a>(
+    static_errors: &[&'static str],
+    dynamic_errors: Vec<String>,
+) -> Vec<Cow<'a, str>> {
+    let mut errors: Vec<Cow<str>> = Vec::new();
+    
+    // Static strings - no allocation
+    for &e in static_errors {
+        errors.push(Cow::Borrowed(e));
+    }
+    
+    // Dynamic strings - take ownership
+    for e in dynamic_errors {
+        errors.push(Cow::Owned(e));
+    }
+    
+    errors
+}
+```
+
+## When to Use Cow
+
+| Situation | Use Cow? |
+|-----------|----------|
+| Usually borrow, sometimes own | Yes |
+| Always need owned data | No, just use owned type |
+| Always borrow | No, just use reference |
+| Hot path, avoiding all allocations | Yes |
+| Returning static strings or formatted | Yes |
+
+## See Also
+
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning
+- [mem-avoid-format](mem-avoid-format.md) - Avoid format! when possible

--- a/.agents/skills/rust-skills/rules/own-lifetime-elision.md
+++ b/.agents/skills/rust-skills/rules/own-lifetime-elision.md
@@ -1,0 +1,134 @@
+# own-lifetime-elision
+
+> Rely on lifetime elision rules; add explicit lifetimes only when required
+
+## Why It Matters
+
+Rust's lifetime elision rules handle most common borrowing patterns automatically. Adding explicit lifetimes where they're not needed clutters code without adding clarity. However, understanding when elision applies helps you know when explicit lifetimes are truly necessary.
+
+## Bad
+
+```rust
+// Unnecessary explicit lifetimes - elision handles these
+fn first_word<'a>(s: &'a str) -> &'a str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+fn get_name<'a>(person: &'a Person) -> &'a str {
+    &person.name
+}
+
+impl<'a> Display for Wrapper<'a> {
+    fn fmt<'b>(&'b self, f: &'b mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+```
+
+## Good
+
+```rust
+// Let elision do its job
+fn first_word(s: &str) -> &str {
+    s.split_whitespace().next().unwrap_or("")
+}
+
+fn get_name(person: &Person) -> &str {
+    &person.name
+}
+
+impl Display for Wrapper<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+```
+
+## The Three Elision Rules
+
+1. **Each input reference gets its own lifetime:**
+   ```rust
+   fn foo(x: &str, y: &str) 
+   // becomes
+   fn foo<'a, 'b>(x: &'a str, y: &'b str)
+   ```
+
+2. **One input reference → output gets same lifetime:**
+   ```rust
+   fn foo(x: &str) -> &str
+   // becomes  
+   fn foo<'a>(x: &'a str) -> &'a str
+   ```
+
+3. **Method with `&self`/`&mut self` → output gets self's lifetime:**
+   ```rust
+   fn foo(&self, x: &str) -> &str
+   // becomes
+   fn foo<'a, 'b>(&'a self, x: &'b str) -> &'a str
+   ```
+
+## When Explicit Lifetimes ARE Required
+
+```rust
+// Multiple input references, output could come from either
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// Struct holding references
+struct Parser<'input> {
+    source: &'input str,
+    position: usize,
+}
+
+// Multiple distinct lifetimes needed
+struct Context<'s, 'c> {
+    source: &'s str,
+    cache: &'c mut Cache,
+}
+
+// Static lifetime for constants
+fn get_default() -> &'static str {
+    "default"
+}
+```
+
+## Anonymous Lifetime `'_`
+
+Use `'_` to let the compiler infer while being explicit about the presence of a lifetime:
+
+```rust
+// In struct definitions
+impl Iterator for Parser<'_> {
+    type Item = Token;
+    fn next(&mut self) -> Option<Self::Item> { ... }
+}
+
+// In function signatures where it adds clarity
+fn parse(input: &str) -> Result<Ast<'_>, Error> { ... }
+
+// Especially useful in trait bounds
+fn process(data: &impl AsRef<str>) -> Cow<'_, str> { ... }
+```
+
+## Common Patterns
+
+```rust
+// ✅ Elision works
+fn trim(s: &str) -> &str { s.trim() }
+fn first(v: &[i32]) -> Option<&i32> { v.first() }
+fn name(&self) -> &str { &self.name }
+
+// ❌ Elision fails - multiple inputs, ambiguous output
+fn pick(a: &str, b: &str, first: bool) -> &str // Error!
+
+// ✅ Fixed with explicit lifetime
+fn pick<'a>(a: &'a str, b: &'a str, first: bool) -> &'a str {
+    if first { a } else { b }
+}
+```
+
+## See Also
+
+- [own-borrow-over-clone](./own-borrow-over-clone.md) - Prefer borrowing to avoid ownership issues
+- [api-impl-asref](./api-impl-asref.md) - Generic borrowing with AsRef

--- a/.agents/skills/rust-skills/rules/own-move-large.md
+++ b/.agents/skills/rust-skills/rules/own-move-large.md
@@ -1,0 +1,134 @@
+# own-move-large
+
+> Move large types instead of copying; use `Box` if moves are expensive
+
+## Why It Matters
+
+In Rust, "moving" a value means copying its bytes to a new location and invalidating the old one. For large types (hundreds of bytes), this memcpy can be expensive. Boxing large types reduces move cost to copying a single pointer (8 bytes), making moves cheap regardless of the actual data size.
+
+## Bad
+
+```rust
+// Large struct moved repeatedly = expensive memcpy each time
+struct GameState {
+    board: [[Cell; 100]; 100],  // 10,000 cells
+    history: [Move; 1000],       // 1,000 moves
+    players: [Player; 4],        // Player data
+    // Total: potentially tens of KB
+}
+
+fn process_state(state: GameState) -> GameState {
+    // Moving ~40KB+ of data
+    let mut new_state = state;  // Memcpy here
+    new_state.apply_rules();
+    new_state  // Memcpy on return
+}
+
+let state = GameState::new();
+let state = process_state(state);  // Two large memcpys
+```
+
+## Good
+
+```rust
+// Box reduces move cost to 8 bytes
+struct GameState {
+    board: Box<[[Cell; 100]; 100]>,  // Pointer to heap
+    history: Vec<Move>,               // Already heap-allocated
+    players: [Player; 4],
+}
+
+fn process_state(mut state: GameState) -> GameState {
+    // Moving just pointers + small inline data
+    state.apply_rules();
+    state  // Cheap move
+}
+
+// Or use Box at call site for one-off cases
+fn process_large(state: Box<LargeStruct>) -> Box<LargeStruct> {
+    // 8-byte move regardless of LargeStruct size
+    state
+}
+```
+
+## When to Box
+
+| Type Size | Move Frequency | Recommendation |
+|-----------|----------------|----------------|
+| < 128 bytes | Any | Don't box |
+| 128-512 bytes | Rare | Probably don't box |
+| 128-512 bytes | Frequent | Consider boxing |
+| > 512 bytes | Any | Box or use references |
+| > 4KB | Any | Definitely box |
+
+## Stack vs Heap Tradeoffs
+
+```rust
+// Stack: fast allocation, limited size, moves copy bytes
+struct StackHeavy {
+    data: [u8; 4096],  // 4KB on stack
+}
+
+// Heap: allocation cost, unlimited size, moves copy pointer
+struct HeapLight {
+    data: Box<[u8; 4096]>,  // 8 bytes on stack, 4KB on heap
+}
+
+// Measure with size_of
+use std::mem::size_of;
+assert_eq!(size_of::<StackHeavy>(), 4096);
+assert_eq!(size_of::<HeapLight>(), 8);
+```
+
+## Alternative: References
+
+When you don't need ownership transfer, use references:
+
+```rust
+// Best: no move at all
+fn analyze_state(state: &GameState) -> Analysis {
+    // Borrows state, no copying
+    compute_analysis(state)
+}
+
+// Mutable borrow for in-place modification
+fn update_state(state: &mut GameState) {
+    state.tick();
+}
+```
+
+## Pattern: Builder Returns Boxed
+
+```rust
+impl LargeConfig {
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::default()
+    }
+}
+
+impl ConfigBuilder {
+    // Return boxed to avoid large move
+    pub fn build(self) -> Box<LargeConfig> {
+        Box::new(LargeConfig {
+            // ... fields from builder
+        })
+    }
+}
+```
+
+## Profile First
+
+Don't prematurely optimize. Use tools to identify if moves are actually a bottleneck:
+
+```rust
+// Check type sizes
+println!("Size of GameState: {}", std::mem::size_of::<GameState>());
+
+// Profile with cargo flamegraph or perf to find hot memcpys
+```
+
+## See Also
+
+- [own-copy-small](./own-copy-small.md) - Cheap types should be Copy
+- [mem-box-large-variant](./mem-box-large-variant.md) - Boxing enum variants
+- [perf-profile-first](./perf-profile-first.md) - Measure before optimizing

--- a/.agents/skills/rust-skills/rules/own-mutex-interior.md
+++ b/.agents/skills/rust-skills/rules/own-mutex-interior.md
@@ -1,0 +1,105 @@
+# own-mutex-interior
+
+> Use `Mutex<T>` for interior mutability across threads
+
+## Why It Matters
+
+When you need shared mutable state across threads, `Mutex<T>` provides safe interior mutability with synchronization. Unlike `RefCell`, `Mutex` is `Send + Sync` and uses OS-level locking to ensure only one thread can access the data at a time.
+
+## Bad
+
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+
+// RefCell is !Sync - this won't compile
+let shared = Arc::new(RefCell::new(vec![]));
+
+// ERROR: RefCell cannot be shared between threads safely
+std::thread::spawn({
+    let shared = shared.clone();
+    move || shared.borrow_mut().push(1)
+});
+```
+
+## Good
+
+```rust
+use std::sync::{Arc, Mutex};
+
+let shared = Arc::new(Mutex::new(vec![]));
+
+let handles: Vec<_> = (0..10).map(|i| {
+    let shared = shared.clone();
+    std::thread::spawn(move || {
+        let mut data = shared.lock().unwrap();
+        data.push(i);
+    })
+}).collect();
+
+for handle in handles {
+    handle.join().unwrap();
+}
+
+println!("{:?}", shared.lock().unwrap()); // All values present
+```
+
+## Mutex Poisoning
+
+If a thread panics while holding a lock, the mutex becomes "poisoned":
+
+```rust
+use std::sync::{Arc, Mutex};
+
+let mutex = Arc::new(Mutex::new(0));
+
+// Handle poisoning gracefully
+match mutex.lock() {
+    Ok(guard) => println!("Value: {}", *guard),
+    Err(poisoned) => {
+        // Recover the data anyway
+        let guard = poisoned.into_inner();
+        println!("Recovered value: {}", *guard);
+    }
+}
+
+// Or ignore poisoning (use with caution)
+let guard = mutex.lock().unwrap_or_else(|e| e.into_inner());
+```
+
+## Prefer parking_lot::Mutex
+
+For better performance, consider `parking_lot::Mutex`:
+
+```rust
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+let shared = Arc::new(Mutex::new(vec![]));
+
+// No poisoning, no Result to unwrap
+let mut data = shared.lock();
+data.push(42);
+// Lock automatically released when guard drops
+```
+
+Benefits of `parking_lot`:
+- No poisoning (returns guard directly)
+- Smaller size (1 byte vs 40+ bytes)
+- Better performance under contention
+- Fair locking option available
+
+## When to Use What
+
+| Type | Threading | Overhead | Use Case |
+|------|-----------|----------|----------|
+| `RefCell<T>` | Single | Minimal | Interior mutability, same thread |
+| `Mutex<T>` | Multi | Locking | Shared mutable state across threads |
+| `RwLock<T>` | Multi | Locking | Many readers, few writers |
+| `parking_lot::Mutex` | Multi | Less | Drop-in std::Mutex replacement |
+
+## See Also
+
+- [own-rwlock-readers](./own-rwlock-readers.md) - When reads dominate writes
+- [own-refcell-interior](./own-refcell-interior.md) - Single-threaded alternative
+- [async-no-lock-await](./async-no-lock-await.md) - Avoiding locks across await points

--- a/.agents/skills/rust-skills/rules/own-rc-single-thread.md
+++ b/.agents/skills/rust-skills/rules/own-rc-single-thread.md
@@ -1,0 +1,65 @@
+# own-rc-single-thread
+
+> Use `Rc<T>` for shared ownership in single-threaded contexts
+
+## Why It Matters
+
+`Rc<T>` (Reference Counted) provides shared ownership without the atomic overhead of `Arc<T>`. In single-threaded code, `Rc` is faster because it uses non-atomic reference counting. Using `Arc` when you don't need thread-safety wastes CPU cycles on unnecessary synchronization.
+
+## Bad
+
+```rust
+use std::sync::Arc;
+
+// Single-threaded application using Arc unnecessarily
+fn build_tree() -> Arc<Node> {
+    let root = Arc::new(Node::new("root"));
+    let child1 = Arc::new(Node::new("child1"));
+    let child2 = Arc::new(Node::new("child2"));
+    
+    // All in same thread, but paying atomic overhead
+    root.add_child(child1.clone());
+    root.add_child(child2.clone());
+    root
+}
+```
+
+Atomic operations have measurable overhead even without contention.
+
+## Good
+
+```rust
+use std::rc::Rc;
+
+// Single-threaded: use Rc for zero atomic overhead
+fn build_tree() -> Rc<Node> {
+    let root = Rc::new(Node::new("root"));
+    let child1 = Rc::new(Node::new("child1"));
+    let child2 = Rc::new(Node::new("child2"));
+    
+    root.add_child(child1.clone());
+    root.add_child(child2.clone());
+    root
+}
+
+// Compiler enforces single-thread: Rc is !Send + !Sync
+// Attempting to send across threads = compile error
+```
+
+## Decision Guide
+
+| Scenario | Use |
+|----------|-----|
+| Single-threaded, shared ownership | `Rc<T>` |
+| Multi-threaded, shared ownership | `Arc<T>` |
+| Single owner, might need multiple later | Start with `Rc`, upgrade if needed |
+| Library code, unknown threading model | `Arc<T>` (safer default) |
+
+## Evidence
+
+The Rust standard library itself uses `Rc` extensively in single-threaded contexts like the `std::rc` module documentation examples.
+
+## See Also
+
+- [own-arc-shared](./own-arc-shared.md) - When you need thread-safe sharing
+- [own-refcell-interior](./own-refcell-interior.md) - Combining Rc with interior mutability

--- a/.agents/skills/rust-skills/rules/own-refcell-interior.md
+++ b/.agents/skills/rust-skills/rules/own-refcell-interior.md
@@ -1,0 +1,97 @@
+# own-refcell-interior
+
+> Use `RefCell<T>` for interior mutability in single-threaded code
+
+## Why It Matters
+
+Rust's borrow checker enforces rules at compile time, but sometimes you need to mutate data through a shared reference. `RefCell<T>` moves borrow checking to runtime, allowing mutation through `&self`. This is essential for patterns like caches, lazy initialization, and observer patterns where compile-time borrowing is too restrictive.
+
+## Bad
+
+```rust
+struct Cache {
+    // Requires &mut self to update, breaking shared reference patterns
+    data: HashMap<String, String>,
+}
+
+impl Cache {
+    fn get_or_compute(&mut self, key: &str) -> &str {
+        // Caller needs &mut Cache, can't share cache reference
+        if !self.data.contains_key(key) {
+            self.data.insert(key.to_string(), expensive_compute(key));
+        }
+        &self.data[key]
+    }
+}
+```
+
+This forces exclusive access even for logically shared operations.
+
+## Good
+
+```rust
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+struct Cache {
+    data: RefCell<HashMap<String, String>>,
+}
+
+impl Cache {
+    fn get_or_compute(&self, key: &str) -> String {
+        // Can mutate through &self
+        let mut data = self.data.borrow_mut();
+        if !data.contains_key(key) {
+            data.insert(key.to_string(), expensive_compute(key));
+        }
+        data[key].clone()
+    }
+}
+
+// Multiple references can coexist
+let cache = Cache::new();
+let ref1 = &cache;
+let ref2 = &cache;
+ref1.get_or_compute("key1");
+ref2.get_or_compute("key2");
+```
+
+## Common Pattern: Rc<RefCell<T>>
+
+```rust
+use std::rc::Rc;
+use std::cell::RefCell;
+
+// Shared mutable state in single-threaded code
+type SharedState = Rc<RefCell<AppState>>;
+
+fn create_handlers(state: SharedState) -> Vec<Box<dyn Fn()>> {
+    vec![
+        Box::new({
+            let state = state.clone();
+            move || state.borrow_mut().increment()
+        }),
+        Box::new({
+            let state = state.clone();
+            move || state.borrow_mut().decrement()
+        }),
+    ]
+}
+```
+
+## Runtime Panics
+
+`RefCell` panics if you violate borrowing rules at runtime:
+
+```rust
+let cell = RefCell::new(5);
+let borrow1 = cell.borrow();
+let borrow2 = cell.borrow_mut(); // PANIC: already borrowed
+```
+
+Use `try_borrow()` and `try_borrow_mut()` for fallible borrowing.
+
+## See Also
+
+- [own-rc-single-thread](./own-rc-single-thread.md) - Combining with Rc for shared ownership
+- [own-mutex-interior](./own-mutex-interior.md) - Thread-safe alternative

--- a/.agents/skills/rust-skills/rules/own-rwlock-readers.md
+++ b/.agents/skills/rust-skills/rules/own-rwlock-readers.md
@@ -1,0 +1,122 @@
+# own-rwlock-readers
+
+> Use `RwLock<T>` when reads significantly outnumber writes
+
+## Why It Matters
+
+`Mutex<T>` allows only one thread to access data at a time, even for reads. `RwLock<T>` allows multiple concurrent readers OR one exclusive writer. For read-heavy workloads, this dramatically improves throughput by eliminating unnecessary serialization of read operations.
+
+## Bad
+
+```rust
+use std::sync::{Arc, Mutex};
+
+// Configuration rarely changes but is read constantly
+let config = Arc::new(Mutex::new(Config::load()));
+
+// Every read blocks other reads unnecessarily
+fn get_setting(config: &Mutex<Config>, key: &str) -> String {
+    let guard = config.lock().unwrap();
+    guard.get(key).to_string()
+}
+
+// 100 threads reading = serialized, one at a time
+```
+
+## Good
+
+```rust
+use std::sync::{Arc, RwLock};
+
+// Multiple readers can proceed concurrently
+let config = Arc::new(RwLock::new(Config::load()));
+
+fn get_setting(config: &RwLock<Config>, key: &str) -> String {
+    let guard = config.read().unwrap(); // Multiple threads can hold read lock
+    guard.get(key).to_string()
+}
+
+fn update_setting(config: &RwLock<Config>, key: &str, value: &str) {
+    let mut guard = config.write().unwrap(); // Exclusive access for writes
+    guard.set(key, value);
+}
+
+// 100 threads reading = parallel execution
+```
+
+## parking_lot::RwLock
+
+Prefer `parking_lot::RwLock` for better performance:
+
+```rust
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+let data = Arc::new(RwLock::new(HashMap::new()));
+
+// Read - no unwrap needed
+let value = data.read().get("key").cloned();
+
+// Write
+data.write().insert("key".to_string(), "value".to_string());
+
+// Upgradeable read lock (unique to parking_lot)
+let upgradeable = data.upgradable_read();
+if upgradeable.get("key").is_none() {
+    let mut write = parking_lot::RwLockUpgradableReadGuard::upgrade(upgradeable);
+    write.insert("key".to_string(), "default".to_string());
+}
+```
+
+## When RwLock Hurts
+
+RwLock has overhead for tracking readers. It can be slower than Mutex when:
+
+| Scenario | Better Choice |
+|----------|---------------|
+| Writes are frequent (>20% of operations) | `Mutex` |
+| Lock held very briefly | `Mutex` |
+| Single-threaded | `RefCell` |
+| Reads dominate, lock held longer | `RwLock` |
+
+## Write Starvation
+
+Standard `RwLock` may starve writers if readers are continuous. `parking_lot::RwLock` is fair by default.
+
+```rust
+// parking_lot is writer-fair, preventing starvation
+use parking_lot::RwLock;
+
+// Or use std with explicit fairness (nightly)
+// #![feature(rwlock_downgrade)]
+```
+
+## Real-World Pattern: Cached Computation
+
+```rust
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+struct CachedData {
+    cache: RwLock<Option<ExpensiveResult>>,
+}
+
+impl CachedData {
+    fn get(&self) -> ExpensiveResult {
+        // Fast path: read lock
+        if let Some(cached) = self.cache.read().as_ref() {
+            return cached.clone();
+        }
+        
+        // Slow path: compute and cache
+        let result = compute_expensive();
+        *self.cache.write() = Some(result.clone());
+        result
+    }
+}
+```
+
+## See Also
+
+- [own-mutex-interior](./own-mutex-interior.md) - When writes are frequent
+- [async-no-lock-await](./async-no-lock-await.md) - RwLock in async contexts

--- a/.agents/skills/rust-skills/rules/own-slice-over-vec.md
+++ b/.agents/skills/rust-skills/rules/own-slice-over-vec.md
@@ -1,0 +1,119 @@
+# own-slice-over-vec
+
+> Accept `&[T]` not `&Vec<T>`, `&str` not `&String`
+
+## Why It Matters
+
+Accepting `&[T]` instead of `&Vec<T>` makes your function more flexible - it can accept slices from arrays, vectors, or other sources. Similarly, `&str` accepts string slices from `String`, `&'static str`, or substrings.
+
+## Bad
+
+```rust
+// Overly restrictive - only accepts &Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// Overly restrictive - only accepts &String
+fn greet(name: &String) {
+    println!("Hello, {}", name);
+}
+
+// Can't call with arrays or slices
+let arr = [1, 2, 3];
+// sum(&arr);  // ERROR: expected &Vec<i32>
+
+let literal = "world";
+// greet(&literal);  // ERROR: expected &String
+```
+
+## Good
+
+```rust
+// Flexible - accepts any slice-like thing
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// Flexible - accepts any string-like thing
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// Now all of these work:
+let vec = vec![1, 2, 3];
+let arr = [4, 5, 6];
+let slice = &vec[0..2];
+
+sum(&vec);    // Vec coerces to slice
+sum(&arr);    // Array coerces to slice
+sum(slice);   // Slice works directly
+
+let string = String::from("Alice");
+let literal = "Bob";
+
+greet(&string);  // String coerces to &str
+greet(literal);  // &str works directly
+```
+
+## The Deref Coercion Chain
+
+```rust
+// These coercions happen automatically:
+// Vec<T>  -> &[T]   (via Deref)
+// String  -> &str   (via Deref)
+// Box<T>  -> &T     (via Deref)
+// Arc<T>  -> &T     (via Deref)
+
+fn process(data: &[u8]) { /* ... */ }
+
+let vec: Vec<u8> = vec![1, 2, 3];
+let boxed: Box<[u8]> = vec.into_boxed_slice();
+let arc: Arc<[u8]> = Arc::from(&[1, 2, 3][..]);
+
+process(&vec);    // Works
+process(&boxed);  // Works
+process(&arc);    // Works
+```
+
+## Path Types Too
+
+```rust
+// Bad
+fn read_config(path: &PathBuf) -> Config { /* ... */ }
+
+// Good - accepts &Path, &PathBuf, &str, &String
+fn read_config(path: &Path) -> Config { /* ... */ }
+
+// Even better - accept anything path-like
+fn read_config(path: impl AsRef<Path>) -> Config {
+    let path = path.as_ref();
+    // ...
+}
+```
+
+## When to Accept Owned Types
+
+```rust
+// Accept owned when you need to store it
+struct Logger {
+    prefix: String,  // Needs to own the string
+}
+
+impl Logger {
+    // Take ownership - caller decides to clone or move
+    fn new(prefix: String) -> Self {
+        Self { prefix }
+    }
+    
+    // Or use Into for flexibility
+    fn with_prefix(prefix: impl Into<String>) -> Self {
+        Self { prefix: prefix.into() }
+    }
+}
+```
+
+## See Also
+
+- [api-impl-asref](api-impl-asref.md) - Accept `impl AsRef<T>` for maximum flexibility
+- [own-borrow-over-clone](own-borrow-over-clone.md) - Prefer borrowing over cloning

--- a/.agents/skills/rust-skills/rules/perf-black-box-bench.md
+++ b/.agents/skills/rust-skills/rules/perf-black-box-bench.md
@@ -1,0 +1,153 @@
+# perf-black-box-bench
+
+> Use black_box in benchmarks
+
+## Why It Matters
+
+The compiler aggressively optimizes code, potentially eliminating computations whose results aren't used. In benchmarks, this can lead to measuring nothing instead of the actual code. `std::hint::black_box()` prevents the compiler from optimizing away values, ensuring accurate measurements.
+
+## Bad
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_bad(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            let result = expensive_computation(42);
+            // Result unused - compiler may eliminate the call!
+        });
+    });
+}
+
+fn benchmark_also_bad(c: &mut Criterion) {
+    let input = 42;  // Constant - compiler may precompute
+    
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            expensive_computation(input)
+            // Return value may still be optimized away
+        });
+    });
+}
+```
+
+## Good
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_good(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| {
+            // black_box on input prevents constant folding
+            let result = expensive_computation(black_box(42));
+            // black_box on output prevents dead code elimination
+            black_box(result)
+        });
+    });
+}
+
+// Or simpler with Criterion's built-in support
+fn benchmark_simpler(c: &mut Criterion) {
+    c.bench_function("compute", |b| {
+        b.iter(|| expensive_computation(black_box(42)))
+    });
+}
+```
+
+## What black_box Does
+
+| Without black_box | With black_box |
+|-------------------|----------------|
+| Input may be constant-folded | Input treated as unknown |
+| Result may be eliminated | Result must be computed |
+| Loops may be optimized away | Each iteration runs |
+| Functions may be inlined | Call semantics preserved |
+
+## Standard Library Usage
+
+```rust
+use std::hint::black_box;
+
+fn main() {
+    // In std since Rust 1.66
+    let result = black_box(compute_something(black_box(input)));
+}
+```
+
+## Criterion's black_box
+
+Criterion re-exports `std::hint::black_box`:
+
+```rust
+use criterion::black_box;
+
+// Equivalent to std::hint::black_box
+```
+
+## Pattern: Benchmark with Setup
+
+```rust
+fn benchmark_with_setup(c: &mut Criterion) {
+    c.bench_function("process_data", |b| {
+        // Setup outside iter - not measured
+        let data = generate_test_data(1000);
+        
+        b.iter(|| {
+            // black_box the input reference
+            let result = process(black_box(&data));
+            black_box(result)
+        });
+    });
+}
+```
+
+## Pattern: Benchmark Multiple Inputs
+
+```rust
+fn benchmark_sizes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scaling");
+    
+    for size in [100, 1000, 10000] {
+        let data = generate_data(size);
+        
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &data,
+            |b, data| {
+                b.iter(|| process(black_box(data)))
+            },
+        );
+    }
+    group.finish();
+}
+```
+
+## Common Mistakes
+
+```rust
+// WRONG: black_box inside loop does nothing useful
+for _ in 0..1000 {
+    black_box(());  // Doesn't help
+    compute();
+}
+
+// RIGHT: black_box the computation result
+for _ in 0..1000 {
+    black_box(compute());
+}
+
+// WRONG: Only blocking output, not input
+let x = 42;  // Constant, may be optimized
+black_box(expensive(x));
+
+// RIGHT: Block both
+black_box(expensive(black_box(42)));
+```
+
+## See Also
+
+- [test-criterion-bench](./test-criterion-bench.md) - Using Criterion
+- [perf-profile-first](./perf-profile-first.md) - Profile before optimize
+- [perf-release-profile](./perf-release-profile.md) - Release settings

--- a/.agents/skills/rust-skills/rules/perf-chain-avoid.md
+++ b/.agents/skills/rust-skills/rules/perf-chain-avoid.md
@@ -1,0 +1,136 @@
+# perf-chain-avoid
+
+> Avoid chain in hot loops
+
+## Why It Matters
+
+`Iterator::chain()` adds overhead for checking which iterator is active on every `.next()` call. In hot loops, this branch prediction overhead can impact performance. For performance-critical code, prefer single iterators or pre-combined collections.
+
+## Bad
+
+```rust
+// Chain in hot inner loop
+fn process_hot_path(a: &[i32], b: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    
+    // Called millions of times
+    for _ in 0..1_000_000 {
+        for x in a.iter().chain(b.iter()) {  // Branch every iteration
+            sum += *x as i64;
+        }
+    }
+    sum
+}
+
+// Chaining multiple small slices in tight loop
+fn combine_results(parts: &[&[u8]]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for part in parts {
+        for byte in std::iter::once(&0u8).chain(part.iter()) {
+            result.push(*byte);
+        }
+    }
+    result
+}
+```
+
+## Good
+
+```rust
+// Separate loops - branch-free inner loops
+fn process_hot_path(a: &[i32], b: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    
+    for _ in 0..1_000_000 {
+        for x in a {
+            sum += *x as i64;
+        }
+        for x in b {
+            sum += *x as i64;
+        }
+    }
+    sum
+}
+
+// Pre-combine outside hot loop
+fn combine_results(parts: &[&[u8]]) -> Vec<u8> {
+    let mut result = Vec::new();
+    for part in parts {
+        result.push(0u8);
+        result.extend_from_slice(part);
+    }
+    result
+}
+```
+
+## When Chain Is Fine
+
+Chain is perfectly acceptable when:
+
+```rust
+// One-time iteration, not in hot path
+fn collect_all(a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    a.into_iter().chain(b).collect()
+}
+
+// Lazy evaluation with short-circuit
+fn find_in_either(a: &[Item], b: &[Item], target: i32) -> Option<&Item> {
+    a.iter().chain(b.iter()).find(|x| x.id == target)
+}
+
+// Small number of elements
+fn get_prefixes() -> impl Iterator<Item = &'static str> {
+    ["Mr.", "Mrs.", "Dr."].iter().copied()
+        .chain(["Prof."].iter().copied())
+}
+```
+
+## Alternative Patterns
+
+### Pre-allocate and Extend
+
+```rust
+fn merge_slices(slices: &[&[i32]]) -> Vec<i32> {
+    let total: usize = slices.iter().map(|s| s.len()).sum();
+    let mut result = Vec::with_capacity(total);
+    for slice in slices {
+        result.extend_from_slice(slice);
+    }
+    result
+}
+```
+
+### Use append for Vecs
+
+```rust
+fn combine_vecs(mut a: Vec<i32>, mut b: Vec<i32>) -> Vec<i32> {
+    a.append(&mut b);  // Moves elements, no reallocation if a has capacity
+    a
+}
+```
+
+### Flatten Instead of Chain
+
+```rust
+// Instead of: a.iter().chain(b.iter()).chain(c.iter())
+let all = [a, b, c];
+for item in all.iter().flat_map(|slice| slice.iter()) {
+    process(item);
+}
+```
+
+## Performance Impact
+
+| Pattern | Per-Item Overhead |
+|---------|-------------------|
+| Single iterator | None |
+| `chain(a, b)` | 1 branch per item |
+| `chain(a, b, c)` | 2 branches per item |
+| Nested chains | Compounds |
+| Separate loops | None (but code duplication) |
+
+## See Also
+
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [opt-cache-friendly](./opt-cache-friendly.md) - Cache-friendly patterns

--- a/.agents/skills/rust-skills/rules/perf-collect-into.md
+++ b/.agents/skills/rust-skills/rules/perf-collect-into.md
@@ -1,0 +1,133 @@
+# perf-collect-into
+
+> Use collect_into for reusing containers
+
+## Why It Matters
+
+`collect_into()` (stabilized in Rust 1.83) allows collecting iterator results into an existing collection, reusing its allocation. This avoids the allocation that `collect()` would make for a new collection.
+
+## Bad
+
+```rust
+// Allocates new Vec each time
+fn process_batches(batches: Vec<Vec<i32>>) -> Vec<Vec<i32>> {
+    batches.into_iter()
+        .map(|batch| {
+            batch.into_iter()
+                .filter(|x| *x > 0)
+                .collect::<Vec<_>>()  // New allocation per batch
+        })
+        .collect()
+}
+
+// Can't reuse cleared buffer
+fn filter_loop(data: &[Vec<i32>]) {
+    for batch in data {
+        let filtered: Vec<_> = batch.iter()
+            .filter(|&&x| x > 0)
+            .copied()
+            .collect();  // New allocation each iteration
+        process(&filtered);
+    }
+}
+```
+
+## Good
+
+```rust
+// Reuse buffer with collect_into
+fn filter_loop(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();  // Keep allocation
+        batch.iter()
+            .filter(|&&x| x > 0)
+            .copied()
+            .collect_into(&mut buffer);
+        process(&buffer);
+    }
+}
+
+// Also works with extend pattern
+fn filter_loop_extend(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();
+        buffer.extend(
+            batch.iter()
+                .filter(|&&x| x > 0)
+                .copied()
+        );
+        process(&buffer);
+    }
+}
+```
+
+## Pre-1.83 Alternative: extend
+
+Before `collect_into()` was stabilized, use `extend()`:
+
+```rust
+fn reuse_buffer(data: &[Vec<i32>]) {
+    let mut buffer = Vec::new();
+    
+    for batch in data {
+        buffer.clear();
+        buffer.extend(batch.iter().filter(|&&x| x > 0).copied());
+        process(&buffer);
+    }
+}
+```
+
+## Pattern: Transform and Reuse
+
+```rust
+fn transform_batches(batches: &[Vec<RawData>]) -> Vec<ProcessedData> {
+    let mut temp = Vec::new();
+    let mut all_results = Vec::new();
+    
+    for batch in batches {
+        temp.clear();
+        batch.iter()
+            .map(ProcessedData::from)
+            .collect_into(&mut temp);
+        
+        // Process temp, append to results
+        all_results.extend(temp.drain(..).filter(|p| p.is_valid()));
+    }
+    
+    all_results
+}
+```
+
+## Supported Collections
+
+`collect_into()` works with any type implementing `Extend`:
+
+```rust
+use std::collections::{HashSet, HashMap, VecDeque};
+
+let mut vec = Vec::new();
+let mut set = HashSet::new();
+let mut deque = VecDeque::new();
+
+(0..10).collect_into(&mut vec);
+(0..10).collect_into(&mut set);
+(0..10).collect_into(&mut deque);
+```
+
+## Comparison
+
+| Method | Allocation | Buffer Reuse |
+|--------|------------|--------------|
+| `.collect()` | New each time | No |
+| `.collect_into(&mut buf)` | Reuses buffer | Yes |
+| `buf.extend(iter)` | Reuses buffer | Yes |
+
+## See Also
+
+- [perf-drain-reuse](./perf-drain-reuse.md) - Drain for reuse
+- [mem-reuse-collections](./mem-reuse-collections.md) - Collection reuse
+- [perf-extend-batch](./perf-extend-batch.md) - Batch extensions

--- a/.agents/skills/rust-skills/rules/perf-collect-once.md
+++ b/.agents/skills/rust-skills/rules/perf-collect-once.md
@@ -1,0 +1,120 @@
+# perf-collect-once
+
+> Don't collect intermediate iterators
+
+## Why It Matters
+
+Each `.collect()` allocates a new collection. Chaining multiple operations with intermediate collections wastes memory and CPU cycles. Keep iterator chains lazy and collect only once at the end.
+
+## Bad
+
+```rust
+// Three allocations, three passes
+fn process_users(users: Vec<User>) -> Vec<String> {
+    let active: Vec<_> = users.into_iter()
+        .filter(|u| u.is_active)
+        .collect();
+    
+    let verified: Vec<_> = active.into_iter()
+        .filter(|u| u.is_verified)
+        .collect();
+    
+    verified.into_iter()
+        .map(|u| u.name)
+        .collect()
+}
+
+// Collecting to count
+fn count_valid(items: &[Item]) -> usize {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .collect::<Vec<_>>()  // Unnecessary!
+        .len()
+}
+```
+
+## Good
+
+```rust
+// One allocation, one pass
+fn process_users(users: Vec<User>) -> Vec<String> {
+    users.into_iter()
+        .filter(|u| u.is_active)
+        .filter(|u| u.is_verified)
+        .map(|u| u.name)
+        .collect()
+}
+
+// No allocation needed
+fn count_valid(items: &[Item]) -> usize {
+    items.iter()
+        .filter(|i| i.is_valid())
+        .count()
+}
+```
+
+## Pattern: Deferred Collection
+
+```rust
+// Create the iterator chain
+fn prepare_data(raw: Vec<RawData>) -> impl Iterator<Item = ProcessedData> {
+    raw.into_iter()
+        .filter(|d| d.is_valid())
+        .map(ProcessedData::from)
+}
+
+// Collect only when needed
+let data: Vec<_> = prepare_data(input).collect();
+
+// Or consume without collecting
+prepare_data(input).for_each(|d| process(d));
+```
+
+## When Intermediate Collection Is Needed
+
+```rust
+// Need to iterate multiple times
+let items: Vec<_> = data.iter()
+    .filter(|x| x.is_valid())
+    .collect();
+
+let count = items.len();
+let first = items.first();
+for item in &items {
+    process(item);
+}
+
+// Need to sort (requires concrete collection)
+let mut sorted: Vec<_> = data.iter()
+    .filter(|x| x.is_active)
+    .collect();
+sorted.sort_by_key(|x| x.priority);
+```
+
+## Comparison
+
+| Approach | Allocations | Passes | Memory |
+|----------|-------------|--------|--------|
+| Multiple `.collect()` | N | N | O(N × data) |
+| Single chain + `.collect()` | 1 | 1 | O(data) |
+| No `.collect()` (streaming) | 0 | 1 | O(1) |
+
+## Pattern: Collect with Capacity
+
+When you must collect, pre-allocate:
+
+```rust
+// With estimated capacity
+let mut result = Vec::with_capacity(items.len());
+result.extend(
+    items.iter()
+        .filter(|x| x.is_valid())
+        .map(|x| x.clone())
+);
+```
+
+## See Also
+
+- [perf-iter-lazy](./perf-iter-lazy.md) - Keep iterators lazy
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocate collections
+- [anti-collect-intermediate](./anti-collect-intermediate.md) - Anti-pattern

--- a/.agents/skills/rust-skills/rules/perf-drain-reuse.md
+++ b/.agents/skills/rust-skills/rules/perf-drain-reuse.md
@@ -1,0 +1,137 @@
+# perf-drain-reuse
+
+> Use drain to reuse allocations
+
+## Why It Matters
+
+`drain()` removes elements from a collection while keeping its allocated capacity. This allows reusing the same allocation across iterations, avoiding repeated allocate/deallocate cycles in loops.
+
+## Bad
+
+```rust
+// Allocates new Vec every iteration
+fn process_batches(data: Vec<Item>) {
+    let mut remaining = data;
+    
+    while !remaining.is_empty() {
+        let batch: Vec<_> = remaining.drain(..100.min(remaining.len())).collect();
+        process_batch(batch);
+        // remaining keeps its capacity - good
+        // but batch allocates new every time - bad
+    }
+}
+
+// Clears and reallocates
+fn reuse_buffer() {
+    for _ in 0..1000 {
+        let mut buffer = Vec::new();  // Allocates each iteration
+        fill_buffer(&mut buffer);
+        process(&buffer);
+    }
+}
+```
+
+## Good
+
+```rust
+// Reuses allocation with drain
+fn process_batches(mut data: Vec<Item>) {
+    let mut batch = Vec::with_capacity(100);
+    
+    while !data.is_empty() {
+        batch.extend(data.drain(..100.min(data.len())));
+        process_batch(&batch);
+        batch.clear();  // Keeps capacity
+    }
+}
+
+// Reuses buffer across iterations
+fn reuse_buffer() {
+    let mut buffer = Vec::new();
+    
+    for _ in 0..1000 {
+        buffer.clear();  // Keeps capacity
+        fill_buffer(&mut buffer);
+        process(&buffer);
+    }
+}
+```
+
+## Drain Methods
+
+| Collection | Method | Behavior |
+|------------|--------|----------|
+| `Vec<T>` | `.drain(range)` | Remove range, shift remaining |
+| `Vec<T>` | `.drain(..)` | Remove all (like clear) |
+| `VecDeque<T>` | `.drain(range)` | Remove range |
+| `String` | `.drain(range)` | Remove char range |
+| `HashMap<K,V>` | `.drain()` | Remove all entries |
+| `HashSet<T>` | `.drain()` | Remove all elements |
+
+## Pattern: Batch Processing
+
+```rust
+fn process_in_chunks(mut items: Vec<Item>, chunk_size: usize) {
+    while !items.is_empty() {
+        let chunk: Vec<_> = items.drain(..chunk_size.min(items.len())).collect();
+        process_chunk(chunk);
+    }
+}
+```
+
+## Pattern: Transfer Between Collections
+
+```rust
+// Move all elements without reallocation
+fn transfer_all(src: &mut Vec<Item>, dst: &mut Vec<Item>) {
+    dst.extend(src.drain(..));
+    // src is now empty but keeps capacity
+}
+
+// Move matching elements
+fn transfer_matching(src: &mut Vec<Item>, dst: &mut Vec<Item>, predicate: impl Fn(&Item) -> bool) {
+    let matching: Vec<_> = src.drain(..).filter(predicate).collect();
+    dst.extend(matching);
+}
+```
+
+## Pattern: HashMap Drain
+
+```rust
+use std::collections::HashMap;
+
+fn process_and_clear(map: &mut HashMap<String, Value>) {
+    // Process all entries, clearing the map
+    for (key, value) in map.drain() {
+        process(key, value);
+    }
+    // map is now empty but keeps capacity
+}
+```
+
+## drain vs clear vs take
+
+| Operation | Elements | Capacity | Returns |
+|-----------|----------|----------|---------|
+| `.clear()` | Removed | Kept | Nothing |
+| `.drain(..)` | Removed | Kept | Iterator |
+| `std::mem::take()` | Moved out | Reset to 0 | Owned collection |
+
+```rust
+// clear: just empty
+vec.clear();
+
+// drain: empty and iterate
+for item in vec.drain(..) {
+    process(item);
+}
+
+// take: swap with empty, get ownership
+let old_vec = std::mem::take(&mut vec);
+```
+
+## See Also
+
+- [mem-reuse-collections](./mem-reuse-collections.md) - Reusing collections
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation

--- a/.agents/skills/rust-skills/rules/perf-entry-api.md
+++ b/.agents/skills/rust-skills/rules/perf-entry-api.md
@@ -1,0 +1,134 @@
+# perf-entry-api
+
+> Use entry API for map insert-or-update
+
+## Why It Matters
+
+The entry API performs a single lookup for insert-or-update operations. Without it, you lookup twice: once to check existence, once to insert. For `HashMap` and `BTreeMap`, the entry API is both faster and more idiomatic.
+
+## Bad
+
+```rust
+use std::collections::HashMap;
+
+// Double lookup: contains_key + insert
+fn increment(map: &mut HashMap<String, u32>, key: String) {
+    if map.contains_key(&key) {
+        *map.get_mut(&key).unwrap() += 1;
+    } else {
+        map.insert(key, 1);
+    }
+}
+
+// Double lookup with get + insert
+fn get_or_insert(map: &mut HashMap<String, Vec<i32>>, key: String) -> &mut Vec<i32> {
+    if !map.contains_key(&key) {
+        map.insert(key.clone(), Vec::new());
+    }
+    map.get_mut(&key).unwrap()
+}
+
+// Triple lookup pattern
+fn update_or_default(map: &mut HashMap<String, Config>, key: &str, value: i32) {
+    match map.get(key) {
+        Some(config) => {
+            let mut new_config = config.clone();
+            new_config.value = value;
+            map.insert(key.to_string(), new_config);
+        }
+        None => {
+            map.insert(key.to_string(), Config::default());
+        }
+    }
+}
+```
+
+## Good
+
+```rust
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+// Single lookup with entry
+fn increment(map: &mut HashMap<String, u32>, key: String) {
+    *map.entry(key).or_insert(0) += 1;
+}
+
+// Single lookup, returns mutable reference
+fn get_or_insert(map: &mut HashMap<String, Vec<i32>>, key: String) -> &mut Vec<i32> {
+    map.entry(key).or_insert_with(Vec::new)
+}
+
+// Single lookup with and_modify
+fn update_or_default(map: &mut HashMap<String, Config>, key: String, value: i32) {
+    map.entry(key)
+        .and_modify(|config| config.value = value)
+        .or_insert_with(Config::default);
+}
+```
+
+## Entry API Methods
+
+| Method | Behavior |
+|--------|----------|
+| `.or_insert(val)` | Insert `val` if empty |
+| `.or_insert_with(f)` | Insert `f()` if empty (lazy) |
+| `.or_default()` | Insert `Default::default()` if empty |
+| `.and_modify(f)` | Apply `f` if occupied |
+| `.or_insert_with_key(f)` | Insert `f(&key)` if empty |
+
+## Pattern: Count Occurrences
+
+```rust
+fn word_count(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for word in text.split_whitespace() {
+        *counts.entry(word).or_insert(0) += 1;
+    }
+    counts
+}
+```
+
+## Pattern: Group By
+
+```rust
+fn group_by_category(items: Vec<Item>) -> HashMap<Category, Vec<Item>> {
+    let mut groups: HashMap<Category, Vec<Item>> = HashMap::new();
+    for item in items {
+        groups.entry(item.category.clone())
+            .or_default()
+            .push(item);
+    }
+    groups
+}
+```
+
+## Pattern: Complex Entry Logic
+
+```rust
+match map.entry(key) {
+    Entry::Occupied(mut entry) => {
+        let value = entry.get_mut();
+        if should_update(value) {
+            *value = new_value;
+        }
+    }
+    Entry::Vacant(entry) => {
+        entry.insert(default_value);
+    }
+}
+```
+
+## Performance
+
+| Pattern | Lookups | Hash Computations |
+|---------|---------|-------------------|
+| `contains_key` + `insert` | 2 | 2 |
+| `get` + `insert` | 2 | 2 |
+| `entry().or_insert()` | 1 | 1 |
+
+## See Also
+
+- [perf-extend-batch](./perf-extend-batch.md) - Batch insertions
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocate maps
+- [perf-drain-reuse](./perf-drain-reuse.md) - Reuse map allocations

--- a/.agents/skills/rust-skills/rules/perf-extend-batch.md
+++ b/.agents/skills/rust-skills/rules/perf-extend-batch.md
@@ -1,0 +1,150 @@
+# perf-extend-batch
+
+> Use extend for batch insertions
+
+## Why It Matters
+
+`extend()` can pre-allocate capacity for the incoming elements and insert them in a single operation. Individual `push()` calls may trigger multiple reallocations as the collection grows. For adding multiple elements, `extend()` is both faster and clearer.
+
+## Bad
+
+```rust
+// Multiple potential reallocations
+fn collect_results(sources: Vec<Source>) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for source in sources {
+        for result in source.get_results() {
+            results.push(result);  // May reallocate
+        }
+    }
+    results
+}
+
+// Loop with push for known data
+fn build_list() -> Vec<i32> {
+    let mut list = Vec::new();
+    for i in 0..1000 {
+        list.push(i);  // Many reallocations
+    }
+    list
+}
+
+// Appending another collection
+fn combine(mut a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    for item in b {
+        a.push(item);
+    }
+    a
+}
+```
+
+## Good
+
+```rust
+// Single extend with size hint
+fn collect_results(sources: Vec<Source>) -> Vec<Result> {
+    let mut results = Vec::new();
+    
+    for source in sources {
+        results.extend(source.get_results());
+    }
+    results
+}
+
+// Direct collection from iterator
+fn build_list() -> Vec<i32> {
+    (0..1000).collect()
+}
+
+// Extend for combining
+fn combine(mut a: Vec<i32>, b: Vec<i32>) -> Vec<i32> {
+    a.extend(b);
+    a
+}
+```
+
+## Extend with Capacity
+
+For best performance, combine with `reserve()`:
+
+```rust
+fn merge_all(chunks: Vec<Vec<Item>>) -> Vec<Item> {
+    // Calculate total size
+    let total: usize = chunks.iter().map(|c| c.len()).sum();
+    
+    let mut result = Vec::with_capacity(total);
+    for chunk in chunks {
+        result.extend(chunk);
+    }
+    result
+}
+```
+
+## Extend Methods
+
+| Method | Description |
+|--------|-------------|
+| `.extend(iter)` | Add all elements from iterator |
+| `.extend_from_slice(&[T])` | Add from slice (for `Copy` types) |
+| `.append(&mut Vec)` | Move all from another Vec |
+
+## Pattern: Building Strings
+
+```rust
+// Bad: multiple allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result.push_str(part);  // May reallocate
+    }
+    result
+}
+
+// Good: extend with known parts
+fn build_message(parts: &[&str]) -> String {
+    let total_len: usize = parts.iter().map(|s| s.len()).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(part);
+    }
+    result
+}
+
+// Better: collect/join
+fn build_message(parts: &[&str]) -> String {
+    parts.concat()  // or parts.join("")
+}
+```
+
+## HashMap/HashSet Extend
+
+```rust
+use std::collections::HashMap;
+
+// Extend from iterator of tuples
+fn merge_maps(mut base: HashMap<String, i32>, other: HashMap<String, i32>) -> HashMap<String, i32> {
+    base.extend(other);  // Moves entries from other
+    base
+}
+
+// Extend from iterator
+let mut set = HashSet::new();
+set.extend(items.iter().map(|i| i.id));
+```
+
+## Performance
+
+| Operation | Allocations | Complexity |
+|-----------|-------------|------------|
+| N × `push()` | O(log N) | O(N) amortized |
+| `extend(iter)` | O(1)* | O(N) |
+| `with_capacity` + `extend` | 1 | O(N) |
+
+*When iterator provides accurate `size_hint()`
+
+## See Also
+
+- [mem-with-capacity](./mem-with-capacity.md) - Pre-allocation
+- [perf-drain-reuse](./perf-drain-reuse.md) - Reusing allocations
+- [mem-reuse-collections](./mem-reuse-collections.md) - Collection reuse

--- a/.agents/skills/rust-skills/rules/perf-iter-lazy.md
+++ b/.agents/skills/rust-skills/rules/perf-iter-lazy.md
@@ -1,0 +1,123 @@
+# perf-iter-lazy
+
+> Keep iterators lazy, collect only when needed
+
+## Why It Matters
+
+Rust iterators are lazy—they compute values on demand. This enables single-pass processing, avoids intermediate allocations, and allows short-circuiting. Calling `.collect()` too early forces evaluation and allocates unnecessarily.
+
+## Bad
+
+```rust
+// Collects intermediate results unnecessarily
+fn process(data: Vec<i32>) -> Vec<i32> {
+    let filtered: Vec<_> = data.into_iter()
+        .filter(|x| *x > 0)
+        .collect();  // Unnecessary allocation
+    
+    let mapped: Vec<_> = filtered.into_iter()
+        .map(|x| x * 2)
+        .collect();  // Another unnecessary allocation
+    
+    mapped.into_iter()
+        .take(10)
+        .collect()
+}
+
+// Collects before checking existence
+fn has_positive(data: &[i32]) -> bool {
+    let positives: Vec<_> = data.iter()
+        .filter(|&&x| x > 0)
+        .collect();  // Allocates entire filtered result
+    
+    !positives.is_empty()
+}
+```
+
+## Good
+
+```rust
+// Single chain, single collect
+fn process(data: Vec<i32>) -> Vec<i32> {
+    data.into_iter()
+        .filter(|x| *x > 0)
+        .map(|x| x * 2)
+        .take(10)
+        .collect()
+}
+
+// Short-circuits on first match
+fn has_positive(data: &[i32]) -> bool {
+    data.iter().any(|&x| x > 0)
+}
+```
+
+## Lazy Iterator Methods
+
+These methods return iterators (lazy):
+
+| Method | Description |
+|--------|-------------|
+| `.filter()` | Keep matching elements |
+| `.map()` | Transform elements |
+| `.take(n)` | Limit to n elements |
+| `.skip(n)` | Skip first n elements |
+| `.zip()` | Pair with another iterator |
+| `.chain()` | Concatenate iterators |
+| `.flat_map()` | Map and flatten |
+| `.enumerate()` | Add index |
+
+## Consuming Methods
+
+These methods consume the iterator (evaluate immediately):
+
+| Method | Description |
+|--------|-------------|
+| `.collect()` | Gather into collection |
+| `.for_each()` | Execute side effect |
+| `.count()` | Count elements |
+| `.sum()` | Sum elements |
+| `.fold()` | Accumulate value |
+| `.any()` | Check if any match |
+| `.all()` | Check if all match |
+| `.find()` | Find first match |
+
+## Short-Circuit Benefits
+
+```rust
+// Without lazy: processes ALL items
+let found: Vec<_> = items.iter()
+    .filter(|x| expensive_check(x))
+    .collect();
+let result = found.first();
+
+// With lazy: stops at first match
+let result = items.iter()
+    .find(|x| expensive_check(x));
+```
+
+## Pattern: Process Without Collecting
+
+```rust
+// Print all matches without allocating
+data.iter()
+    .filter(|x| x.is_valid())
+    .for_each(|x| println!("{}", x));
+
+// Count without collecting
+let count = data.iter()
+    .filter(|x| x.is_valid())
+    .count();
+
+// Sum without intermediate collection
+let total: i64 = data.iter()
+    .filter(|x| x.is_valid())
+    .map(|x| x.value as i64)
+    .sum();
+```
+
+## See Also
+
+- [perf-collect-once](./perf-collect-once.md) - Single collect
+- [perf-iter-over-index](./perf-iter-over-index.md) - Prefer iterators
+- [anti-collect-intermediate](./anti-collect-intermediate.md) - Anti-pattern

--- a/.agents/skills/rust-skills/rules/perf-iter-over-index.md
+++ b/.agents/skills/rust-skills/rules/perf-iter-over-index.md
@@ -1,0 +1,113 @@
+# perf-iter-over-index
+
+> Prefer iterators over manual indexing
+
+## Why It Matters
+
+Iterators are the idiomatic way to traverse collections in Rust. They enable bounds check elimination, SIMD auto-vectorization, and cleaner code. Manual indexing (`for i in 0..len`) often prevents these optimizations and introduces off-by-one error risks.
+
+## Bad
+
+```rust
+// Manual indexing - bounds checked every iteration
+fn sum_squares(data: &[i32]) -> i64 {
+    let mut sum = 0i64;
+    for i in 0..data.len() {
+        sum += (data[i] as i64) * (data[i] as i64);
+    }
+    sum
+}
+
+// Index-based iteration with multiple collections
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    let mut sum = 0.0;
+    for i in 0..a.len().min(b.len()) {
+        sum += a[i] * b[i];
+    }
+    sum
+}
+
+// Mutating with indices
+fn double_values(data: &mut [i32]) {
+    for i in 0..data.len() {
+        data[i] *= 2;
+    }
+}
+```
+
+## Good
+
+```rust
+// Iterator - bounds checks eliminated, SIMD-friendly
+fn sum_squares(data: &[i32]) -> i64 {
+    data.iter()
+        .map(|&x| (x as i64) * (x as i64))
+        .sum()
+}
+
+// Zip iterators - no manual length handling
+fn dot_product(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| x * y)
+        .sum()
+}
+
+// Mutable iteration
+fn double_values(data: &mut [i32]) {
+    for x in data.iter_mut() {
+        *x *= 2;
+    }
+}
+```
+
+## When Indexing Is Needed
+
+Sometimes you genuinely need indices:
+
+```rust
+// Need the index for output or processing
+for (i, value) in data.iter().enumerate() {
+    println!("Index {}: {}", i, value);
+}
+
+// Non-sequential access patterns
+fn interleave(data: &mut [i32]) {
+    let mid = data.len() / 2;
+    for i in 0..mid {
+        data.swap(i * 2, mid + i);
+    }
+}
+```
+
+## Performance Comparison
+
+| Pattern | Bounds Checks | SIMD Potential | Clarity |
+|---------|---------------|----------------|---------|
+| `for i in 0..len` | Every access | Limited | Medium |
+| `for &x in slice` | None | High | High |
+| `.iter().enumerate()` | None | Medium | High |
+| `get_unchecked` | None (unsafe) | High | Low |
+
+## Iterator Advantages
+
+```rust
+// Chaining operations - single pass
+let result: Vec<_> = data.iter()
+    .filter(|x| **x > 0)
+    .map(|x| x * 2)
+    .collect();
+
+// Early termination optimized
+let found = data.iter().any(|&x| x == target);
+
+// Parallel iteration (with rayon)
+use rayon::prelude::*;
+let sum: i64 = data.par_iter().map(|&x| x as i64).sum();
+```
+
+## See Also
+
+- [perf-iter-lazy](./perf-iter-lazy.md) - Keep iterators lazy
+- [opt-bounds-check](./opt-bounds-check.md) - Bounds check elimination
+- [anti-index-over-iter](./anti-index-over-iter.md) - Anti-pattern

--- a/.agents/skills/rust-skills/rules/perf-profile-first.md
+++ b/.agents/skills/rust-skills/rules/perf-profile-first.md
@@ -1,0 +1,175 @@
+# perf-profile-first
+
+> Profile before optimizing
+
+## Why It Matters
+
+Intuition about performance is often wrong. The code you think is slow frequently isn't, while actual bottlenecks hide in unexpected places. Profiling shows you exactly where time is spent, preventing wasted effort on optimizations that don't matter.
+
+## Bad
+
+```rust
+// Optimizing without measuring
+fn process(data: &[Item]) -> Vec<Output> {
+    // "I bet this clone is slow..."
+    let cloned: Vec<_> = data.iter().cloned().collect();
+    
+    // Actually, 99% of time is spent here:
+    cloned.iter().map(|x| expensive_computation(x)).collect()
+}
+
+// Over-engineering rarely-called code
+#[inline(always)]
+fn rarely_called() {
+    // This runs once at startup...
+}
+```
+
+## Good
+
+```rust
+// 1. Profile first
+// cargo flamegraph --bin myapp
+// cargo instruments -t time --bin myapp (macOS)
+
+// 2. Find the actual bottleneck
+// Flamegraph shows expensive_computation takes 95% of time
+
+// 3. Optimize the hot spot
+fn process(data: &[Item]) -> Vec<Output> {
+    // Clone is fine - only 1% of time
+    let cloned: Vec<_> = data.iter().cloned().collect();
+    
+    // Focus optimization HERE
+    cloned.par_iter()  // Parallelize the expensive part
+        .map(|x| expensive_computation(x))
+        .collect()
+}
+```
+
+## Profiling Tools
+
+### Flamegraphs (Recommended Start)
+
+```bash
+# Install
+cargo install flamegraph
+
+# Profile
+cargo flamegraph --bin myapp -- <args>
+
+# Opens flamegraph.svg showing call stacks by time
+```
+
+### perf (Linux)
+
+```bash
+# Record
+perf record -g cargo run --release
+
+# Report
+perf report
+
+# Or generate flamegraph
+perf script | inferno-collapse-perf | inferno-flamegraph > flamegraph.svg
+```
+
+### Instruments (macOS)
+
+```bash
+# Install cargo-instruments
+cargo install cargo-instruments
+
+# Time profiler
+cargo instruments -t time --release
+
+# Allocations profiler
+cargo instruments -t alloc --release
+```
+
+### DHAT (Heap Profiling)
+
+```bash
+# In your code
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() {
+    let _profiler = dhat::Profiler::new_heap();
+    // ... your code
+}
+
+# Run and get allocation report
+cargo run --release
+```
+
+### criterion (Micro-benchmarks)
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_my_function(c: &mut Criterion) {
+    c.bench_function("my_function", |b| {
+        b.iter(|| my_function(black_box(input)))
+    });
+}
+
+criterion_group!(benches, bench_my_function);
+criterion_main!(benches);
+```
+
+## What to Look For
+
+```
+Flamegraph Reading:
+├── Width = time spent
+├── Height = call stack depth
+└── Look for:
+    ├── Wide bars (time hogs)
+    ├── malloc/free (allocation heavy)
+    ├── memcpy (copying data)
+    └── Unexpected functions taking time
+```
+
+## Common Findings
+
+```rust
+// Finding: HashMap operations are slow
+// Fix: Use FxHashMap or AHashMap for non-crypto hashing
+
+// Finding: String allocation in hot loop
+// Fix: Pre-allocate with capacity, use &str
+
+// Finding: Clone in hot path
+// Fix: Use references or Cow
+
+// Finding: Bounds checks visible in profile
+// Fix: Use iterators instead of indexing
+
+// Finding: Lock contention
+// Fix: Reduce critical section, use RwLock, or partition data
+```
+
+## Optimization Workflow
+
+```
+1. Write correct code first
+2. Write benchmarks for hot paths
+3. Profile under realistic load
+4. Identify actual bottlenecks
+5. Optimize ONE thing
+6. Measure improvement
+7. Repeat if needed
+```
+
+## Evidence: Rust Performance Book
+
+> "The biggest performance improvements often come from changes to algorithms or data structures, rather than low-level optimizations."
+
+> "It is worth understanding which Rust data structures and operations cause allocations, because avoiding them can greatly improve performance."
+
+## See Also
+
+- [opt-lto-release](opt-lto-release.md) - Enable LTO for release builds
+- [test-criterion-bench](test-criterion-bench.md) - Use criterion for benchmarking
+- [anti-premature-optimize](anti-premature-optimize.md) - Don't optimize without data

--- a/.agents/skills/rust-skills/rules/perf-release-profile.md
+++ b/.agents/skills/rust-skills/rules/perf-release-profile.md
@@ -1,0 +1,149 @@
+# perf-release-profile
+
+> Optimize release profile settings
+
+## Why It Matters
+
+The default release profile prioritizes compile speed over runtime performance. For production binaries, tuning the release profile can yield significant performance improvements (10-40% in some cases) at the cost of longer compile times.
+
+## Default Profile
+
+```toml
+[profile.release]
+opt-level = 3
+debug = false
+lto = false
+codegen-units = 16
+```
+
+## Optimized Profile
+
+```toml
+[profile.release]
+opt-level = 3          # Maximum optimization
+lto = "fat"            # Full link-time optimization
+codegen-units = 1      # Better optimization, slower compile
+panic = "abort"        # Smaller binary, no unwinding
+strip = true           # Remove symbols
+
+[profile.release.package."*"]
+# Keep dependencies optimized even if main crate changes
+opt-level = 3
+```
+
+## Profile Options
+
+| Option | Values | Effect |
+|--------|--------|--------|
+| `opt-level` | 0-3, "s", "z" | Optimization level |
+| `lto` | false, "thin", "fat" | Link-time optimization |
+| `codegen-units` | 1-256 | Parallel compilation units |
+| `panic` | "unwind", "abort" | Panic behavior |
+| `strip` | true, false, "symbols", "debuginfo" | Binary stripping |
+| `debug` | true, false, 0-2 | Debug info level |
+
+## Optimization Levels
+
+| Level | Description | Use Case |
+|-------|-------------|----------|
+| `0` | No optimization | Debug builds |
+| `1` | Basic optimization | Fast compile |
+| `2` | Most optimizations | Balanced |
+| `3` | All optimizations | Maximum performance |
+| `"s"` | Optimize for size | Embedded |
+| `"z"` | Minimize size | Smallest binary |
+
+## LTO Options
+
+| Option | Compile Time | Performance | Binary Size |
+|--------|--------------|-------------|-------------|
+| `false` | Fast | Baseline | Larger |
+| `"thin"` | Medium | Good | Smaller |
+| `"fat"` | Slow | Best | Smallest |
+
+## Custom Profiles
+
+```toml
+# Fast release builds for development
+[profile.release-dev]
+inherits = "release"
+lto = false
+codegen-units = 16
+
+# Maximum performance for production
+[profile.release-prod]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+strip = true
+
+# Profiling with symbols
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false
+```
+
+Use with: `cargo build --profile release-prod`
+
+## Dev Dependencies Optimization
+
+Speed up tests and dev builds:
+
+```toml
+[profile.dev]
+opt-level = 0
+
+# Optimize dependencies even in dev
+[profile.dev.package."*"]
+opt-level = 3
+```
+
+## Benchmarking Profile
+
+```toml
+[profile.bench]
+inherits = "release"
+debug = true      # For profiling
+strip = false     # Keep symbols for flamegraphs
+lto = "fat"       # Consistent with release-prod
+```
+
+## Size vs Speed Trade-offs
+
+```toml
+# Smallest binary
+[profile.min-size]
+inherits = "release"
+opt-level = "z"
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = true
+
+# Balance size and speed
+[profile.balanced]
+inherits = "release"
+opt-level = "s"
+lto = "thin"
+```
+
+## Workspace Configuration
+
+```toml
+# In workspace Cargo.toml
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
+# Override for specific package
+[profile.release.package.fast-compile-lib]
+lto = false
+codegen-units = 16
+```
+
+## See Also
+
+- [opt-lto-release](./opt-lto-release.md) - LTO details
+- [opt-codegen-units](./opt-codegen-units.md) - Codegen units
+- [opt-pgo-profile](./opt-pgo-profile.md) - Profile-guided optimization

--- a/.agents/skills/rust-skills/rules/proj-bin-dir.md
+++ b/.agents/skills/rust-skills/rules/proj-bin-dir.md
@@ -1,0 +1,142 @@
+# proj-bin-dir
+
+> Put multiple binaries in src/bin/
+
+## Why It Matters
+
+When a crate produces multiple binaries, placing them in `src/bin/` keeps the project organized. Each file becomes a separate binary target automatically, without manual `Cargo.toml` configuration.
+
+## Bad
+
+```
+my-project/
+├── Cargo.toml        # Complex [[bin]] sections for each binary
+├── src/
+│   ├── main.rs       # Which binary is this?
+│   ├── server.rs     # Is this a module or binary?
+│   ├── cli.rs        # Unclear
+│   └── lib.rs
+```
+
+```toml
+# Cargo.toml - verbose and error-prone
+[[bin]]
+name = "server"
+path = "src/server.rs"
+
+[[bin]]
+name = "cli"
+path = "src/cli.rs"
+```
+
+## Good
+
+```
+my-project/
+├── Cargo.toml        # Clean, no [[bin]] needed
+├── src/
+│   ├── lib.rs        # Shared library code
+│   └── bin/
+│       ├── server.rs # Binary: my-project-server (or just server)
+│       └── cli.rs    # Binary: my-project-cli (or just cli)
+```
+
+Each file in `src/bin/` automatically becomes a binary named after the file.
+
+## Running Binaries
+
+```bash
+# Run specific binary
+cargo run --bin server
+cargo run --bin cli
+
+# Build specific binary
+cargo build --bin server
+
+# Build all binaries
+cargo build --bins
+```
+
+## Pattern: Binary with Multiple Files
+
+For complex binaries, use directories:
+
+```
+src/
+├── lib.rs
+└── bin/
+    ├── server/
+    │   ├── main.rs      # Entry point
+    │   ├── config.rs    # Server-specific module
+    │   └── handlers.rs
+    └── cli/
+        ├── main.rs
+        └── commands.rs
+```
+
+## Pattern: Shared Library Code
+
+```rust
+// src/lib.rs - Shared code
+pub mod config;
+pub mod database;
+pub mod models;
+
+// src/bin/server.rs - Server binary
+use my_project::{config, database, models};
+
+fn main() {
+    let config = config::load();
+    let db = database::connect(&config);
+    // ...
+}
+
+// src/bin/cli.rs - CLI binary
+use my_project::{config, models};
+
+fn main() {
+    let config = config::load();
+    // CLI logic using shared code
+}
+```
+
+## Binary Naming
+
+| File Path | Binary Name |
+|-----------|-------------|
+| `src/main.rs` | `my-project` (crate name) |
+| `src/bin/server.rs` | `server` |
+| `src/bin/my-cli.rs` | `my-cli` |
+| `src/bin/server/main.rs` | `server` |
+
+## Explicit Configuration
+
+When you need custom settings:
+
+```toml
+[[bin]]
+name = "my-server"
+path = "src/bin/server.rs"
+required-features = ["server"]
+
+[[bin]]
+name = "my-cli"
+path = "src/bin/cli.rs"
+```
+
+## Pattern: Default Binary
+
+```toml
+# src/main.rs is the default binary
+# Additional binaries in src/bin/
+
+[package]
+name = "my-tool"
+default-run = "my-tool"  # Or specify another
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Keep main.rs minimal
+- [proj-workspace-large](./proj-workspace-large.md) - Workspace for larger projects
+- [proj-flat-small](./proj-flat-small.md) - Simple project structure

--- a/.agents/skills/rust-skills/rules/proj-flat-small.md
+++ b/.agents/skills/rust-skills/rules/proj-flat-small.md
@@ -1,0 +1,133 @@
+# proj-flat-small
+
+> Keep small projects flat
+
+## Why It Matters
+
+Over-organizing small projects adds navigation overhead without benefit. A project with 5-10 files doesn't need nested directories. Start flat, add structure only when complexity demands it.
+
+## Bad
+
+```
+src/
+├── core/
+│   └── mod.rs           # Just re-exports
+├── domain/
+│   ├── mod.rs
+│   └── models/
+│       ├── mod.rs
+│       └── user.rs      # 50 lines
+├── infrastructure/
+│   ├── mod.rs
+│   └── database/
+│       ├── mod.rs
+│       └── connection.rs # 30 lines
+├── application/
+│   ├── mod.rs
+│   └── services/
+│       └── mod.rs       # Empty
+└── main.rs
+```
+
+## Good
+
+```
+src/
+├── main.rs
+├── lib.rs
+├── config.rs
+├── database.rs
+├── user.rs
+└── error.rs
+```
+
+## When to Add Structure
+
+| File Count | Structure |
+|------------|-----------|
+| < 10 files | Flat in `src/` |
+| 10-20 files | Group by feature |
+| 20+ files | Feature folders with submodules |
+
+## Progressive Structuring
+
+### Stage 1: Flat
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+└── database.rs
+```
+
+### Stage 2: Logical Groups
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+├── order.rs        # Getting bigger
+├── order_item.rs   # Related to order
+└── database.rs
+```
+
+### Stage 3: Feature Folders
+
+```
+src/
+├── main.rs
+├── config.rs
+├── user.rs
+├── order/          # Now complex enough
+│   ├── mod.rs
+│   ├── model.rs
+│   └── item.rs
+└── database.rs
+```
+
+## Signs You Need More Structure
+
+- Files exceed 300-500 lines
+- Related files are hard to identify
+- You're adding `_` prefixes for grouping (`user_model.rs`, `user_service.rs`)
+- New team members get lost
+- Same concepts repeated in file names
+
+## Signs of Over-Structure
+
+- Folders with 1-2 files
+- `mod.rs` files that only re-export
+- Deep nesting for simple concepts
+- More lines in module declarations than code
+
+## Example: CLI Tool
+
+```
+src/
+├── main.rs         # Argument parsing, entry point
+├── commands.rs     # CLI subcommands
+├── config.rs       # Configuration loading
+└── output.rs       # Formatting, printing
+```
+
+Not:
+
+```
+src/
+├── cli/
+│   └── commands/
+│       └── mod.rs
+├── config/
+│   └── mod.rs
+└── presentation/
+    └── output/
+        └── mod.rs
+```
+
+## See Also
+
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation
+- [proj-mod-rs-dir](./proj-mod-rs-dir.md) - Multi-file modules

--- a/.agents/skills/rust-skills/rules/proj-lib-main-split.md
+++ b/.agents/skills/rust-skills/rules/proj-lib-main-split.md
@@ -1,0 +1,148 @@
+# proj-lib-main-split
+
+> Keep `main.rs` minimal, logic in `lib.rs`
+
+## Why It Matters
+
+Putting your logic in `lib.rs` makes it testable, reusable, and keeps `main.rs` as a thin entry point. Integration tests can only access your library crate, not binary code in `main.rs`.
+
+## Bad
+
+```rust
+// src/main.rs - everything here
+fn main() {
+    let args = parse_args();
+    let config = load_config(&args.config_path).unwrap();
+    let db = connect_database(&config.db_url).unwrap();
+    
+    // Hundreds of lines of application logic...
+    // All untestable from integration tests!
+}
+
+fn parse_args() -> Args { /* ... */ }
+fn load_config(path: &str) -> Result<Config, Error> { /* ... */ }
+fn connect_database(url: &str) -> Result<Db, Error> { /* ... */ }
+// ... more functions that can't be tested
+```
+
+## Good
+
+```rust
+// src/main.rs - thin entry point
+use my_app::{run, Config};
+
+fn main() -> anyhow::Result<()> {
+    let config = Config::from_env()?;
+    run(config)
+}
+
+// src/lib.rs - all the logic
+pub mod config;
+pub mod database;
+pub mod handlers;
+
+pub use config::Config;
+
+pub fn run(config: Config) -> anyhow::Result<()> {
+    let db = database::connect(&config.db_url)?;
+    let app = handlers::build_app(db);
+    app.run()
+}
+```
+
+## With CLI Arguments
+
+```rust
+// src/main.rs
+use clap::Parser;
+use my_app::{run, Args};
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    run(args)
+}
+
+// src/lib.rs
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "myapp", version, about)]
+pub struct Args {
+    #[arg(short, long)]
+    pub config: PathBuf,
+    
+    #[arg(short, long, default_value = "info")]
+    pub log_level: String,
+}
+
+pub fn run(args: Args) -> anyhow::Result<()> {
+    // All application logic here - testable!
+}
+```
+
+## Project Structure
+
+```
+my_app/
+├── Cargo.toml
+├── src/
+│   ├── main.rs       # Entry point only
+│   ├── lib.rs        # Library root, re-exports
+│   ├── config.rs     # Configuration
+│   ├── database.rs   # Database connection
+│   └── handlers/     # Request handlers
+│       ├── mod.rs
+│       └── users.rs
+└── tests/
+    └── integration.rs  # Can access lib.rs!
+```
+
+## Testing Benefits
+
+```rust
+// tests/integration.rs - can test everything!
+use my_app::{Config, run, database};
+
+#[test]
+fn test_database_connection() {
+    let config = Config::test_config();
+    let db = database::connect(&config.db_url).unwrap();
+    assert!(db.is_connected());
+}
+
+#[test]
+fn test_full_workflow() {
+    let config = Config::test_config();
+    // Test the actual run function
+    assert!(my_app::run(config).is_ok());
+}
+```
+
+## Multiple Binaries
+
+```rust
+// src/lib.rs - shared code
+pub mod core;
+pub mod utils;
+
+// src/bin/server.rs
+use my_app::core::Server;
+
+fn main() -> anyhow::Result<()> {
+    Server::new()?.run()
+}
+
+// src/bin/cli.rs
+use my_app::core::Client;
+
+fn main() -> anyhow::Result<()> {
+    let client = Client::new()?;
+    client.execute_command()
+}
+```
+
+## See Also
+
+- [proj-bin-dir](proj-bin-dir.md) - Put multiple binaries in src/bin/
+- [proj-mod-by-feature](proj-mod-by-feature.md) - Organize modules by feature
+- [test-integration-dir](test-integration-dir.md) - Integration tests in tests/

--- a/.agents/skills/rust-skills/rules/proj-mod-by-feature.md
+++ b/.agents/skills/rust-skills/rules/proj-mod-by-feature.md
@@ -1,0 +1,130 @@
+# proj-mod-by-feature
+
+> Organize modules by feature, not type
+
+## Why It Matters
+
+Feature-based organization keeps related code together, making navigation intuitive and changes localized. Type-based organization (all handlers in one folder, all models in another) scatters related code across the codebase, making features harder to understand and modify.
+
+## Bad
+
+```
+src/
+├── controllers/
+│   ├── user_controller.rs
+│   ├── order_controller.rs
+│   └── product_controller.rs
+├── models/
+│   ├── user.rs
+│   ├── order.rs
+│   └── product.rs
+├── services/
+│   ├── user_service.rs
+│   ├── order_service.rs
+│   └── product_service.rs
+└── repositories/
+    ├── user_repository.rs
+    ├── order_repository.rs
+    └── product_repository.rs
+```
+
+## Good
+
+```
+src/
+├── user/
+│   ├── mod.rs           # Re-exports public items
+│   ├── model.rs         # User struct, types
+│   ├── repository.rs    # Database operations
+│   ├── service.rs       # Business logic
+│   └── handler.rs       # HTTP handlers
+├── order/
+│   ├── mod.rs
+│   ├── model.rs
+│   ├── repository.rs
+│   ├── service.rs
+│   └── handler.rs
+├── product/
+│   ├── mod.rs
+│   ├── model.rs
+│   ├── repository.rs
+│   └── handler.rs
+└── lib.rs
+```
+
+## Benefits
+
+| Aspect | Type-Based | Feature-Based |
+|--------|------------|---------------|
+| Finding code | Search across folders | One folder per feature |
+| Adding feature | Touch 4+ folders | Create one folder |
+| Understanding feature | Jump between folders | Everything in one place |
+| Deleting feature | Hunt through codebase | Delete one folder |
+| Code ownership | Unclear | Clear feature owners |
+
+## Module Structure
+
+```rust
+// src/user/mod.rs
+mod model;
+mod repository;
+mod service;
+mod handler;
+
+// Re-export public API
+pub use model::{User, UserId, CreateUserRequest};
+pub use handler::router;
+pub(crate) use service::UserService;
+```
+
+## Shared Code
+
+```
+src/
+├── user/
+├── order/
+├── shared/              # Cross-cutting concerns
+│   ├── mod.rs
+│   ├── database.rs      # Connection pool
+│   ├── error.rs         # Common error types
+│   └── middleware.rs    # Auth, logging
+└── lib.rs
+```
+
+## When to Flatten
+
+Small modules don't need deep nesting:
+
+```
+src/
+├── user/
+│   ├── mod.rs           # Contains User struct + simple functions
+│   └── repository.rs    # Only if complex enough
+├── config.rs            # Simple enough for single file
+└── lib.rs
+```
+
+## Hybrid Approach
+
+For larger features, nest further by concern:
+
+```
+src/
+├── billing/
+│   ├── mod.rs
+│   ├── invoice/
+│   │   ├── mod.rs
+│   │   ├── model.rs
+│   │   └── service.rs
+│   ├── payment/
+│   │   ├── mod.rs
+│   │   ├── model.rs
+│   │   └── processor.rs
+│   └── shared.rs
+```
+
+## See Also
+
+- [proj-flat-small](./proj-flat-small.md) - Keep small projects flat
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Clean public API
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation

--- a/.agents/skills/rust-skills/rules/proj-mod-rs-dir.md
+++ b/.agents/skills/rust-skills/rules/proj-mod-rs-dir.md
@@ -1,0 +1,120 @@
+# proj-mod-rs-dir
+
+> Use mod.rs for multi-file modules
+
+## Why It Matters
+
+Rust offers two styles for multi-file modules. The `mod.rs` style is clearer for larger modules and aligns with how most Rust projects are structured. Choose one style consistently.
+
+## Two Styles
+
+### Style 1: mod.rs (Recommended for larger modules)
+
+```
+src/
+├── user/
+│   ├── mod.rs          # Module root
+│   ├── model.rs
+│   └── repository.rs
+└── lib.rs
+```
+
+```rust
+// src/lib.rs
+mod user;  // Looks for user/mod.rs or user.rs
+
+// src/user/mod.rs
+mod model;
+mod repository;
+pub use model::User;
+```
+
+### Style 2: Adjacent file (Recommended for smaller modules)
+
+```
+src/
+├── user.rs             # Module root
+├── user/
+│   ├── model.rs
+│   └── repository.rs
+└── lib.rs
+```
+
+```rust
+// src/lib.rs
+mod user;  // Looks for user.rs, then user/ for submodules
+
+// src/user.rs
+mod model;
+mod repository;
+pub use model::User;
+```
+
+## When to Use Each
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Simple module (1-3 submodules) | Adjacent file (`user.rs` + `user/`) |
+| Complex module (4+ submodules) | `mod.rs` style (`user/mod.rs`) |
+| Deep nesting | `mod.rs` at each level |
+| Library with public modules | Consistent style throughout |
+
+## mod.rs Benefits
+
+- Clear that `user/` is a module directory
+- All module code inside the folder
+- Easier to move/rename entire modules
+- Common in large codebases (tokio, serde)
+
+## Adjacent File Benefits
+
+- Module declaration outside directory
+- Can see module's interface without entering folder
+- Matches Rust 2018+ default lint preference
+- Good for small modules with few submodules
+
+## Example: Complex Module
+
+```
+src/
+├── database/
+│   ├── mod.rs          # Main module, re-exports
+│   ├── connection.rs   # Connection pool
+│   ├── migrations.rs   # Schema migrations
+│   ├── queries/        # Sub-module for queries
+│   │   ├── mod.rs
+│   │   ├── user.rs
+│   │   └── order.rs
+│   └── error.rs
+└── lib.rs
+```
+
+```rust
+// src/database/mod.rs
+mod connection;
+mod migrations;
+mod queries;
+mod error;
+
+pub use connection::Pool;
+pub use error::DatabaseError;
+pub use queries::{UserQueries, OrderQueries};
+```
+
+## Consistency Rule
+
+Pick one style for your project and stick with it:
+
+```rust
+// Cargo.toml or clippy.toml
+[lints.clippy]
+mod_module_files = "warn"  # Enforces mod.rs style
+# OR
+self_named_module_files = "warn"  # Enforces adjacent style
+```
+
+## See Also
+
+- [proj-flat-small](./proj-flat-small.md) - Keep small projects flat
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns

--- a/.agents/skills/rust-skills/rules/proj-prelude-module.md
+++ b/.agents/skills/rust-skills/rules/proj-prelude-module.md
@@ -1,0 +1,155 @@
+# proj-prelude-module
+
+> Create prelude module for common imports
+
+## Why It Matters
+
+A `prelude` module collects the most commonly used types and traits for glob import. Users write `use my_crate::prelude::*` instead of many individual imports. This follows the pattern established by `std::prelude`.
+
+## Bad
+
+```rust
+// Users must import everything individually
+use my_crate::Client;
+use my_crate::Config;
+use my_crate::Error;
+use my_crate::Request;
+use my_crate::Response;
+use my_crate::traits::Handler;
+use my_crate::traits::Middleware;
+use my_crate::types::Method;
+```
+
+## Good
+
+```rust
+// src/lib.rs
+pub mod prelude {
+    pub use crate::{
+        Client,
+        Config,
+        Error,
+        Request,
+        Response,
+    };
+    pub use crate::traits::{Handler, Middleware};
+    pub use crate::types::Method;
+}
+
+// Users write:
+use my_crate::prelude::*;
+```
+
+## What to Include
+
+| Include | Don't Include |
+|---------|---------------|
+| Core types users always need | Rarely-used types |
+| Common traits | Implementation details |
+| Error types | Internal helpers |
+| Extension traits | Feature-gated items (usually) |
+| Type aliases | Everything |
+
+## Example: Web Framework Prelude
+
+```rust
+pub mod prelude {
+    // Core request/response
+    pub use crate::{Request, Response, Body};
+    
+    // Error handling
+    pub use crate::Error;
+    
+    // Common traits
+    pub use crate::traits::{FromRequest, IntoResponse};
+    
+    // Routing
+    pub use crate::Router;
+    
+    // HTTP types
+    pub use crate::http::{Method, StatusCode};
+}
+```
+
+## Example: Database Library Prelude
+
+```rust
+pub mod prelude {
+    // Connection and pool
+    pub use crate::{Connection, Pool};
+    
+    // Query building
+    pub use crate::query::{Query, Select, Insert, Update, Delete};
+    
+    // Traits for custom types
+    pub use crate::traits::{FromRow, ToSql};
+    
+    // Error type
+    pub use crate::Error;
+}
+```
+
+## Pattern: Tiered Preludes
+
+```rust
+// Minimal prelude
+pub mod prelude {
+    pub use crate::{Client, Config, Error};
+}
+
+// Full prelude for power users
+pub mod full_prelude {
+    pub use crate::prelude::*;
+    pub use crate::advanced::*;
+    pub use crate::extensions::*;
+}
+```
+
+## Pattern: Feature-Gated Prelude Items
+
+```rust
+pub mod prelude {
+    pub use crate::{Client, Error};
+    
+    #[cfg(feature = "async")]
+    pub use crate::async_client::AsyncClient;
+    
+    #[cfg(feature = "serde")]
+    pub use crate::serde::{Serialize, Deserialize};
+}
+```
+
+## Guidelines
+
+1. **Be conservative** - Only include truly common items
+2. **Avoid conflicts** - Don't include names that might clash (e.g., `Error`)
+3. **Document it** - List what's included in module docs
+4. **Stay stable** - Removing items is breaking change
+
+## Documenting the Prelude
+
+```rust
+//! Common imports for convenient glob importing.
+//!
+//! # Usage
+//!
+//! ```
+//! use my_crate::prelude::*;
+//! ```
+//!
+//! # Contents
+//!
+//! This prelude re-exports:
+//! - [`Client`] - The main API client
+//! - [`Config`] - Client configuration
+//! - [`Error`] - Error type
+pub mod prelude {
+    // ...
+}
+```
+
+## See Also
+
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns
+- [api-extension-trait](./api-extension-trait.md) - Extension traits
+- [doc-module-inner](./doc-module-inner.md) - Module documentation

--- a/.agents/skills/rust-skills/rules/proj-pub-crate-internal.md
+++ b/.agents/skills/rust-skills/rules/proj-pub-crate-internal.md
@@ -1,0 +1,139 @@
+# proj-pub-crate-internal
+
+> Use pub(crate) for internal APIs
+
+## Why It Matters
+
+`pub(crate)` exposes items within the crate but hides them from external users. This creates clear boundaries between public API and internal implementation, preventing accidental breakage and reducing public API surface.
+
+## Bad
+
+```rust
+// Everything public - users depend on internals
+pub mod internal {
+    pub struct InternalState {
+        pub buffer: Vec<u8>,    // Implementation detail exposed
+        pub dirty: bool,
+    }
+    
+    pub fn process_internal(state: &mut InternalState) {
+        // Users can call this, creating coupling
+    }
+}
+
+pub struct Widget {
+    pub state: internal::InternalState,  // Exposed!
+}
+```
+
+## Good
+
+```rust
+// Internal module with crate visibility
+pub(crate) mod internal {
+    pub(crate) struct InternalState {
+        pub(crate) buffer: Vec<u8>,
+        pub(crate) dirty: bool,
+    }
+    
+    pub(crate) fn process_internal(state: &mut InternalState) {
+        // Only callable within crate
+    }
+}
+
+pub struct Widget {
+    state: internal::InternalState,  // Private field
+}
+
+impl Widget {
+    pub fn new() -> Self {
+        Self {
+            state: internal::InternalState {
+                buffer: Vec::new(),
+                dirty: false,
+            }
+        }
+    }
+    
+    pub fn do_something(&mut self) {
+        internal::process_internal(&mut self.state);
+    }
+}
+```
+
+## Visibility Levels
+
+| Visibility | Accessible From |
+|------------|-----------------|
+| `pub` | Everywhere |
+| `pub(crate)` | Current crate only |
+| `pub(super)` | Parent module only |
+| `pub(in path)` | Specific module path |
+| (private) | Current module only |
+
+## Pattern: Internal Module
+
+```rust
+// src/lib.rs
+mod internal;  // Private module
+pub mod api;   // Public API
+
+// src/internal.rs
+pub(crate) struct Helper;
+pub(crate) fn helper_function() -> Helper { Helper }
+
+// src/api.rs
+use crate::internal::{Helper, helper_function};
+
+pub struct PublicType {
+    helper: Helper,  // Uses internal type, but field is private
+}
+```
+
+## Pattern: Test Visibility
+
+```rust
+pub struct Parser {
+    // Private implementation
+    state: ParserState,
+}
+
+// Expose for testing but not public API
+#[cfg(test)]
+pub(crate) fn debug_state(&self) -> &ParserState {
+    &self.state
+}
+
+// Or use a dedicated test helper
+#[doc(hidden)]
+pub mod __test_helpers {
+    pub use super::ParserState;
+}
+```
+
+## Pattern: Feature Module Internals
+
+```rust
+// src/user/mod.rs
+mod repository;  // Private
+mod service;     // Private
+
+pub use service::UserService;  // Only export the public API
+
+// repository and service are pub(crate) internally
+// so other modules in crate can use them if needed
+```
+
+## Benefits
+
+| Approach | API Stability | Flexibility |
+|----------|---------------|-------------|
+| All `pub` | Any change breaks users | None |
+| `pub(crate)` internals | Only `pub` items matter | Can refactor freely |
+| Private | Maximum encapsulation | Limits crate flexibility |
+
+## See Also
+
+- [proj-pub-super-parent](./proj-pub-super-parent.md) - Parent-only visibility
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Clean re-exports
+- [api-non-exhaustive](./api-non-exhaustive.md) - Future-proof structs

--- a/.agents/skills/rust-skills/rules/proj-pub-super-parent.md
+++ b/.agents/skills/rust-skills/rules/proj-pub-super-parent.md
@@ -1,0 +1,135 @@
+# proj-pub-super-parent
+
+> Use pub(super) for parent-only visibility
+
+## Why It Matters
+
+`pub(super)` exposes items only to the immediate parent module. This is useful for helper functions and types that submodules share but shouldn't be visible to the rest of the crate.
+
+## Bad
+
+```rust
+// src/parser/mod.rs
+pub mod lexer;
+pub mod ast;
+
+// src/parser/lexer.rs
+pub fn internal_helper() {  // Visible to entire crate!
+    // Helper only needed by lexer and ast
+}
+
+pub(crate) struct Token {  // Visible to entire crate
+    // Only parser submodules need this
+}
+```
+
+## Good
+
+```rust
+// src/parser/mod.rs
+pub mod lexer;
+pub mod ast;
+
+// Shared types for parser submodules only
+pub(super) struct Token {
+    pub(super) kind: TokenKind,
+    pub(super) span: Span,
+}
+
+pub(super) fn shared_helper() -> Token {
+    // Only visible in parser/*
+}
+
+// src/parser/lexer.rs
+use super::{Token, shared_helper};
+
+pub fn lex(input: &str) -> Vec<Token> {
+    shared_helper();
+    // ...
+}
+
+// src/parser/ast.rs
+use super::Token;
+
+pub fn parse(tokens: Vec<Token>) -> Ast {
+    // ...
+}
+```
+
+## Visibility Hierarchy
+
+```
+src/
+├── lib.rs           # crate root
+├── parser/
+│   ├── mod.rs       # pub(super) items visible here
+│   ├── lexer.rs     # can use pub(super) from mod.rs
+│   └── ast.rs       # can use pub(super) from mod.rs
+└── codegen.rs       # CANNOT see pub(super) parser items
+```
+
+## Pattern: Layered Visibility
+
+```rust
+// src/database/mod.rs
+mod connection;
+mod query;
+mod pool;
+
+// Only this module's children can see
+pub(super) struct RawConnection { /* ... */ }
+
+// Entire crate can see
+pub(crate) struct Pool { /* ... */ }
+
+// Everyone can see
+pub struct Database { /* ... */ }
+```
+
+## Pattern: Test Helpers
+
+```rust
+// src/parser/mod.rs
+mod lexer;
+mod ast;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test helper visible only to parser module's tests
+    pub(super) fn make_test_token() -> Token {
+        Token { kind: TokenKind::Test, span: Span::dummy() }
+    }
+}
+
+// src/parser/lexer.rs
+#[cfg(test)]
+mod tests {
+    use super::super::tests::make_test_token;
+    // ...
+}
+```
+
+## Comparison
+
+| Visibility | Scope | Use Case |
+|------------|-------|----------|
+| `pub` | Everywhere | Public API |
+| `pub(crate)` | Crate-wide | Internal shared utilities |
+| `pub(super)` | Parent module | Submodule helpers |
+| `pub(in path)` | Specific path | Precise control |
+| (private) | Current module | Implementation details |
+
+## When to Use pub(super)
+
+- Helper functions shared between sibling modules
+- Types used by submodules but not the rest of crate
+- Implementation details of a module group
+- Test utilities for a module tree
+
+## See Also
+
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Crate visibility
+- [proj-pub-use-reexport](./proj-pub-use-reexport.md) - Re-export patterns
+- [proj-mod-by-feature](./proj-mod-by-feature.md) - Feature organization

--- a/.agents/skills/rust-skills/rules/proj-pub-use-reexport.md
+++ b/.agents/skills/rust-skills/rules/proj-pub-use-reexport.md
@@ -1,0 +1,162 @@
+# proj-pub-use-reexport
+
+> Use pub use for clean public API
+
+## Why It Matters
+
+`pub use` re-exports items from submodules at the current module level. This creates a flat, ergonomic public API while keeping internal organization flexible. Users import from one place; you can reorganize internals without breaking their code.
+
+## Bad
+
+```rust
+// lib.rs - Deep module paths exposed
+pub mod error;
+pub mod config;
+pub mod client;
+pub mod types;
+
+// Users must write:
+use my_crate::error::MyError;
+use my_crate::config::Config;
+use my_crate::client::http::HttpClient;
+use my_crate::types::request::Request;
+```
+
+## Good
+
+```rust
+// lib.rs - Flat public API
+mod error;
+mod config;
+mod client;
+mod types;
+
+pub use error::MyError;
+pub use config::Config;
+pub use client::http::HttpClient;
+pub use types::request::Request;
+
+// Users write:
+use my_crate::{Config, HttpClient, MyError, Request};
+```
+
+## Pattern: Selective Re-export
+
+```rust
+// src/lib.rs
+mod internal;
+
+// Only re-export what users need
+pub use internal::{
+    PublicStruct,
+    PublicTrait,
+    public_function,
+};
+
+// Keep implementation details hidden
+// internal::helper_function is NOT exported
+```
+
+## Pattern: Rename on Re-export
+
+```rust
+mod v1 {
+    pub struct Client { /* old implementation */ }
+}
+
+mod v2 {
+    pub struct Client { /* new implementation */ }
+}
+
+// Re-export with clear names
+pub use v2::Client;
+pub use v1::Client as LegacyClient;
+```
+
+## Pattern: Prelude Module
+
+```rust
+// src/lib.rs
+pub mod prelude {
+    pub use crate::{
+        Config,
+        Client,
+        Error,
+        Request,
+        Response,
+    };
+}
+
+// Users can glob import common items
+use my_crate::prelude::*;
+```
+
+## Pattern: Feature-Gated Re-exports
+
+```rust
+// src/lib.rs
+mod core;
+mod serde_impl;
+mod async_impl;
+
+pub use core::*;
+
+#[cfg(feature = "serde")]
+pub use serde_impl::*;
+
+#[cfg(feature = "async")]
+pub use async_impl::*;
+```
+
+## Comparison: Module Structure vs Public API
+
+```rust
+// Internal structure (complex)
+src/
+├── transport/
+│   ├── http/
+│   │   └── client.rs    // HttpClient
+│   └── grpc/
+│       └── client.rs    // GrpcClient
+├── auth/
+│   └── token.rs         // Token
+└── lib.rs
+
+// Public API (flat)
+pub use transport::http::client::HttpClient;
+pub use transport::grpc::client::GrpcClient;
+pub use auth::token::Token;
+
+// Users see:
+my_crate::HttpClient
+my_crate::GrpcClient
+my_crate::Token
+```
+
+## Re-export External Types
+
+```rust
+// Re-export dependencies users will need
+pub use bytes::Bytes;
+pub use http::{Method, StatusCode};
+
+// Now users don't need to depend on these crates directly
+```
+
+## Glob Re-exports
+
+Use sparingly:
+
+```rust
+// OK for internal modules
+pub use internal::*;
+
+// Careful with external crates - pollutes namespace
+pub use serde::*;  // Usually too broad
+```
+
+## See Also
+
+- [proj-prelude-module](./proj-prelude-module.md) - Prelude pattern
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Internal visibility
+- [api-non-exhaustive](./api-non-exhaustive.md) - API stability

--- a/.agents/skills/rust-skills/rules/proj-workspace-deps.md
+++ b/.agents/skills/rust-skills/rules/proj-workspace-deps.md
@@ -1,0 +1,186 @@
+# proj-workspace-deps
+
+> Use workspace dependency inheritance for consistent versions across crates
+
+## Why It Matters
+
+Multi-crate workspaces often have dependency version drift—different crates using different versions of the same dependency. Workspace dependency inheritance (Rust 1.64+) lets you declare dependencies once in the workspace `Cargo.toml` and inherit them in member crates, ensuring consistency.
+
+## Bad
+
+```toml
+# crate-a/Cargo.toml
+[dependencies]
+serde = "1.0.150"
+tokio = "1.25"
+
+# crate-b/Cargo.toml  
+[dependencies]
+serde = "1.0.188"  # Different version!
+tokio = "1.32"     # Different version!
+
+# Version drift leads to:
+# - Larger binaries (multiple versions)
+# - Compilation time increase
+# - Subtle behavior differences
+```
+
+## Good
+
+```toml
+# Root Cargo.toml
+[workspace]
+members = ["crate-a", "crate-b", "crate-c"]
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.32", features = ["full"] }
+thiserror = "1.0"
+anyhow = "1.0"
+tracing = "0.1"
+
+# crate-a/Cargo.toml
+[dependencies]
+serde.workspace = true
+tokio.workspace = true
+
+# crate-b/Cargo.toml
+[dependencies]
+serde.workspace = true
+tokio.workspace = true
+thiserror.workspace = true
+```
+
+## Override Features
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+tokio = { version = "1.32", features = ["rt-multi-thread"] }
+
+# crate-a/Cargo.toml - add extra features
+[dependencies]
+tokio = { workspace = true, features = ["net", "io-util"] }
+# Gets both workspace features AND local features
+
+# crate-b/Cargo.toml - minimal features
+[dependencies]
+tokio = { workspace = true }  # Just workspace features
+```
+
+## Dev and Build Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+criterion = "0.5"
+proptest = "1.0"
+trybuild = "1.0"
+cc = "1.0"
+
+# crate-a/Cargo.toml
+[dev-dependencies]
+criterion.workspace = true
+proptest.workspace = true
+
+[build-dependencies]
+cc.workspace = true
+```
+
+## Internal Crate Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+# Internal crates
+my-core = { path = "crates/core" }
+my-utils = { path = "crates/utils" }
+my-derive = { path = "crates/derive" }
+
+# External crates
+serde = "1.0"
+
+# crate-a/Cargo.toml
+[dependencies]
+my-core.workspace = true
+my-utils.workspace = true
+serde.workspace = true
+```
+
+## Optional Dependencies
+
+```toml
+# Root Cargo.toml
+[workspace.dependencies]
+serde = { version = "1.0", optional = true }  # Won't work!
+
+# Optional must be set in member, not workspace
+[workspace.dependencies]
+serde = "1.0"
+
+# crate-a/Cargo.toml
+[dependencies]
+serde = { workspace = true, optional = true }
+
+[features]
+serde = ["dep:serde"]
+```
+
+## Complete Workspace Example
+
+```toml
+# Root Cargo.toml
+[workspace]
+members = ["crates/*"]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/user/repo"
+
+[workspace.dependencies]
+# Internal
+my-core = { path = "crates/core", version = "0.1" }
+
+# Async
+tokio = { version = "1.32", features = ["full"] }
+futures = "0.3"
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+thiserror = "1.0"
+anyhow = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+# Testing
+proptest = "1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+# crates/core/Cargo.toml
+[package]
+name = "my-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+```
+
+## See Also
+
+- [proj-lib-main-split](./proj-lib-main-split.md) - Workspace structure
+- [api-serde-optional](./api-serde-optional.md) - Optional dependencies
+- [lint-deny-correctness](./lint-deny-correctness.md) - Workspace lints

--- a/.agents/skills/rust-skills/rules/proj-workspace-large.md
+++ b/.agents/skills/rust-skills/rules/proj-workspace-large.md
@@ -1,0 +1,162 @@
+# proj-workspace-large
+
+> Use workspaces for large projects
+
+## Why It Matters
+
+Cargo workspaces manage multiple related crates under one repository. They share a single `Cargo.lock`, build cache, and can be versioned together. For large projects, workspaces improve build times, enforce modularity, and simplify dependency management.
+
+## Bad
+
+```
+# Separate repositories for each crate
+my-app-core/
+my-app-cli/
+my-app-server/
+my-app-common/
+
+# Each has its own Cargo.lock
+# Dependencies may drift
+# Cross-crate development is painful
+```
+
+## Good
+
+```
+my-app/
+├── Cargo.toml          # Workspace root
+├── Cargo.lock          # Shared lock file
+├── crates/
+│   ├── core/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   ├── cli/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   ├── server/
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   └── common/
+│       ├── Cargo.toml
+│       └── src/
+└── README.md
+```
+
+## Workspace Cargo.toml
+
+```toml
+# Root Cargo.toml
+[workspace]
+resolver = "2"  # Use the new resolver
+members = [
+    "crates/core",
+    "crates/cli",
+    "crates/server",
+    "crates/common",
+]
+
+# Shared dependencies - all crates use same versions
+[workspace.dependencies]
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+tracing = "0.1"
+anyhow = "1.0"
+
+# Shared lints
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace.lints.clippy]
+all = "warn"
+```
+
+## Member Crate Cargo.toml
+
+```toml
+# crates/core/Cargo.toml
+[package]
+name = "my-app-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# Inherit from workspace
+tokio = { workspace = true }
+serde = { workspace = true }
+
+# Crate-specific dependencies
+uuid = "1.0"
+
+# Internal dependency
+my-app-common = { path = "../common" }
+
+[lints]
+workspace = true  # Inherit workspace lints
+```
+
+## When to Use Workspaces
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Single binary/library | No workspace needed |
+| Library + CLI | Maybe, depends on size |
+| Multiple related crates | Yes |
+| Shared internal libraries | Yes |
+| Microservices mono-repo | Yes |
+| Plugin architecture | Yes |
+
+## Benefits
+
+| Aspect | Single Crate | Workspace |
+|--------|--------------|-----------|
+| Build cache | Crate only | Shared across all |
+| Dependency versions | Per-crate | Synchronized |
+| Compile times | Full rebuild | Incremental |
+| Modularity | Files/modules | Crate boundaries |
+| Publishing | Single crate | Independent |
+
+## Commands
+
+```bash
+# Build all crates
+cargo build --workspace
+
+# Build specific crate
+cargo build -p my-app-core
+
+# Test all crates
+cargo test --workspace
+
+# Run specific binary
+cargo run -p my-app-cli
+
+# Check all
+cargo check --workspace
+```
+
+## Pattern: Virtual Workspace
+
+Root Cargo.toml is workspace-only (no `[package]`):
+
+```toml
+[workspace]
+members = ["crates/*"]
+
+[workspace.dependencies]
+# ...
+```
+
+## Pattern: Crate Interdependencies
+
+```toml
+# crates/server/Cargo.toml
+[dependencies]
+my-app-core = { path = "../core" }
+my-app-common = { path = "../common" }
+```
+
+## See Also
+
+- [proj-workspace-deps](./proj-workspace-deps.md) - Workspace dependencies
+- [proj-bin-dir](./proj-bin-dir.md) - Multiple binaries
+- [proj-lib-main-split](./proj-lib-main-split.md) - Lib/main separation

--- a/.agents/skills/rust-skills/rules/test-arrange-act-assert.md
+++ b/.agents/skills/rust-skills/rules/test-arrange-act-assert.md
@@ -1,0 +1,160 @@
+# test-arrange-act-assert
+
+> Structure tests with clear Arrange, Act, Assert sections
+
+## Why It Matters
+
+The AAA pattern makes tests readable and maintainable. Each section has a clear purpose: set up test data, execute the code under test, verify the results. This structure helps identify what's being tested and makes tests easier to debug when they fail.
+
+## Bad
+
+```rust
+#[test]
+fn test_user() {
+    assert_eq!(User::new("alice", "alice@example.com").unwrap().name(), "alice");
+    assert!(User::new("", "email@example.com").is_err());
+    let u = User::new("bob", "bob@example.com").unwrap();
+    assert!(u.validate());
+    assert_eq!(u.email(), "bob@example.com");
+}
+// Multiple concerns, hard to understand, hard to debug
+```
+
+## Good
+
+```rust
+#[test]
+fn new_user_has_correct_name() {
+    // Arrange
+    let name = "alice";
+    let email = "alice@example.com";
+    
+    // Act
+    let user = User::new(name, email).unwrap();
+    
+    // Assert
+    assert_eq!(user.name(), "alice");
+}
+
+#[test]
+fn user_creation_fails_with_empty_name() {
+    // Arrange
+    let name = "";
+    let email = "email@example.com";
+    
+    // Act
+    let result = User::new(name, email);
+    
+    // Assert
+    assert!(result.is_err());
+    assert!(matches!(result, Err(UserError::EmptyName)));
+}
+```
+
+## With Comments
+
+```rust
+#[test]
+fn order_total_includes_tax() {
+    // Arrange
+    let mut order = Order::new();
+    order.add_item(Item::new("Widget", 100.00));
+    order.add_item(Item::new("Gadget", 50.00));
+    let tax_rate = 0.10;
+    
+    // Act
+    let total = order.calculate_total(tax_rate);
+    
+    // Assert
+    let expected = (100.00 + 50.00) * 1.10;
+    assert_eq!(total, expected);
+}
+```
+
+## Complex Arrange
+
+```rust
+#[test]
+fn search_returns_matching_documents() {
+    // Arrange
+    let mut index = SearchIndex::new();
+    index.add_document(Document::new(1, "rust programming"));
+    index.add_document(Document::new(2, "python programming"));
+    index.add_document(Document::new(3, "rust web development"));
+    
+    let query = Query::new("rust");
+    
+    // Act
+    let results = index.search(&query);
+    
+    // Assert
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().any(|d| d.id == 1));
+    assert!(results.iter().any(|d| d.id == 3));
+}
+```
+
+## Async Tests
+
+```rust
+#[tokio::test]
+async fn fetch_user_returns_user_data() {
+    // Arrange
+    let client = TestClient::new();
+    let user_id = 42;
+    
+    // Act
+    let result = client.fetch_user(user_id).await;
+    
+    // Assert
+    assert!(result.is_ok());
+    let user = result.unwrap();
+    assert_eq!(user.id, user_id);
+}
+```
+
+## Helper Functions
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Arrange helpers
+    fn create_test_user() -> User {
+        User::new("test", "test@example.com").unwrap()
+    }
+    
+    fn create_order_with_items(items: &[(&str, f64)]) -> Order {
+        let mut order = Order::new();
+        for (name, price) in items {
+            order.add_item(Item::new(name, *price));
+        }
+        order
+    }
+    
+    // Assert helpers
+    fn assert_order_total(order: &Order, expected: f64) {
+        let total = order.calculate_total(0.0);
+        assert!((total - expected).abs() < 0.01);
+    }
+    
+    #[test]
+    fn order_total_sums_items() {
+        // Arrange
+        let order = create_order_with_items(&[
+            ("A", 10.0),
+            ("B", 20.0),
+        ]);
+        
+        // Act & Assert
+        assert_order_total(&order, 30.0);
+    }
+}
+```
+
+## See Also
+
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming
+- [test-fixture-raii](./test-fixture-raii.md) - Test setup/teardown
+- [test-mock-traits](./test-mock-traits.md) - Mocking dependencies

--- a/.agents/skills/rust-skills/rules/test-cfg-test-module.md
+++ b/.agents/skills/rust-skills/rules/test-cfg-test-module.md
@@ -1,0 +1,151 @@
+# test-cfg-test-module
+
+> Put unit tests in `#[cfg(test)] mod tests { }` within each module
+
+## Why It Matters
+
+The `#[cfg(test)]` attribute ensures test code is only compiled during `cargo test`, not in release builds. Placing tests in a `tests` submodule within the same file keeps tests close to the code they test while maintaining separation. This is Rust's idiomatic unit test pattern.
+
+## Bad
+
+```rust
+// Tests without cfg(test) - compiled into release binary
+mod tests {
+    #[test]
+    fn test_something() { ... }  // Included in release build!
+}
+
+// Tests in separate file without access to private items
+// src/my_module.rs
+fn private_helper() { ... }
+
+// tests/my_module_test.rs
+// Can't access private_helper!
+```
+
+## Good
+
+```rust
+// src/my_module.rs
+
+fn public_api() -> i32 {
+    private_helper() * 2
+}
+
+fn private_helper() -> i32 {
+    21
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;  // Access to private items
+    
+    #[test]
+    fn test_public_api() {
+        assert_eq!(public_api(), 42);
+    }
+    
+    #[test]
+    fn test_private_helper() {
+        assert_eq!(private_helper(), 21);  // Can test private!
+    }
+}
+```
+
+## Module Structure
+
+```rust
+// src/lib.rs
+mod parser;
+mod lexer;
+mod ast;
+
+// src/parser.rs
+pub fn parse(input: &str) -> Result<Ast, Error> {
+    let tokens = tokenize(input)?;
+    build_ast(tokens)
+}
+
+fn tokenize(input: &str) -> Result<Vec<Token>, Error> { ... }
+fn build_ast(tokens: Vec<Token>) -> Result<Ast, Error> { ... }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_parse_simple() {
+        let ast = parse("1 + 2").unwrap();
+        assert_eq!(ast.evaluate(), 3);
+    }
+    
+    #[test]
+    fn test_tokenize() {
+        let tokens = tokenize("1 + 2").unwrap();
+        assert_eq!(tokens.len(), 3);
+    }
+}
+```
+
+## Test Helpers
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test-only helpers
+    fn create_test_data() -> Data {
+        Data {
+            id: 1,
+            name: "test".into(),
+            values: vec![1, 2, 3],
+        }
+    }
+    
+    fn assert_valid(data: &Data) {
+        assert!(data.id > 0);
+        assert!(!data.name.is_empty());
+    }
+    
+    #[test]
+    fn test_processing() {
+        let data = create_test_data();
+        let result = process(&data);
+        assert_valid(&result);
+    }
+}
+```
+
+## Multiple Test Modules
+
+```rust
+// For larger test suites, use submodules
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod parsing {
+        use super::*;
+        
+        #[test]
+        fn test_parse_number() { ... }
+        
+        #[test]
+        fn test_parse_string() { ... }
+    }
+    
+    mod validation {
+        use super::*;
+        
+        #[test]
+        fn test_validate_range() { ... }
+    }
+}
+```
+
+## See Also
+
+- [test-use-super](./test-use-super.md) - Importing from parent module
+- [test-integration-dir](./test-integration-dir.md) - Integration tests
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming

--- a/.agents/skills/rust-skills/rules/test-criterion-bench.md
+++ b/.agents/skills/rust-skills/rules/test-criterion-bench.md
@@ -1,0 +1,171 @@
+# test-criterion-bench
+
+> Use `criterion` for benchmarking
+
+## Why It Matters
+
+Criterion provides statistically rigorous benchmarking with warmup, multiple iterations, outlier detection, and comparison between runs. It's far more reliable than simple timing with `Instant::now()`.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "my_benchmark"
+harness = false
+```
+
+## Basic Benchmark
+
+```rust
+// benches/my_benchmark.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+fn bench_fibonacci(c: &mut Criterion) {
+    c.bench_function("fib 20", |b| {
+        b.iter(|| fibonacci(black_box(20)))
+    });
+}
+
+criterion_group!(benches, bench_fibonacci);
+criterion_main!(benches);
+```
+
+## black_box is Critical
+
+```rust
+// BAD: Compiler may optimize away the computation
+b.iter(|| fibonacci(20));  // Result unused, might be eliminated
+
+// GOOD: black_box prevents optimization
+b.iter(|| fibonacci(black_box(20)));
+
+// Also wrap the result if needed
+b.iter(|| black_box(fibonacci(black_box(20))));
+```
+
+## Comparing Implementations
+
+```rust
+fn bench_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("String concat");
+    
+    let data = "hello";
+    
+    group.bench_function("format!", |b| {
+        b.iter(|| format!("{}{}", black_box(data), " world"))
+    });
+    
+    group.bench_function("push_str", |b| {
+        b.iter(|| {
+            let mut s = String::from(black_box(data));
+            s.push_str(" world");
+            s
+        })
+    });
+    
+    group.bench_function("concat", |b| {
+        b.iter(|| [black_box(data), " world"].concat())
+    });
+    
+    group.finish();
+}
+```
+
+## Parameterized Benchmarks
+
+```rust
+fn bench_vec_push(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Vec::push");
+    
+    for size in [100, 1000, 10000].iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            size,
+            |b, &size| {
+                b.iter(|| {
+                    let mut v = Vec::new();
+                    for i in 0..size {
+                        v.push(black_box(i));
+                    }
+                    v
+                });
+            },
+        );
+    }
+    
+    group.finish();
+}
+```
+
+## Throughput Measurement
+
+```rust
+use criterion::Throughput;
+
+fn bench_parse(c: &mut Criterion) {
+    let input = "a]ong string to parse...";
+    
+    let mut group = c.benchmark_group("Parser");
+    group.throughput(Throughput::Bytes(input.len() as u64));
+    
+    group.bench_function("parse", |b| {
+        b.iter(|| parse(black_box(input)))
+    });
+    
+    group.finish();
+}
+```
+
+## Running Benchmarks
+
+```bash
+# Run all benchmarks
+cargo bench
+
+# Run specific benchmark
+cargo bench -- fib
+
+# Save baseline for comparison
+cargo bench -- --save-baseline main
+
+# Compare against baseline
+cargo bench -- --baseline main
+```
+
+## Evidence from tokio
+
+```rust
+// https://github.com/tokio-rs/tokio/blob/master/benches/sync_mpsc.rs
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn send_data<T: Default, const SIZE: usize>(
+    g: &mut BenchmarkGroup<WallTime>, 
+    prefix: &str
+) {
+    let rt = rt();
+    g.bench_function(format!("{prefix}_{SIZE}"), |b| {
+        b.iter(|| {
+            let (tx, mut rx) = mpsc::channel::<T>(SIZE);
+            rt.block_on(tx.send(T::default())).unwrap();
+            rt.block_on(rx.recv()).unwrap();
+        })
+    });
+}
+```
+
+## See Also
+
+- [perf-profile-first](perf-profile-first.md) - Profile before optimizing
+- [perf-black-box-bench](perf-black-box-bench.md) - Use black_box in benchmarks

--- a/.agents/skills/rust-skills/rules/test-descriptive-names.md
+++ b/.agents/skills/rust-skills/rules/test-descriptive-names.md
@@ -1,0 +1,142 @@
+# test-descriptive-names
+
+> Use descriptive test names that explain what is being tested
+
+## Why It Matters
+
+Test names appear in test output and serve as documentation. A good test name tells you what behavior is being verified without reading the test body. When a test fails, a descriptive name immediately tells you what broke.
+
+## Bad
+
+```rust
+#[test]
+fn test1() { ... }
+
+#[test]
+fn test_parse() { ... }  // Parse what? What behavior?
+
+#[test]
+fn it_works() { ... }
+
+#[test]
+fn test_function() { ... }
+
+// Failure output: "test test_parse ... FAILED"
+// What failed? No idea.
+```
+
+## Good
+
+```rust
+#[test]
+fn parse_returns_error_for_empty_input() { ... }
+
+#[test]
+fn parse_handles_unicode_characters() { ... }
+
+#[test]
+fn user_creation_requires_valid_email() { ... }
+
+#[test]
+fn expired_token_is_rejected() { ... }
+
+// Failure output: "test parse_returns_error_for_empty_input ... FAILED"
+// Immediately know what broke!
+```
+
+## Naming Patterns
+
+```rust
+// Pattern: function_condition_expected_result
+#[test]
+fn parse_valid_json_returns_document() { ... }
+
+#[test]
+fn parse_invalid_json_returns_syntax_error() { ... }
+
+// Pattern: scenario_expectation
+#[test]
+fn empty_cart_has_zero_total() { ... }
+
+#[test]
+fn adding_item_increases_cart_total() { ... }
+
+// Pattern: when_given_then (BDD-style)
+#[test]
+fn when_user_not_found_then_returns_404() { ... }
+```
+
+## Edge Cases
+
+```rust
+#[test]
+fn handles_empty_string() { ... }
+
+#[test]
+fn handles_max_length_input() { ... }
+
+#[test]
+fn handles_unicode_emoji() { ... }
+
+#[test]
+fn handles_null_bytes() { ... }
+
+#[test]
+fn handles_concurrent_access() { ... }
+```
+
+## Error Cases
+
+```rust
+#[test]
+fn rejects_negative_quantity() { ... }
+
+#[test]
+fn returns_error_for_invalid_email_format() { ... }
+
+#[test]
+fn panics_on_double_initialization() { ... }
+
+#[test]
+fn timeout_returns_timeout_error() { ... }
+```
+
+## Module Organization
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod parsing {
+        use super::*;
+        
+        #[test]
+        fn accepts_valid_json() { ... }
+        
+        #[test]
+        fn rejects_trailing_comma() { ... }
+    }
+    
+    mod validation {
+        use super::*;
+        
+        #[test]
+        fn requires_name_field() { ... }
+        
+        #[test]
+        fn email_must_contain_at_symbol() { ... }
+    }
+}
+
+// Test output:
+// tests::parsing::accepts_valid_json
+// tests::parsing::rejects_trailing_comma
+// tests::validation::requires_name_field
+```
+
+## See Also
+
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure
+- [test-cfg-test-module](./test-cfg-test-module.md) - Test module organization
+- [doc-examples-section](./doc-examples-section.md) - Documentation tests

--- a/.agents/skills/rust-skills/rules/test-doctest-examples.md
+++ b/.agents/skills/rust-skills/rules/test-doctest-examples.md
@@ -1,0 +1,168 @@
+# test-doctest-examples
+
+> Keep documentation examples as executable doctests
+
+## Why It Matters
+
+Doctests are examples in documentation that are automatically tested. They serve dual purposes: demonstrating usage to readers and verifying the examples compile and work. When your API changes, failing doctests catch outdated documentation.
+
+## Bad
+
+```rust
+/// Parses a number from a string.
+/// 
+/// Example:
+/// let n = parse("42");  // Not tested!
+/// assert_eq!(n, 42);
+pub fn parse(s: &str) -> i32 {
+    s.parse().unwrap()
+}
+
+// Documentation can become outdated:
+/// Adds two numbers.
+/// 
+/// ```
+/// let sum = add(1, 2, 3);  // Wrong number of args - not caught!
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Good
+
+```rust
+/// Parses a number from a string.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::parse;
+/// 
+/// let n = parse("42");
+/// assert_eq!(n, 42);
+/// ```
+pub fn parse(s: &str) -> i32 {
+    s.parse().unwrap()
+}
+
+/// Adds two numbers.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::add;
+/// 
+/// let sum = add(1, 2);
+/// assert_eq!(sum, 3);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Hiding Setup Code
+
+```rust
+/// Processes data from a file.
+/// 
+/// # Examples
+/// 
+/// ```
+/// # use std::io::Write;
+/// # let mut file = tempfile::NamedTempFile::new().unwrap();
+/// # writeln!(file, "test data").unwrap();
+/// # let path = file.path();
+/// use my_crate::process_file;
+/// 
+/// let result = process_file(path)?;
+/// assert!(!result.is_empty());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn process_file(path: &Path) -> Result<String, Error> {
+    std::fs::read_to_string(path).map_err(Error::from)
+}
+```
+
+## Showing Error Handling
+
+```rust
+/// Parses and validates an email address.
+/// 
+/// # Examples
+/// 
+/// ```
+/// use my_crate::Email;
+/// 
+/// let email = Email::parse("user@example.com")?;
+/// assert_eq!(email.domain(), "example.com");
+/// # Ok::<(), my_crate::EmailError>(())
+/// ```
+/// 
+/// # Errors
+/// 
+/// Returns error for invalid format:
+/// 
+/// ```
+/// use my_crate::Email;
+/// 
+/// assert!(Email::parse("not-an-email").is_err());
+/// ```
+pub fn parse(s: &str) -> Result<Email, EmailError> {
+    // ...
+}
+```
+
+## no_run and ignore
+
+```rust
+/// Starts the server.
+/// 
+/// ```no_run
+/// use my_crate::Server;
+/// 
+/// // This compiles but doesn't run (would block forever)
+/// Server::new().run();
+/// ```
+pub fn run(&self) { ... }
+
+/// Platform-specific example.
+/// 
+/// ```ignore
+/// // This might not compile on all platforms
+/// use windows_specific::Feature;
+/// ```
+```
+
+## compile_fail
+
+```rust
+/// This type is not Clone.
+/// 
+/// ```compile_fail
+/// use my_crate::UniqueHandle;
+/// 
+/// let a = UniqueHandle::new();
+/// let b = a.clone();  // Error: Clone not implemented
+/// ```
+pub struct UniqueHandle { ... }
+```
+
+## Running Doctests
+
+```bash
+# Run all tests including doctests
+cargo test
+
+# Run only doctests
+cargo test --doc
+
+# Run doctests for specific item
+cargo test --doc my_function
+```
+
+## See Also
+
+- [doc-examples-section](./doc-examples-section.md) - Documentation structure
+- [doc-hidden-setup](./doc-hidden-setup.md) - Hiding setup code
+- [doc-question-mark](./doc-question-mark.md) - Error handling in examples

--- a/.agents/skills/rust-skills/rules/test-fixture-raii.md
+++ b/.agents/skills/rust-skills/rules/test-fixture-raii.md
@@ -1,0 +1,151 @@
+# test-fixture-raii
+
+> Use RAII pattern (Drop trait) for automatic test cleanup
+
+## Why It Matters
+
+Tests often need setup and teardown—creating temp files, starting servers, setting environment variables. Using RAII (Resource Acquisition Is Initialization) with Drop ensures cleanup happens automatically, even if the test panics. This prevents test pollution and resource leaks.
+
+## Bad
+
+```rust
+#[test]
+fn test_with_temp_file() {
+    let path = "/tmp/test_file.txt";
+    std::fs::write(path, "test data").unwrap();
+    
+    let result = process_file(path);
+    
+    std::fs::remove_file(path).unwrap();  // Might not run if test panics!
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_with_env_var() {
+    std::env::set_var("MY_VAR", "test_value");
+    
+    let result = read_config();
+    
+    std::env::remove_var("MY_VAR");  // Might not run if test panics!
+    assert!(result.is_ok());
+}
+```
+
+## Good
+
+```rust
+use tempfile::NamedTempFile;
+
+#[test]
+fn test_with_temp_file() {
+    // Arrange - file deleted automatically when `file` drops
+    let file = NamedTempFile::new().unwrap();
+    std::fs::write(file.path(), "test data").unwrap();
+    
+    // Act
+    let result = process_file(file.path());
+    
+    // Assert - file cleaned up even if assertion panics
+    assert!(result.is_ok());
+}
+
+// Custom RAII guard for environment variables
+struct EnvGuard {
+    key: String,
+    original: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let original = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        EnvGuard {
+            key: key.to_string(),
+            original,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.original {
+            Some(v) => std::env::set_var(&self.key, v),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+#[test]
+fn test_with_env_var() {
+    let _guard = EnvGuard::set("MY_VAR", "test_value");
+    
+    let result = read_config();
+    
+    assert!(result.is_ok());
+}  // MY_VAR automatically restored
+```
+
+## Common RAII Patterns
+
+```rust
+// Temporary directory
+use tempfile::TempDir;
+
+#[test]
+fn test_with_temp_dir() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("test.txt");
+    std::fs::write(&file_path, "data").unwrap();
+    
+    // dir and all contents deleted on drop
+}
+
+// Server guard
+struct TestServer {
+    handle: std::thread::JoinHandle<()>,
+    shutdown: std::sync::mpsc::Sender<()>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(());
+        // Wait for server to stop
+    }
+}
+
+// Database transaction rollback
+struct TestTransaction<'a> {
+    conn: &'a mut Connection,
+}
+
+impl Drop for TestTransaction<'_> {
+    fn drop(&mut self) {
+        self.conn.execute("ROLLBACK").unwrap();
+    }
+}
+```
+
+## scopeguard Crate
+
+```rust
+use scopeguard::defer;
+
+#[test]
+fn test_with_defer() {
+    let path = "/tmp/test_file.txt";
+    std::fs::write(path, "data").unwrap();
+    
+    defer! {
+        std::fs::remove_file(path).ok();
+    }
+    
+    // Test logic here
+    // File removed when scope exits
+}
+```
+
+## See Also
+
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure
+- [test-tokio-async](./test-tokio-async.md) - Async test cleanup
+- [test-mock-traits](./test-mock-traits.md) - Mocking with RAII

--- a/.agents/skills/rust-skills/rules/test-integration-dir.md
+++ b/.agents/skills/rust-skills/rules/test-integration-dir.md
@@ -1,0 +1,144 @@
+# test-integration-dir
+
+> Put integration tests in the `tests/` directory
+
+## Why It Matters
+
+Integration tests live in `tests/` at the crate root, separate from `src/`. Each file in `tests/` is compiled as a separate crate, testing your library's public API as external users would. This separation ensures you're testing the real public interface, not implementation details.
+
+## Structure
+
+```
+my_project/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs
+│   └── internal.rs
+└── tests/
+    ├── integration_test.rs    # Each file is a separate test binary
+    ├── api_tests.rs
+    └── common/                 # Shared test utilities
+        └── mod.rs
+```
+
+## Bad
+
+```rust
+// src/lib.rs
+// Mixing integration test logic in library code
+#[test]
+fn integration_test_full_workflow() {
+    // This is a unit test location, not integration
+}
+```
+
+## Good
+
+```rust
+// tests/integration_test.rs
+use my_crate::{Client, Config};  // Uses public API only
+
+#[test]
+fn test_full_workflow() {
+    let config = Config::default();
+    let client = Client::new(config);
+    
+    let result = client.process("input");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_error_handling() {
+    let client = Client::new(Config::strict());
+    
+    let result = client.process("invalid");
+    assert!(matches!(result, Err(Error::InvalidInput { .. })));
+}
+```
+
+## Shared Test Utilities
+
+```rust
+// tests/common/mod.rs
+use my_crate::Config;
+
+pub fn test_config() -> Config {
+    Config {
+        timeout: Duration::from_secs(5),
+        retries: 3,
+        debug: true,
+    }
+}
+
+pub fn setup_test_environment() {
+    // Set up test fixtures
+}
+
+// tests/api_tests.rs
+mod common;
+
+use my_crate::Client;
+
+#[test]
+fn test_with_shared_config() {
+    common::setup_test_environment();
+    let client = Client::new(common::test_config());
+    // ...
+}
+```
+
+## Organizing Many Tests
+
+```rust
+// tests/api/mod.rs
+mod auth;
+mod users;
+mod orders;
+
+// tests/api/auth.rs
+use my_crate::auth::{login, logout};
+
+#[test]
+fn test_login_success() { ... }
+
+#[test]
+fn test_login_invalid_credentials() { ... }
+
+// tests/api/users.rs
+use my_crate::users::{create_user, get_user};
+
+#[test]
+fn test_create_user() { ... }
+```
+
+## Integration vs Unit Tests
+
+| Unit Tests | Integration Tests |
+|------------|-------------------|
+| In `src/` with `#[cfg(test)]` | In `tests/` directory |
+| Access private items | Public API only |
+| Test individual functions | Test module interactions |
+| Fast, isolated | May be slower |
+| `cargo test --lib` | `cargo test --test '*'` |
+
+## Running Specific Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run only integration tests
+cargo test --test '*'
+
+# Run specific integration test file
+cargo test --test integration_test
+
+# Run tests matching pattern
+cargo test --test api_tests test_login
+```
+
+## See Also
+
+- [test-cfg-test-module](./test-cfg-test-module.md) - Unit test modules
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming
+- [test-tokio-async](./test-tokio-async.md) - Async integration tests

--- a/.agents/skills/rust-skills/rules/test-mock-traits.md
+++ b/.agents/skills/rust-skills/rules/test-mock-traits.md
@@ -1,0 +1,189 @@
+# test-mock-traits
+
+> Use traits for dependencies to enable mocking in tests
+
+## Why It Matters
+
+Concrete dependencies make testing hard—you can't easily test error paths, timeouts, or edge cases without real external systems. Extracting dependencies behind traits lets you inject test doubles (mocks, fakes, stubs), enabling isolated unit tests that run fast and cover edge cases.
+
+## Bad
+
+```rust
+struct UserService {
+    db: PostgresConnection,  // Concrete type - hard to test
+}
+
+impl UserService {
+    async fn get_user(&self, id: u64) -> Result<User, Error> {
+        // Directly calls Postgres - needs real database to test
+        self.db.query("SELECT * FROM users WHERE id = $1", &[&id]).await
+    }
+}
+
+// Test requires real Postgres instance
+#[tokio::test]
+async fn test_get_user() {
+    let db = PostgresConnection::connect("postgres://...").await?;
+    let service = UserService { db };
+    // Slow, flaky, can't test error paths
+}
+```
+
+## Good
+
+```rust
+// Define trait for dependency
+#[async_trait]
+trait UserRepository: Send + Sync {
+    async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError>;
+    async fn save(&self, user: &User) -> Result<(), DbError>;
+}
+
+// Production implementation
+struct PostgresUserRepo {
+    pool: PgPool,
+}
+
+#[async_trait]
+impl UserRepository for PostgresUserRepo {
+    async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError> {
+        sqlx::query_as("SELECT * FROM users WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await
+    }
+    // ...
+}
+
+// Service depends on trait, not concrete type
+struct UserService<R: UserRepository> {
+    repo: R,
+}
+
+impl<R: UserRepository> UserService<R> {
+    async fn get_user(&self, id: u64) -> Result<User, Error> {
+        self.repo.find_by_id(id).await?
+            .ok_or(Error::NotFound)
+    }
+}
+
+// Test with mock
+#[cfg(test)]
+mod tests {
+    struct MockUserRepo {
+        users: HashMap<u64, User>,
+    }
+    
+    #[async_trait]
+    impl UserRepository for MockUserRepo {
+        async fn find_by_id(&self, id: u64) -> Result<Option<User>, DbError> {
+            Ok(self.users.get(&id).cloned())
+        }
+        // ...
+    }
+    
+    #[tokio::test]
+    async fn test_get_user_found() {
+        let mut mock = MockUserRepo { users: HashMap::new() };
+        mock.users.insert(1, User { id: 1, name: "Alice".into() });
+        
+        let service = UserService { repo: mock };
+        let user = service.get_user(1).await.unwrap();
+        
+        assert_eq!(user.name, "Alice");
+    }
+    
+    #[tokio::test]
+    async fn test_get_user_not_found() {
+        let mock = MockUserRepo { users: HashMap::new() };
+        let service = UserService { repo: mock };
+        
+        let result = service.get_user(999).await;
+        assert!(matches!(result, Err(Error::NotFound)));
+    }
+}
+```
+
+## mockall Crate
+
+```rust
+use mockall::*;
+use mockall::predicate::*;
+
+#[automock]
+#[async_trait]
+trait Database: Send + Sync {
+    async fn query(&self, sql: &str) -> Result<Vec<Row>, Error>;
+}
+
+#[tokio::test]
+async fn test_with_mockall() {
+    let mut mock = MockDatabase::new();
+    
+    mock.expect_query()
+        .with(eq("SELECT 1"))
+        .times(1)
+        .returning(|_| Ok(vec![Row::new()]));
+    
+    let result = mock.query("SELECT 1").await;
+    assert!(result.is_ok());
+}
+```
+
+## Testing Error Paths
+
+```rust
+#[async_trait]
+trait HttpClient: Send + Sync {
+    async fn get(&self, url: &str) -> Result<Response, HttpError>;
+}
+
+struct FailingClient;
+
+#[async_trait]
+impl HttpClient for FailingClient {
+    async fn get(&self, _url: &str) -> Result<Response, HttpError> {
+        Err(HttpError::Timeout)  // Always fails
+    }
+}
+
+#[tokio::test]
+async fn test_handles_timeout() {
+    let client = FailingClient;
+    let service = ApiService { client };
+    
+    let result = service.fetch_data().await;
+    assert!(matches!(result, Err(Error::NetworkError(_))));
+}
+```
+
+## Dynamic Dispatch Alternative
+
+```rust
+// When you don't want generics everywhere
+struct UserService {
+    repo: Box<dyn UserRepository>,
+}
+
+impl UserService {
+    fn new(repo: impl UserRepository + 'static) -> Self {
+        Self { repo: Box::new(repo) }
+    }
+}
+
+// Slight runtime cost but cleaner API
+```
+
+## Cargo.toml
+
+```toml
+[dev-dependencies]
+mockall = "0.11"
+async-trait = "0.1"  # For async trait mocking
+```
+
+## See Also
+
+- [api-sealed-trait](./api-sealed-trait.md) - Trait design
+- [test-proptest-properties](./test-proptest-properties.md) - Property-based testing
+- [proj-lib-main-split](./proj-lib-main-split.md) - Testable architecture

--- a/.agents/skills/rust-skills/rules/test-mockall-mocking.md
+++ b/.agents/skills/rust-skills/rules/test-mockall-mocking.md
@@ -1,0 +1,226 @@
+# test-mockall-mocking
+
+> Use mockall for trait mocking
+
+## Why It Matters
+
+Unit tests should isolate the code under test from external dependencies (databases, APIs, file systems). Mockall generates mock implementations of traits, allowing you to control and verify behavior without real dependencies.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+mockall = "0.12"
+```
+
+## Basic Usage
+
+```rust
+use mockall::automock;
+
+#[automock]
+trait Database {
+    fn get_user(&self, id: u64) -> Option<User>;
+    fn save_user(&self, user: &User) -> Result<(), Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    
+    #[test]
+    fn test_get_user() {
+        let mut mock = MockDatabase::new();
+        
+        mock.expect_get_user()
+            .with(eq(42))
+            .returning(|_| Some(User { id: 42, name: "Alice".into() }));
+        
+        let service = UserService::new(mock);
+        let user = service.find_user(42);
+        
+        assert_eq!(user.unwrap().name, "Alice");
+    }
+}
+```
+
+## Expectations
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_save_calls() {
+        let mut mock = MockDatabase::new();
+        
+        // Expect exactly one call
+        mock.expect_save_user()
+            .times(1)
+            .returning(|_| Ok(()));
+        
+        // Expect call with specific argument
+        mock.expect_get_user()
+            .with(eq(42))
+            .returning(|_| Some(User::default()));
+        
+        // Expect multiple calls
+        mock.expect_get_user()
+            .times(3..)  // At least 3 times
+            .returning(|_| None);
+        
+        // Expectations are verified on drop
+    }
+}
+```
+
+## Predicates
+
+```rust
+use mockall::predicate::*;
+
+mock.expect_process()
+    .with(eq(42))                    // Exact match
+    .returning(|_| Ok(()));
+
+mock.expect_validate()
+    .with(function(|s: &str| s.len() > 5))  // Custom predicate
+    .returning(|_| true);
+
+mock.expect_search()
+    .withf(|query, limit| {           // Multiple args
+        query.len() < 100 && *limit <= 1000
+    })
+    .returning(|_, _| vec![]);
+```
+
+## Sequences
+
+```rust
+use mockall::Sequence;
+
+#[test]
+fn test_ordered_calls() {
+    let mut seq = Sequence::new();
+    let mut mock = MockDatabase::new();
+    
+    mock.expect_connect()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|| Ok(()));
+    
+    mock.expect_query()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|_| Ok(vec![]));
+    
+    mock.expect_disconnect()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(|| Ok(()));
+}
+```
+
+## Return Values
+
+```rust
+// Fixed value
+mock.expect_count().returning(|| 42);
+
+// Based on input
+mock.expect_double().returning(|x| x * 2);
+
+// Different values per call
+mock.expect_next()
+    .times(3)
+    .returning(|| 1)
+    .returning(|| 2)
+    .returning(|| 3);
+
+// Return owned values
+mock.expect_get_name()
+    .returning(|| "Alice".to_string());
+```
+
+## Mocking External Traits
+
+```rust
+// For traits you don't own
+#[cfg_attr(test, mockall::automock)]
+trait HttpClient {
+    fn get(&self, url: &str) -> Result<Response, Error>;
+}
+
+// In production
+struct RealHttpClient;
+impl HttpClient for RealHttpClient {
+    fn get(&self, url: &str) -> Result<Response, Error> { /* ... */ }
+}
+
+// In tests
+#[cfg(test)]
+fn mock_client() -> MockHttpClient {
+    let mut mock = MockHttpClient::new();
+    mock.expect_get()
+        .returning(|_| Ok(Response::new(200, "OK")));
+    mock
+}
+```
+
+## Async Mocking
+
+```rust
+#[automock]
+#[async_trait]
+trait AsyncDatabase {
+    async fn fetch(&self, id: u64) -> Option<Data>;
+}
+
+#[tokio::test]
+async fn test_async() {
+    let mut mock = MockAsyncDatabase::new();
+    
+    mock.expect_fetch()
+        .returning(|_| Some(Data::default()));
+    
+    let result = mock.fetch(1).await;
+    assert!(result.is_some());
+}
+```
+
+## Design for Testability
+
+```rust
+// Accept trait, not concrete type
+struct Service<D: Database> {
+    db: D,
+}
+
+impl<D: Database> Service<D> {
+    fn new(db: D) -> Self {
+        Self { db }
+    }
+}
+
+// Tests use mock
+#[test]
+fn test_service() {
+    let mock = MockDatabase::new();
+    let service = Service::new(mock);
+}
+
+// Production uses real implementation
+fn main() {
+    let db = PostgresDatabase::connect();
+    let service = Service::new(db);
+}
+```
+
+## See Also
+
+- [test-mock-traits](./test-mock-traits.md) - Mock trait design
+- [test-proptest-properties](./test-proptest-properties.md) - Property testing
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure

--- a/.agents/skills/rust-skills/rules/test-proptest-properties.md
+++ b/.agents/skills/rust-skills/rules/test-proptest-properties.md
@@ -1,0 +1,161 @@
+# test-proptest-properties
+
+> Use proptest for property-based testing
+
+## Why It Matters
+
+Property-based testing generates random inputs to verify that properties hold across all possible values, not just hand-picked examples. Proptest finds edge cases you wouldn't think to test manually—empty strings, integer overflows, unicode edge cases.
+
+## Setup
+
+```toml
+# Cargo.toml
+[dev-dependencies]
+proptest = "1.0"
+```
+
+## Basic Usage
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn test_reverse_reverse_is_identity(s in ".*") {
+        let reversed: String = s.chars().rev().collect();
+        let double_reversed: String = reversed.chars().rev().collect();
+        assert_eq!(s, double_reversed);
+    }
+    
+    #[test]
+    fn test_sort_is_idempotent(mut v in prop::collection::vec(any::<i32>(), 0..100)) {
+        v.sort();
+        let sorted = v.clone();
+        v.sort();
+        assert_eq!(v, sorted);
+    }
+}
+```
+
+## Common Strategies
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    // Any type implementing Arbitrary
+    #[test]
+    fn test_i32(x in any::<i32>()) { }
+    
+    // Regex-based string generation
+    #[test]
+    fn test_email(email in "[a-z]+@[a-z]+\\.[a-z]{2,3}") { }
+    
+    // Ranges
+    #[test]
+    fn test_range(x in 0..100i32) { }
+    
+    // Collections
+    #[test]
+    fn test_vec(v in prop::collection::vec(any::<i32>(), 0..10)) { }
+    
+    // Optionals
+    #[test]
+    fn test_option(opt in prop::option::of(any::<i32>())) { }
+}
+```
+
+## Custom Strategies
+
+```rust
+use proptest::prelude::*;
+
+#[derive(Debug, Clone)]
+struct User {
+    name: String,
+    age: u8,
+}
+
+fn user_strategy() -> impl Strategy<Value = User> {
+    ("[a-zA-Z]{1,20}", 0..120u8)
+        .prop_map(|(name, age)| User { name, age })
+}
+
+proptest! {
+    #[test]
+    fn test_user(user in user_strategy()) {
+        assert!(user.age < 150);
+        assert!(!user.name.is_empty());
+    }
+}
+
+// Or derive Arbitrary
+use proptest_derive::Arbitrary;
+
+#[derive(Debug, Arbitrary)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+```
+
+## Properties to Test
+
+| Property | Example |
+|----------|---------|
+| Roundtrip | `decode(encode(x)) == x` |
+| Idempotence | `f(f(x)) == f(x)` |
+| Commutativity | `f(a, b) == f(b, a)` |
+| Associativity | `f(f(a, b), c) == f(a, f(b, c))` |
+| Identity | `f(x, identity) == x` |
+| Invariants | `len(push(v, x)) == len(v) + 1` |
+
+## Example: Parser Roundtrip
+
+```rust
+proptest! {
+    #[test]
+    fn parse_roundtrip(config in valid_config_strategy()) {
+        let serialized = config.to_string();
+        let parsed = Config::parse(&serialized).unwrap();
+        assert_eq!(config, parsed);
+    }
+}
+```
+
+## Shrinking
+
+Proptest automatically shrinks failing inputs to minimal cases:
+
+```rust
+// If this fails with vec![100, 50, 75, 25, 0]
+// Proptest will shrink to vec![1, 0] (minimal failing case)
+proptest! {
+    #[test]
+    fn test_sorted(v in prop::collection::vec(0..1000i32, 1..100)) {
+        let sorted = is_sorted(&v);
+        // This will fail and shrink
+    }
+}
+```
+
+## Configuration
+
+```rust
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 1000,  // More test cases
+        max_shrink_iters: 10000,  // More shrinking
+        ..ProptestConfig::default()
+    })]
+    
+    #[test]
+    fn extensive_test(x in any::<i32>()) { }
+}
+```
+
+## See Also
+
+- [test-criterion-bench](./test-criterion-bench.md) - Benchmarking
+- [test-mockall-mocking](./test-mockall-mocking.md) - Mocking
+- [test-arrange-act-assert](./test-arrange-act-assert.md) - Test structure

--- a/.agents/skills/rust-skills/rules/test-should-panic.md
+++ b/.agents/skills/rust-skills/rules/test-should-panic.md
@@ -1,0 +1,130 @@
+# test-should-panic
+
+> Use `#[should_panic]` to test that code panics as expected
+
+## Why It Matters
+
+Some code should panic on invalid inputs or invariant violations. `#[should_panic]` verifies the panic occurs, optionally checking the panic message. This ensures defensive panics work correctly and documents expected panic conditions.
+
+## Bad
+
+```rust
+#[test]
+fn test_panic() {
+    // Just calling panicking code makes test fail
+    divide(1, 0);  // Test fails with panic
+}
+
+// Using catch_unwind is verbose
+#[test]
+fn test_panic_manual() {
+    let result = std::panic::catch_unwind(|| divide(1, 0));
+    assert!(result.is_err());
+}
+```
+
+## Good
+
+```rust
+#[test]
+#[should_panic]
+fn divide_by_zero_panics() {
+    divide(1, 0);  // Test passes when this panics
+}
+
+// With expected message
+#[test]
+#[should_panic(expected = "division by zero")]
+fn divide_by_zero_panics_with_message() {
+    divide(1, 0);  // Panics with "division by zero"
+}
+
+// Partial message match
+#[test]
+#[should_panic(expected = "index out of bounds")]
+fn index_panic_contains_message() {
+    let v = vec![1, 2, 3];
+    let _ = v[100];  // Message contains "index out of bounds"
+}
+```
+
+## Testing Invariants
+
+```rust
+struct NonEmpty<T>(Vec<T>);
+
+impl<T> NonEmpty<T> {
+    fn new(items: Vec<T>) -> Self {
+        assert!(!items.is_empty(), "NonEmpty cannot be empty");
+        NonEmpty(items)
+    }
+}
+
+#[test]
+#[should_panic(expected = "NonEmpty cannot be empty")]
+fn non_empty_rejects_empty_vec() {
+    NonEmpty::new(Vec::<i32>::new());
+}
+
+#[test]
+fn non_empty_accepts_non_empty_vec() {
+    let ne = NonEmpty::new(vec![1, 2, 3]);
+    assert_eq!(ne.0.len(), 3);
+}
+```
+
+## With expect() Messages
+
+```rust
+fn get_config_value(key: &str) -> String {
+    CONFIG.get(key)
+        .expect(&format!("missing required config: {}", key))
+        .to_string()
+}
+
+#[test]
+#[should_panic(expected = "missing required config: DATABASE_URL")]
+fn missing_config_panics_with_key() {
+    get_config_value("DATABASE_URL");
+}
+```
+
+## When NOT to Use should_panic
+
+```rust
+// ❌ For recoverable errors - use Result
+#[test]
+#[should_panic]  // Wrong: this should return Err, not panic
+fn invalid_input_panics() {
+    parse_config("invalid");  // Should return Err, not panic
+}
+
+// ✅ Return Result and test the error
+#[test]
+fn invalid_input_returns_error() {
+    let result = parse_config("invalid");
+    assert!(result.is_err());
+}
+```
+
+## Combining with Result
+
+```rust
+#[test]
+#[should_panic]
+fn test_panics() -> Result<(), Error> {
+    // Can combine with Result for setup
+    let data = setup_test_data()?;
+    
+    // This should panic
+    process_invalid(&data);
+    
+    Ok(())  // Never reached
+}
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - Panic vs Result
+- [err-expect-bugs-only](./err-expect-bugs-only.md) - When to use expect
+- [test-descriptive-names](./test-descriptive-names.md) - Test naming

--- a/.agents/skills/rust-skills/rules/test-tokio-async.md
+++ b/.agents/skills/rust-skills/rules/test-tokio-async.md
@@ -1,0 +1,154 @@
+# test-tokio-async
+
+> Use `#[tokio::test]` for async tests
+
+## Why It Matters
+
+Async functions can't be called directly—they need a runtime to drive them. `#[tokio::test]` provides a Tokio runtime for your test, handling setup automatically. This is simpler than manually creating a runtime and essential for testing async code.
+
+## Bad
+
+```rust
+// Won't compile - async fn can't be called without runtime
+#[test]
+async fn test_async_function() {  // Error!
+    let result = fetch_data().await;
+    assert!(result.is_ok());
+}
+
+// Manual runtime - verbose and error-prone
+#[test]
+fn test_async_function() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let result = fetch_data().await;
+        assert!(result.is_ok());
+    });
+}
+```
+
+## Good
+
+```rust
+#[tokio::test]
+async fn test_async_function() {
+    let result = fetch_data().await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_concurrent_operations() {
+    let (a, b) = tokio::join!(
+        fetch_user(1),
+        fetch_user(2),
+    );
+    assert!(a.is_ok());
+    assert!(b.is_ok());
+}
+```
+
+## Runtime Configuration
+
+```rust
+// Multi-threaded runtime (default)
+#[tokio::test]
+async fn test_default_runtime() {
+    // Uses multi-thread runtime
+}
+
+// Single-threaded (current_thread)
+#[tokio::test(flavor = "current_thread")]
+async fn test_single_threaded() {
+    // Simpler, deterministic
+}
+
+// With specific thread count
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_with_workers() {
+    // Exactly 2 worker threads
+}
+
+// With time control
+#[tokio::test(start_paused = true)]
+async fn test_with_time_control() {
+    // Time starts paused for deterministic testing
+    tokio::time::advance(Duration::from_secs(60)).await;
+}
+```
+
+## Testing Timeouts
+
+```rust
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn test_operation_completes_in_time() {
+    let result = timeout(
+        Duration::from_secs(5),
+        slow_operation()
+    ).await;
+    
+    assert!(result.is_ok(), "Operation timed out");
+}
+
+#[tokio::test]
+async fn test_timeout_triggers() {
+    let result = timeout(
+        Duration::from_millis(100),
+        never_completes()
+    ).await;
+    
+    assert!(result.is_err(), "Expected timeout");
+}
+```
+
+## Testing Channels
+
+```rust
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn test_channel_communication() {
+    let (tx, mut rx) = mpsc::channel(10);
+    
+    tokio::spawn(async move {
+        tx.send("hello").await.unwrap();
+        tx.send("world").await.unwrap();
+    });
+    
+    assert_eq!(rx.recv().await, Some("hello"));
+    assert_eq!(rx.recv().await, Some("world"));
+    assert_eq!(rx.recv().await, None);
+}
+```
+
+## Testing with Mocks
+
+```rust
+use mockall::*;
+
+#[automock]
+#[async_trait::async_trait]
+trait Database {
+    async fn get_user(&self, id: u64) -> Option<User>;
+}
+
+#[tokio::test]
+async fn test_with_mock_database() {
+    let mut mock = MockDatabase::new();
+    mock.expect_get_user()
+        .with(eq(42))
+        .returning(|_| Some(User { id: 42, name: "Alice".into() }));
+    
+    let service = UserService::new(mock);
+    let user = service.find_user(42).await;
+    
+    assert_eq!(user.unwrap().name, "Alice");
+}
+```
+
+## See Also
+
+- [async-tokio-runtime](./async-tokio-runtime.md) - Runtime configuration
+- [test-mock-traits](./test-mock-traits.md) - Mocking async traits
+- [test-fixture-raii](./test-fixture-raii.md) - Async test cleanup

--- a/.agents/skills/rust-skills/rules/test-use-super.md
+++ b/.agents/skills/rust-skills/rules/test-use-super.md
@@ -1,0 +1,127 @@
+# test-use-super
+
+> Use `use super::*;` in test modules to access parent module items
+
+## Why It Matters
+
+The test module is a child of the module being tested. `use super::*` imports all items from the parent module, including private ones. This gives tests access to both public API and internal implementation details for thorough testing.
+
+## Bad
+
+```rust
+// Verbose imports
+#[cfg(test)]
+mod tests {
+    use crate::my_module::public_function;
+    use crate::my_module::MyStruct;
+    // Can't access private items this way!
+    
+    #[test]
+    fn test_function() {
+        let result = public_function();
+        // ...
+    }
+}
+```
+
+## Good
+
+```rust
+// src/my_module.rs
+pub struct PublicStruct { ... }
+struct PrivateStruct { ... }  // Private
+
+pub fn public_function() -> i32 { ... }
+fn private_helper() -> i32 { ... }  // Private
+
+#[cfg(test)]
+mod tests {
+    use super::*;  // Imports everything from parent
+    
+    #[test]
+    fn test_public_struct() {
+        let s = PublicStruct::new();
+        // ...
+    }
+    
+    #[test]
+    fn test_private_struct() {
+        let s = PrivateStruct::new();  // Can access private!
+        // ...
+    }
+    
+    #[test]
+    fn test_private_helper() {
+        assert_eq!(private_helper(), 42);  // Can test private!
+    }
+}
+```
+
+## Selective Imports
+
+```rust
+#[cfg(test)]
+mod tests {
+    // When you want to be explicit
+    use super::{parse, ParseError, Token};
+    
+    // Or import all plus test utilities
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn test_parse() { ... }
+}
+```
+
+## Nested Modules
+
+```rust
+mod outer {
+    pub fn outer_fn() -> i32 { 1 }
+    
+    mod inner {
+        pub fn inner_fn() -> i32 { 2 }
+        
+        #[cfg(test)]
+        mod tests {
+            use super::*;           // Gets inner's items
+            use super::super::*;    // Gets outer's items
+            
+            #[test]
+            fn test_inner() {
+                assert_eq!(inner_fn(), 2);
+                assert_eq!(outer_fn(), 1);
+            }
+        }
+    }
+}
+```
+
+## With External Dependencies
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    // Test-only dependencies
+    use proptest::prelude::*;
+    use mockall::predicate::*;
+    
+    proptest! {
+        #[test]
+        fn test_property(s: String) {
+            let result = process(&s);
+            prop_assert!(result.is_ok());
+        }
+    }
+}
+```
+
+## See Also
+
+- [test-cfg-test-module](./test-cfg-test-module.md) - Test module structure
+- [test-integration-dir](./test-integration-dir.md) - Integration tests
+- [proj-pub-crate-internal](./proj-pub-crate-internal.md) - Visibility modifiers

--- a/.agents/skills/rust-skills/rules/type-enum-states.md
+++ b/.agents/skills/rust-skills/rules/type-enum-states.md
@@ -1,0 +1,154 @@
+# type-enum-states
+
+> Use enums for mutually exclusive states
+
+## Why It Matters
+
+When a value can be in exactly one of several states, an enum makes invalid states unrepresentable. The compiler ensures all states are handled. Contrast with boolean flags or optional fields that can represent impossible combinations.
+
+## Bad
+
+```rust
+struct Connection {
+    is_connected: bool,
+    is_authenticated: bool,
+    is_disconnected: bool,  // Can all three be true? False?
+    socket: Option<TcpStream>,
+    credentials: Option<Credentials>,
+}
+
+// Possible invalid states:
+// - is_connected && is_disconnected (contradiction)
+// - is_authenticated && !is_connected (impossible)
+// - socket is None but is_connected is true (inconsistent)
+```
+
+## Good
+
+```rust
+enum ConnectionState {
+    Disconnected,
+    Connecting { address: SocketAddr },
+    Connected { socket: TcpStream },
+    Authenticated { socket: TcpStream, session: Session },
+    Failed { error: ConnectionError },
+}
+
+struct Connection {
+    state: ConnectionState,
+}
+
+// Impossible states are unrepresentable
+// Each state has exactly the data it needs
+```
+
+## Pattern Matching Ensures Completeness
+
+```rust
+fn handle_connection(conn: &Connection) {
+    match &conn.state {
+        ConnectionState::Disconnected => {
+            println!("Not connected");
+        }
+        ConnectionState::Connecting { address } => {
+            println!("Connecting to {}", address);
+        }
+        ConnectionState::Connected { socket } => {
+            println!("Connected, not authenticated");
+        }
+        ConnectionState::Authenticated { socket, session } => {
+            println!("Authenticated as {}", session.user);
+        }
+        ConnectionState::Failed { error } => {
+            println!("Failed: {}", error);
+        }
+    }
+    // Compiler error if any state is missing
+}
+```
+
+## State Transitions
+
+```rust
+impl Connection {
+    fn connect(&mut self, addr: SocketAddr) -> Result<(), Error> {
+        match &self.state {
+            ConnectionState::Disconnected => {
+                self.state = ConnectionState::Connecting { address: addr };
+                Ok(())
+            }
+            _ => Err(Error::AlreadyConnected),
+        }
+    }
+    
+    fn on_connected(&mut self, socket: TcpStream) {
+        if let ConnectionState::Connecting { .. } = &self.state {
+            self.state = ConnectionState::Connected { socket };
+        }
+    }
+    
+    fn authenticate(&mut self, creds: Credentials) -> Result<(), Error> {
+        match std::mem::replace(&mut self.state, ConnectionState::Disconnected) {
+            ConnectionState::Connected { socket } => {
+                let session = perform_auth(&socket, creds)?;
+                self.state = ConnectionState::Authenticated { socket, session };
+                Ok(())
+            }
+            other => {
+                self.state = other;
+                Err(Error::NotConnected)
+            }
+        }
+    }
+}
+```
+
+## Result and Option as State Enums
+
+```rust
+// Option<T> is an enum for "might not exist"
+enum Option<T> {
+    Some(T),
+    None,
+}
+
+// Result<T, E> is an enum for "might have failed"
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+// Use these instead of nullable/sentinel values
+fn find_user(id: u64) -> Option<User> { ... }
+fn parse_config(s: &str) -> Result<Config, ParseError> { ... }
+```
+
+## Avoid Boolean Flags
+
+```rust
+// Bad: boolean flags
+struct Task {
+    is_running: bool,
+    is_completed: bool,
+    is_failed: bool,
+    error: Option<Error>,
+}
+
+// Good: enum state
+enum TaskState {
+    Pending,
+    Running { started_at: Instant },
+    Completed { result: Output },
+    Failed { error: Error },
+}
+
+struct Task {
+    state: TaskState,
+}
+```
+
+## See Also
+
+- [api-typestate](./api-typestate.md) - Type-level state machines
+- [api-non-exhaustive](./api-non-exhaustive.md) - Forward-compatible enums
+- [type-option-nullable](./type-option-nullable.md) - Option for optional values

--- a/.agents/skills/rust-skills/rules/type-generic-bounds.md
+++ b/.agents/skills/rust-skills/rules/type-generic-bounds.md
@@ -1,0 +1,142 @@
+# type-generic-bounds
+
+> Add trait bounds only where needed, prefer where clauses for readability
+
+## Why It Matters
+
+Trait bounds constrain what types can be used with generic code. Adding unnecessary bounds limits flexibility. Adding bounds in the right place (impl vs function vs where clause) affects usability and readability. Well-placed bounds keep APIs flexible while ensuring type safety.
+
+## Bad
+
+```rust
+// Bounds on struct definition - limits all uses
+struct Container<T: Clone + Debug> {  // Even storage requires Clone?
+    items: Vec<T>,
+}
+
+// Inline bounds make signature hard to read
+fn process<T: Clone + Debug + Send + Sync + 'static, E: Error + Send + Clone>(
+    value: T
+) -> Result<T, E> { ... }
+
+// Redundant bounds
+fn print_twice<T: Clone + Debug>(value: T)
+where
+    T: Clone,  // Already specified above
+{ ... }
+```
+
+## Good
+
+```rust
+// No bounds on struct - store anything
+struct Container<T> {
+    items: Vec<T>,
+}
+
+// Bounds only on impls that need them
+impl<T: Clone> Container<T> {
+    fn duplicate(&self) -> Self {
+        Container { items: self.items.clone() }
+    }
+}
+
+impl<T: Debug> Container<T> {
+    fn debug_print(&self) {
+        println!("{:?}", self.items);
+    }
+}
+
+// Where clause for readability
+fn process<T, E>(value: T) -> Result<T, E>
+where
+    T: Clone + Debug + Send + Sync + 'static,
+    E: Error + Send + Clone,
+{ ... }
+```
+
+## Bound Placement
+
+```rust
+// On struct: affects all uses of the type
+struct MustBeClone<T: Clone> { data: T }  // Rarely needed
+
+// On impl: affects specific functionality
+impl<T: Clone> Container<T> { ... }  // Common pattern
+
+// On function: affects that function only
+fn requires_send<T: Send>(value: T) { ... }
+
+// Recommendation: start with no bounds, add as needed
+```
+
+## Where Clause Benefits
+
+```rust
+// Inline: hard to read
+fn complex<T: Clone + Debug + Send, U: AsRef<str> + Into<String>>(t: T, u: U) { }
+
+// Where clause: clear and scannable
+fn complex<T, U>(t: T, u: U)
+where
+    T: Clone + Debug + Send,
+    U: AsRef<str> + Into<String>,
+{ }
+
+// Essential for complex bounds
+fn foo<T, U>(t: T, u: U)
+where
+    T: Iterator<Item = U>,
+    U: Clone + Into<String>,
+    Vec<U>: Debug,  // Bounds on expressions
+{ }
+```
+
+## Implied Bounds
+
+```rust
+// Supertrait bounds are implied
+trait Foo: Clone + Debug {}
+
+fn process<T: Foo>(value: T) {
+    // T: Clone and T: Debug are implied by T: Foo
+    let cloned = value.clone();
+    println!("{:?}", cloned);
+}
+
+// Associated type bounds
+fn process<I>(iter: I)
+where
+    I: Iterator,
+    I::Item: Clone,  // Bound on associated type
+{ }
+```
+
+## Conditional Trait Implementation
+
+```rust
+struct Wrapper<T>(T);
+
+// Implement Clone only when T: Clone
+impl<T: Clone> Clone for Wrapper<T> {
+    fn clone(&self) -> Self {
+        Wrapper(self.0.clone())
+    }
+}
+
+// Implement Debug only when T: Debug  
+impl<T: Debug> Debug for Wrapper<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Wrapper").field(&self.0).finish()
+    }
+}
+
+// Wrapper<i32> is Clone + Debug
+// Wrapper<NonCloneable> is neither
+```
+
+## See Also
+
+- [api-impl-into](./api-impl-into.md) - Using Into bounds
+- [api-impl-asref](./api-impl-asref.md) - Using AsRef bounds
+- [name-type-param-single](./name-type-param-single.md) - Type parameter naming

--- a/.agents/skills/rust-skills/rules/type-never-diverge.md
+++ b/.agents/skills/rust-skills/rules/type-never-diverge.md
@@ -1,0 +1,146 @@
+# type-never-diverge
+
+> Use `!` (never type) for functions that never return
+
+## Why It Matters
+
+The never type `!` indicates a function will never return normally—it either loops forever, panics, or exits the process. This helps the compiler understand control flow and enables `!` to coerce to any type, making it useful in match arms and expressions.
+
+## Bad
+
+```rust
+// Return type doesn't indicate non-returning
+fn infinite_loop() {
+    loop {
+        process_events();
+    }
+    // Implicit () return type, but never returns
+}
+
+// Using Option when it always panics
+fn unreachable_code() -> Option<()> {
+    panic!("This should never be called");
+}
+```
+
+## Good
+
+```rust
+// ! indicates function never returns
+fn infinite_loop() -> ! {
+    loop {
+        process_events();
+    }
+}
+
+fn abort_with_error(msg: &str) -> ! {
+    eprintln!("Fatal error: {}", msg);
+    std::process::exit(1);
+}
+
+fn panic_handler() -> ! {
+    panic!("Unexpected state");
+}
+```
+
+## Coercion to Any Type
+
+```rust
+// ! coerces to any type
+fn get_value(opt: Option<i32>) -> i32 {
+    match opt {
+        Some(v) => v,
+        None => panic!("No value"),  // panic! returns !, coerces to i32
+    }
+}
+
+// Useful in Result handling
+fn must_get_config() -> Config {
+    match load_config() {
+        Ok(c) => c,
+        Err(e) => {
+            log_error(&e);
+            std::process::exit(1)  // Returns !, coerces to Config
+        }
+    }
+}
+```
+
+## Standard Library Examples
+
+```rust
+// std::process::exit
+pub fn exit(code: i32) -> !
+
+// panic! macro
+// Expands to an expression of type !
+
+// std::hint::unreachable_unchecked
+pub unsafe fn unreachable_unchecked() -> !
+
+// loop {} with no break
+fn forever() -> ! {
+    loop {}
+}
+```
+
+## In Match Expressions
+
+```rust
+enum State {
+    Running,
+    Stopped,
+    Error,
+}
+
+fn get_status(state: &State) -> &str {
+    match state {
+        State::Running => "running",
+        State::Stopped => "stopped",
+        State::Error => unreachable!(),  // ! coerces to &str
+    }
+}
+
+// With Result
+fn process(r: Result<Data, Error>) -> Data {
+    match r {
+        Ok(d) => d,
+        Err(e) => panic!("Unexpected error: {}", e),  // ! coerces to Data
+    }
+}
+```
+
+## Diverging Closures
+
+```rust
+// Closures that never return
+let handler: fn() -> ! = || {
+    panic!("Handler called");
+};
+
+// In thread spawn
+std::thread::spawn(|| -> ! {
+    loop {
+        process_work();
+    }
+});
+```
+
+## Current Limitations (Nightly)
+
+```rust
+// Full ! type is nightly
+#![feature(never_type)]
+
+// Can use ! as type parameter
+type NeverResult = Result<(), !>;  // Can never be Err
+
+// On stable, use std::convert::Infallible
+type StableNeverResult = Result<(), std::convert::Infallible>;
+```
+
+## See Also
+
+- [err-result-over-panic](./err-result-over-panic.md) - When to panic vs return Result
+- [type-result-fallible](./type-result-fallible.md) - Result for errors
+- [opt-cold-unlikely](./opt-cold-unlikely.md) - Marking unlikely paths

--- a/.agents/skills/rust-skills/rules/type-newtype-ids.md
+++ b/.agents/skills/rust-skills/rules/type-newtype-ids.md
@@ -1,0 +1,160 @@
+# type-newtype-ids
+
+> Wrap IDs in newtypes: `UserId(u64)`
+
+## Why It Matters
+
+Using raw integers for IDs is error-prone. It's easy to accidentally pass a `user_id` where a `post_id` is expected. Newtypes make these mix-ups compile-time errors instead of runtime bugs.
+
+## Bad
+
+```rust
+fn get_user_posts(user_id: u64, post_id: u64) -> Vec<Post> {
+    // Which is which? Easy to swap by accident
+}
+
+// Oops! Arguments swapped - compiles fine, wrong at runtime
+let posts = get_user_posts(post_id, user_id);
+
+// Even worse with multiple IDs
+fn transfer(from: u64, to: u64, amount: u64) {
+    // from/to can easily be swapped
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PostId(pub u64);
+
+fn get_user_posts(user_id: UserId, post_id: PostId) -> Vec<Post> {
+    // Types are distinct
+}
+
+// This won't compile - types don't match
+// let posts = get_user_posts(post_id, user_id);  // ERROR!
+
+// Correct usage
+let posts = get_user_posts(UserId(1), PostId(42));
+```
+
+## Derive Common Traits
+
+```rust
+#[derive(
+    Debug,      // For printing
+    Clone,      // For copying
+    Copy,       // For implicit copies (if small)
+    PartialEq,  // For == comparison
+    Eq,         // For HashMap keys
+    Hash,       // For HashMap keys
+    PartialOrd, // For sorting (optional)
+    Ord,        // For BTreeMap keys (optional)
+)]
+pub struct UserId(pub u64);
+```
+
+## Add Useful Methods
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct UserId(u64);
+
+impl UserId {
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
+    
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+    
+    // For database queries
+    pub fn as_i64(self) -> i64 {
+        self.0 as i64
+    }
+}
+
+impl From<u64> for UserId {
+    fn from(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "user:{}", self.0)
+    }
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]  // Serializes as just the inner value
+pub struct UserId(pub u64);
+
+// JSON: {"user_id": 123} not {"user_id": {"0": 123}}
+```
+
+## String IDs (UUIDs, etc.)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionId(String);
+
+impl SessionId {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+    
+    pub fn parse(s: &str) -> Result<Self, ParseError> {
+        // Validate format
+        uuid::Uuid::parse_str(s)?;
+        Ok(Self(s.to_string()))
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+## Multiple Related IDs
+
+```rust
+// Macro for consistent ID types
+macro_rules! define_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub struct $name(pub u64);
+        
+        impl $name {
+            pub const fn new(id: u64) -> Self { Self(id) }
+            pub const fn get(self) -> u64 { self.0 }
+        }
+        
+        impl From<u64> for $name {
+            fn from(id: u64) -> Self { Self(id) }
+        }
+    };
+}
+
+define_id!(UserId);
+define_id!(PostId);
+define_id!(CommentId);
+define_id!(TeamId);
+```
+
+## See Also
+
+- [api-newtype-safety](api-newtype-safety.md) - Newtypes for type safety
+- [type-newtype-validated](type-newtype-validated.md) - Newtypes for validated data
+- [api-parse-dont-validate](api-parse-dont-validate.md) - Parse into validated types

--- a/.agents/skills/rust-skills/rules/type-newtype-validated.md
+++ b/.agents/skills/rust-skills/rules/type-newtype-validated.md
@@ -1,0 +1,159 @@
+# type-newtype-validated
+
+> Use newtypes to enforce validation at construction time
+
+## Why It Matters
+
+A validated newtype guarantees its inner value is always valid. Once you have an `Email`, you know it passed validation—no re-checking needed. This "parse, don't validate" pattern catches errors at boundaries and makes invalid states unrepresentable.
+
+## Bad
+
+```rust
+// Validation scattered throughout code
+fn send_email(to: &str, body: &str) -> Result<(), Error> {
+    if !is_valid_email(to) {  // Must check every time
+        return Err(Error::InvalidEmail);
+    }
+    // ...
+}
+
+fn add_recipient(list: &mut Vec<String>, email: &str) -> Result<(), Error> {
+    if !is_valid_email(email) {  // Check again
+        return Err(Error::InvalidEmail);
+    }
+    list.push(email.to_string());
+    Ok(())
+}
+```
+
+## Good
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Email(String);
+
+impl Email {
+    pub fn new(s: &str) -> Result<Self, EmailError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(EmailError::Invalid(s.to_string()))
+        }
+    }
+    
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+// No validation needed - Email is always valid
+fn send_email(to: &Email, body: &str) -> Result<(), Error> {
+    // to is guaranteed valid
+    send_to_address(to.as_str(), body)
+}
+
+fn add_recipient(list: &mut Vec<Email>, email: Email) {
+    // email is guaranteed valid
+    list.push(email);
+}
+```
+
+## Common Validated Types
+
+```rust
+// URLs
+pub struct Url(url::Url);
+
+impl Url {
+    pub fn parse(s: &str) -> Result<Self, UrlError> {
+        url::Url::parse(s)
+            .map(Url)
+            .map_err(UrlError::from)
+    }
+}
+
+// Non-empty strings
+pub struct NonEmptyString(String);
+
+impl NonEmptyString {
+    pub fn new(s: String) -> Option<Self> {
+        if s.is_empty() {
+            None
+        } else {
+            Some(NonEmptyString(s))
+        }
+    }
+}
+
+// Positive numbers
+pub struct PositiveI32(i32);
+
+impl PositiveI32 {
+    pub fn new(n: i32) -> Option<Self> {
+        if n > 0 {
+            Some(PositiveI32(n))
+        } else {
+            None
+        }
+    }
+    
+    pub fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+// Bounded ranges
+pub struct Percentage(f64);
+
+impl Percentage {
+    pub fn new(value: f64) -> Result<Self, RangeError> {
+        if (0.0..=100.0).contains(&value) {
+            Ok(Percentage(value))
+        } else {
+            Err(RangeError::OutOfBounds)
+        }
+    }
+}
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Email(String);
+
+impl<'de> Deserialize<'de> for Email {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Email::new(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+// JSON deserialization automatically validates
+let email: Email = serde_json::from_str(r#""user@example.com""#)?;
+```
+
+## Compile-Time Validation
+
+```rust
+// For values known at compile time
+macro_rules! email {
+    ($s:literal) => {{
+        const _: () = assert!(is_valid_email_const($s));
+        Email::new_unchecked($s)
+    }};
+}
+
+let admin = email!("admin@example.com");  // Validated at compile time
+```
+
+## See Also
+
+- [api-parse-dont-validate](./api-parse-dont-validate.md) - Parse at boundaries
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe distinctions
+- [type-newtype-ids](./type-newtype-ids.md) - ID newtypes

--- a/.agents/skills/rust-skills/rules/type-no-stringly.md
+++ b/.agents/skills/rust-skills/rules/type-no-stringly.md
@@ -1,0 +1,144 @@
+# type-no-stringly
+
+> Avoid stringly-typed APIs; use enums, newtypes, or validated types
+
+## Why It Matters
+
+Strings accept any value—typos, wrong formats, invalid data all compile fine. Enums, newtypes, and validated types catch errors at compile time or construction time, not runtime. They also provide better IDE support, documentation, and make invalid states unrepresentable.
+
+## Bad
+
+```rust
+// Status as string - easy to get wrong
+fn set_status(status: &str) {
+    match status {
+        "pending" => { ... }
+        "active" => { ... }
+        "completed" => { ... }
+        _ => panic!("Unknown status"),  // Runtime error
+    }
+}
+
+// Easy to misuse
+set_status("pending");   // OK
+set_status("Pending");   // Runtime error - wrong case
+set_status("aktive");    // Runtime error - typo
+set_status("done");      // Runtime error - wrong word
+
+// Configuration as strings
+fn configure(key: &str, value: &str) {
+    // No type safety, no validation
+}
+```
+
+## Good
+
+```rust
+// Status as enum - compile-time safety
+enum Status {
+    Pending,
+    Active,
+    Completed,
+}
+
+fn set_status(status: Status) {
+    match status {
+        Status::Pending => { ... }
+        Status::Active => { ... }
+        Status::Completed => { ... }
+    }  // Exhaustive - compiler checks all cases
+}
+
+// Can only pass valid values
+set_status(Status::Pending);  // OK
+set_status(Status::Aktivev);  // Compile error - typo caught!
+
+// Configuration with typed builder
+struct Config {
+    timeout: Duration,
+    retries: u32,
+    mode: Mode,
+}
+
+enum Mode { Fast, Safe, Balanced }
+```
+
+## Parsing at Boundaries
+
+```rust
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy)]
+enum Priority {
+    Low,
+    Medium,
+    High,
+}
+
+impl FromStr for Priority {
+    type Err = ParseError;
+    
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "low" => Ok(Priority::Low),
+            "medium" | "med" => Ok(Priority::Medium),
+            "high" => Ok(Priority::High),
+            _ => Err(ParseError::UnknownPriority(s.to_string())),
+        }
+    }
+}
+
+// Parse once at boundary
+fn handle_request(priority_str: &str) -> Result<(), Error> {
+    let priority: Priority = priority_str.parse()?;
+    // From here, priority is type-safe
+    process(priority);
+    Ok(())
+}
+```
+
+## Validated Newtypes
+
+```rust
+// Instead of string for email
+struct Email(String);
+
+impl Email {
+    fn new(s: &str) -> Result<Self, ValidationError> {
+        if is_valid_email(s) {
+            Ok(Email(s.to_string()))
+        } else {
+            Err(ValidationError::InvalidEmail)
+        }
+    }
+}
+
+// Instead of string for UUID
+struct UserId(uuid::Uuid);
+
+// Instead of string for paths
+struct ConfigPath(PathBuf);
+```
+
+## With Serde
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EventType {
+    UserCreated,
+    UserDeleted,
+    UserUpdated,
+}
+
+// JSON: {"type": "user_created", ...}
+// Automatically validated during deserialization
+```
+
+## See Also
+
+- [anti-stringly-typed](./anti-stringly-typed.md) - Anti-pattern details
+- [type-newtype-validated](./type-newtype-validated.md) - Validated newtypes
+- [type-enum-states](./type-enum-states.md) - Enums for states

--- a/.agents/skills/rust-skills/rules/type-option-nullable.md
+++ b/.agents/skills/rust-skills/rules/type-option-nullable.md
@@ -1,0 +1,137 @@
+# type-option-nullable
+
+> Use `Option<T>` for values that might not exist
+
+## Why It Matters
+
+`Option<T>` explicitly represents "value or nothing" in the type system. Unlike null pointers or sentinel values, you can't accidentally use a missing value—the compiler forces you to handle the `None` case. This eliminates null pointer exceptions at compile time.
+
+## Bad
+
+```rust
+// Sentinel values - easy to forget to check
+fn find_user(id: u64) -> User {
+    // Returns "empty" user if not found - caller might not check
+    users.get(&id).cloned().unwrap_or(User::empty())
+}
+
+// Nullable-style with raw pointers
+fn find_user(id: u64) -> *const User {
+    // Null if not found - unsafe, no compiler help
+}
+
+// Error-prone usage
+let user = find_user(42);
+println!("{}", user.name);  // Might be empty user - silent bug
+```
+
+## Good
+
+```rust
+// Option makes absence explicit
+fn find_user(id: u64) -> Option<User> {
+    users.get(&id).cloned()
+}
+
+// Must handle the None case
+let user = find_user(42);
+match user {
+    Some(u) => println!("{}", u.name),
+    None => println!("User not found"),
+}
+
+// Or use combinators
+let name = find_user(42)
+    .map(|u| u.name)
+    .unwrap_or_else(|| "Unknown".to_string());
+```
+
+## Common Option Patterns
+
+```rust
+// if let for single case
+if let Some(user) = find_user(id) {
+    process(user);
+}
+
+// Chaining with map
+let upper_name = find_user(id)
+    .map(|u| u.name)
+    .map(|n| n.to_uppercase());
+
+// Providing defaults
+let user = find_user(id).unwrap_or_default();
+let user = find_user(id).unwrap_or_else(|| User::guest());
+
+// ? operator for propagation
+fn get_user_email(id: u64) -> Option<String> {
+    let user = find_user(id)?;
+    Some(user.email)
+}
+
+// and_then for chained optionals
+fn get_user_country(id: u64) -> Option<String> {
+    find_user(id)
+        .and_then(|u| u.address)
+        .and_then(|a| a.country)
+}
+```
+
+## Struct Fields
+
+```rust
+struct User {
+    name: String,
+    email: String,
+    phone: Option<String>,        // Optional field
+    avatar_url: Option<Url>,      // Optional field
+}
+
+impl User {
+    fn display_phone(&self) -> &str {
+        self.phone.as_deref().unwrap_or("Not provided")
+    }
+}
+```
+
+## Option vs Result
+
+```rust
+// Option: value might not exist (no error context)
+fn find(key: &str) -> Option<Value> { ... }
+
+// Result: operation might fail (with error context)
+fn parse(input: &str) -> Result<Value, ParseError> { ... }
+
+// Convert Option to Result
+let value = find("key").ok_or(Error::NotFound)?;
+
+// Convert Result to Option
+let value = parse("input").ok();  // Discards error
+```
+
+## Option References
+
+```rust
+// Option<&T> for optional borrows
+fn get(&self, key: &str) -> Option<&Value> {
+    self.map.get(key)
+}
+
+// as_ref() to borrow Option contents
+let opt: Option<String> = Some("hello".to_string());
+let opt_ref: Option<&String> = opt.as_ref();
+let opt_str: Option<&str> = opt.as_deref();
+
+// as_mut() for mutable borrow
+let mut opt = Some(vec![1, 2, 3]);
+if let Some(v) = opt.as_mut() {
+    v.push(4);
+}
+```
+
+## See Also
+
+- [type-result-fallible](./type-result-fallible.md) - Result for errors
+- [type-enum-states](./type-enum-states.md) - Enums for states
+- [err-no-unwrap-prod](./err-no-unwrap-prod.md) - Handling Option safely

--- a/.agents/skills/rust-skills/rules/type-phantom-marker.md
+++ b/.agents/skills/rust-skills/rules/type-phantom-marker.md
@@ -1,0 +1,188 @@
+# type-phantom-marker
+
+> Use `PhantomData` to express type relationships without runtime cost
+
+## Why It Matters
+
+Sometimes your type needs to be parameterized by a type that doesn't appear in any field—for variance, drop order, or semantic purposes. `PhantomData<T>` tells the compiler your type is "associated with" `T` without storing any `T` data. It has zero runtime cost.
+
+## Bad
+
+```rust
+// Type parameter unused - compiler error
+struct Handle<T> {
+    id: u64,
+    // Error: parameter `T` is never used
+}
+
+// Workaround with unnecessary storage
+struct Handle<T> {
+    id: u64,
+    _type: Option<T>,  // Wastes memory, requires T: Default
+}
+```
+
+## Good
+
+```rust
+use std::marker::PhantomData;
+
+struct Handle<T> {
+    id: u64,
+    _marker: PhantomData<T>,  // Zero-size, tells compiler about T
+}
+
+impl<T> Handle<T> {
+    fn new(id: u64) -> Self {
+        Handle {
+            id,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// Different Handle types are incompatible
+struct User;
+struct Order;
+
+fn process_user(h: Handle<User>) { ... }
+
+let user_handle = Handle::<User>::new(1);
+let order_handle = Handle::<Order>::new(2);
+
+process_user(user_handle);   // OK
+process_user(order_handle);  // Error: expected Handle<User>, found Handle<Order>
+```
+
+## Expressing Ownership
+
+```rust
+use std::marker::PhantomData;
+
+// Owns T conceptually (like Box<T>)
+struct Container<T> {
+    ptr: *mut T,
+    _marker: PhantomData<T>,  // Acts like we own a T
+}
+
+// Drop will be called on T when Container drops
+impl<T> Drop for Container<T> {
+    fn drop(&mut self) {
+        unsafe {
+            std::ptr::drop_in_place(self.ptr);
+        }
+    }
+}
+```
+
+## Expressing Borrowing
+
+```rust
+use std::marker::PhantomData;
+
+// Borrows T for lifetime 'a
+struct Ref<'a, T> {
+    ptr: *const T,
+    _marker: PhantomData<&'a T>,  // Acts like &'a T
+}
+
+// Compiler tracks lifetime correctly
+impl<'a, T> Ref<'a, T> {
+    fn get(&self) -> &'a T {
+        unsafe { &*self.ptr }
+    }
+}
+```
+
+## Type-Level State Machine
+
+```rust
+use std::marker::PhantomData;
+
+// States as zero-size types
+struct Unlocked;
+struct Locked;
+
+struct Door<State> {
+    _state: PhantomData<State>,
+}
+
+impl Door<Unlocked> {
+    fn lock(self) -> Door<Locked> {
+        println!("Locking...");
+        Door { _state: PhantomData }
+    }
+    
+    fn open(&self) {
+        println!("Opening...");
+    }
+}
+
+impl Door<Locked> {
+    fn unlock(self) -> Door<Unlocked> {
+        println!("Unlocking...");
+        Door { _state: PhantomData }
+    }
+    
+    // Can't call open() on Locked door - method doesn't exist
+}
+
+fn example() {
+    let door: Door<Unlocked> = Door { _state: PhantomData };
+    door.open();           // OK
+    let locked = door.lock();
+    // locked.open();      // Error: no method `open` for Door<Locked>
+    let unlocked = locked.unlock();
+    unlocked.open();       // OK
+}
+```
+
+## Variance Control
+
+```rust
+use std::marker::PhantomData;
+
+// Covariant in T (PhantomData<T>)
+struct Producer<T> {
+    _marker: PhantomData<T>,  // Covariant
+}
+
+// Contravariant in T (PhantomData<fn(T)>)
+struct Consumer<T> {
+    _marker: PhantomData<fn(T)>,  // Contravariant
+}
+
+// Invariant in T (PhantomData<fn(T) -> T>)
+struct Both<T> {
+    _marker: PhantomData<fn(T) -> T>,  // Invariant
+}
+```
+
+## Common Uses
+
+```rust
+// 1. FFI handles with type safety
+struct FileHandle<T: FileType> {
+    fd: i32,
+    _marker: PhantomData<T>,
+}
+
+// 2. Generic iterators
+struct Iter<'a, T> {
+    ptr: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,
+}
+
+// 3. Allocator-aware types
+struct Vec<T, A: Allocator = Global> {
+    buf: RawVec<T, A>,
+    len: usize,
+}
+```
+
+## See Also
+
+- [api-typestate](./api-typestate.md) - State machine pattern
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe wrappers
+- [type-newtype-ids](./type-newtype-ids.md) - ID types

--- a/.agents/skills/rust-skills/rules/type-repr-transparent.md
+++ b/.agents/skills/rust-skills/rules/type-repr-transparent.md
@@ -1,0 +1,143 @@
+# type-repr-transparent
+
+> Use `#[repr(transparent)]` for newtypes in FFI contexts
+
+## Why It Matters
+
+`#[repr(transparent)]` guarantees a newtype has the same memory layout as its inner type. This is essential for FFI where you need type safety in Rust but must match C ABI layouts. Without it, the compiler may add padding or change layout.
+
+## Bad
+
+```rust
+// No layout guarantee - might not match inner type in FFI
+struct Handle(u64);
+
+// Passing to C code might fail
+extern "C" {
+    fn process_handle(h: Handle);  // May not work correctly
+}
+
+// Wrapping C type without layout guarantee
+struct SafePointer(*mut c_void);
+```
+
+## Good
+
+```rust
+// Guaranteed same layout as inner type
+#[repr(transparent)]
+struct Handle(u64);
+
+// Safe for FFI
+extern "C" {
+    fn process_handle(h: Handle);  // Works - same layout as u64
+}
+
+// FFI pointer wrapper
+#[repr(transparent)]
+struct SafePointer(*mut c_void);
+
+impl SafePointer {
+    // Safe Rust API around raw pointer
+    pub fn new(ptr: *mut c_void) -> Option<Self> {
+        if ptr.is_null() {
+            None
+        } else {
+            Some(SafePointer(ptr))
+        }
+    }
+}
+```
+
+## What repr(transparent) Guarantees
+
+```rust
+use std::mem::{size_of, align_of};
+
+#[repr(transparent)]
+struct Meters(f64);
+
+// Same size
+assert_eq!(size_of::<Meters>(), size_of::<f64>());
+
+// Same alignment
+assert_eq!(align_of::<Meters>(), align_of::<f64>());
+
+// Same ABI - can pass where f64 expected
+extern "C" fn measure(distance: Meters) { ... }
+```
+
+## With PhantomData
+
+```rust
+use std::marker::PhantomData;
+
+// PhantomData is zero-sized, doesn't affect layout
+#[repr(transparent)]
+struct TypedHandle<T> {
+    raw: u64,
+    _marker: PhantomData<T>,  // Zero-sized, ignored for layout
+}
+
+// Still same layout as u64
+assert_eq!(size_of::<TypedHandle<String>>(), size_of::<u64>());
+```
+
+## NonZero Wrappers
+
+```rust
+use std::num::NonZeroU64;
+
+#[repr(transparent)]
+struct NonZeroHandle(NonZeroU64);
+
+// Inherits null-pointer optimization
+assert_eq!(size_of::<Option<NonZeroHandle>>(), size_of::<u64>());
+```
+
+## FFI Pattern
+
+```rust
+mod ffi {
+    use std::os::raw::c_int;
+    
+    #[repr(transparent)]
+    pub struct FileDescriptor(c_int);
+    
+    extern "C" {
+        pub fn open(path: *const i8, flags: c_int) -> FileDescriptor;
+        pub fn close(fd: FileDescriptor) -> c_int;
+        pub fn read(fd: FileDescriptor, buf: *mut u8, len: usize) -> isize;
+    }
+}
+
+// Safe wrapper
+pub struct File {
+    fd: ffi::FileDescriptor,
+}
+
+impl File {
+    pub fn open(path: &str) -> std::io::Result<Self> {
+        let c_path = std::ffi::CString::new(path)?;
+        let fd = unsafe { ffi::open(c_path.as_ptr(), 0) };
+        // ... error handling
+        Ok(File { fd })
+    }
+}
+```
+
+## When to Use
+
+| Scenario | Use `#[repr(transparent)]`? |
+|----------|----------------------------|
+| FFI newtype wrappers | Yes |
+| Type-safe handles | Yes |
+| NonZero optimization | Yes |
+| Pure Rust newtypes | Optional (doesn't hurt) |
+| Multi-field structs | N/A (only for single-field) |
+
+## See Also
+
+- [type-newtype-ids](./type-newtype-ids.md) - Newtype pattern
+- [type-phantom-marker](./type-phantom-marker.md) - PhantomData usage
+- [api-newtype-safety](./api-newtype-safety.md) - Type-safe newtypes

--- a/.agents/skills/rust-skills/rules/type-result-fallible.md
+++ b/.agents/skills/rust-skills/rules/type-result-fallible.md
@@ -1,0 +1,131 @@
+# type-result-fallible
+
+> Use `Result<T, E>` for operations that can fail
+
+## Why It Matters
+
+`Result<T, E>` makes failure explicit in the type system. Callers must acknowledge and handle potential errors—they can't accidentally ignore failures. The `?` operator makes error propagation ergonomic while maintaining explicit error handling.
+
+## Bad
+
+```rust
+// Returning Option loses error context
+fn read_config(path: &str) -> Option<Config> {
+    let content = std::fs::read_to_string(path).ok()?;  // Why did it fail?
+    toml::from_str(&content).ok()  // Parse error lost
+}
+
+// Panicking on errors
+fn read_config(path: &str) -> Config {
+    let content = std::fs::read_to_string(path).unwrap();  // Crashes
+    toml::from_str(&content).unwrap()  // Crashes
+}
+
+// Sentinel values
+fn divide(a: i32, b: i32) -> i32 {
+    if b == 0 { return -1; }  // Magic value, easy to miss
+    a / b
+}
+```
+
+## Good
+
+```rust
+// Result with clear error type
+fn read_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(ConfigError::IoError)?;
+    toml::from_str(&content)
+        .map_err(ConfigError::ParseError)
+}
+
+fn divide(a: i32, b: i32) -> Result<i32, DivisionError> {
+    if b == 0 {
+        return Err(DivisionError::DivideByZero);
+    }
+    Ok(a / b)
+}
+
+// Caller must handle
+match divide(10, 0) {
+    Ok(result) => println!("Result: {}", result),
+    Err(e) => println!("Error: {}", e),
+}
+```
+
+## The ? Operator
+
+```rust
+fn process_file(path: &str) -> Result<ProcessedData, Error> {
+    let content = std::fs::read_to_string(path)?;  // Propagates Err
+    let parsed: RawData = serde_json::from_str(&content)?;
+    let validated = validate(parsed)?;
+    let processed = transform(validated)?;
+    Ok(processed)
+}
+
+// Equivalent to:
+fn process_file(path: &str) -> Result<ProcessedData, Error> {
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => return Err(e.into()),
+    };
+    // ... etc
+}
+```
+
+## Result Combinators
+
+```rust
+let result: Result<i32, Error> = Ok(42);
+
+// map: transform success value
+let doubled = result.map(|n| n * 2);  // Ok(84)
+
+// map_err: transform error
+let with_context = result.map_err(|e| format!("Failed: {}", e));
+
+// and_then: chain fallible operations
+let processed = result.and_then(|n| {
+    if n > 0 { Ok(n * 2) } else { Err(Error::Negative) }
+});
+
+// unwrap_or: provide default on error
+let value = result.unwrap_or(0);
+
+// ok(): convert to Option, discarding error
+let maybe_value: Option<i32> = result.ok();
+```
+
+## Defining Error Types
+
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("failed to read file: {0}")]
+    Io(#[from] std::io::Error),
+    
+    #[error("failed to parse config: {0}")]
+    Parse(#[from] toml::de::Error),
+    
+    #[error("missing required field: {0}")]
+    MissingField(String),
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    let content = std::fs::read_to_string(path)?;  // Io error
+    let config: Config = toml::from_str(&content)?;  // Parse error
+    if config.name.is_empty() {
+        return Err(ConfigError::MissingField("name".into()));
+    }
+    Ok(config)
+}
+```
+
+## See Also
+
+- [err-thiserror-lib](./err-thiserror-lib.md) - Defining error types
+- [err-question-mark](./err-question-mark.md) - Using ? operator
+- [type-option-nullable](./type-option-nullable.md) - Option vs Result

--- a/.agents/skills/rust-symbol-analyzer/SKILL.md
+++ b/.agents/skills/rust-symbol-analyzer/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: rust-symbol-analyzer
+description: "Analyze Rust project structure using LSP symbols. Triggers on: /symbols, project structure, list structs, list traits, list functions, 符号分析, 项目结构, 列出所有, 有哪些struct"
+argument-hint: "[file.rs] [--type struct|trait|fn|mod]"
+allowed-tools: ["LSP", "Read", "Glob"]
+---
+
+# Rust Symbol Analyzer
+
+Analyze project structure by examining symbols across your Rust codebase.
+
+## Usage
+
+```
+/rust-symbol-analyzer [file.rs] [--type struct|trait|fn|mod]
+```
+
+**Examples:**
+- `/rust-symbol-analyzer` - Analyze entire project
+- `/rust-symbol-analyzer src/lib.rs` - Analyze single file
+- `/rust-symbol-analyzer --type trait` - List all traits in project
+
+## LSP Operations
+
+### 1. Document Symbols (Single File)
+
+Get all symbols in a file with their hierarchy.
+
+```
+LSP(
+  operation: "documentSymbol",
+  filePath: "src/lib.rs",
+  line: 1,
+  character: 1
+)
+```
+
+**Returns:** Nested structure of modules, structs, functions, etc.
+
+### 2. Workspace Symbols (Entire Project)
+
+Search for symbols across the workspace.
+
+```
+LSP(
+  operation: "workspaceSymbol",
+  filePath: "src/lib.rs",
+  line: 1,
+  character: 1
+)
+```
+
+**Note:** Query is implicit in the operation context.
+
+## Workflow
+
+```
+User: "What's the structure of this project?"
+    │
+    ▼
+[1] Find all Rust files
+    Glob("**/*.rs")
+    │
+    ▼
+[2] Get symbols from each key file
+    LSP(documentSymbol) for lib.rs, main.rs
+    │
+    ▼
+[3] Categorize by type
+    │
+    ▼
+[4] Generate structure visualization
+```
+
+## Output Format
+
+### Project Overview
+
+```
+## Project Structure: my-project
+
+### Modules
+├── src/
+│   ├── lib.rs (root)
+│   ├── config/
+│   │   ├── mod.rs
+│   │   └── parser.rs
+│   ├── handlers/
+│   │   ├── mod.rs
+│   │   ├── auth.rs
+│   │   └── api.rs
+│   └── models/
+│       ├── mod.rs
+│       ├── user.rs
+│       └── order.rs
+└── tests/
+    └── integration.rs
+```
+
+### By Symbol Type
+
+```
+## Symbols by Type
+
+### Structs (12)
+| Name | Location | Fields | Derives |
+|------|----------|--------|---------|
+| Config | src/config.rs:10 | 5 | Debug, Clone |
+| User | src/models/user.rs:8 | 4 | Debug, Serialize |
+| Order | src/models/order.rs:15 | 6 | Debug, Serialize |
+| ... | | | |
+
+### Traits (4)
+| Name | Location | Methods | Implementors |
+|------|----------|---------|--------------|
+| Handler | src/handlers/mod.rs:5 | 3 | AuthHandler, ApiHandler |
+| Repository | src/db/mod.rs:12 | 5 | UserRepo, OrderRepo |
+| ... | | | |
+
+### Functions (25)
+| Name | Location | Visibility | Async |
+|------|----------|------------|-------|
+| main | src/main.rs:10 | pub | yes |
+| parse_config | src/config.rs:45 | pub | no |
+| ... | | | |
+
+### Enums (6)
+| Name | Location | Variants |
+|------|----------|----------|
+| Error | src/error.rs:5 | 8 |
+| Status | src/models/order.rs:5 | 4 |
+| ... | | |
+```
+
+### Single File Analysis
+
+```
+## src/handlers/auth.rs
+
+### Symbols Hierarchy
+
+mod auth
+├── struct AuthHandler
+│   ├── field: config: Config
+│   ├── field: db: Pool
+│   └── impl AuthHandler
+│       ├── fn new(config, db) -> Self
+│       ├── fn authenticate(&self, token) -> Result<User>
+│       └── fn refresh_token(&self, user) -> Result<Token>
+├── struct Token
+│   ├── field: value: String
+│   └── field: expires: DateTime
+├── enum AuthError
+│   ├── InvalidToken
+│   ├── Expired
+│   └── Unauthorized
+└── impl Handler for AuthHandler
+    ├── fn handle(&self, req) -> Response
+    └── fn name(&self) -> &str
+```
+
+## Analysis Features
+
+### Complexity Metrics
+
+```
+## Complexity Analysis
+
+| File | Structs | Functions | Lines | Complexity |
+|------|---------|-----------|-------|------------|
+| src/handlers/auth.rs | 2 | 8 | 150 | Medium |
+| src/models/user.rs | 3 | 12 | 200 | High |
+| src/config.rs | 1 | 3 | 50 | Low |
+
+**Hotspots:** Files with high complexity that may need refactoring
+- src/handlers/api.rs (15 functions, 300 lines)
+```
+
+### Dependency Analysis
+
+```
+## Internal Dependencies
+
+auth.rs
+├── imports from: config.rs, models/user.rs, db/mod.rs
+└── imported by: main.rs, handlers/mod.rs
+
+user.rs
+├── imports from: (none - leaf module)
+└── imported by: auth.rs, api.rs, tests/
+```
+
+## Symbol Types
+
+| Type | Icon | LSP Kind |
+|------|------|----------|
+| Module | 📦 | Module |
+| Struct | 🏗️ | Struct |
+| Enum | 🔢 | Enum |
+| Trait | 📜 | Interface |
+| Function | ⚡ | Function |
+| Method | 🔧 | Method |
+| Constant | 🔒 | Constant |
+| Field | 📎 | Field |
+
+## Common Queries
+
+| User Says | Analysis |
+|-----------|----------|
+| "What structs are in this project?" | workspaceSymbol + filter |
+| "Show me src/lib.rs structure" | documentSymbol |
+| "Find all async functions" | workspaceSymbol + async filter |
+| "List public API" | documentSymbol + pub filter |
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Navigate to symbol | rust-code-navigator |
+| Call relationships | rust-call-graph |
+| Trait implementations | rust-trait-explorer |
+| Safe refactoring | rust-refactor-helper |

--- a/.agents/skills/rust-trait-explorer/SKILL.md
+++ b/.agents/skills/rust-trait-explorer/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: rust-trait-explorer
+description: "Explore Rust trait implementations using LSP. Triggers on: /trait-impl, find implementations, who implements, trait 实现, 谁实现了, 实现了哪些trait"
+argument-hint: "<TraitName|StructName>"
+allowed-tools: ["LSP", "Read", "Glob", "Grep"]
+---
+
+# Rust Trait Explorer
+
+Discover trait implementations and understand polymorphic designs.
+
+## Usage
+
+```
+/rust-trait-explorer <TraitName|StructName>
+```
+
+**Examples:**
+- `/rust-trait-explorer Handler` - Find all implementors of Handler trait
+- `/rust-trait-explorer MyStruct` - Find all traits implemented by MyStruct
+
+## LSP Operations
+
+### Go to Implementation
+
+Find all implementations of a trait.
+
+```
+LSP(
+  operation: "goToImplementation",
+  filePath: "src/traits.rs",
+  line: 10,
+  character: 11
+)
+```
+
+**Use when:**
+- Trait name is known
+- Want to find all implementors
+- Understanding polymorphic code
+
+## Workflow
+
+### Find Trait Implementors
+
+```
+User: "Who implements the Handler trait?"
+    │
+    ▼
+[1] Find trait definition
+    LSP(goToDefinition) or workspaceSymbol
+    │
+    ▼
+[2] Get implementations
+    LSP(goToImplementation)
+    │
+    ▼
+[3] For each impl, get details
+    LSP(documentSymbol) for methods
+    │
+    ▼
+[4] Generate implementation map
+```
+
+### Find Traits for a Type
+
+```
+User: "What traits does MyStruct implement?"
+    │
+    ▼
+[1] Find struct definition
+    │
+    ▼
+[2] Search for "impl * for MyStruct"
+    Grep pattern matching
+    │
+    ▼
+[3] Get trait details for each
+    │
+    ▼
+[4] Generate trait list
+```
+
+## Output Format
+
+### Trait Implementors
+
+```
+## Implementations of `Handler`
+
+**Trait defined at:** src/traits.rs:15
+
+​```rust
+pub trait Handler {
+    fn handle(&self, request: Request) -> Response;
+    fn name(&self) -> &str;
+}
+​```
+
+### Implementors (4)
+
+| Type | Location | Notes |
+|------|----------|-------|
+| AuthHandler | src/handlers/auth.rs:20 | Handles authentication |
+| ApiHandler | src/handlers/api.rs:15 | REST API endpoints |
+| WebSocketHandler | src/handlers/ws.rs:10 | WebSocket connections |
+| MockHandler | tests/mocks.rs:5 | Test mock |
+
+### Implementation Details
+
+#### AuthHandler
+​```rust
+impl Handler for AuthHandler {
+    fn handle(&self, request: Request) -> Response {
+        // Authentication logic
+    }
+
+    fn name(&self) -> &str {
+        "auth"
+    }
+}
+​```
+
+#### ApiHandler
+​```rust
+impl Handler for ApiHandler {
+    fn handle(&self, request: Request) -> Response {
+        // API routing logic
+    }
+
+    fn name(&self) -> &str {
+        "api"
+    }
+}
+​```
+```
+
+### Traits for a Type
+
+```
+## Traits implemented by `User`
+
+**Struct defined at:** src/models/user.rs:10
+
+### Standard Library Traits
+| Trait | Derived/Manual | Notes |
+|-------|----------------|-------|
+| Debug | #[derive] | Auto-generated |
+| Clone | #[derive] | Auto-generated |
+| Default | manual | Custom defaults |
+| Display | manual | User-friendly output |
+
+### Serde Traits
+| Trait | Location |
+|-------|----------|
+| Serialize | #[derive] |
+| Deserialize | #[derive] |
+
+### Project Traits
+| Trait | Location | Methods |
+|-------|----------|---------|
+| Entity | src/db/entity.rs:30 | id(), created_at() |
+| Validatable | src/validation.rs:15 | validate() |
+
+### Implementation Hierarchy
+
+​```
+User
+├── derive
+│   ├── Debug
+│   ├── Clone
+│   ├── Serialize
+│   └── Deserialize
+└── impl
+    ├── Default (src/models/user.rs:50)
+    ├── Display (src/models/user.rs:60)
+    ├── Entity (src/models/user.rs:70)
+    └── Validatable (src/models/user.rs:85)
+​```
+```
+
+## Trait Hierarchy Visualization
+
+```
+## Trait Hierarchy
+
+                    ┌─────────────┐
+                    │    Error    │ (std)
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+      ┌───────▼───────┐ ┌──▼──┐ ┌───────▼───────┐
+      │  AppError     │ │ ... │ │  DbError      │
+      └───────┬───────┘ └─────┘ └───────┬───────┘
+              │                         │
+      ┌───────▼───────┐         ┌───────▼───────┐
+      │ AuthError     │         │ QueryError    │
+      └───────────────┘         └───────────────┘
+```
+
+## Analysis Features
+
+### Coverage Check
+
+```
+## Trait Implementation Coverage
+
+Trait: Handler (3 required methods)
+
+| Implementor | handle() | name() | priority() | Complete |
+|-------------|----------|--------|------------|----------|
+| AuthHandler | ✅ | ✅ | ✅ | Yes |
+| ApiHandler | ✅ | ✅ | ❌ default | Yes |
+| MockHandler | ✅ | ✅ | ✅ | Yes |
+```
+
+### Blanket Implementations
+
+```
+## Blanket Implementations
+
+The following blanket impls may apply to your types:
+
+| Trait | Blanket Impl | Applies To |
+|-------|--------------|------------|
+| From<T> | `impl<T> From<T> for T` | All types |
+| Into<U> | `impl<T, U> Into<U> for T where U: From<T>` | Types with From |
+| ToString | `impl<T: Display> ToString for T` | Types with Display |
+```
+
+## Common Patterns
+
+| User Says | Action |
+|-----------|--------|
+| "Who implements X?" | goToImplementation on trait |
+| "What traits does Y impl?" | Grep for `impl * for Y` |
+| "Show trait hierarchy" | Find super-traits recursively |
+| "Is X: Send + Sync?" | Check std trait impls |
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Navigate to impl | rust-code-navigator |
+| Call relationships | rust-call-graph |
+| Project structure | rust-symbol-analyzer |
+| Safe refactoring | rust-refactor-helper |

--- a/.agents/skills/unsafe-checker/AGENTS.md
+++ b/.agents/skills/unsafe-checker/AGENTS.md
@@ -1,0 +1,136 @@
+# Unsafe Checker - Quick Reference
+
+**Auto-generated from rules/**
+
+## Rule Summary by Section
+
+### General Principles (3 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| general-01 | P | Do Not Abuse Unsafe to Escape Compiler Safety Checks |
+| general-02 | P | Do Not Blindly Use Unsafe for Performance |
+| general-03 | G | Do Not Create Aliases for Types/Methods Named "Unsafe" |
+
+### Safety Abstraction (11 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| safety-01 | P | Be Aware of Memory Safety Issues from Panics |
+| safety-02 | P | Unsafe Code Authors Must Verify Safety Invariants |
+| safety-03 | P | Do Not Expose Uninitialized Memory in Public APIs |
+| safety-04 | P | Avoid Double-Free from Panic Safety Issues |
+| safety-05 | P | Consider Safety When Manually Implementing Auto Traits |
+| safety-06 | P | Do Not Expose Raw Pointers in Public APIs |
+| safety-07 | P | Provide Unsafe Counterparts for Performance Alongside Safe Methods |
+| safety-08 | P | Mutable Return from Immutable Parameter is Wrong |
+| safety-09 | P | Add SAFETY Comment Before Any Unsafe Block |
+| safety-10 | G | Add Safety Section in Docs for Public Unsafe Functions |
+| safety-11 | G | Use assert! Instead of debug_assert! in Unsafe Functions |
+
+### Raw Pointers (6 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| ptr-01 | P | Do Not Share Raw Pointers Across Threads |
+| ptr-02 | P | Prefer NonNull<T> Over *mut T |
+| ptr-03 | P | Use PhantomData<T> for Variance and Ownership |
+| ptr-04 | G | Do Not Dereference Pointers Cast to Misaligned Types |
+| ptr-05 | G | Do Not Manually Convert Immutable Pointer to Mutable |
+| ptr-06 | G | Prefer pointer::cast Over `as` for Pointer Casting |
+
+### Union (2 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| union-01 | P | Avoid Union Except for C Interop |
+| union-02 | P | Do Not Use Union Variants Across Different Lifetimes |
+
+### Memory Layout (6 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| mem-01 | P | Choose Appropriate Data Layout for Struct/Tuple/Enum |
+| mem-02 | P | Do Not Modify Memory Variables of Other Processes |
+| mem-03 | P | Do Not Let String/Vec Auto-Drop Other Process's Memory |
+| mem-04 | P | Prefer Reentrant Versions of C-API or Syscalls |
+| mem-05 | P | Use Third-Party Crates for Bitfields |
+| mem-06 | G | Use MaybeUninit<T> for Uninitialized Memory |
+
+### FFI (18 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| ffi-01 | P | Avoid Passing Strings Directly to C |
+| ffi-02 | P | Read Documentation Carefully for std::ffi Types |
+| ffi-03 | P | Implement Drop for Wrapped C Pointers |
+| ffi-04 | P | Handle Panics When Crossing FFI Boundaries |
+| ffi-05 | P | Use Portable Type Aliases from std or libc |
+| ffi-06 | P | Ensure C-ABI String Compatibility |
+| ffi-07 | P | Do Not Implement Drop for Types Passed to External Code |
+| ffi-08 | P | Handle Errors Properly in FFI |
+| ffi-09 | P | Use References Instead of Raw Pointers in Safe Wrappers |
+| ffi-10 | P | Exported Functions Must Be Thread-Safe |
+| ffi-11 | P | Be Careful with repr(packed) Field References |
+| ffi-12 | P | Document Invariant Assumptions for C Parameters |
+| ffi-13 | P | Ensure Consistent Data Layout for Custom Types |
+| ffi-14 | P | Types in FFI Should Have Stable Layout |
+| ffi-15 | P | Validate Non-Robust External Values |
+| ffi-16 | P | Separate Data and Code for Closures to C |
+| ffi-17 | P | Use Opaque Types Instead of c_void |
+| ffi-18 | P | Avoid Passing Trait Objects to C |
+
+### I/O Safety (1 rule)
+| ID | Level | Title |
+|----|-------|-------|
+| io-01 | P | Ensure I/O Safety When Using Raw Handles |
+
+## Clippy Lint Mapping
+
+| Clippy Lint | Rule | Category |
+|-------------|------|----------|
+| `undocumented_unsafe_blocks` | safety-09 | SAFETY comments |
+| `missing_safety_doc` | safety-10 | Safety docs |
+| `panic_in_result_fn` | safety-01, ffi-04 | Panic safety |
+| `non_send_fields_in_send_ty` | safety-05 | Send/Sync |
+| `uninit_assumed_init` | safety-03 | Initialization |
+| `uninit_vec` | mem-06 | Initialization |
+| `mut_from_ref` | safety-08 | Aliasing |
+| `cast_ptr_alignment` | ptr-04 | Alignment |
+| `cast_ref_to_mut` | ptr-05 | Aliasing |
+| `ptr_as_ptr` | ptr-06 | Pointer casting |
+| `unaligned_references` | ffi-11 | Packed structs |
+| `debug_assert_with_mut_call` | safety-11 | Assertions |
+
+## Quick Decision Tree
+
+```
+Writing unsafe code?
+    │
+    ├─ FFI with C?
+    │   └─ See ffi-* rules
+    │
+    ├─ Raw pointers?
+    │   └─ See ptr-* rules
+    │
+    ├─ Manual Send/Sync?
+    │   └─ See safety-05
+    │
+    ├─ MaybeUninit/uninitialized?
+    │   └─ See safety-03, mem-06
+    │
+    └─ Performance optimization?
+        └─ See general-02, safety-07
+```
+
+## Essential Checklist
+
+Before every unsafe block:
+- [ ] SAFETY comment present
+- [ ] Invariants documented
+- [ ] Pointer validity checked
+- [ ] Aliasing rules followed
+- [ ] Panic safety considered
+- [ ] Tested with Miri
+
+## Resources
+
+- `checklists/before-unsafe.md` - Pre-writing checklist
+- `checklists/review-unsafe.md` - Code review checklist
+- `checklists/common-pitfalls.md` - Common bugs and fixes
+- `examples/safe-abstraction.md` - Safe wrapper patterns
+- `examples/ffi-patterns.md` - FFI best practices

--- a/.agents/skills/unsafe-checker/SKILL.md
+++ b/.agents/skills/unsafe-checker/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: unsafe-checker
+description: "CRITICAL: Use for unsafe Rust code review and FFI. Triggers on: unsafe, raw pointer, FFI, extern, transmute, *mut, *const, union, #[repr(C)], libc, std::ffi, MaybeUninit, NonNull, SAFETY comment, soundness, undefined behavior, UB, safe wrapper, memory layout, bindgen, cbindgen, CString, CStr, 安全抽象, 裸指针, 外部函数接口, 内存布局, 不安全代码, FFI 绑定, 未定义行为"
+globs: ["**/*.rs"]
+allowed-tools: ["Read", "Grep", "Glob"]
+---
+
+Display the following ASCII art exactly as shown. Do not modify spaces or line breaks:
+```text
+⚠️ **Unsafe Rust Checker Loaded**
+
+     *  ^  *
+    /◉\_~^~_/◉\
+ ⚡/     o     \⚡
+   '_        _'
+   / '-----' \
+```
+
+---
+
+# Unsafe Rust Checker
+
+## When Unsafe is Valid
+
+| Use Case | Example |
+|----------|---------|
+| FFI | Calling C functions |
+| Low-level abstractions | Implementing `Vec`, `Arc` |
+| Performance | Measured bottleneck with safe alternative too slow |
+
+**NOT valid:** Escaping borrow checker without understanding why.
+
+## Required Documentation
+
+```rust
+// SAFETY: <why this is safe>
+unsafe { ... }
+
+/// # Safety
+/// <caller requirements>
+pub unsafe fn dangerous() { ... }
+```
+
+## Quick Reference
+
+| Operation | Safety Requirements |
+|-----------|---------------------|
+| `*ptr` deref | Valid, aligned, initialized |
+| `&*ptr` | + No aliasing violations |
+| `transmute` | Same size, valid bit pattern |
+| `extern "C"` | Correct signature, ABI |
+| `static mut` | Synchronization guaranteed |
+| `impl Send/Sync` | Actually thread-safe |
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| Null pointer deref | Check for null before deref |
+| Use after free | Ensure lifetime validity |
+| Data race | Add proper synchronization |
+| Alignment violation | Use `#[repr(C)]`, check alignment |
+| Invalid bit pattern | Use `MaybeUninit` |
+| Missing SAFETY comment | Add `// SAFETY:` |
+
+## Deprecated → Better
+
+| Deprecated | Use Instead |
+|------------|-------------|
+| `mem::uninitialized()` | `MaybeUninit<T>` |
+| `mem::zeroed()` for refs | `MaybeUninit<T>` |
+| Raw pointer arithmetic | `NonNull<T>`, `ptr::add` |
+| `CString::new().unwrap().as_ptr()` | Store `CString` first |
+| `static mut` | `AtomicT` or `Mutex` |
+| Manual extern | `bindgen` |
+
+## FFI Crates
+
+| Direction | Crate |
+|-----------|-------|
+| C → Rust | bindgen |
+| Rust → C | cbindgen |
+| Python | PyO3 |
+| Node.js | napi-rs |
+
+Claude knows unsafe Rust. Focus on SAFETY comments and soundness.

--- a/.agents/skills/unsafe-checker/checklists/before-unsafe.md
+++ b/.agents/skills/unsafe-checker/checklists/before-unsafe.md
@@ -1,0 +1,115 @@
+# Checklist: Before Writing Unsafe Code
+
+Use this checklist before writing any `unsafe` block or `unsafe fn`.
+
+## 1. Do You Really Need Unsafe?
+
+- [ ] Have you tried all safe alternatives?
+- [ ] Can you restructure the code to satisfy the borrow checker?
+- [ ] Would interior mutability (`Cell`, `RefCell`, `Mutex`) solve the problem?
+- [ ] Is there a safe crate that already does this?
+- [ ] Is the performance gain (if any) worth the safety risk?
+
+**If you answered "no" to all, proceed with unsafe.**
+
+## 2. What Unsafe Operation Do You Need?
+
+Identify which specific unsafe operation you're performing:
+
+- [ ] Dereferencing a raw pointer (`*const T`, `*mut T`)
+- [ ] Calling an `unsafe` function
+- [ ] Accessing a mutable static variable
+- [ ] Implementing an unsafe trait (`Send`, `Sync`, etc.)
+- [ ] Accessing fields of a `union`
+- [ ] Using `extern "C"` functions (FFI)
+
+## 3. Safety Invariants
+
+For each unsafe operation, document the invariants:
+
+### For Pointer Dereference:
+- [ ] Is the pointer non-null?
+- [ ] Is the pointer properly aligned for the type?
+- [ ] Does the pointer point to valid, initialized memory?
+- [ ] Is the memory not being mutated by other code?
+- [ ] Will the memory remain valid for the entire duration of use?
+
+### For Mutable Aliasing:
+- [ ] Are you creating multiple mutable references to the same memory?
+- [ ] Is there any possibility of aliasing `&mut` and `&`?
+- [ ] Have you verified no other code can access this memory?
+
+### For FFI:
+- [ ] Is the function signature correct (types, ABI)?
+- [ ] Are you handling potential null pointers?
+- [ ] Are you handling potential panics (catch_unwind)?
+- [ ] Is memory ownership clear (who allocates, who frees)?
+
+### For Send/Sync:
+- [ ] Is concurrent access properly synchronized?
+- [ ] Are there any data races possible?
+- [ ] Does the type truly satisfy the trait requirements?
+
+## 4. Panic Safety
+
+- [ ] What happens if this code panics at any line?
+- [ ] Are data structures left in a valid state on panic?
+- [ ] Do you need a panic guard for cleanup?
+- [ ] Could a destructor see invalid state?
+
+## 5. Documentation
+
+- [ ] Have you written a `// SAFETY:` comment explaining:
+  - What invariants must hold?
+  - Why those invariants are upheld here?
+
+- [ ] For `unsafe fn`, have you written `# Safety` docs explaining:
+  - What the caller must guarantee?
+  - What happens if requirements are violated?
+
+## 6. Testing and Verification
+
+- [ ] Can you add debug assertions to verify invariants?
+- [ ] Have you tested with Miri (`cargo miri test`)?
+- [ ] Have you tested with address sanitizer (`RUSTFLAGS="-Zsanitizer=address"`)?
+- [ ] Have you considered fuzzing the unsafe code?
+
+## Quick Reference: Common SAFETY Comments
+
+```rust
+// SAFETY: We checked that index < len above, so this is in bounds.
+
+// SAFETY: The pointer was created from a valid reference and hasn't been invalidated.
+
+// SAFETY: We hold the lock, guaranteeing exclusive access.
+
+// SAFETY: The type is #[repr(C)] and all fields are initialized.
+
+// SAFETY: Caller guarantees the pointer is non-null and properly aligned.
+```
+
+## Decision Flowchart
+
+```
+Need unsafe?
+     |
+     v
+Can you use safe Rust? --Yes--> Don't use unsafe
+     |
+     No
+     v
+Can you use existing safe abstraction? --Yes--> Use it (std, crates)
+     |
+     No
+     v
+Document all invariants
+     |
+     v
+Add SAFETY comments
+     |
+     v
+Write the unsafe code
+     |
+     v
+Test with Miri
+```

--- a/.agents/skills/unsafe-checker/checklists/common-pitfalls.md
+++ b/.agents/skills/unsafe-checker/checklists/common-pitfalls.md
@@ -1,0 +1,253 @@
+# Common Unsafe Pitfalls and Fixes
+
+A reference of frequently encountered unsafe bugs and how to fix them.
+
+## Pitfall 1: Dangling Pointer from Local
+
+**Bug:**
+```rust
+fn bad() -> *const i32 {
+    let x = 42;
+    &x as *const i32  // Dangling after return!
+}
+```
+
+**Fix:**
+```rust
+fn good() -> Box<i32> {
+    Box::new(42)  // Heap allocation lives beyond function
+}
+
+// Or return the value itself
+fn better() -> i32 {
+    42
+}
+```
+
+## Pitfall 2: CString Lifetime
+
+**Bug:**
+```rust
+fn bad() -> *const c_char {
+    let s = CString::new("hello").unwrap();
+    s.as_ptr()  // Dangling! CString dropped
+}
+```
+
+**Fix:**
+```rust
+fn good(s: &CString) -> *const c_char {
+    s.as_ptr()  // Caller keeps CString alive
+}
+
+// Or take ownership
+fn also_good(s: CString) -> *const c_char {
+    s.into_raw()  // Caller must free with CString::from_raw
+}
+```
+
+## Pitfall 3: Vec set_len with Uninitialized Data
+
+**Bug:**
+```rust
+fn bad() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    unsafe { v.set_len(10); }  // Strings are uninitialized!
+    v
+}
+```
+
+**Fix:**
+```rust
+fn good() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    for _ in 0..10 {
+        v.push(String::new());
+    }
+    v
+}
+
+// Or use resize
+fn also_good() -> Vec<String> {
+    let mut v = Vec::new();
+    v.resize(10, String::new());
+    v
+}
+```
+
+## Pitfall 4: Reference to Packed Field
+
+**Bug:**
+```rust
+#[repr(packed)]
+struct Packed { a: u8, b: u32 }
+
+fn bad(p: &Packed) -> &u32 {
+    &p.b  // UB: misaligned reference!
+}
+```
+
+**Fix:**
+```rust
+fn good(p: &Packed) -> u32 {
+    unsafe { std::ptr::addr_of!(p.b).read_unaligned() }
+}
+```
+
+## Pitfall 5: Mutable Aliasing Through Raw Pointers
+
+**Bug:**
+```rust
+fn bad() {
+    let mut x = 42;
+    let ptr1 = &mut x as *mut i32;
+    let ptr2 = &mut x as *mut i32;  // Already have ptr1!
+    unsafe {
+        *ptr1 = 1;
+        *ptr2 = 2;  // Aliasing mutable pointers!
+    }
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let mut x = 42;
+    let ptr = &mut x as *mut i32;
+    unsafe {
+        *ptr = 1;
+        *ptr = 2;  // Same pointer, sequential access
+    }
+}
+```
+
+## Pitfall 6: Transmute to Wrong Size
+
+**Bug:**
+```rust
+fn bad() {
+    let x: u32 = 42;
+    let y: u64 = unsafe { std::mem::transmute(x) };  // UB: size mismatch!
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let x: u32 = 42;
+    let y: u64 = x as u64;  // Use conversion
+}
+```
+
+## Pitfall 7: Invalid Enum Discriminant
+
+**Bug:**
+```rust
+#[repr(u8)]
+enum Status { A = 0, B = 1, C = 2 }
+
+fn bad(raw: u8) -> Status {
+    unsafe { std::mem::transmute(raw) }  // UB if raw > 2!
+}
+```
+
+**Fix:**
+```rust
+fn good(raw: u8) -> Option<Status> {
+    match raw {
+        0 => Some(Status::A),
+        1 => Some(Status::B),
+        2 => Some(Status::C),
+        _ => None,
+    }
+}
+```
+
+## Pitfall 8: FFI Panic Unwinding
+
+**Bug:**
+```rust
+#[no_mangle]
+extern "C" fn callback(x: i32) -> i32 {
+    if x < 0 {
+        panic!("negative!");  // UB: unwinding across FFI!
+    }
+    x * 2
+}
+```
+
+**Fix:**
+```rust
+#[no_mangle]
+extern "C" fn callback(x: i32) -> i32 {
+    std::panic::catch_unwind(|| {
+        if x < 0 {
+            panic!("negative!");
+        }
+        x * 2
+    }).unwrap_or(-1)  // Return error code on panic
+}
+```
+
+## Pitfall 9: Double Free from Clone + into_raw
+
+**Bug:**
+```rust
+struct Handle(*mut c_void);
+
+impl Clone for Handle {
+    fn clone(&self) -> Self {
+        Handle(self.0)  // Both now "own" same pointer!
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        unsafe { free(self.0); }  // Double free when both drop!
+    }
+}
+```
+
+**Fix:**
+```rust
+struct Handle(*mut c_void);
+
+// Don't implement Clone, or implement proper reference counting
+impl Handle {
+    fn clone_ptr(&self) -> *mut c_void {
+        self.0  // Return raw pointer, no ownership
+    }
+}
+```
+
+## Pitfall 10: Forget Doesn't Run Destructors
+
+**Bug:**
+```rust
+fn bad() {
+    let guard = lock.lock();
+    std::mem::forget(guard);  // Lock never released!
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let guard = lock.lock();
+    // Let guard drop naturally
+    // or explicitly: drop(guard);
+}
+```
+
+## Quick Reference Table
+
+| Pitfall | Detection | Fix |
+|---------|-----------|-----|
+| Dangling pointer | Miri | Extend lifetime or heap allocate |
+| Uninitialized read | Miri | Use MaybeUninit properly |
+| Misaligned access | Miri, UBsan | read_unaligned, copy by value |
+| Data race | TSan | Use atomics or mutex |
+| Double free | ASan | Track ownership carefully |
+| Invalid enum | Manual review | Use TryFrom |
+| FFI panic | Testing | catch_unwind |
+| Type confusion | Miri | Match types exactly |

--- a/.agents/skills/unsafe-checker/checklists/review-unsafe.md
+++ b/.agents/skills/unsafe-checker/checklists/review-unsafe.md
@@ -1,0 +1,113 @@
+# Checklist: Reviewing Unsafe Code
+
+Use this checklist when reviewing code containing `unsafe`.
+
+## 1. Surface-Level Checks
+
+- [ ] Does every `unsafe` block have a `// SAFETY:` comment?
+- [ ] Does every `unsafe fn` have `# Safety` documentation?
+- [ ] Are the safety comments specific and verifiable, not vague?
+- [ ] Is the unsafe code minimized (smallest possible unsafe block)?
+
+## 2. Pointer Validity
+
+For each pointer dereference:
+
+- [ ] **Non-null**: Is null checked before dereference?
+- [ ] **Aligned**: Is alignment verified or guaranteed by construction?
+- [ ] **Valid**: Does the pointer point to allocated memory?
+- [ ] **Initialized**: Is the memory initialized before reading?
+- [ ] **Lifetime**: Is the memory valid for the entire use duration?
+- [ ] **Unique**: For `&mut`, is there only one mutable reference?
+
+## 3. Memory Safety
+
+- [ ] **No aliasing**: Are `&` and `&mut` never created to the same memory simultaneously?
+- [ ] **No use-after-free**: Is memory not accessed after deallocation?
+- [ ] **No double-free**: Is memory freed exactly once?
+- [ ] **No data races**: Is concurrent access properly synchronized?
+- [ ] **Bounds checked**: Are array/slice accesses in bounds?
+
+## 4. Type Safety
+
+- [ ] **Transmute**: Are transmuted types actually compatible?
+- [ ] **Repr**: Do FFI types have `#[repr(C)]`?
+- [ ] **Enum values**: Are enum discriminants validated from external sources?
+- [ ] **Unions**: Is the correct union field accessed?
+
+## 5. Panic Safety
+
+- [ ] What state is the program in if this code panics?
+- [ ] Are partially constructed objects properly cleaned up?
+- [ ] Do Drop implementations see valid state?
+- [ ] Is there a panic guard if needed?
+
+## 6. FFI-Specific Checks
+
+- [ ] **Types**: Do Rust types match C types exactly?
+- [ ] **Strings**: Are strings properly null-terminated?
+- [ ] **Ownership**: Is it clear who owns/frees memory?
+- [ ] **Thread safety**: Are callbacks thread-safe?
+- [ ] **Panic boundary**: Are panics caught before crossing FFI?
+- [ ] **Error handling**: Are C-style errors properly handled?
+
+## 7. Concurrency Checks
+
+- [ ] **Send/Sync**: Are manual implementations actually sound?
+- [ ] **Atomics**: Are memory orderings correct?
+- [ ] **Locks**: Is there potential for deadlock?
+- [ ] **Data races**: Is all shared mutable state synchronized?
+
+## 8. Red Flags (Require Extra Scrutiny)
+
+| Pattern | Concern |
+|---------|---------|
+| `transmute` | Type compatibility, provenance |
+| `as` on pointers | Alignment, type punning |
+| `static mut` | Data races |
+| `*const T as *mut T` | Aliasing violation |
+| Manual `Send`/`Sync` | Thread safety |
+| `assume_init` | Initialization |
+| `set_len` on Vec | Uninitialized memory |
+| `from_raw_parts` | Lifetime, validity |
+| `offset`/`add`/`sub` | Out of bounds |
+| FFI callbacks | Panic safety |
+
+## 9. Verification Questions
+
+Ask the author:
+- "What would happen if [X invariant] was violated?"
+- "How do you know [pointer/reference] is valid here?"
+- "What if this panics at [specific line]?"
+- "Who is responsible for freeing this memory?"
+
+## 10. Testing Requirements
+
+- [ ] Has this been tested with Miri?
+- [ ] Are there unit tests covering edge cases?
+- [ ] Are there tests for error conditions?
+- [ ] Has concurrent code been tested under stress?
+
+## Review Severity Guide
+
+| Severity | Requires |
+|----------|----------|
+| `transmute` | Two reviewers, Miri test |
+| Manual `Send`/`Sync` | Thread safety expert review |
+| FFI | Documentation of C interface |
+| `static mut` | Justification for not using atomic/mutex |
+| Pointer arithmetic | Bounds proof |
+
+## Sample Review Comments
+
+```
+// Good SAFETY comment ✓
+// SAFETY: index was checked to be < len on line 42
+
+// Needs improvement ✗
+// SAFETY: This is safe because we know it works
+
+// Missing information ✗
+// SAFETY: ptr is valid
+// (Why is it valid? How do we know?)
+```

--- a/.agents/skills/unsafe-checker/examples/ffi-patterns.md
+++ b/.agents/skills/unsafe-checker/examples/ffi-patterns.md
@@ -1,0 +1,353 @@
+# FFI Best Practices and Patterns
+
+Examples of safe and idiomatic Rust-C interoperability.
+
+## Pattern 1: Basic FFI Wrapper
+
+```rust
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr::NonNull;
+
+// Raw C API
+mod ffi {
+    use super::*;
+
+    extern "C" {
+        pub fn lib_create(name: *const c_char) -> *mut c_void;
+        pub fn lib_destroy(handle: *mut c_void);
+        pub fn lib_process(handle: *mut c_void, data: *const u8, len: usize) -> c_int;
+        pub fn lib_get_error() -> *const c_char;
+    }
+}
+
+// Safe Rust wrapper
+pub struct Library {
+    handle: NonNull<c_void>,
+}
+
+#[derive(Debug)]
+pub struct LibraryError(String);
+
+impl Library {
+    pub fn new(name: &str) -> Result<Self, LibraryError> {
+        let c_name = CString::new(name).map_err(|_| LibraryError("invalid name".into()))?;
+
+        let handle = unsafe { ffi::lib_create(c_name.as_ptr()) };
+
+        NonNull::new(handle)
+            .map(|handle| Self { handle })
+            .ok_or_else(|| Self::last_error())
+    }
+
+    pub fn process(&self, data: &[u8]) -> Result<(), LibraryError> {
+        let result = unsafe {
+            ffi::lib_process(self.handle.as_ptr(), data.as_ptr(), data.len())
+        };
+
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(Self::last_error())
+        }
+    }
+
+    fn last_error() -> LibraryError {
+        let ptr = unsafe { ffi::lib_get_error() };
+        if ptr.is_null() {
+            LibraryError("unknown error".into())
+        } else {
+            let msg = unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned();
+            LibraryError(msg)
+        }
+    }
+}
+
+impl Drop for Library {
+    fn drop(&mut self) {
+        unsafe { ffi::lib_destroy(self.handle.as_ptr()); }
+    }
+}
+
+// Prevent accidental copies
+impl !Clone for Library {}
+```
+
+## Pattern 2: Callback Registration
+
+```rust
+use std::os::raw::{c_int, c_void};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+type CCallback = extern "C" fn(value: c_int, user_data: *mut c_void) -> c_int;
+
+extern "C" {
+    fn register_callback(cb: CCallback, user_data: *mut c_void);
+    fn unregister_callback();
+}
+
+/// Safely register a Rust closure as a C callback.
+pub struct CallbackGuard<F> {
+    _closure: Box<F>,
+}
+
+impl<F: FnMut(i32) -> i32 + 'static> CallbackGuard<F> {
+    pub fn register(closure: F) -> Self {
+        let boxed = Box::new(closure);
+        let user_data = Box::into_raw(boxed) as *mut c_void;
+
+        extern "C" fn trampoline<F: FnMut(i32) -> i32>(
+            value: c_int,
+            user_data: *mut c_void,
+        ) -> c_int {
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                let closure = unsafe { &mut *(user_data as *mut F) };
+                closure(value as i32) as c_int
+            }));
+            result.unwrap_or(-1)
+        }
+
+        unsafe {
+            register_callback(trampoline::<F>, user_data);
+        }
+
+        Self {
+            // SAFETY: We just created this box and need to keep it alive
+            _closure: unsafe { Box::from_raw(user_data as *mut F) },
+        }
+    }
+}
+
+impl<F> Drop for CallbackGuard<F> {
+    fn drop(&mut self) {
+        unsafe { unregister_callback(); }
+        // Box in _closure is dropped automatically
+    }
+}
+
+// Usage
+fn example() {
+    let multiplier = 2;
+    let _guard = CallbackGuard::register(move |x| x * multiplier);
+    // Callback is active until _guard is dropped
+}
+```
+
+## Pattern 3: Opaque Handle Types
+
+```rust
+use std::marker::PhantomData;
+
+// Opaque type markers - prevents mixing up handles
+#[repr(C)]
+pub struct DatabaseHandle {
+    _data: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct ConnectionHandle {
+    _data: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+mod ffi {
+    use super::*;
+
+    extern "C" {
+        pub fn db_open(path: *const c_char) -> *mut DatabaseHandle;
+        pub fn db_close(db: *mut DatabaseHandle);
+        pub fn db_connect(db: *mut DatabaseHandle) -> *mut ConnectionHandle;
+        pub fn conn_close(conn: *mut ConnectionHandle);
+        pub fn conn_query(conn: *mut ConnectionHandle, sql: *const c_char) -> c_int;
+    }
+}
+
+// Type-safe wrappers
+pub struct Database {
+    handle: NonNull<DatabaseHandle>,
+}
+
+pub struct Connection<'db> {
+    handle: NonNull<ConnectionHandle>,
+    _db: PhantomData<&'db Database>,
+}
+
+impl Database {
+    pub fn open(path: &str) -> Result<Self, ()> {
+        let c_path = CString::new(path).map_err(|_| ())?;
+        let handle = unsafe { ffi::db_open(c_path.as_ptr()) };
+        NonNull::new(handle).map(|h| Self { handle: h }).ok_or(())
+    }
+
+    pub fn connect(&self) -> Result<Connection<'_>, ()> {
+        let handle = unsafe { ffi::db_connect(self.handle.as_ptr()) };
+        NonNull::new(handle)
+            .map(|h| Connection { handle: h, _db: PhantomData })
+            .ok_or(())
+    }
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        // All Connections must be dropped first (enforced by lifetime)
+        unsafe { ffi::db_close(self.handle.as_ptr()); }
+    }
+}
+
+impl Connection<'_> {
+    pub fn query(&self, sql: &str) -> Result<(), ()> {
+        let c_sql = CString::new(sql).map_err(|_| ())?;
+        let result = unsafe { ffi::conn_query(self.handle.as_ptr(), c_sql.as_ptr()) };
+        if result == 0 { Ok(()) } else { Err(()) }
+    }
+}
+
+impl Drop for Connection<'_> {
+    fn drop(&mut self) {
+        unsafe { ffi::conn_close(self.handle.as_ptr()); }
+    }
+}
+```
+
+## Pattern 4: Error Handling Across FFI
+
+```rust
+use std::os::raw::c_int;
+
+// Error codes for C
+pub const SUCCESS: c_int = 0;
+pub const ERR_NULL_PTR: c_int = 1;
+pub const ERR_INVALID_UTF8: c_int = 2;
+pub const ERR_IO: c_int = 3;
+pub const ERR_PANIC: c_int = -1;
+
+// Thread-local error storage
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<Box<dyn std::error::Error>>> =
+        std::cell::RefCell::new(None);
+}
+
+fn set_last_error<E: std::error::Error + 'static>(err: E) {
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = Some(Box::new(err));
+    });
+}
+
+/// Get the last error message. Caller must free with `free_string`.
+#[no_mangle]
+pub extern "C" fn get_last_error() -> *mut c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow()
+            .as_ref()
+            .map(|err| {
+                CString::new(err.to_string())
+                    .unwrap_or_else(|_| CString::new("error").unwrap())
+                    .into_raw()
+            })
+            .unwrap_or(std::ptr::null_mut())
+    })
+}
+
+/// Free a string returned by this library.
+#[no_mangle]
+pub extern "C" fn free_string(s: *mut c_char) {
+    if !s.is_null() {
+        // SAFETY: String was created by CString::into_raw
+        unsafe { drop(CString::from_raw(s)); }
+    }
+}
+
+/// Example function with proper error handling.
+#[no_mangle]
+pub extern "C" fn do_operation(data: *const u8, len: usize) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| -> Result<(), c_int> {
+        if data.is_null() {
+            return Err(ERR_NULL_PTR);
+        }
+
+        let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+        std::str::from_utf8(slice)
+            .map_err(|e| {
+                set_last_error(e);
+                ERR_INVALID_UTF8
+            })?;
+
+        // Do actual work...
+
+        Ok(())
+    }));
+
+    match result {
+        Ok(Ok(())) => SUCCESS,
+        Ok(Err(code)) => code,
+        Err(_) => ERR_PANIC,
+    }
+}
+```
+
+## Pattern 5: Struct with C Layout
+
+```rust
+use std::os::raw::{c_char, c_int};
+
+/// A C-compatible configuration struct.
+#[repr(C)]
+pub struct Config {
+    pub version: c_int,
+    pub flags: u32,
+    pub name: [c_char; 64],
+    pub name_len: usize,
+}
+
+impl Config {
+    pub fn new(version: i32, flags: u32, name: &str) -> Option<Self> {
+        if name.len() >= 64 {
+            return None;
+        }
+
+        let mut config = Self {
+            version: version as c_int,
+            flags,
+            name: [0; 64],
+            name_len: name.len(),
+        };
+
+        // Copy name bytes
+        for (i, byte) in name.bytes().enumerate() {
+            config.name[i] = byte as c_char;
+        }
+
+        Some(config)
+    }
+
+    pub fn name(&self) -> &str {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                self.name.as_ptr() as *const u8,
+                self.name_len,
+            )
+        };
+        // SAFETY: We only store valid UTF-8 in new()
+        unsafe { std::str::from_utf8_unchecked(bytes) }
+    }
+}
+
+// Verify layout at compile time
+const _: () = {
+    assert!(std::mem::size_of::<Config>() == 80);  // 4 + 4 + 64 + 8
+    assert!(std::mem::align_of::<Config>() == 8);
+};
+```
+
+## Key FFI Guidelines
+
+1. **Always use `#[repr(C)]`** for types crossing FFI
+2. **Handle null pointers** at the boundary
+3. **Catch panics** before returning to C
+4. **Document ownership** clearly
+5. **Use opaque types** for type safety
+6. **Keep unsafe minimal** and well-documented

--- a/.agents/skills/unsafe-checker/examples/safe-abstraction.md
+++ b/.agents/skills/unsafe-checker/examples/safe-abstraction.md
@@ -1,0 +1,272 @@
+# Safe Abstraction Examples
+
+Examples of building safe APIs on top of unsafe code.
+
+## Example 1: Simple Wrapper with Bounds Check
+
+```rust
+/// A slice wrapper that provides unchecked access internally
+/// but safe access externally.
+pub struct SafeSlice<'a, T> {
+    ptr: *const T,
+    len: usize,
+    _marker: std::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T> SafeSlice<'a, T> {
+    /// Creates a SafeSlice from a regular slice.
+    pub fn new(slice: &'a [T]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Safe get - returns Option.
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            // SAFETY: We just verified index < len
+            Some(unsafe { &*self.ptr.add(index) })
+        } else {
+            None
+        }
+    }
+
+    /// Unsafe get - caller must ensure bounds.
+    ///
+    /// # Safety
+    /// `index` must be less than `self.len()`.
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        debug_assert!(index < self.len);
+        &*self.ptr.add(index)
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+```
+
+## Example 2: Resource Wrapper with Drop
+
+```rust
+use std::ptr::NonNull;
+
+/// Safe wrapper around a C-allocated buffer.
+pub struct CBuffer {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+extern "C" {
+    fn c_alloc(size: usize) -> *mut u8;
+    fn c_free(ptr: *mut u8);
+}
+
+impl CBuffer {
+    /// Creates a new buffer. Returns None if allocation fails.
+    pub fn new(size: usize) -> Option<Self> {
+        let ptr = unsafe { c_alloc(size) };
+        NonNull::new(ptr).map(|ptr| Self { ptr, len: size })
+    }
+
+    /// Returns a slice view of the buffer.
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for len bytes (from c_alloc contract)
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Returns a mutable slice view.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: We have &mut self, so exclusive access
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl Drop for CBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by c_alloc and not yet freed
+        unsafe { c_free(self.ptr.as_ptr()); }
+    }
+}
+
+// Prevent double-free
+impl !Clone for CBuffer {}
+
+// Safe to send between threads (assuming c_alloc is thread-safe)
+unsafe impl Send for CBuffer {}
+```
+
+## Example 3: Interior Mutability with UnsafeCell
+
+```rust
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A simple spinlock demonstrating safe abstraction over UnsafeCell.
+pub struct SpinLock<T> {
+    locked: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+pub struct SpinLockGuard<'a, T> {
+    lock: &'a SpinLock<T>,
+}
+
+impl<T> SpinLock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> SpinLockGuard<'_, T> {
+        // Spin until we acquire the lock
+        while self.locked.compare_exchange_weak(
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ).is_err() {
+            std::hint::spin_loop();
+        }
+        SpinLockGuard { lock: self }
+    }
+}
+
+impl<T> std::ops::Deref for SpinLockGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: We hold the lock, so we have exclusive access
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T> std::ops::DerefMut for SpinLockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We hold the lock, so we have exclusive access
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<T> Drop for SpinLockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}
+
+// SAFETY: The lock ensures only one thread accesses data at a time
+unsafe impl<T: Send> Sync for SpinLock<T> {}
+unsafe impl<T: Send> Send for SpinLock<T> {}
+```
+
+## Example 4: Iterator with Lifetime Tracking
+
+```rust
+use std::marker::PhantomData;
+
+/// An iterator over raw pointer range with proper lifetime tracking.
+pub struct PtrIter<'a, T> {
+    current: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T> PtrIter<'a, T> {
+    /// Creates an iterator from a slice.
+    pub fn new(slice: &'a [T]) -> Self {
+        let ptr = slice.as_ptr();
+        Self {
+            current: ptr,
+            // SAFETY: Adding len to slice pointer is always valid
+            end: unsafe { ptr.add(slice.len()) },
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for PtrIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.end {
+            None
+        } else {
+            // SAFETY:
+            // - current < end (checked above)
+            // - PhantomData<&'a T> ensures the data lives for 'a
+            let item = unsafe { &*self.current };
+            self.current = unsafe { self.current.add(1) };
+            Some(item)
+        }
+    }
+}
+```
+
+## Example 5: Builder Pattern with Delayed Initialization
+
+```rust
+use std::mem::MaybeUninit;
+
+/// A builder that collects exactly N items, then produces an array.
+pub struct ArrayBuilder<T, const N: usize> {
+    data: [MaybeUninit<T>; N],
+    count: usize,
+}
+
+impl<T, const N: usize> ArrayBuilder<T, N> {
+    pub fn new() -> Self {
+        Self {
+            // SAFETY: MaybeUninit doesn't require initialization
+            data: unsafe { MaybeUninit::uninit().assume_init() },
+            count: 0,
+        }
+    }
+
+    pub fn push(&mut self, value: T) -> Result<(), T> {
+        if self.count >= N {
+            return Err(value);
+        }
+        self.data[self.count].write(value);
+        self.count += 1;
+        Ok(())
+    }
+
+    pub fn build(self) -> Option<[T; N]> {
+        if self.count != N {
+            return None;
+        }
+
+        // SAFETY: All N elements have been initialized
+        let result = unsafe {
+            // Prevent drop of self.data (we're moving out)
+            let data = std::ptr::read(&self.data);
+            std::mem::forget(self);
+            // Transmute MaybeUninit array to initialized array
+            std::mem::transmute_copy::<[MaybeUninit<T>; N], [T; N]>(&data)
+        };
+        Some(result)
+    }
+}
+
+impl<T, const N: usize> Drop for ArrayBuilder<T, N> {
+    fn drop(&mut self) {
+        // Drop only initialized elements
+        for i in 0..self.count {
+            // SAFETY: Elements 0..count are initialized
+            unsafe { self.data[i].assume_init_drop(); }
+        }
+    }
+}
+```
+
+## Key Patterns
+
+1. **Encapsulation**: Hide unsafe behind safe public API
+2. **Invariant maintenance**: Use private fields to maintain invariants
+3. **PhantomData**: Track lifetimes and ownership for pointers
+4. **RAII**: Use Drop for cleanup
+5. **Type state**: Use types to encode valid states

--- a/.agents/skills/unsafe-checker/rules/_sections.md
+++ b/.agents/skills/unsafe-checker/rules/_sections.md
@@ -1,0 +1,77 @@
+# Unsafe Checker - Section Definitions
+
+## Section Overview
+
+| # | Section | Prefix | Level | Count | Impact |
+|---|---------|--------|-------|-------|--------|
+| 1 | General Principles | `general-` | CRITICAL | 3 | Foundational unsafe usage guidance |
+| 2 | Safety Abstraction | `safety-` | CRITICAL | 11 | Building sound safe APIs |
+| 3 | Raw Pointers | `ptr-` | HIGH | 6 | Pointer manipulation safety |
+| 4 | Union | `union-` | HIGH | 2 | Union type safety |
+| 5 | Memory Layout | `mem-` | HIGH | 6 | Data representation correctness |
+| 6 | FFI | `ffi-` | CRITICAL | 18 | C interoperability safety |
+| 7 | I/O Safety | `io-` | MEDIUM | 1 | Handle/resource safety |
+
+## Section Details
+
+### 1. General Principles (`general-`)
+
+**Focus**: When and why to use unsafe
+
+- P.UNS.01: Don't abuse unsafe to escape borrow checker
+- P.UNS.02: Don't use unsafe blindly for performance
+- G.UNS.01: Don't create aliases for "unsafe" named items
+
+### 2. Safety Abstraction (`safety-`)
+
+**Focus**: Building sound safe abstractions over unsafe code
+
+Key invariants:
+- Panic safety
+- Memory initialization
+- Send/Sync correctness
+- API soundness
+
+### 3. Raw Pointers (`ptr-`)
+
+**Focus**: Safe pointer manipulation patterns
+
+- Aliasing rules
+- Alignment requirements
+- Null/dangling prevention
+- Type casting
+
+### 4. Union (`union-`)
+
+**Focus**: Safe union usage (primarily for C interop)
+
+- Initialization rules
+- Lifetime considerations
+- Type punning dangers
+
+### 5. Memory Layout (`mem-`)
+
+**Focus**: Correct data representation
+
+- `#[repr(C)]` usage
+- Alignment and padding
+- Uninitialized memory
+- Cross-process memory
+
+### 6. FFI (`ffi-`)
+
+**Focus**: Safe C interoperability
+
+Subcategories:
+- String handling (CString, CStr)
+- Type compatibility
+- Error handling across FFI
+- Thread safety
+- Resource management
+
+### 7. I/O Safety (`io-`)
+
+**Focus**: Handle and resource ownership
+
+- Raw file descriptor safety
+- Handle validity guarantees

--- a/.agents/skills/unsafe-checker/rules/_template.md
+++ b/.agents/skills/unsafe-checker/rules/_template.md
@@ -1,0 +1,53 @@
+# Rule Template
+
+Use this template for all unsafe-checker rules.
+
+---
+
+```markdown
+---
+id: {prefix}-{number}
+original_id: P.UNS.XXX.YY or G.UNS.XXX.YY
+level: P|G
+impact: CRITICAL|HIGH|MEDIUM
+clippy: <clippy_lint_name> (if applicable)
+---
+
+# {Rule Title}
+
+## Summary
+
+One-sentence description of what this rule requires.
+
+## Rationale
+
+Why this rule matters for safety/soundness.
+
+## Bad Example
+
+```rust
+// DON'T: Description of the anti-pattern
+<code that violates the rule>
+```
+
+## Good Example
+
+```rust
+// DO: Description of the correct pattern
+<code that follows the rule>
+```
+
+## Common Violations
+
+1. Violation pattern 1
+2. Violation pattern 2
+
+## Checklist
+
+- [ ] Check item 1
+- [ ] Check item 2
+
+## Related Rules
+
+- `{other-rule-id}`: Brief description
+```

--- a/.agents/skills/unsafe-checker/rules/ffi-01-no-string-direct.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-01-no-string-direct.md
@@ -1,0 +1,122 @@
+---
+id: ffi-01
+original_id: P.UNS.FFI.01
+level: P
+impact: HIGH
+---
+
+# Avoid Passing Strings Directly to C from Public Rust API
+
+## Summary
+
+Use `CString` and `CStr` for string handling at FFI boundaries. Never pass Rust `String` or `&str` directly to C.
+
+## Rationale
+
+- Rust strings are UTF-8, not null-terminated
+- C strings require null terminator
+- Rust strings may contain interior null bytes
+- Memory layout differs between Rust String and C char*
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn c_print(s: *const u8);
+    fn c_strlen(s: *const u8) -> usize;
+}
+
+// DON'T: Pass Rust string directly
+fn bad_print(s: &str) {
+    unsafe {
+        c_print(s.as_ptr());  // Not null-terminated!
+    }
+}
+
+// DON'T: Assume length matches
+fn bad_strlen(s: &str) -> usize {
+    unsafe {
+        c_strlen(s.as_ptr())  // May read past buffer
+    }
+}
+
+// DON'T: Use String in FFI signatures
+extern "C" fn bad_callback(s: String) {  // Wrong!
+    println!("{}", s);
+}
+```
+
+## Good Example
+
+```rust
+use std::ffi::{CString, CStr};
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_print(s: *const c_char);
+    fn c_strlen(s: *const c_char) -> usize;
+    fn c_get_string() -> *const c_char;
+}
+
+// DO: Convert to CString for passing to C
+fn good_print(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;  // Adds null terminator, checks for interior nulls
+    unsafe {
+        c_print(c_string.as_ptr());
+    }
+    Ok(())
+}
+
+// DO: Use CStr for receiving C strings
+fn good_receive() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        let c_str = CStr::from_ptr(ptr);
+        c_str.to_string_lossy().into_owned()
+    }
+}
+
+// DO: Handle interior null bytes
+fn handle_nulls(s: &str) {
+    match CString::new(s) {
+        Ok(c_string) => unsafe { c_print(c_string.as_ptr()) },
+        Err(e) => {
+            // String contains interior null at position e.nul_position()
+            eprintln!("String contains null byte at {}", e.nul_position());
+        }
+    }
+}
+
+// DO: Use proper types in callbacks
+extern "C" fn good_callback(s: *const c_char) {
+    if !s.is_null() {
+        let c_str = unsafe { CStr::from_ptr(s) };
+        if let Ok(rust_str) = c_str.to_str() {
+            println!("{}", rust_str);
+        }
+    }
+}
+```
+
+## String Type Comparison
+
+| Type | Null-terminated | Encoding | Use |
+|------|-----------------|----------|-----|
+| `String` | No | UTF-8 | Rust owned |
+| `&str` | No | UTF-8 | Rust borrowed |
+| `CString` | Yes | Byte | Rust-to-C owned |
+| `&CStr` | Yes | Byte | Rust-to-C borrowed |
+| `*const c_char` | Yes | Byte | FFI pointer |
+| `OsString` | Platform | Platform | Paths, env |
+
+## Checklist
+
+- [ ] Am I passing Rust strings to C? → Use CString
+- [ ] Am I receiving C strings? → Use CStr
+- [ ] Does my string contain null bytes? → Handle NulError
+- [ ] Am I checking for null pointers from C?
+
+## Related Rules
+
+- `ffi-02`: Read documentation for std::ffi types
+- `ffi-06`: Ensure C-ABI string compatibility

--- a/.agents/skills/unsafe-checker/rules/ffi-02-read-ffi-docs.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-02-read-ffi-docs.md
@@ -1,0 +1,133 @@
+---
+id: ffi-02
+original_id: P.UNS.FFI.02
+level: P
+impact: MEDIUM
+---
+
+# Read Documentation Carefully When Using std::ffi Types
+
+## Summary
+
+The `std::ffi` module has many types with subtle differences. Read their documentation carefully to avoid misuse.
+
+## Key Types in std::ffi
+
+### CString vs CStr
+
+```rust
+use std::ffi::{CString, CStr};
+use std::os::raw::c_char;
+
+// CString: Owned, heap-allocated, null-terminated
+// - Use when creating strings to pass to C
+// - Owns the memory
+let owned = CString::new("hello").unwrap();
+let ptr: *const c_char = owned.as_ptr();
+// ptr valid until `owned` is dropped
+
+// CStr: Borrowed, null-terminated
+// - Use when receiving strings from C
+// - Does not own memory
+let borrowed: &CStr = unsafe { CStr::from_ptr(ptr) };
+// borrowed valid as long as ptr is valid
+```
+
+### OsString vs OsStr
+
+```rust
+use std::ffi::{OsString, OsStr};
+use std::path::Path;
+
+// OsString/OsStr: Platform-native strings
+// - Windows: potentially ill-formed UTF-16
+// - Unix: arbitrary bytes
+// - Use for paths and environment variables
+
+let path = Path::new("/some/path");
+let os_str: &OsStr = path.as_os_str();
+
+// Convert to Rust string (may fail)
+if let Some(s) = os_str.to_str() {
+    println!("Valid UTF-8: {}", s);
+}
+```
+
+### c_void and Opaque Types
+
+```rust
+use std::ffi::c_void;
+
+extern "C" {
+    fn get_handle() -> *mut c_void;
+    fn use_handle(h: *mut c_void);
+}
+
+// c_void is for truly opaque pointers
+// Better: use dedicated opaque types (see ffi-17)
+```
+
+## Common Pitfalls
+
+```rust
+use std::ffi::CString;
+
+// PITFALL 1: CString::as_ptr() lifetime
+fn bad_ptr() -> *const i8 {
+    let s = CString::new("hello").unwrap();
+    s.as_ptr()  // Dangling! s dropped at end of function
+}
+
+fn good_ptr(s: &CString) -> *const i8 {
+    s.as_ptr()  // OK: s outlives the pointer
+}
+
+// PITFALL 2: CString::new with interior nulls
+let result = CString::new("hello\0world");
+assert!(result.is_err());  // Interior null!
+
+// PITFALL 3: CStr::from_ptr safety
+unsafe {
+    let ptr: *const i8 = std::ptr::null();
+    // let cstr = CStr::from_ptr(ptr);  // UB: null pointer!
+
+    // Always check for null first
+    if !ptr.is_null() {
+        let cstr = CStr::from_ptr(ptr);
+    }
+}
+
+// PITFALL 4: CStr assumes valid null-terminated string
+unsafe {
+    let bytes = [104, 101, 108, 108, 111];  // "hello" without null
+    let ptr = bytes.as_ptr() as *const i8;
+    // let cstr = CStr::from_ptr(ptr);  // UB: no null terminator!
+
+    // Use from_bytes_with_nul instead
+    let bytes_with_nul = b"hello\0";
+    let cstr = CStr::from_bytes_with_nul(bytes_with_nul).unwrap();
+}
+```
+
+## Type Selection Guide
+
+| Scenario | Type |
+|----------|------|
+| Create string for C | `CString` |
+| Borrow string from C | `&CStr` |
+| File paths | `OsString`, `Path` |
+| Environment variables | `OsString` |
+| Opaque C pointers | Newtype over `*mut c_void` |
+| C integers | `c_int`, `c_long`, etc. |
+
+## Checklist
+
+- [ ] Have I read the docs for the std::ffi type I'm using?
+- [ ] Am I aware of the lifetime constraints?
+- [ ] Am I handling potential errors (NulError, UTF-8 errors)?
+- [ ] Is there a better type for my use case?
+
+## Related Rules
+
+- `ffi-01`: Use CString/CStr for strings
+- `ffi-17`: Use opaque types instead of c_void

--- a/.agents/skills/unsafe-checker/rules/ffi-03-drop-for-c-ptr.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-03-drop-for-c-ptr.md
@@ -1,0 +1,162 @@
+---
+id: ffi-03
+original_id: P.UNS.FFI.03
+level: P
+impact: CRITICAL
+---
+
+# Implement Drop for Rust Types Wrapping Memory-Managing C Pointers
+
+## Summary
+
+When wrapping a C pointer that owns memory, implement `Drop` to call the appropriate C deallocation function.
+
+## Rationale
+
+- C allocated memory must be freed with the matching C function
+- Rust's default drop won't clean up foreign memory
+- Resource leaks and double-frees are common FFI bugs
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn create_resource() -> *mut Resource;
+    fn free_resource(r: *mut Resource);
+}
+
+// DON'T: Wrapper without Drop
+struct ResourceHandle {
+    ptr: *mut Resource,
+}
+
+impl ResourceHandle {
+    fn new() -> Self {
+        Self {
+            ptr: unsafe { create_resource() }
+        }
+    }
+    // Memory leak! ptr is never freed
+}
+
+// DON'T: Forget to handle null
+impl Drop for BadHandle {
+    fn drop(&mut self) {
+        unsafe {
+            free_resource(self.ptr);  // Crash if ptr is null!
+        }
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::ptr::NonNull;
+
+extern "C" {
+    fn create_resource() -> *mut Resource;
+    fn free_resource(r: *mut Resource);
+}
+
+// DO: Proper wrapper with Drop
+struct ResourceHandle {
+    ptr: NonNull<Resource>,
+}
+
+impl ResourceHandle {
+    fn new() -> Option<Self> {
+        let ptr = unsafe { create_resource() };
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+
+    fn as_ptr(&self) -> *mut Resource {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for ResourceHandle {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by create_resource
+        // and hasn't been freed yet
+        unsafe {
+            free_resource(self.ptr.as_ptr());
+        }
+    }
+}
+
+// Prevent accidental copies that would cause double-free
+impl !Clone for ResourceHandle {}
+
+// DO: Document ownership transfer
+impl ResourceHandle {
+    /// Consumes the handle and returns the raw pointer.
+    ///
+    /// The caller is responsible for freeing the resource.
+    fn into_raw(self) -> *mut Resource {
+        let ptr = self.ptr.as_ptr();
+        std::mem::forget(self);  // Don't run Drop
+        ptr
+    }
+
+    /// Creates a handle from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// ptr must have been allocated by create_resource()
+    /// and not yet freed.
+    unsafe fn from_raw(ptr: *mut Resource) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+}
+```
+
+## Complete Pattern with Multiple Resources
+
+```rust
+struct Connection {
+    handle: NonNull<c_void>,
+}
+
+struct Statement<'conn> {
+    handle: NonNull<c_void>,
+    _conn: std::marker::PhantomData<&'conn Connection>,
+}
+
+impl Connection {
+    fn prepare(&self, sql: &str) -> Option<Statement<'_>> {
+        let handle = unsafe { db_prepare(self.handle.as_ptr(), sql.as_ptr()) };
+        NonNull::new(handle).map(|handle| Statement {
+            handle,
+            _conn: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Statements must be dropped before Connection
+        // PhantomData ensures this at compile time
+        unsafe { db_close(self.handle.as_ptr()); }
+    }
+}
+
+impl Drop for Statement<'_> {
+    fn drop(&mut self) {
+        unsafe { db_finalize(self.handle.as_ptr()); }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Does my wrapper own the C resource?
+- [ ] Did I implement Drop with the correct C free function?
+- [ ] Did I handle null pointers?
+- [ ] Did I prevent Clone/Copy to avoid double-free?
+- [ ] Did I consider ownership transfer methods (into_raw/from_raw)?
+
+## Related Rules
+
+- `mem-03`: Don't let String/Vec drop foreign memory
+- `ffi-07`: Don't implement Drop for types passed to external code

--- a/.agents/skills/unsafe-checker/rules/ffi-04-panic-boundary.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-04-panic-boundary.md
@@ -1,0 +1,145 @@
+---
+id: ffi-04
+original_id: P.UNS.FFI.04
+level: P
+impact: CRITICAL
+clippy: panic_in_result_fn
+---
+
+# Handle Panics When Crossing FFI Boundaries
+
+## Summary
+
+Panics must not unwind across FFI boundaries. Use `catch_unwind` or mark functions as `extern "C-unwind"`.
+
+## Rationale
+
+- Unwinding across C code is undefined behavior
+- C has no concept of Rust panics
+- Can corrupt C stack frames and cause crashes
+- Even with `panic=abort`, still UB to attempt unwinding in `extern "C"`
+
+## Bad Example
+
+```rust
+// DON'T: Allow panics to escape to C
+#[no_mangle]
+pub extern "C" fn callback(data: *const u8, len: usize) -> i32 {
+    let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+    // If this panics, UB occurs!
+    let sum: i32 = slice.iter().map(|&x| x as i32).sum();
+
+    // If this panics due to overflow in debug, UB!
+    process(sum)
+}
+
+// DON'T: Unwrap in extern functions
+#[no_mangle]
+pub extern "C" fn parse_config(path: *const c_char) -> i32 {
+    let path = unsafe { CStr::from_ptr(path) };
+    let config = std::fs::read_to_string(path.to_str().unwrap()).unwrap();  // Can panic!
+    0
+}
+```
+
+## Good Example
+
+```rust
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+// DO: Catch panics at FFI boundary
+#[no_mangle]
+pub extern "C" fn safe_callback(data: *const u8, len: usize) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        if data.is_null() || len == 0 {
+            return -1;
+        }
+
+        let slice = unsafe { std::slice::from_raw_parts(data, len) };
+        let sum: i32 = slice.iter().map(|&x| x as i32).sum();
+        sum
+    }));
+
+    match result {
+        Ok(value) => value,
+        Err(_) => {
+            // Log error, return error code
+            eprintln!("Panic caught at FFI boundary");
+            -1
+        }
+    }
+}
+
+// DO: Use Result-based API internally
+#[no_mangle]
+pub extern "C" fn parse_config(path: *const c_char) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| -> Result<(), Box<dyn std::error::Error>> {
+        let path = unsafe { CStr::from_ptr(path) }.to_str()?;
+        let _config = std::fs::read_to_string(path)?;
+        Ok(())
+    }));
+
+    match result {
+        Ok(Ok(())) => 0,
+        Ok(Err(e)) => {
+            eprintln!("Error: {}", e);
+            -1
+        }
+        Err(_) => {
+            eprintln!("Panic in parse_config");
+            -2
+        }
+    }
+}
+
+// DO: For Rust-calling-Rust across C, use "C-unwind"
+#[no_mangle]
+pub extern "C-unwind" fn rust_callback_can_unwind() {
+    // This is OK to panic if called from Rust through C
+    // The "C-unwind" ABI allows unwinding
+    panic!("This is allowed");
+}
+```
+
+## FFI Error Handling Pattern
+
+```rust
+// Define error codes
+const SUCCESS: c_int = 0;
+const ERR_NULL_PTR: c_int = -1;
+const ERR_INVALID_UTF8: c_int = -2;
+const ERR_IO: c_int = -3;
+const ERR_PANIC: c_int = -99;
+
+// Thread-local for detailed error
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> = std::cell::RefCell::new(None);
+}
+
+fn set_error(msg: String) {
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg));
+}
+
+#[no_mangle]
+pub extern "C" fn get_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow().as_ref().map(|s| s.as_ptr() as *const c_char)
+            .unwrap_or(std::ptr::null())
+    })
+}
+```
+
+## Checklist
+
+- [ ] Does my extern "C" function use catch_unwind?
+- [ ] Am I avoiding unwrap/expect in FFI functions?
+- [ ] Do I return error codes for error conditions?
+- [ ] Have I considered using "C-unwind" for Rust-to-Rust through C?
+
+## Related Rules
+
+- `ffi-08`: Handle errors properly in FFI
+- `safety-01`: Panic safety

--- a/.agents/skills/unsafe-checker/rules/ffi-05-portable-types.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-05-portable-types.md
@@ -1,0 +1,113 @@
+---
+id: ffi-05
+original_id: P.UNS.FFI.05
+level: P
+impact: HIGH
+---
+
+# Use Portable Type Aliases from std or libc
+
+## Summary
+
+Use type aliases from `std::os::raw` or the `libc` crate for C-compatible types. Don't assume sizes of C types.
+
+## Rationale
+
+- C types have platform-dependent sizes (`int` is not always 32 bits)
+- `long` is 32 bits on Windows, 64 bits on Unix
+- Using Rust primitives directly causes portability bugs
+
+## Bad Example
+
+```rust
+// DON'T: Use Rust types directly for C interop
+extern "C" {
+    fn c_function(x: i32, y: i64) -> i32;  // Might not match C types!
+}
+
+// DON'T: Assume sizes
+#[repr(C)]
+struct BadStruct {
+    count: i32,   // C 'int' might not be 32 bits
+    size: i64,    // C 'long' varies by platform!
+    ptr: usize,   // size_t? intptr_t? Different!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_long, c_char, c_void};
+
+// DO: Use std::os::raw types
+extern "C" {
+    fn c_function(x: c_int, y: c_long) -> c_int;
+}
+
+// DO: Use libc for more types
+use libc::{size_t, ssize_t, off_t, pid_t, time_t};
+
+extern "C" {
+    fn read(fd: c_int, buf: *mut c_void, count: size_t) -> ssize_t;
+    fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    fn getpid() -> pid_t;
+}
+
+// DO: Match C struct layout
+#[repr(C)]
+struct GoodStruct {
+    count: c_int,
+    size: c_long,
+    data: *mut c_void,
+}
+
+// DO: Use isize/usize for pointer-sized integers
+#[repr(C)]
+struct PointerSized {
+    offset: isize,     // intptr_t equivalent
+    size: usize,       // size_t in pointer arithmetic
+}
+```
+
+## Type Mapping Reference
+
+| C Type | Rust Type | Notes |
+|--------|-----------|-------|
+| `char` | `c_char` | May be signed or unsigned! |
+| `signed char` | `i8` | |
+| `unsigned char` | `u8` | |
+| `short` | `c_short` | Usually i16 |
+| `int` | `c_int` | Usually i32 |
+| `long` | `c_long` | 32 or 64 bits! |
+| `long long` | `c_longlong` | Usually i64 |
+| `size_t` | `usize` or `libc::size_t` | |
+| `ssize_t` | `isize` or `libc::ssize_t` | |
+| `float` | `c_float` / `f32` | |
+| `double` | `c_double` / `f64` | |
+| `void*` | `*mut c_void` | |
+| `const void*` | `*const c_void` | |
+
+## Platform Differences
+
+```rust
+#[cfg(target_pointer_width = "64")]
+type PtrDiff = i64;
+
+#[cfg(target_pointer_width = "32")]
+type PtrDiff = i32;
+
+// Better: use isize
+let diff: isize = ptr1 as isize - ptr2 as isize;
+```
+
+## Checklist
+
+- [ ] Am I using std::os::raw or libc types for FFI?
+- [ ] Have I avoided assuming c_long is 64 bits?
+- [ ] Am I using size_t/usize for sizes?
+- [ ] Have I tested on multiple platforms?
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout
+- `ffi-14`: Types in FFI should have stable layout

--- a/.agents/skills/unsafe-checker/rules/ffi-06-string-abi.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-06-string-abi.md
@@ -1,0 +1,151 @@
+---
+id: ffi-06
+original_id: P.UNS.FFI.06
+level: P
+impact: HIGH
+---
+
+# Ensure C-ABI Compatibility for Strings Between Rust and C
+
+## Summary
+
+When passing strings across FFI, ensure both sides agree on encoding, null-termination, and memory ownership.
+
+## Rationale
+
+- Rust strings are UTF-8, C strings are byte arrays
+- C expects null termination, Rust strings don't have it
+- Memory ownership must be explicit to avoid leaks/double-frees
+
+## String Passing Patterns
+
+### Rust to C (Caller Allocates)
+
+```rust
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_process_string(s: *const c_char);
+}
+
+fn rust_to_c(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;
+    // c_string lives until end of scope
+    unsafe {
+        c_process_string(c_string.as_ptr());
+    }
+    // c_string dropped here, memory freed
+    Ok(())
+}
+```
+
+### C to Rust (C Allocates, Rust Borrows)
+
+```rust
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_get_string() -> *const c_char;
+}
+
+fn c_to_rust() -> Option<String> {
+    let ptr = unsafe { c_get_string() };
+    if ptr.is_null() {
+        return None;
+    }
+    // Borrow from C, don't take ownership
+    let c_str = unsafe { CStr::from_ptr(ptr) };
+    Some(c_str.to_string_lossy().into_owned())
+}
+```
+
+### C to Rust (Ownership Transfer)
+
+```rust
+extern "C" {
+    fn c_create_string() -> *mut c_char;
+    fn c_free_string(s: *mut c_char);
+}
+
+struct CAllocatedString {
+    ptr: *mut c_char,
+}
+
+impl CAllocatedString {
+    fn new() -> Option<Self> {
+        let ptr = unsafe { c_create_string() };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self { ptr })
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        let c_str = unsafe { CStr::from_ptr(self.ptr) };
+        c_str.to_str().unwrap_or("")
+    }
+}
+
+impl Drop for CAllocatedString {
+    fn drop(&mut self) {
+        unsafe { c_free_string(self.ptr); }
+    }
+}
+```
+
+### Rust to C (Ownership Transfer)
+
+```rust
+extern "C" {
+    fn c_take_ownership(s: *mut c_char);  // C will free
+}
+
+fn give_to_c(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;
+    let ptr = c_string.into_raw();  // Don't drop CString
+
+    unsafe {
+        c_take_ownership(ptr);
+        // C now owns this memory
+        // To free it back in Rust: let _ = CString::from_raw(ptr);
+    }
+    Ok(())
+}
+```
+
+## Encoding Considerations
+
+```rust
+// UTF-8 to platform encoding
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStrExt;
+
+fn to_platform_string(s: &str) -> CString {
+    // On Unix, UTF-8 usually works
+    CString::new(s).unwrap()
+}
+
+#[cfg(windows)]
+fn to_wide_string(s: &str) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    std::ffi::OsStr::new(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+```
+
+## Checklist
+
+- [ ] Is the string null-terminated when passed to C?
+- [ ] Who allocates the memory? Who frees it?
+- [ ] Is the encoding (UTF-8, ASCII, platform) documented?
+- [ ] Am I handling conversion errors (interior nulls, invalid UTF-8)?
+
+## Related Rules
+
+- `ffi-01`: Use CString/CStr at FFI boundaries
+- `ffi-02`: Read std::ffi documentation

--- a/.agents/skills/unsafe-checker/rules/ffi-07-no-drop-external.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-07-no-drop-external.md
@@ -1,0 +1,131 @@
+---
+id: ffi-07
+original_id: P.UNS.FFI.07
+level: P
+impact: HIGH
+---
+
+# Do Not Implement Drop for Types Passed to External Code
+
+## Summary
+
+If a type will be passed to external code that manages its lifetime, don't implement `Drop`. Otherwise, both Rust and the external code will try to free it.
+
+## Rationale
+
+- External code (C library) may take ownership of the data
+- If Rust also tries to drop it, you get double-free
+- Need clear ownership boundaries
+
+## Bad Example
+
+```rust
+// DON'T: Drop on type that external code will free
+#[repr(C)]
+struct EventHandler {
+    callback: extern "C" fn(i32),
+    user_data: *mut c_void,
+}
+
+impl Drop for EventHandler {
+    fn drop(&mut self) {
+        // BAD: What if the C library already freed user_data?
+        unsafe { libc::free(self.user_data); }
+    }
+}
+
+extern "C" {
+    // C takes ownership and frees EventHandler when done
+    fn register_handler(h: *mut EventHandler);
+}
+
+fn bad_register() {
+    let handler = EventHandler { /* ... */ };
+    let ptr = Box::into_raw(Box::new(handler));
+    unsafe {
+        register_handler(ptr);
+        // If C code frees this, and Rust's Drop runs too = double-free
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: No Drop for types whose lifetime is managed externally
+#[repr(C)]
+struct EventHandler {
+    callback: extern "C" fn(i32),
+    user_data: *mut c_void,
+}
+// No Drop impl - C library manages lifetime
+
+extern "C" {
+    fn register_handler(h: *mut EventHandler);
+    fn unregister_handler(h: *mut EventHandler);
+}
+
+// DO: Wrap in a Rust type that knows when it's safe to drop
+struct RegisteredHandler {
+    ptr: *mut EventHandler,
+    registered: bool,
+}
+
+impl RegisteredHandler {
+    fn register(handler: EventHandler) -> Self {
+        let ptr = Box::into_raw(Box::new(handler));
+        unsafe { register_handler(ptr); }
+        Self { ptr, registered: true }
+    }
+
+    fn unregister(&mut self) {
+        if self.registered {
+            unsafe { unregister_handler(self.ptr); }
+            self.registered = false;
+        }
+    }
+}
+
+impl Drop for RegisteredHandler {
+    fn drop(&mut self) {
+        self.unregister();
+        // Only free if we still own it
+        if !self.registered {
+            unsafe { drop(Box::from_raw(self.ptr)); }
+        }
+    }
+}
+
+// DO: Use ManuallyDrop for explicit control
+use std::mem::ManuallyDrop;
+
+fn explicit_ownership() {
+    let handler = ManuallyDrop::new(EventHandler { /* ... */ });
+    let ptr = &*handler as *const EventHandler as *mut EventHandler;
+    unsafe {
+        register_handler(ptr);
+        // C now owns handler, don't drop it in Rust
+    }
+}
+```
+
+## Ownership Patterns
+
+| Pattern | Who Owns | Rust Drop? |
+|---------|----------|------------|
+| Rust creates, Rust frees | Rust | Yes |
+| Rust creates, C frees | C | No |
+| C creates, C frees | C | No (use wrapper) |
+| C creates, Rust frees | Rust | Yes (in wrapper) |
+
+## Checklist
+
+- [ ] Who will free this type's memory?
+- [ ] If external code frees it, am I avoiding Drop?
+- [ ] If ownership is conditional, do I track it?
+- [ ] Am I using ManuallyDrop or forget() when transferring ownership?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for wrapped C pointers (opposite case)
+- `mem-03`: Don't let String/Vec drop foreign memory

--- a/.agents/skills/unsafe-checker/rules/ffi-08-error-handling.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-08-error-handling.md
@@ -1,0 +1,146 @@
+---
+id: ffi-08
+original_id: P.UNS.FFI.08
+level: P
+impact: HIGH
+---
+
+# Handle Errors Properly in FFI
+
+## Summary
+
+FFI functions must use C-compatible error handling (return codes, errno, out parameters). Rust's Result/Option don't cross FFI boundaries.
+
+## Rationale
+
+- C doesn't have Result or Option
+- Exceptions don't exist in C
+- Must use patterns C code understands
+
+## Bad Example
+
+```rust
+// DON'T: Return Result across FFI
+#[no_mangle]
+pub extern "C" fn bad_open(path: *const c_char) -> Result<Handle, Error> {
+    // Result is not C-compatible!
+    unimplemented!()
+}
+
+// DON'T: Return Option across FFI
+#[no_mangle]
+pub extern "C" fn bad_find(id: i32) -> Option<*mut Data> {
+    // Option<*mut T> might work but is confusing
+    unimplemented!()
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_char, c_int};
+
+// Error codes
+const SUCCESS: c_int = 0;
+const ERR_NULL_PTR: c_int = 1;
+const ERR_INVALID_PATH: c_int = 2;
+const ERR_FILE_NOT_FOUND: c_int = 3;
+const ERR_PERMISSION: c_int = 4;
+const ERR_UNKNOWN: c_int = -1;
+
+// DO: Return error code, output via pointer
+#[no_mangle]
+pub extern "C" fn open_file(
+    path: *const c_char,
+    out_handle: *mut *mut Handle
+) -> c_int {
+    if path.is_null() || out_handle.is_null() {
+        return ERR_NULL_PTR;
+    }
+
+    let path_str = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return ERR_INVALID_PATH,
+    };
+
+    match File::open(path_str) {
+        Ok(file) => {
+            let handle = Box::into_raw(Box::new(Handle { file }));
+            unsafe { *out_handle = handle; }
+            SUCCESS
+        }
+        Err(e) => {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => ERR_FILE_NOT_FOUND,
+                std::io::ErrorKind::PermissionDenied => ERR_PERMISSION,
+                _ => ERR_UNKNOWN,
+            }
+        }
+    }
+}
+
+// DO: Use errno for POSIX-style APIs
+#[cfg(unix)]
+#[no_mangle]
+pub extern "C" fn posix_style_read(
+    fd: c_int,
+    buf: *mut u8,
+    count: usize
+) -> isize {
+    if buf.is_null() {
+        unsafe { *libc::__errno_location() = libc::EINVAL; }
+        return -1;
+    }
+
+    // ... do read ...
+    // On error:
+    // unsafe { *libc::__errno_location() = error_code; }
+    // return -1;
+
+    count as isize
+}
+
+// DO: Provide error message function
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> = std::cell::RefCell::new(None);
+}
+
+#[no_mangle]
+pub extern "C" fn get_error_message(buf: *mut c_char, len: usize) -> c_int {
+    LAST_ERROR.with(|e| {
+        if let Some(msg) = e.borrow().as_ref() {
+            let bytes = msg.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), len.saturating_sub(1));
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf as *mut u8, copy_len);
+                *buf.add(copy_len) = 0;
+            }
+            SUCCESS
+        } else {
+            ERR_UNKNOWN
+        }
+    })
+}
+```
+
+## Error Handling Patterns
+
+| Pattern | Usage |
+|---------|-------|
+| Return code | Simple success/failure |
+| Return code + out param | Return value on success |
+| errno | POSIX-style APIs |
+| Error message function | Detailed error info |
+| Last-error thread-local | Windows-style APIs |
+
+## Checklist
+
+- [ ] Am I returning C-compatible error indicators?
+- [ ] Are output parameters used for return values?
+- [ ] Is there a way to get detailed error info?
+- [ ] Am I documenting all possible error codes?
+
+## Related Rules
+
+- `ffi-04`: Handle panics at FFI boundary
+- `safety-10`: Document safety requirements

--- a/.agents/skills/unsafe-checker/rules/ffi-09-ref-not-ptr.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-09-ref-not-ptr.md
@@ -1,0 +1,136 @@
+---
+id: ffi-09
+original_id: P.UNS.FFI.09
+level: P
+impact: MEDIUM
+---
+
+# Use References Instead of Raw Pointers When Calling Safe C Functions
+
+## Summary
+
+When wrapping C functions that don't need null pointers, use Rust references in the safe wrapper to enforce non-null at compile time.
+
+## Rationale
+
+- References guarantee non-null
+- References have lifetime tracking
+- Raw pointers should stay in the unsafe FFI layer
+- Safe Rust API should use safe types
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn c_process(data: *const u8, len: usize);
+}
+
+// DON'T: Expose raw pointers in safe API
+pub fn process(data: *const u8, len: usize) {
+    // Caller might pass null!
+    unsafe { c_process(data, len); }
+}
+
+// DON'T: Unsafe function when it could be safe
+pub unsafe fn process_unsafe(data: *const u8, len: usize) {
+    // Why force caller to use unsafe?
+    c_process(data, len);
+}
+```
+
+## Good Example
+
+```rust
+extern "C" {
+    fn c_process(data: *const u8, len: usize);
+    fn c_modify(data: *mut Data);
+    fn c_optional(data: *const Data);  // Can be null
+}
+
+// DO: Use slice reference for safe API
+pub fn process(data: &[u8]) {
+    // Reference guarantees non-null
+    // Slice guarantees valid length
+    unsafe { c_process(data.as_ptr(), data.len()); }
+}
+
+// DO: Use &mut for exclusive access
+pub fn modify(data: &mut Data) {
+    // Mutable reference guarantees:
+    // - Non-null
+    // - Exclusive access
+    // - Valid for duration
+    unsafe { c_modify(data as *mut Data); }
+}
+
+// DO: Use Option<&T> for nullable parameters
+pub fn optional(data: Option<&Data>) {
+    let ptr = data.map(|d| d as *const Data).unwrap_or(std::ptr::null());
+    unsafe { c_optional(ptr); }
+}
+
+// DO: Wrap FFI types in safe Rust types
+pub struct SafeHandle(*mut c_void);
+
+impl SafeHandle {
+    pub fn new() -> Option<Self> {
+        let ptr = unsafe { create_handle() };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr))
+        }
+    }
+
+    // Methods take &self or &mut self, not raw pointers
+    pub fn do_something(&self) {
+        unsafe { handle_operation(self.0); }
+    }
+}
+```
+
+## Converting Between References and Pointers
+
+```rust
+// Reference to pointer
+fn ref_to_ptr(r: &Data) -> *const Data {
+    r as *const Data
+}
+
+fn mut_ref_to_ptr(r: &mut Data) -> *mut Data {
+    r as *mut Data
+}
+
+// Slice to pointer
+fn slice_to_ptr(s: &[u8]) -> (*const u8, usize) {
+    (s.as_ptr(), s.len())
+}
+
+// Pointer to reference (unsafe)
+unsafe fn ptr_to_ref<'a>(p: *const Data) -> &'a Data {
+    &*p
+}
+
+unsafe fn ptr_to_mut<'a>(p: *mut Data) -> &'a mut Data {
+    &mut *p
+}
+```
+
+## When to Use Raw Pointers
+
+- FFI declarations (`extern "C"`)
+- Implementing the unsafe boundary layer
+- When null is a valid value
+- When the pointee might not be valid Rust (e.g., uninitialized)
+
+## Checklist
+
+- [ ] Can this parameter be a reference instead of a pointer?
+- [ ] Am I checking for null in the unsafe layer?
+- [ ] Is the safe API free of raw pointers?
+- [ ] Do I use Option<&T> for nullable references?
+
+## Related Rules
+
+- `safety-06`: Don't expose raw pointers in public APIs
+- `ffi-02`: Read std::ffi documentation

--- a/.agents/skills/unsafe-checker/rules/ffi-10-thread-safety.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-10-thread-safety.md
@@ -1,0 +1,132 @@
+---
+id: ffi-10
+original_id: P.UNS.FFI.10
+level: P
+impact: CRITICAL
+---
+
+# Exported Rust Functions Must Be Designed for Thread-Safety
+
+## Summary
+
+Functions exported to C with `#[no_mangle] extern "C"` may be called from multiple threads. Ensure they are thread-safe.
+
+## Rationale
+
+- C code doesn't know about Rust's thread safety guarantees
+- C may call your function from any thread
+- Global state must be synchronized
+- Race conditions are undefined behavior
+
+## Bad Example
+
+```rust
+// DON'T: Unsynchronized global state
+static mut COUNTER: i32 = 0;
+
+#[no_mangle]
+pub extern "C" fn increment() -> i32 {
+    unsafe {
+        COUNTER += 1;  // Data race if called from multiple threads!
+        COUNTER
+    }
+}
+
+// DON'T: Thread-local assuming single thread
+thread_local! {
+    static CONFIG: RefCell<Config> = RefCell::new(Config::default());
+}
+
+#[no_mangle]
+pub extern "C" fn set_config(value: i32) {
+    // Different threads get different configs!
+    // Is that what the C caller expects?
+    CONFIG.with(|c| c.borrow_mut().value = value);
+}
+
+// DON'T: Non-Send types in globals
+static mut HANDLE: Option<Rc<Data>> = None;  // Rc is not Send!
+```
+
+## Good Example
+
+```rust
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+// DO: Use atomics for simple counters
+static COUNTER: AtomicI32 = AtomicI32::new(0);
+
+#[no_mangle]
+pub extern "C" fn increment() -> i32 {
+    COUNTER.fetch_add(1, Ordering::SeqCst) + 1
+}
+
+// DO: Use Mutex for complex state
+static CONFIG: OnceLock<Mutex<Config>> = OnceLock::new();
+
+fn get_config() -> &'static Mutex<Config> {
+    CONFIG.get_or_init(|| Mutex::new(Config::default()))
+}
+
+#[no_mangle]
+pub extern "C" fn set_config_value(value: i32) -> i32 {
+    match get_config().lock() {
+        Ok(mut config) => {
+            config.value = value;
+            0  // Success
+        }
+        Err(_) => -1  // Lock poisoned
+    }
+}
+
+// DO: Document thread safety requirements
+/// Initializes the library. NOT thread-safe.
+/// Must be called once from main thread before any other function.
+#[no_mangle]
+pub extern "C" fn init() -> i32 {
+    // One-time initialization
+    0
+}
+
+/// Processes data. Thread-safe.
+/// May be called from multiple threads concurrently.
+#[no_mangle]
+pub extern "C" fn process(data: *const u8, len: usize) -> i32 {
+    // Uses only local state or synchronized globals
+    0
+}
+
+// DO: Make non-thread-safe APIs explicit
+/// Handle for single-threaded use only.
+///
+/// # Thread Safety
+///
+/// This handle must only be used from the thread that created it.
+struct SingleThreadHandle {
+    data: *mut Data,
+    _not_send: std::marker::PhantomData<*const ()>,  // !Send
+}
+```
+
+## Synchronization Patterns
+
+| Pattern | Use Case |
+|---------|----------|
+| `AtomicT` | Simple counters, flags |
+| `Mutex<T>` | Complex shared state |
+| `RwLock<T>` | Read-heavy shared state |
+| `OnceLock<T>` | Lazy one-time init |
+| `thread_local!` | Per-thread state (document!) |
+
+## Checklist
+
+- [ ] Does my exported function access global state?
+- [ ] Is that state properly synchronized?
+- [ ] Have I documented thread-safety guarantees?
+- [ ] Are any types !Send/!Sync exposed across FFI?
+
+## Related Rules
+
+- `ptr-01`: Don't share raw pointers across threads
+- `safety-05`: Send/Sync implementation safety

--- a/.agents/skills/unsafe-checker/rules/ffi-11-packed-ub.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-11-packed-ub.md
@@ -1,0 +1,142 @@
+---
+id: ffi-11
+original_id: P.UNS.FFI.11
+level: P
+impact: HIGH
+clippy: unaligned_references
+---
+
+# Be Careful with UB When Referencing #[repr(packed)] Struct Fields
+
+## Summary
+
+Creating references to fields in `#[repr(packed)]` structs is undefined behavior if the field is misaligned. Use raw pointers and `read_unaligned`/`write_unaligned` instead.
+
+## Rationale
+
+- Packed structs have no padding, so fields may be misaligned
+- References must be aligned; misaligned references are UB
+- Even implicit references (method calls, match) can cause UB
+
+## Bad Example
+
+```rust
+#[repr(C, packed)]
+struct Packet {
+    header: u8,
+    value: u32,   // Misaligned! At offset 1, not 4
+    data: u64,    // Misaligned! At offset 5, not 8
+}
+
+fn bad_reference(p: &Packet) -> &u32 {
+    &p.value  // UB: Creates misaligned reference!
+}
+
+fn bad_match(p: &Packet) {
+    match p.value {  // UB: Match creates a reference
+        0 => {},
+        _ => {},
+    }
+}
+
+fn bad_method(p: &Packet) {
+    p.value.to_string();  // UB: Method call creates reference
+}
+
+fn bad_borrow(p: &mut Packet) {
+    let v = &mut p.value;  // UB: Misaligned mutable reference
+    *v = 42;
+}
+```
+
+## Good Example
+
+```rust
+#[repr(C, packed)]
+struct Packet {
+    header: u8,
+    value: u32,
+    data: u64,
+}
+
+// DO: Copy out the value
+fn good_read(p: &Packet) -> u32 {
+    p.value  // Copies the value, no reference created
+}
+
+// DO: Use addr_of! for raw pointer (Rust 2021+)
+fn good_ptr_read(p: &Packet) -> u32 {
+    // SAFETY: read_unaligned handles misalignment
+    unsafe {
+        std::ptr::addr_of!(p.value).read_unaligned()
+    }
+}
+
+// DO: Use addr_of_mut! for writing
+fn good_ptr_write(p: &mut Packet, value: u32) {
+    // SAFETY: write_unaligned handles misalignment
+    unsafe {
+        std::ptr::addr_of_mut!(p.value).write_unaligned(value);
+    }
+}
+
+// DO: Create accessor methods
+impl Packet {
+    fn value(&self) -> u32 {
+        unsafe { std::ptr::addr_of!(self.value).read_unaligned() }
+    }
+
+    fn set_value(&mut self, value: u32) {
+        unsafe { std::ptr::addr_of_mut!(self.value).write_unaligned(value); }
+    }
+
+    fn data(&self) -> u64 {
+        unsafe { std::ptr::addr_of!(self.data).read_unaligned() }
+    }
+}
+
+// DO: Consider using byte arrays + from_ne_bytes
+#[repr(C, packed)]
+struct PacketBytes {
+    header: u8,
+    value: [u8; 4],  // Store as bytes
+    data: [u8; 8],
+}
+
+impl PacketBytes {
+    fn value(&self) -> u32 {
+        u32::from_ne_bytes(self.value)  // Safe, no alignment issue
+    }
+}
+```
+
+## Safe Alternatives
+
+```rust
+// Alternative 1: Don't use packed
+#[repr(C)]
+struct AlignedPacket {
+    header: u8,
+    _pad: [u8; 3],
+    value: u32,
+    data: u64,
+}
+
+// Alternative 2: Use zerocopy crate
+// use zerocopy::{AsBytes, FromBytes};
+
+// Alternative 3: Use bytemuck
+// use bytemuck::{Pod, Zeroable};
+```
+
+## Checklist
+
+- [ ] Am I creating references to packed struct fields?
+- [ ] Am I using addr_of! / addr_of_mut! for field access?
+- [ ] Am I using read_unaligned / write_unaligned?
+- [ ] Would a byte array representation be safer?
+
+## Related Rules
+
+- `ptr-04`: Don't dereference misaligned pointers
+- `mem-01`: Choose appropriate data layout

--- a/.agents/skills/unsafe-checker/rules/ffi-12-invariant-doc.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-12-invariant-doc.md
@@ -1,0 +1,164 @@
+---
+id: ffi-12
+original_id: P.UNS.FFI.12
+level: P
+impact: MEDIUM
+---
+
+# Document Invariant Assumptions for C-Provided Parameters
+
+## Summary
+
+When receiving parameters from C, document what invariants you assume (non-null, alignment, validity, lifetime) and verify them when possible.
+
+## Rationale
+
+- C doesn't enforce invariants at compile time
+- Rust code needs to validate or document assumptions
+- Debugging FFI bugs is hard without clear documentation
+
+## Bad Example
+
+```rust
+// DON'T: Undocumented assumptions
+extern "C" {
+    fn get_data() -> *mut Data;
+}
+
+fn bad_use() -> &'static Data {
+    let ptr = unsafe { get_data() };
+    // Assumes:
+    // - ptr is non-null (not documented)
+    // - ptr is aligned (not checked)
+    // - Data is valid (not verified)
+    // - Lifetime is 'static (just guessing)
+    unsafe { &*ptr }
+}
+
+// DON'T: Silent assumptions in function signature
+#[no_mangle]
+pub extern "C" fn process(data: *const Data, len: usize) {
+    // What if data is null?
+    // What if len is wrong?
+    // What if data contains invalid Data?
+    let slice = unsafe {
+        std::slice::from_raw_parts(data, len)
+    };
+}
+```
+
+## Good Example
+
+```rust
+/// Retrieves data from the C library.
+///
+/// # Invariants Assumed from C
+///
+/// - Returns a non-null pointer on success, null on failure
+/// - Returned pointer is valid for the lifetime of the library
+/// - Returned pointer is aligned for `Data`
+/// - The `Data` struct is fully initialized
+extern "C" {
+    fn get_data() -> *mut Data;
+}
+
+fn documented_use() -> Option<&'static Data> {
+    let ptr = unsafe { get_data() };
+
+    // Verify what we can
+    if ptr.is_null() {
+        return None;
+    }
+
+    // Document what we can't verify
+    // SAFETY:
+    // - Non-null: checked above
+    // - Aligned: documented in C library docs
+    // - Valid: C library guarantees initialized Data
+    // - Lifetime: C library guarantees static lifetime
+    Some(unsafe { &*ptr })
+}
+
+/// Processes data provided by C caller.
+///
+/// # Parameters
+///
+/// - `data`: Must be non-null, aligned for `Data`, and point to `len` valid `Data` items
+/// - `len`: Number of items. Must not exceed `isize::MAX / size_of::<Data>()`
+///
+/// # Returns
+///
+/// - `0` on success
+/// - `-1` if `data` is null
+/// - `-2` if `len` is invalid
+///
+/// # Thread Safety
+///
+/// This function is thread-safe. The `data` array must not be mutated during the call.
+#[no_mangle]
+pub extern "C" fn process_documented(data: *const Data, len: usize) -> i32 {
+    // Verify invariants we can check
+    if data.is_null() {
+        return -1;
+    }
+
+    if len > isize::MAX as usize / std::mem::size_of::<Data>() {
+        return -2;
+    }
+
+    // SAFETY:
+    // - Non-null: checked above
+    // - Aligned: documented requirement for caller
+    // - Valid for len items: documented requirement for caller
+    // - Not mutated: documented thread safety requirement
+    let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+    for item in slice {
+        // process...
+    }
+
+    0
+}
+```
+
+## Documentation Template
+
+```rust
+/// Brief description.
+///
+/// # Parameters
+///
+/// - `param`: Description, constraints (non-null, aligned, etc.)
+///
+/// # Invariants Assumed
+///
+/// The following invariants are assumed and NOT verified:
+/// - Invariant 1: explanation
+/// - Invariant 2: explanation
+///
+/// The following invariants ARE verified at runtime:
+/// - Verified 1: how it's checked
+///
+/// # Safety (for unsafe fn)
+///
+/// Caller must ensure:
+/// - Requirement 1
+/// - Requirement 2
+///
+/// # Errors
+///
+/// Returns error code when:
+/// - Condition 1: error code
+```
+
+## Checklist
+
+- [ ] Have I documented all assumptions about C parameters?
+- [ ] Which invariants can I verify at runtime?
+- [ ] Which must I trust the C caller to uphold?
+- [ ] Have I documented error conditions and return values?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-10`: Document safety requirements

--- a/.agents/skills/unsafe-checker/rules/ffi-13-data-layout.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-13-data-layout.md
@@ -1,0 +1,146 @@
+---
+id: ffi-13
+original_id: P.UNS.FFI.13
+level: P
+impact: HIGH
+---
+
+# Ensure Consistent Data Layout for Custom Types
+
+## Summary
+
+Types shared between Rust and C must have `#[repr(C)]` to ensure the memory layout matches what C expects.
+
+## Rationale
+
+- Rust's default layout is unspecified and may change
+- C has specific, standardized layout rules
+- Mismatched layouts cause memory corruption
+
+## Bad Example
+
+```rust
+// DON'T: Rust layout for FFI types
+struct BadStruct {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Rust may reorder to: b, a, c (for better packing)
+// C expects: a, padding, b, c, padding
+
+extern "C" {
+    fn use_struct(s: *const BadStruct);  // Layout mismatch!
+}
+
+// DON'T: Assume Rust enum layout matches C
+enum BadEnum {
+    A,
+    B(i32),
+    C { x: u8, y: u8 },
+}
+// Rust enum layout is complex and not C-compatible
+```
+
+## Good Example
+
+```rust
+// DO: Use repr(C) for FFI structs
+#[repr(C)]
+struct GoodStruct {
+    a: u8,      // offset 0
+    // 3 bytes padding
+    b: u32,     // offset 4
+    c: u8,      // offset 8
+    // 3 bytes padding
+}
+// Total size: 12, align: 4
+
+// DO: Use repr(C) for enums with explicit discriminant
+#[repr(C)]
+enum GoodEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+// Equivalent to C: enum { A = 0, B = 1, C = 2 };
+
+// DO: For complex enums, use tagged unions
+#[repr(C)]
+struct TaggedUnion {
+    tag: GoodEnum,
+    data: GoodUnionData,
+}
+
+#[repr(C)]
+union GoodUnionData {
+    a: (),         // For GoodEnum::A
+    b: i32,        // For GoodEnum::B
+    c: [u8; 2],    // For GoodEnum::C
+}
+
+// DO: Verify layout at compile time
+const _: () = {
+    assert!(std::mem::size_of::<GoodStruct>() == 12);
+    assert!(std::mem::align_of::<GoodStruct>() == 4);
+};
+```
+
+## Layout Verification
+
+```rust
+use std::mem::{size_of, align_of, offset_of};
+
+#[repr(C)]
+struct Verified {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+
+// Compile-time layout verification
+const _: () = {
+    assert!(size_of::<Verified>() == 12);
+    assert!(align_of::<Verified>() == 4);
+    // offset_of! requires nightly or crate
+    // assert!(offset_of!(Verified, a) == 0);
+    // assert!(offset_of!(Verified, b) == 4);
+    // assert!(offset_of!(Verified, c) == 8);
+};
+
+// Runtime verification
+#[test]
+fn verify_layout() {
+    assert_eq!(size_of::<Verified>(), 12);
+    assert_eq!(align_of::<Verified>(), 4);
+
+    let v = Verified { a: 0, b: 0, c: 0 };
+    let base = &v as *const _ as usize;
+
+    assert_eq!(&v.a as *const _ as usize - base, 0);
+    assert_eq!(&v.b as *const _ as usize - base, 4);
+    assert_eq!(&v.c as *const _ as usize - base, 8);
+}
+```
+
+## repr Options
+
+| Attribute | Effect |
+|-----------|--------|
+| `#[repr(C)]` | C-compatible layout |
+| `#[repr(C, packed)]` | C layout, no padding |
+| `#[repr(C, align(N))]` | C layout, minimum align N |
+| `#[repr(transparent)]` | Same layout as single field |
+| `#[repr(u8)]` etc. | Enum discriminant type |
+
+## Checklist
+
+- [ ] Is every FFI struct marked `#[repr(C)]`?
+- [ ] Is every FFI enum using explicit discriminants?
+- [ ] Have I verified the layout matches the C header?
+- [ ] Have I added compile-time assertions?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-14`: Types in FFI should have stable layout

--- a/.agents/skills/unsafe-checker/rules/ffi-14-stable-layout.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-14-stable-layout.md
@@ -1,0 +1,135 @@
+---
+id: ffi-14
+original_id: P.UNS.FFI.14
+level: P
+impact: HIGH
+---
+
+# Types Used in FFI Should Have Stable Layout
+
+## Summary
+
+FFI types should not change layout between versions. Use `#[repr(C)]` and avoid types with unstable layout like generic `std` types.
+
+## Rationale
+
+- ABI compatibility requires stable layout
+- Dynamic libraries may be loaded with different compiler versions
+- Layout changes break binary compatibility
+
+## Bad Example
+
+```rust
+// DON'T: Use Rust std types with unstable layout in FFI
+extern "C" {
+    // Vec layout is not stable!
+    fn bad_vec(v: Vec<i32>);
+
+    // String layout is not stable!
+    fn bad_string(s: String);
+
+    // HashMap layout varies between versions
+    fn bad_map(m: std::collections::HashMap<i32, i32>);
+}
+
+// DON'T: Use Rust-specific types in C structs
+#[repr(C)]
+struct BadMixed {
+    id: i32,
+    data: Vec<u8>,  // Vec is not C-compatible!
+}
+
+// DON'T: Use Option with non-null optimization assumptions
+#[repr(C)]
+struct BadOption {
+    value: Option<std::num::NonZeroU32>,  // Layout may change!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_char, c_void};
+
+// DO: Use C-compatible types
+#[repr(C)]
+struct GoodStruct {
+    id: c_int,
+    name: *const c_char,  // C-style string
+    data: *const c_void,  // Generic pointer
+    data_len: usize,
+}
+
+// DO: Use explicit struct for what Vec would provide
+#[repr(C)]
+struct GoodBuffer {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+}
+
+impl GoodBuffer {
+    fn from_vec(mut v: Vec<u8>) -> Self {
+        let buf = Self {
+            ptr: v.as_mut_ptr(),
+            len: v.len(),
+            cap: v.capacity(),
+        };
+        std::mem::forget(v);
+        buf
+    }
+
+    /// # Safety
+    /// Must have been created by from_vec()
+    unsafe fn into_vec(self) -> Vec<u8> {
+        Vec::from_raw_parts(self.ptr, self.len, self.cap)
+    }
+}
+
+// DO: Use fixed-size arrays for bounded data
+#[repr(C)]
+struct FixedName {
+    name: [c_char; 64],
+    name_len: usize,
+}
+
+// DO: Define your own stable option type
+#[repr(C)]
+struct OptionalU32 {
+    has_value: bool,
+    value: u32,
+}
+
+impl From<Option<u32>> for OptionalU32 {
+    fn from(opt: Option<u32>) -> Self {
+        match opt {
+            Some(v) => Self { has_value: true, value: v },
+            None => Self { has_value: false, value: 0 },
+        }
+    }
+}
+```
+
+## Stable Types for FFI
+
+| Use Instead Of | Stable Type |
+|----------------|-------------|
+| `Vec<T>` | `*mut T` + `len` + `cap` |
+| `String` | `*const c_char` or `*mut c_char` + `len` |
+| `&[T]` | `*const T` + `len` |
+| `Option<T>` | Custom tagged struct |
+| `Result<T, E>` | Error code + out parameter |
+| `Box<T>` | `*mut T` |
+| `bool` | `c_int` or explicit `u8` |
+
+## Checklist
+
+- [ ] Am I using only C-compatible primitive types?
+- [ ] Am I avoiding std collection types in FFI signatures?
+- [ ] Have I created stable wrappers for Rust types?
+- [ ] Is the layout documented for other languages?
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout
+- `ffi-05`: Use portable type aliases

--- a/.agents/skills/unsafe-checker/rules/ffi-15-validate-external.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-15-validate-external.md
@@ -1,0 +1,145 @@
+---
+id: ffi-15
+original_id: P.UNS.FFI.15
+level: P
+impact: HIGH
+---
+
+# Validate Non-Robust External Values
+
+## Summary
+
+Data received from external sources (FFI, files, network) may be invalid. Validate before using it as Rust types with stricter invariants.
+
+## Rationale
+
+- External data can be malicious or corrupted
+- Rust types have invariants (e.g., valid UTF-8 for str)
+- Invalid data causes undefined behavior
+
+## Bad Example
+
+```rust
+// DON'T: Trust external data
+extern "C" {
+    fn get_status() -> u8;
+}
+
+#[derive(Debug)]
+enum Status { Active = 0, Inactive = 1, Pending = 2 }
+
+fn bad_convert() -> Status {
+    let raw = unsafe { get_status() };
+    // BAD: Assumes C returns valid enum value
+    unsafe { std::mem::transmute(raw) }  // UB if raw > 2
+}
+
+// DON'T: Trust strings from C
+fn bad_string(ptr: *const c_char) -> &str {
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    // BAD: Assumes valid UTF-8
+    cstr.to_str().unwrap()
+}
+
+// DON'T: Trust size values
+fn bad_size(ptr: *const u8, len: usize) -> Vec<u8> {
+    // BAD: len could be huge, causing OOM
+    // BAD: len could exceed actual data
+    unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+}
+```
+
+## Good Example
+
+```rust
+// DO: Validate enum values
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+enum Status {
+    Active = 0,
+    Inactive = 1,
+    Pending = 2,
+}
+
+impl TryFrom<u8> for Status {
+    type Error = InvalidStatusError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Status::Active),
+            1 => Ok(Status::Inactive),
+            2 => Ok(Status::Pending),
+            _ => Err(InvalidStatusError(value)),
+        }
+    }
+}
+
+fn good_convert() -> Result<Status, InvalidStatusError> {
+    let raw = unsafe { get_status() };
+    Status::try_from(raw)  // Returns error for invalid values
+}
+
+// DO: Handle invalid UTF-8
+fn good_string(ptr: *const c_char) -> Result<String, std::str::Utf8Error> {
+    if ptr.is_null() {
+        return Ok(String::new());
+    }
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    cstr.to_str().map(|s| s.to_owned())
+}
+
+fn good_string_lossy(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    cstr.to_string_lossy().into_owned()  // Replaces invalid UTF-8
+}
+
+// DO: Validate sizes
+const MAX_REASONABLE_SIZE: usize = 100 * 1024 * 1024;  // 100 MB
+
+fn good_size(ptr: *const u8, len: usize) -> Result<Vec<u8>, ValidationError> {
+    if ptr.is_null() {
+        return Err(ValidationError::NullPointer);
+    }
+    if len > MAX_REASONABLE_SIZE {
+        return Err(ValidationError::SizeTooLarge);
+    }
+
+    // Still need to trust that ptr points to len valid bytes
+    // Document this as a caller requirement
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    Ok(slice.to_vec())
+}
+
+// DO: Use num_enum for safe enum conversion
+// use num_enum::TryFromPrimitive;
+//
+// #[derive(TryFromPrimitive)]
+// #[repr(u8)]
+// enum Status { Active = 0, Inactive = 1, Pending = 2 }
+```
+
+## Validation Patterns
+
+| External Data | Validation |
+|---------------|------------|
+| Enum discriminant | Match against valid values |
+| String | Check UTF-8 or use lossy conversion |
+| Size/length | Check against maximum |
+| Pointer | Check for null |
+| Boolean | Explicit 0/1 check or treat any non-zero as true |
+| Float | Check for NaN, infinity if problematic |
+
+## Checklist
+
+- [ ] Am I validating external enum values?
+- [ ] Am I handling potential invalid UTF-8?
+- [ ] Am I checking sizes against reasonable limits?
+- [ ] Am I using TryFrom instead of transmute?
+
+## Related Rules
+
+- `ffi-12`: Document invariant assumptions
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ffi-16-closure-to-c.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-16-closure-to-c.md
@@ -1,0 +1,141 @@
+---
+id: ffi-16
+original_id: P.UNS.FFI.16
+level: P
+impact: HIGH
+---
+
+# Separate Data and Code When Passing Rust Closures to C
+
+## Summary
+
+C callbacks are function pointers without captured state. To pass Rust closures to C, separate the function pointer from the closure data using a "trampoline" pattern.
+
+## Rationale
+
+- Rust closures can capture state (like lambdas)
+- C function pointers are just addresses, no state
+- Must pass state separately via `void*` user_data
+
+## Bad Example
+
+```rust
+// DON'T: Try to pass closure directly
+extern "C" {
+    fn set_callback(cb: fn(i32) -> i32);  // Only works for non-capturing!
+}
+
+fn bad_closure() {
+    let multiplier = 2;
+    let closure = |x| x * multiplier;  // Captures multiplier
+
+    // This won't compile - closure is not fn pointer
+    // set_callback(closure);
+}
+
+// DON'T: Transmute closure to function pointer
+fn bad_transmute() {
+    let closure = |x: i32| x * 2;
+    let fp: fn(i32) -> i32 = unsafe { std::mem::transmute(closure) };
+    // UB: Closure may have non-zero size
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::c_void;
+use std::ffi::c_int;
+
+// C callback signature with user_data
+type CCallback = extern "C" fn(value: c_int, user_data: *mut c_void) -> c_int;
+
+extern "C" {
+    fn set_callback(cb: CCallback, user_data: *mut c_void);
+    fn remove_callback();
+}
+
+// DO: Use trampoline pattern
+fn good_closure<F: FnMut(i32) -> i32>(mut closure: F) {
+    // Trampoline function that forwards to the closure
+    extern "C" fn trampoline<F: FnMut(i32) -> i32>(
+        value: c_int,
+        user_data: *mut c_void,
+    ) -> c_int {
+        let closure = unsafe { &mut *(user_data as *mut F) };
+        closure(value as i32) as c_int
+    }
+
+    let user_data = &mut closure as *mut F as *mut c_void;
+
+    unsafe {
+        set_callback(trampoline::<F>, user_data);
+        // Important: closure must live until callback is removed!
+    }
+}
+
+// DO: Box the closure for 'static lifetime
+struct CallbackHandle {
+    closure: Box<dyn FnMut(i32) -> i32>,
+}
+
+impl CallbackHandle {
+    fn new<F: FnMut(i32) -> i32 + 'static>(closure: F) -> Self {
+        Self { closure: Box::new(closure) }
+    }
+
+    fn register(&mut self) {
+        extern "C" fn trampoline(value: c_int, user_data: *mut c_void) -> c_int {
+            let closure = unsafe { &mut *(user_data as *mut Box<dyn FnMut(i32) -> i32>) };
+            closure(value as i32) as c_int
+        }
+
+        let user_data = &mut self.closure as *mut _ as *mut c_void;
+        unsafe { set_callback(trampoline, user_data); }
+    }
+}
+
+impl Drop for CallbackHandle {
+    fn drop(&mut self) {
+        unsafe { remove_callback(); }
+        // Now safe to drop closure
+    }
+}
+
+// Usage
+fn example() {
+    let multiplier = 2;
+    let mut handle = CallbackHandle::new(move |x| x * multiplier);
+    handle.register();
+    // handle must live until callback is no longer needed
+}
+```
+
+## Trampoline Pattern
+
+```
+Rust Closure: |x| x * captured_value
+     |
+     v
++-----------------+     +-----------------+
+| trampoline fn   | --> | closure data    |
+| (no captures)   |     | (captured_value)|
++-----------------+     +-----------------+
+     |                         ^
+     |    user_data ptr        |
+     +-------------------------+
+
+C sees: function pointer + void* user_data
+```
+
+## Checklist
+
+- [ ] Does my closure capture any state?
+- [ ] Am I using the trampoline pattern?
+- [ ] Does the closure data live long enough?
+- [ ] Am I unregistering before dropping the closure?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for resource wrappers
+- `ffi-10`: Thread safety for callbacks

--- a/.agents/skills/unsafe-checker/rules/ffi-17-opaque-types.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-17-opaque-types.md
@@ -1,0 +1,152 @@
+---
+id: ffi-17
+original_id: P.UNS.FFI.17
+level: P
+impact: MEDIUM
+---
+
+# Use Dedicated Opaque Type Pointers Instead of c_void for C Opaque Types
+
+## Summary
+
+Instead of using `*mut c_void` for opaque C handles, create dedicated marker types that provide type safety.
+
+## Rationale
+
+- `*mut c_void` accepts any pointer, easy to mix up handles
+- Dedicated types catch mistakes at compile time
+- Self-documenting code
+- Prevents accidental use of wrong free function
+
+## Bad Example
+
+```rust
+use std::ffi::c_void;
+
+extern "C" {
+    fn create_database() -> *mut c_void;
+    fn create_connection() -> *mut c_void;
+    fn execute(conn: *mut c_void, query: *const i8);
+    fn close_database(db: *mut c_void);
+    fn close_connection(conn: *mut c_void);
+}
+
+fn bad_usage() {
+    let db = unsafe { create_database() };
+    let conn = unsafe { create_connection() };
+
+    // BUG: Passed db where conn was expected - compiles fine!
+    unsafe { execute(db, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    // BUG: Wrong close function - compiles fine!
+    unsafe { close_connection(db) };
+    unsafe { close_database(conn) };
+}
+```
+
+## Good Example
+
+```rust
+use std::marker::PhantomData;
+
+// DO: Define opaque marker types
+#[repr(C)]
+pub struct Database {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct Connection {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+extern "C" {
+    fn create_database() -> *mut Database;
+    fn create_connection(db: *mut Database) -> *mut Connection;
+    fn execute(conn: *mut Connection, query: *const i8) -> i32;
+    fn close_database(db: *mut Database);
+    fn close_connection(conn: *mut Connection);
+}
+
+fn good_usage() {
+    let db = unsafe { create_database() };
+    let conn = unsafe { create_connection(db) };
+
+    // Compile error: expected *mut Connection, found *mut Database
+    // unsafe { execute(db, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    // Correct usage
+    unsafe { execute(conn, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    unsafe { close_connection(conn) };
+    unsafe { close_database(db) };
+}
+
+// DO: Wrap in safe Rust types
+pub struct SafeDatabase {
+    ptr: *mut Database,
+}
+
+impl SafeDatabase {
+    pub fn new() -> Option<Self> {
+        let ptr = unsafe { create_database() };
+        if ptr.is_null() { None } else { Some(Self { ptr }) }
+    }
+
+    pub fn connect(&self) -> Option<SafeConnection<'_>> {
+        let ptr = unsafe { create_connection(self.ptr) };
+        if ptr.is_null() { None } else { Some(SafeConnection { ptr, _db: PhantomData }) }
+    }
+}
+
+impl Drop for SafeDatabase {
+    fn drop(&mut self) {
+        unsafe { close_database(self.ptr); }
+    }
+}
+
+pub struct SafeConnection<'db> {
+    ptr: *mut Connection,
+    _db: PhantomData<&'db SafeDatabase>,
+}
+
+impl SafeConnection<'_> {
+    pub fn execute(&self, query: &str) -> Result<(), ()> {
+        let query = std::ffi::CString::new(query).map_err(|_| ())?;
+        let result = unsafe { execute(self.ptr, query.as_ptr()) };
+        if result == 0 { Ok(()) } else { Err(()) }
+    }
+}
+
+impl Drop for SafeConnection<'_> {
+    fn drop(&mut self) {
+        unsafe { close_connection(self.ptr); }
+    }
+}
+```
+
+## Opaque Type Pattern
+
+```rust
+// The zero-sized array makes it impossible to construct
+// PhantomData ensures proper variance and !Send/!Sync if needed
+#[repr(C)]
+pub struct OpaqueHandle {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+```
+
+## Checklist
+
+- [ ] Am I using `*mut c_void` for distinct handle types?
+- [ ] Would dedicated types prevent bugs?
+- [ ] Have I wrapped opaque pointers in safe Rust types?
+- [ ] Do my types enforce correct handle/function pairing?
+
+## Related Rules
+
+- `ffi-02`: Read std::ffi documentation
+- `ffi-03`: Implement Drop for wrapped pointers

--- a/.agents/skills/unsafe-checker/rules/ffi-18-no-trait-objects.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-18-no-trait-objects.md
@@ -1,0 +1,165 @@
+---
+id: ffi-18
+original_id: P.UNS.FFI.18
+level: P
+impact: HIGH
+---
+
+# Avoid Passing Trait Objects to C Interfaces
+
+## Summary
+
+Trait objects (`dyn Trait`) have Rust-specific layout (fat pointers with vtable) that is not compatible with C.
+
+## Rationale
+
+- Trait objects are "fat pointers": data ptr + vtable ptr
+- C expects thin pointers (single pointer)
+- Vtable layout is not stable across Rust versions
+- C cannot call Rust vtable methods
+
+## Bad Example
+
+```rust
+// DON'T: Pass trait objects to C
+trait Handler {
+    fn handle(&self, data: i32);
+}
+
+extern "C" {
+    // This won't work - dyn Handler is a fat pointer!
+    fn set_handler(h: *const dyn Handler);
+}
+
+// DON'T: Store trait objects in FFI structs
+#[repr(C)]
+struct BadCallback {
+    handler: *const dyn Handler,  // Not C-compatible!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_void};
+
+// DO: Use function pointers with user_data (trampoline pattern)
+type HandlerFn = extern "C" fn(data: c_int, user_data: *mut c_void);
+
+extern "C" {
+    fn set_handler(handler: HandlerFn, user_data: *mut c_void);
+}
+
+trait Handler {
+    fn handle(&self, data: i32);
+}
+
+fn register_handler<H: Handler + 'static>(handler: H) {
+    // Box the handler
+    let boxed: Box<H> = Box::new(handler);
+    let user_data = Box::into_raw(boxed) as *mut c_void;
+
+    extern "C" fn trampoline<H: Handler>(data: c_int, user_data: *mut c_void) {
+        let handler = unsafe { &*(user_data as *const H) };
+        handler.handle(data as i32);
+    }
+
+    unsafe {
+        set_handler(trampoline::<H>, user_data);
+    }
+}
+
+// DO: Use concrete types when possible
+struct ConcreteHandler {
+    multiplier: i32,
+}
+
+impl Handler for ConcreteHandler {
+    fn handle(&self, data: i32) {
+        println!("{}", data * self.multiplier);
+    }
+}
+
+// DO: Create C-compatible vtable manually if needed
+#[repr(C)]
+struct HandlerVtable {
+    handle: extern "C" fn(this: *const c_void, data: c_int),
+    drop: extern "C" fn(this: *mut c_void),
+}
+
+#[repr(C)]
+struct CCompatibleHandler {
+    data: *mut c_void,
+    vtable: *const HandlerVtable,
+}
+
+impl CCompatibleHandler {
+    fn new<H: Handler + 'static>(handler: H) -> Self {
+        extern "C" fn handle_impl<H: Handler>(this: *const c_void, data: c_int) {
+            let handler = unsafe { &*(this as *const H) };
+            handler.handle(data as i32);
+        }
+
+        extern "C" fn drop_impl<H: Handler>(this: *mut c_void) {
+            unsafe { drop(Box::from_raw(this as *mut H)); }
+        }
+
+        static VTABLE: HandlerVtable = HandlerVtable {
+            handle: handle_impl::<ConcreteHandler>,  // Need concrete type
+            drop: drop_impl::<ConcreteHandler>,
+        };
+
+        Self {
+            data: Box::into_raw(Box::new(handler)) as *mut c_void,
+            vtable: &VTABLE,
+        }
+    }
+
+    fn handle(&self, data: i32) {
+        unsafe {
+            ((*self.vtable).handle)(self.data, data as c_int);
+        }
+    }
+}
+
+impl Drop for CCompatibleHandler {
+    fn drop(&mut self) {
+        unsafe {
+            ((*self.vtable).drop)(self.data);
+        }
+    }
+}
+```
+
+## Why Trait Objects Don't Work
+
+```
+Rust trait object (*const dyn Handler):
+[data pointer][vtable pointer]  <- 16 bytes on 64-bit
+
+C pointer (void*):
+[pointer]  <- 8 bytes on 64-bit
+
+The sizes don't match!
+```
+
+## Alternatives to Trait Objects
+
+| Instead of | Use |
+|------------|-----|
+| `dyn Trait` | Function pointer + user_data |
+| `Box<dyn Trait>` | Boxed concrete type + trampoline |
+| `&dyn Trait` | C-compatible vtable struct |
+| `Arc<dyn Trait>` | Reference counting wrapper |
+
+## Checklist
+
+- [ ] Am I passing trait objects across FFI?
+- [ ] Can I use concrete types instead?
+- [ ] Have I used the trampoline pattern for callbacks?
+- [ ] If vtable is needed, is it C-compatible?
+
+## Related Rules
+
+- `ffi-16`: Closure to C with trampoline pattern
+- `ffi-14`: Types should have stable layout

--- a/.agents/skills/unsafe-checker/rules/general-01-no-abuse.md
+++ b/.agents/skills/unsafe-checker/rules/general-01-no-abuse.md
@@ -1,0 +1,71 @@
+---
+id: general-01
+original_id: P.UNS.01
+level: P
+impact: CRITICAL
+---
+
+# Do Not Abuse Unsafe to Escape Compiler Safety Checks
+
+## Summary
+
+Unsafe Rust should not be used as an escape hatch from the borrow checker or other compiler safety mechanisms.
+
+## Rationale
+
+The borrow checker exists to prevent memory safety bugs. Using `unsafe` to bypass it defeats Rust's safety guarantees and introduces potential undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Using unsafe to bypass borrow checker
+fn bad_alias() {
+    let mut data = vec![1, 2, 3];
+    let ptr = data.as_mut_ptr();
+
+    // Unsafe used to create aliasing mutable references
+    unsafe {
+        let ref1 = &mut *ptr;
+        let ref2 = &mut *ptr;  // UB: Two mutable references!
+        *ref1 = 10;
+        *ref2 = 20;
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Work with the borrow checker, not against it
+fn good_sequential() {
+    let mut data = vec![1, 2, 3];
+    data[0] = 10;
+    data[0] = 20;  // Sequential mutations are fine
+}
+
+// DO: Use interior mutability when needed
+use std::cell::RefCell;
+
+fn good_interior_mut() {
+    let data = RefCell::new(vec![1, 2, 3]);
+    data.borrow_mut()[0] = 10;
+}
+```
+
+## Legitimate Uses of Unsafe
+
+1. **FFI**: Calling C functions or implementing C-compatible interfaces
+2. **Low-level abstractions**: Implementing collections, synchronization primitives
+3. **Performance**: Only after profiling shows measurable improvement, and with careful safety analysis
+
+## Checklist
+
+- [ ] Have I tried all safe alternatives first?
+- [ ] Is the borrow checker preventing a genuine design need?
+- [ ] Can I restructure the code to satisfy the borrow checker?
+- [ ] If unsafe is necessary, have I documented the safety invariants?
+
+## Related Rules
+
+- `general-02`: Don't blindly use unsafe for performance
+- `safety-02`: Unsafe code authors must verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/general-02-not-for-perf.md
+++ b/.agents/skills/unsafe-checker/rules/general-02-not-for-perf.md
@@ -1,0 +1,90 @@
+---
+id: general-02
+original_id: P.UNS.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Blindly Use Unsafe for Performance
+
+## Summary
+
+Do not assume that using `unsafe` will automatically improve performance. Always measure first and verify the safety invariants.
+
+## Rationale
+
+1. Modern Rust optimizers often eliminate bounds checks when they can prove safety
+2. Unsafe code may prevent optimizations by breaking aliasing assumptions
+3. Unmeasured "optimizations" often provide no real benefit while introducing risk
+
+## Bad Example
+
+```rust
+// DON'T: Blind unsafe for "performance"
+fn sum_bad(slice: &[i32]) -> i32 {
+    let mut sum = 0;
+    // Unnecessary unsafe - LLVM can optimize the safe version
+    for i in 0..slice.len() {
+        unsafe {
+            sum += *slice.get_unchecked(i);
+        }
+    }
+    sum
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use safe iteration - compiler optimizes bounds checks away
+fn sum_good(slice: &[i32]) -> i32 {
+    slice.iter().sum()
+}
+
+// DO: If unsafe is justified, document why
+fn sum_justified(slice: &[i32]) -> i32 {
+    let mut sum = 0;
+    // This is actually slower than iter().sum() in most cases
+    // Only use get_unchecked when:
+    // 1. Profiler shows bounds checks as bottleneck
+    // 2. Iterator patterns can't be used
+    // 3. Safety is proven by other means
+    for i in 0..slice.len() {
+        // SAFETY: i is always < slice.len() due to loop condition
+        unsafe {
+            sum += *slice.get_unchecked(i);
+        }
+    }
+    sum
+}
+```
+
+## When Unsafe Might Be Justified for Performance
+
+1. **Hot inner loops** where profiling shows bounds checks are a bottleneck
+2. **SIMD operations** that require specific memory alignment
+3. **Lock-free data structures** with carefully verified memory orderings
+
+## Measurement Workflow
+
+```bash
+# 1. Benchmark the safe version first
+cargo bench --bench my_bench
+
+# 2. Profile to identify actual bottlenecks
+cargo flamegraph --bench my_bench
+
+# 3. Only then consider unsafe, with measurements
+```
+
+## Checklist
+
+- [ ] Have I benchmarked the safe version?
+- [ ] Does profiling show this specific code as a bottleneck?
+- [ ] Have I measured the actual improvement from unsafe?
+- [ ] Is the performance gain worth the safety risk?
+
+## Related Rules
+
+- `general-01`: Don't abuse unsafe to escape safety checks
+- `safety-02`: Unsafe code authors must verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/general-03-no-alias.md
+++ b/.agents/skills/unsafe-checker/rules/general-03-no-alias.md
@@ -1,0 +1,74 @@
+---
+id: general-03
+original_id: G.UNS.01
+level: G
+impact: MEDIUM
+---
+
+# Do Not Create Aliases for Types/Methods Named "Unsafe"
+
+## Summary
+
+Do not create type aliases, re-exports, or wrapper methods that hide the "unsafe" nature of operations.
+
+## Rationale
+
+The word "unsafe" in Rust is a signal to developers that extra scrutiny is required. Hiding this signal makes code review harder and can lead to accidental misuse.
+
+## Bad Example
+
+```rust
+// DON'T: Hide unsafe behind an alias
+type SafePointer = *mut u8;  // Still unsafe to dereference!
+
+// DON'T: Wrap unsafe in a "safe-looking" name
+pub fn get_value(ptr: *const i32) -> i32 {
+    unsafe { *ptr }  // Caller doesn't know this is unsafe!
+}
+
+// DON'T: Re-export unsafe functions with different names
+pub use std::mem::transmute as convert;
+```
+
+## Good Example
+
+```rust
+// DO: Keep "unsafe" visible in the API
+pub unsafe fn get_value_unchecked(ptr: *const i32) -> i32 {
+    *ptr
+}
+
+// DO: If providing a safe wrapper, make the safety contract clear
+/// Returns the value at the pointer.
+///
+/// # Safety
+/// This is safe because the pointer is validated internally.
+pub fn get_value_checked(ptr: *const i32) -> Option<i32> {
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: We checked for null above
+        Some(unsafe { *ptr })
+    }
+}
+
+// DO: Use clear naming for raw pointer types
+type RawHandle = *mut c_void;  // "Raw" signals potential unsafety
+```
+
+## Common Violations
+
+1. Creating type aliases that hide pointer types
+2. Wrapping unsafe functions in safe-looking functions without proper safety analysis
+3. Re-exporting unsafe functions with "friendlier" names
+
+## Checklist
+
+- [ ] Does my API preserve visibility of unsafe operations?
+- [ ] If wrapping unsafe code in safe API, is the safety invariant enforced?
+- [ ] Are type aliases clearly named to indicate their nature?
+
+## Related Rules
+
+- `safety-06`: Don't expose raw pointers in public APIs
+- `safety-09`: Add SAFETY comment before any unsafe block

--- a/.agents/skills/unsafe-checker/rules/io-01-raw-handle.md
+++ b/.agents/skills/unsafe-checker/rules/io-01-raw-handle.md
@@ -1,0 +1,151 @@
+---
+id: io-01
+original_id: P.UNS.FIO.01
+level: P
+impact: HIGH
+---
+
+# Ensure I/O Safety When Using Raw Handles
+
+## Summary
+
+When working with raw file descriptors or handles, ensure they are valid for the duration of use and properly ownership-tracked.
+
+## Rationale
+
+- Raw handles can be closed by other code
+- Using a closed handle is undefined behavior
+- Handle reuse can cause data corruption
+- Rust 1.63+ provides I/O safety traits
+
+## Bad Example
+
+```rust
+#[cfg(unix)]
+mod bad_example {
+    use std::os::unix::io::RawFd;
+
+    // DON'T: Accept raw handle without ownership
+    fn bad_read(fd: RawFd) -> std::io::Result<Vec<u8>> {
+        // What if fd was closed? What if it's reused?
+        let mut buf = vec![0u8; 1024];
+        let n = unsafe {
+            libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+        };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            buf.truncate(n as usize);
+            Ok(buf)
+        }
+    }
+
+    // DON'T: Store raw handle without tracking ownership
+    struct BadFileRef {
+        fd: RawFd,  // Who owns this? Who closes it?
+    }
+}
+```
+
+## Good Example
+
+```rust
+#[cfg(unix)]
+mod good_example {
+    use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd, FromRawFd, AsRawFd};
+    use std::fs::File;
+
+    // DO: Use BorrowedFd for borrowed access (Rust 1.63+)
+    fn good_read(fd: BorrowedFd<'_>) -> std::io::Result<Vec<u8>> {
+        let mut buf = vec![0u8; 1024];
+        // BorrowedFd guarantees the fd is valid for this call
+        let n = unsafe {
+            libc::read(
+                fd.as_raw_fd(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len()
+            )
+        };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            buf.truncate(n as usize);
+            Ok(buf)
+        }
+    }
+
+    // DO: Use OwnedFd for owned handles
+    struct GoodFileOwner {
+        fd: OwnedFd,  // Clearly owns the handle
+    }
+
+    impl Drop for GoodFileOwner {
+        fn drop(&mut self) {
+            // OwnedFd closes automatically
+        }
+    }
+
+    // DO: Use generic AsFd bound for flexibility
+    fn generic_read<F: AsFd>(f: &F) -> std::io::Result<Vec<u8>> {
+        good_read(f.as_fd())
+    }
+
+    // Usage
+    fn example() -> std::io::Result<()> {
+        let file = File::open("test.txt")?;
+
+        // Pass as BorrowedFd
+        let data = good_read(file.as_fd())?;
+
+        // Or use generic function
+        let data = generic_read(&file)?;
+
+        Ok(())
+    }
+
+    // DO: Take ownership from raw fd
+    fn from_raw(fd: i32) -> Option<GoodFileOwner> {
+        if fd < 0 {
+            return None;
+        }
+        // SAFETY: Caller guarantees fd is valid and ownership is transferred
+        let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+        Some(GoodFileOwner { fd: owned })
+    }
+}
+```
+
+## I/O Safety Types (Rust 1.63+)
+
+| Type | Meaning |
+|------|---------|
+| `OwnedFd` | Owns a file descriptor, closes on drop |
+| `BorrowedFd<'a>` | Borrows a fd for lifetime 'a |
+| `RawFd` | Raw integer, no safety guarantees |
+| `AsFd` | Trait for types that have a fd |
+| `From<OwnedFd>` | Create from owned fd |
+| `Into<OwnedFd>` | Convert to owned fd |
+
+## Windows Equivalents
+
+```rust
+#[cfg(windows)]
+use std::os::windows::io::{
+    OwnedHandle, BorrowedHandle, RawHandle,
+    AsHandle, FromRawHandle,
+    OwnedSocket, BorrowedSocket, RawSocket,
+    AsSocket, FromRawSocket,
+};
+```
+
+## Checklist
+
+- [ ] Am I using BorrowedFd/OwnedFd instead of RawFd?
+- [ ] Is ownership of handles clear?
+- [ ] Am I using the AsFd trait for generic code?
+- [ ] Is the fd guaranteed valid for the duration of use?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for resource wrappers
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/mem-01-repr-layout.md
+++ b/.agents/skills/unsafe-checker/rules/mem-01-repr-layout.md
@@ -1,0 +1,130 @@
+---
+id: mem-01
+original_id: P.UNS.MEM.01
+level: P
+impact: HIGH
+---
+
+# Choose Appropriate Data Layout for Struct/Tuple/Enum
+
+## Summary
+
+Use `#[repr(...)]` attributes to control data layout when interfacing with C, doing memory mapping, or needing specific guarantees.
+
+## Rationale
+
+Rust's default layout is unspecified and may change between compiler versions. For FFI, persistence, or low-level memory operations, you need predictable layout.
+
+## Repr Attributes
+
+| Attribute | Use Case |
+|-----------|----------|
+| `#[repr(C)]` | C-compatible layout, stable field order |
+| `#[repr(transparent)]` | Single-field struct with same layout as field |
+| `#[repr(packed)]` | No padding (alignment = 1), careful with references! |
+| `#[repr(align(N))]` | Minimum alignment of N bytes |
+| `#[repr(u8)]`, `#[repr(i32)]`, etc. | Enum discriminant type |
+
+## Bad Example
+
+```rust
+// DON'T: Assume Rust struct layout matches C
+struct BadFFI {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Rust may reorder fields or add different padding than C
+
+// DON'T: Use packed without understanding the risks
+#[repr(packed)]
+struct Dangerous {
+    a: u8,
+    b: u32,
+}
+
+fn bad_ref(d: &Dangerous) -> &u32 {
+    &d.b  // UB: Creates unaligned reference!
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use repr(C) for FFI
+#[repr(C)]
+struct GoodFFI {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Guaranteed: a at 0, padding 1-3, b at 4, c at 8, padding 9-11
+
+// DO: Use repr(transparent) for newtypes
+#[repr(transparent)]
+struct Wrapper(u32);
+// Guaranteed same layout as u32, can be transmuted
+
+// DO: Use repr(packed) carefully, access via copy
+#[repr(C, packed)]
+struct PackedData {
+    header: u8,
+    value: u32,
+}
+
+impl PackedData {
+    fn value(&self) -> u32 {
+        // Copy out the value to avoid unaligned reference
+        let ptr = std::ptr::addr_of!(self.value);
+        // SAFETY: Reading unaligned is OK with read_unaligned
+        unsafe { ptr.read_unaligned() }
+    }
+}
+
+// DO: Use align for SIMD or cache line alignment
+#[repr(C, align(64))]
+struct CacheAligned {
+    data: [u8; 64],
+}
+
+// DO: Specify enum discriminant for FFI
+#[repr(u8)]
+enum Status {
+    Ok = 0,
+    Error = 1,
+    Unknown = 255,
+}
+```
+
+## Layout Guarantees
+
+```rust
+use std::mem::{size_of, align_of};
+
+#[repr(C)]
+struct Example {
+    a: u8,   // offset 0, size 1
+    // padding: 3 bytes
+    b: u32,  // offset 4, size 4
+    c: u8,   // offset 8, size 1
+    // padding: 3 bytes
+}
+
+assert_eq!(size_of::<Example>(), 12);
+assert_eq!(align_of::<Example>(), 4);
+
+// repr(Rust) might reorder to: b, a, c -> size 8
+```
+
+## Checklist
+
+- [ ] Is this type used in FFI? → Use `#[repr(C)]`
+- [ ] Is this a newtype wrapper? → Consider `#[repr(transparent)]`
+- [ ] Do I need specific alignment? → Use `#[repr(align(N))]`
+- [ ] Am I using packed? → Never create references to packed fields
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout for custom types
+- `ffi-14`: Types in FFI should have stable layout
+- `ptr-04`: Alignment considerations

--- a/.agents/skills/unsafe-checker/rules/mem-02-no-other-process.md
+++ b/.agents/skills/unsafe-checker/rules/mem-02-no-other-process.md
@@ -1,0 +1,113 @@
+---
+id: mem-02
+original_id: P.UNS.MEM.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Modify Memory Variables of Other Processes or Dynamic Libraries
+
+## Summary
+
+Do not directly manipulate memory belonging to other processes or dynamically loaded libraries. Use proper IPC or FFI mechanisms.
+
+## Rationale
+
+- Other processes have separate address spaces; direct access is impossible on modern OSes
+- Shared memory requires explicit setup and synchronization
+- Dynamic library memory has ownership rules that must be respected
+- Violating these causes undefined behavior or security vulnerabilities
+
+## Bad Example
+
+```rust
+// DON'T: Try to access another process's memory directly
+fn bad_cross_process(ptr: *mut i32) {
+    // This pointer from another process is meaningless in our address space
+    unsafe { *ptr = 42; }  // Undefined behavior or crash
+}
+
+// DON'T: Modify library internals
+extern "C" {
+    static mut LIBRARY_INTERNAL: i32;
+}
+
+fn bad_library_access() {
+    // Modifying library internals breaks encapsulation
+    unsafe { LIBRARY_INTERNAL = 100; }  // May corrupt library state
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use proper IPC for cross-process communication
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+
+fn ipc_communication() -> std::io::Result<()> {
+    let mut stream = UnixStream::connect("/tmp/socket")?;
+    stream.write_all(b"message")?;
+    Ok(())
+}
+
+// DO: Use shared memory with proper synchronization
+#[cfg(unix)]
+fn shared_memory_example() {
+    use std::sync::atomic::{AtomicI32, Ordering};
+
+    // Properly set up shared memory region
+    // let shm = mmap shared memory...
+
+    // Use atomic operations for synchronization
+    let shared: &AtomicI32 = /* ... */;
+    shared.store(42, Ordering::Release);
+}
+
+// DO: Use proper FFI for library interaction
+mod ffi {
+    extern "C" {
+        pub fn library_set_value(value: i32);
+        pub fn library_get_value() -> i32;
+    }
+}
+
+fn proper_library_access() {
+    unsafe {
+        ffi::library_set_value(42);
+        let value = ffi::library_get_value();
+    }
+}
+
+// DO: Use Rust's libloading for dynamic libraries
+fn dynamic_library() -> Result<(), Box<dyn std::error::Error>> {
+    let lib = unsafe { libloading::Library::new("mylib.so")? };
+    let func: libloading::Symbol<extern "C" fn(i32) -> i32> =
+        unsafe { lib.get(b"my_function")? };
+    let result = func(42);
+    Ok(())
+}
+```
+
+## Memory Ownership Rules
+
+| Memory Type | Owner | Safe Access |
+|-------------|-------|-------------|
+| Stack variables | Current function | Direct |
+| Heap (Box, Vec) | Rust allocator | Through smart pointers |
+| Static | Program | With proper synchronization |
+| Shared memory | Multiple processes | Atomic ops, mutexes |
+| Library memory | Library | Through library API |
+| FFI-allocated | C allocator | Through C free functions |
+
+## Checklist
+
+- [ ] Who allocated this memory?
+- [ ] Who is responsible for freeing it?
+- [ ] Is proper synchronization in place for shared access?
+- [ ] Am I using the correct API for cross-boundary access?
+
+## Related Rules
+
+- `mem-03`: Don't let String/Vec drop other process's memory
+- `ffi-03`: Implement Drop for wrapped C pointers

--- a/.agents/skills/unsafe-checker/rules/mem-03-no-auto-drop-foreign.md
+++ b/.agents/skills/unsafe-checker/rules/mem-03-no-auto-drop-foreign.md
@@ -1,0 +1,127 @@
+---
+id: mem-03
+original_id: P.UNS.MEM.03
+level: P
+impact: CRITICAL
+---
+
+# Do Not Let String/Vec Auto-Drop Other Process's Memory
+
+## Summary
+
+Never create `String`, `Vec`, or `Box` from memory allocated outside Rust's allocator. They will try to free the memory with the wrong deallocator.
+
+## Rationale
+
+`String`, `Vec`, and `Box` assume memory was allocated by Rust's global allocator. When dropped, they call `dealloc`. If the memory came from C's `malloc`, a different allocator, or shared memory, this causes undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Create String from C-allocated memory
+extern "C" {
+    fn c_get_string() -> *mut std::os::raw::c_char;
+}
+
+fn bad_string() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        // BAD: String will try to free with Rust allocator
+        String::from_raw_parts(ptr as *mut u8, len, cap)
+    }
+}
+
+// DON'T: Create Vec from foreign memory
+fn bad_vec(ptr: *mut u8, len: usize) -> Vec<u8> {
+    // BAD: Vec will free this memory incorrectly
+    unsafe { Vec::from_raw_parts(ptr, len, len) }
+}
+
+// DON'T: Wrap shared memory in Box
+fn bad_box(shared_ptr: *mut Data) -> Box<Data> {
+    // BAD: Box will try to deallocate shared memory!
+    unsafe { Box::from_raw(shared_ptr) }
+}
+```
+
+## Good Example
+
+```rust
+use std::ffi::CStr;
+
+extern "C" {
+    fn c_get_string() -> *mut std::os::raw::c_char;
+    fn c_free_string(s: *mut std::os::raw::c_char);
+}
+
+// DO: Copy data into Rust-owned allocation
+fn good_string() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        let cstr = CStr::from_ptr(ptr);
+        let result = cstr.to_string_lossy().into_owned();
+        c_free_string(ptr);  // Free with correct deallocator
+        result
+    }
+}
+
+// DO: Use wrapper that calls correct deallocator
+struct CString {
+    ptr: *mut std::os::raw::c_char,
+}
+
+impl Drop for CString {
+    fn drop(&mut self) {
+        unsafe { c_free_string(self.ptr); }
+    }
+}
+
+// DO: Use slice for borrowed view, don't take ownership
+fn good_slice(ptr: *const u8, len: usize) -> &'static [u8] {
+    // Only borrow, don't own
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+// DO: For shared memory, use raw pointers or custom wrapper
+struct SharedBuffer {
+    ptr: *mut u8,
+    len: usize,
+}
+
+impl SharedBuffer {
+    fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl Drop for SharedBuffer {
+    fn drop(&mut self) {
+        // Unmap shared memory, don't deallocate
+        // munmap(self.ptr, self.len);
+    }
+}
+```
+
+## Memory Allocation Compatibility
+
+| Allocator | Can use Rust Vec/String/Box? |
+|-----------|------------------------------|
+| Rust global allocator | Yes |
+| C malloc | No - use wrapper with C free |
+| C++ new | No - use wrapper with C++ delete |
+| Custom allocator | No - use allocator_api |
+| mmap/shared memory | No - use munmap |
+| Stack/static | No - never "free" |
+
+## Checklist
+
+- [ ] Who allocated this memory?
+- [ ] Is it from Rust's global allocator?
+- [ ] If not, do I have a custom Drop that frees correctly?
+- [ ] Am I copying data or taking ownership?
+
+## Related Rules
+
+- `mem-02`: Don't modify other process's memory
+- `ffi-03`: Implement Drop for wrapped C pointers
+- `ffi-07`: Don't implement Drop for types passed to external code

--- a/.agents/skills/unsafe-checker/rules/mem-04-reentrant.md
+++ b/.agents/skills/unsafe-checker/rules/mem-04-reentrant.md
@@ -1,0 +1,121 @@
+---
+id: mem-04
+original_id: P.UNS.MEM.04
+level: P
+impact: HIGH
+---
+
+# Prefer Reentrant Versions of C-API or Syscalls
+
+## Summary
+
+When calling C functions or system calls, use reentrant (`_r`) versions to avoid data races from global state.
+
+## Rationale
+
+Many C library functions use static buffers or global state, making them unsafe in multithreaded programs. Reentrant versions use caller-provided buffers instead.
+
+## Bad Example
+
+```rust
+use std::ffi::CStr;
+
+extern "C" {
+    fn strtok(s: *mut i8, delim: *const i8) -> *mut i8;
+    fn localtime(time: *const i64) -> *mut Tm;
+    fn rand() -> i32;
+}
+
+// DON'T: Use non-reentrant functions
+fn bad_tokenize(s: &mut [i8]) {
+    unsafe {
+        let delim = b" \0".as_ptr() as *const i8;
+        // strtok uses static buffer - not thread-safe!
+        let token = strtok(s.as_mut_ptr(), delim);
+    }
+}
+
+fn bad_time() {
+    unsafe {
+        let now: i64 = 0;
+        // localtime returns pointer to static buffer
+        let tm = localtime(&now);  // Data race if called from multiple threads!
+    }
+}
+
+fn bad_random() -> i32 {
+    // rand() uses global state - not thread-safe
+    unsafe { rand() }
+}
+```
+
+## Good Example
+
+```rust
+extern "C" {
+    fn strtok_r(s: *mut i8, delim: *const i8, saveptr: *mut *mut i8) -> *mut i8;
+    fn localtime_r(time: *const i64, result: *mut Tm) -> *mut Tm;
+    fn rand_r(seed: *mut u32) -> i32;
+}
+
+// DO: Use reentrant versions
+fn good_tokenize(s: &mut [i8]) {
+    unsafe {
+        let delim = b" \0".as_ptr() as *const i8;
+        let mut saveptr: *mut i8 = std::ptr::null_mut();
+        // strtok_r uses caller-provided saveptr
+        let token = strtok_r(s.as_mut_ptr(), delim, &mut saveptr);
+    }
+}
+
+fn good_time() {
+    unsafe {
+        let now: i64 = 0;
+        let mut result: Tm = std::mem::zeroed();
+        // localtime_r writes to caller-provided buffer
+        localtime_r(&now, &mut result);
+    }
+}
+
+fn good_random(seed: &mut u32) -> i32 {
+    // rand_r uses caller-provided seed
+    unsafe { rand_r(seed) }
+}
+
+// BETTER: Use Rust standard library
+fn best_time() {
+    use std::time::SystemTime;
+    let now = SystemTime::now();  // Thread-safe!
+}
+
+fn best_random() -> u32 {
+    use rand::Rng;
+    rand::thread_rng().gen()  // Thread-safe!
+}
+```
+
+## Common Non-Reentrant Functions
+
+| Non-Reentrant | Reentrant | Rust Alternative |
+|---------------|-----------|------------------|
+| `strtok` | `strtok_r` | `str::split` |
+| `localtime` | `localtime_r` | `chrono` crate |
+| `gmtime` | `gmtime_r` | `chrono` crate |
+| `ctime` | `ctime_r` | `chrono` crate |
+| `rand` | `rand_r` | `rand` crate |
+| `strerror` | `strerror_r` | `std::io::Error` |
+| `getenv` | None (inherent race) | `std::env::var` (not atomic) |
+| `readdir` | `readdir_r` | `std::fs::read_dir` |
+| `gethostbyname` | `getaddrinfo` | `std::net::ToSocketAddrs` |
+
+## Checklist
+
+- [ ] Am I calling a C function that might use global state?
+- [ ] Is there a `_r` reentrant version available?
+- [ ] Is there a Rust standard library alternative?
+- [ ] If neither, do I need synchronization?
+
+## Related Rules
+
+- `ffi-10`: Exported functions must be thread-safe
+- `ptr-01`: Don't share raw pointers across threads

--- a/.agents/skills/unsafe-checker/rules/mem-05-bitfield-crates.md
+++ b/.agents/skills/unsafe-checker/rules/mem-05-bitfield-crates.md
@@ -1,0 +1,147 @@
+---
+id: mem-05
+original_id: P.UNS.MEM.05
+level: P
+impact: MEDIUM
+---
+
+# Use Third-Party Crates for Bitfields
+
+## Summary
+
+Use crates like `bitflags`, `bitvec`, or `modular-bitfield` instead of manual bit manipulation for complex bitfield operations.
+
+## Rationale
+
+- Manual bit manipulation is error-prone
+- Easy to get offsets, masks, or endianness wrong
+- Crates provide type-safe, tested abstractions
+- Proc-macro crates generate efficient code
+
+## Bad Example
+
+```rust
+// DON'T: Manual bitfield manipulation
+struct Flags(u32);
+
+impl Flags {
+    const READ: u32 = 1 << 0;
+    const WRITE: u32 = 1 << 1;
+    const EXECUTE: u32 = 1 << 2;
+
+    fn has_read(&self) -> bool {
+        (self.0 & Self::READ) != 0
+    }
+
+    fn set_read(&mut self) {
+        self.0 |= Self::READ;
+    }
+
+    fn clear_read(&mut self) {
+        self.0 &= !Self::READ;  // Easy to forget the !
+    }
+}
+
+// DON'T: Manual packed bitfields for FFI
+#[repr(C)]
+struct PackedHeader {
+    data: u32,
+}
+
+impl PackedHeader {
+    // Error-prone: wrong shift or mask values
+    fn version(&self) -> u8 {
+        ((self.data >> 24) & 0xFF) as u8
+    }
+
+    fn flags(&self) -> u16 {
+        ((self.data >> 8) & 0xFFFF) as u16
+    }
+
+    fn tag(&self) -> u8 {
+        (self.data & 0xFF) as u8
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use bitflags for flag sets
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Flags: u32 {
+        const READ = 1 << 0;
+        const WRITE = 1 << 1;
+        const EXECUTE = 1 << 2;
+        const RW = Self::READ.bits() | Self::WRITE.bits();
+    }
+}
+
+fn use_flags() {
+    let mut flags = Flags::READ | Flags::WRITE;
+    flags.insert(Flags::EXECUTE);
+    flags.remove(Flags::WRITE);
+
+    if flags.contains(Flags::READ) {
+        println!("Readable");
+    }
+}
+
+// DO: Use modular-bitfield for packed structures
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[repr(C)]
+struct PackedHeader {
+    tag: B8,      // 8 bits
+    flags: B16,   // 16 bits
+    version: B8,  // 8 bits
+}
+
+fn use_packed() {
+    let header = PackedHeader::new()
+        .with_version(1)
+        .with_flags(0x1234)
+        .with_tag(0xAB);
+
+    assert_eq!(header.version(), 1);
+    assert_eq!(header.flags(), 0x1234);
+}
+
+// DO: Use bitvec for arbitrary bit manipulation
+use bitvec::prelude::*;
+
+fn use_bitvec() {
+    let mut bits = bitvec![u8, Msb0; 0; 16];
+    bits.set(0, true);
+    bits.set(7, true);
+
+    let byte: u8 = bits[0..8].load_be();
+    assert_eq!(byte, 0b1000_0001);
+}
+```
+
+## Recommended Crates
+
+| Crate | Use Case | Features |
+|-------|----------|----------|
+| `bitflags` | Flag sets (like C enums) | Type-safe, const, derives |
+| `modular-bitfield` | Packed struct fields | Proc macro, repr(C) |
+| `bitvec` | Arbitrary bit arrays | Slicing, iteration |
+| `packed_struct` | Binary protocol structs | Endianness, derive |
+| `deku` | Binary parsing | Derive, read/write |
+
+## Checklist
+
+- [ ] Am I manipulating multiple bit flags? → Use `bitflags`
+- [ ] Am I packing fields into bytes? → Use `modular-bitfield` or `packed_struct`
+- [ ] Am I doing binary protocol work? → Consider `deku`
+- [ ] Is the manual approach really simpler?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/mem-06-maybeuninit.md
+++ b/.agents/skills/unsafe-checker/rules/mem-06-maybeuninit.md
@@ -1,0 +1,146 @@
+---
+id: mem-06
+original_id: G.UNS.MEM.01
+level: G
+impact: HIGH
+clippy: uninit_assumed_init, uninit_vec
+---
+
+# Use MaybeUninit<T> for Uninitialized Memory
+
+## Summary
+
+Use `MaybeUninit<T>` instead of `mem::uninitialized()` or `mem::zeroed()` when working with uninitialized memory.
+
+## Rationale
+
+- `mem::uninitialized()` is deprecated and unsound
+- `mem::zeroed()` is UB for types where zero is invalid (references, NonZero, bool)
+- `MaybeUninit<T>` clearly marks memory as potentially uninitialized
+- Compiler can optimize based on initialization state
+
+## Bad Example
+
+```rust
+// DON'T: Use deprecated uninitialized
+fn bad_uninit<T>() -> T {
+    unsafe { std::mem::uninitialized() }  // Deprecated, UB
+}
+
+// DON'T: Use zeroed for types where zero is invalid
+fn bad_zeroed() -> &'static str {
+    unsafe { std::mem::zeroed() }  // UB: null reference
+}
+
+fn bad_zeroed_bool() -> bool {
+    unsafe { std::mem::zeroed() }  // UB: 0 might not be valid bool
+}
+
+// DON'T: Transmute to "initialize"
+fn bad_transmute() -> [String; 10] {
+    unsafe { std::mem::transmute([0u8; std::mem::size_of::<[String; 10]>()]) }
+}
+
+// DON'T: Set Vec length without initializing
+fn bad_vec() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    unsafe { v.set_len(10); }  // Elements are uninitialized!
+    v
+}
+```
+
+## Good Example
+
+```rust
+use std::mem::MaybeUninit;
+
+// DO: Use MaybeUninit for delayed initialization
+fn good_array() -> [String; 10] {
+    let mut arr: [MaybeUninit<String>; 10] =
+        unsafe { MaybeUninit::uninit().assume_init() };
+
+    for (i, elem) in arr.iter_mut().enumerate() {
+        elem.write(format!("item {}", i));
+    }
+
+    // SAFETY: All elements initialized above
+    unsafe { std::mem::transmute::<_, [String; 10]>(arr) }
+}
+
+// DO: Use MaybeUninit with arrays (cleaner with array_assume_init)
+fn good_array_nightly() -> [String; 10] {
+    let mut arr: [MaybeUninit<String>; 10] =
+        [const { MaybeUninit::uninit() }; 10];
+
+    for (i, elem) in arr.iter_mut().enumerate() {
+        elem.write(format!("item {}", i));
+    }
+
+    // On nightly: arr.map(|e| unsafe { e.assume_init() })
+    unsafe { MaybeUninit::array_assume_init(arr) }
+}
+
+// DO: Use zeroed only for types where it's valid
+fn good_zeroed() -> [u8; 1024] {
+    // SAFETY: All-zero bytes is valid for u8
+    unsafe { std::mem::zeroed() }
+}
+
+// DO: Initialize buffer properly
+fn good_vec() -> Vec<u8> {
+    let mut v = Vec::with_capacity(1024);
+
+    // Option 1: Resize with default value
+    v.resize(1024, 0);
+
+    // Option 2: Use spare_capacity_mut
+    let spare = v.spare_capacity_mut();
+    for elem in spare.iter_mut().take(1024) {
+        elem.write(0);
+    }
+    unsafe { v.set_len(1024); }
+
+    v
+}
+
+// DO: Use MaybeUninit::uninit_array (nightly) or const array
+fn good_uninit_array<const N: usize>() -> [MaybeUninit<u8>; N] {
+    // Stable: create array of uninit
+    [const { MaybeUninit::uninit() }; N]
+}
+```
+
+## MaybeUninit API
+
+```rust
+use std::mem::MaybeUninit;
+
+// Creation
+let uninit: MaybeUninit<T> = MaybeUninit::uninit();
+let zeroed: MaybeUninit<T> = MaybeUninit::zeroed();
+let init: MaybeUninit<T> = MaybeUninit::new(value);
+
+// Writing
+uninit.write(value);  // Returns &mut T
+
+// Reading (unsafe)
+let value: T = unsafe { uninit.assume_init() };
+let ref_: &T = unsafe { uninit.assume_init_ref() };
+let mut_: &mut T = unsafe { uninit.assume_init_mut() };
+
+// Pointer access
+let ptr: *const T = uninit.as_ptr();
+let mut_ptr: *mut T = uninit.as_mut_ptr();
+```
+
+## Checklist
+
+- [ ] Am I using `mem::uninitialized()`? → Replace with `MaybeUninit`
+- [ ] Am I using `mem::zeroed()` for non-POD types? → Use `MaybeUninit`
+- [ ] Am I setting Vec length without initialization? → Use proper initialization
+- [ ] Have I initialized all MaybeUninit before assume_init?
+
+## Related Rules
+
+- `safety-03`: Don't expose uninitialized memory in APIs
+- `safety-01`: Panic safety with partial initialization

--- a/.agents/skills/unsafe-checker/rules/ptr-01-no-thread-share.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-01-no-thread-share.md
@@ -1,0 +1,113 @@
+---
+id: ptr-01
+original_id: P.UNS.PTR.01
+level: P
+impact: CRITICAL
+---
+
+# Do Not Share Raw Pointers Across Threads
+
+## Summary
+
+Raw pointers (`*const T`, `*mut T`) are not `Send` or `Sync` by default. Do not share them across threads without ensuring proper synchronization.
+
+## Rationale
+
+Raw pointers have no synchronization guarantees. Sharing them across threads can lead to data races, which are undefined behavior.
+
+## Bad Example
+
+```rust
+use std::thread;
+
+// DON'T: Share raw pointers across threads
+fn bad_sharing() {
+    let mut data = 42i32;
+    let ptr = &mut data as *mut i32;
+
+    let handle = thread::spawn(move || {
+        // This is undefined behavior!
+        unsafe { *ptr = 100; }
+    });
+
+    // Main thread also accesses - data race!
+    unsafe { *ptr = 200; }
+
+    handle.join().unwrap();
+}
+
+// DON'T: Wrap in struct and impl Send unsafely
+struct UnsafePtr(*mut i32);
+unsafe impl Send for UnsafePtr {}  // Unsound without synchronization!
+```
+
+## Good Example
+
+```rust
+use std::sync::{Arc, Mutex, atomic::{AtomicPtr, Ordering}};
+use std::thread;
+
+// DO: Use Arc<Mutex<T>> for shared mutable access
+fn good_mutex() {
+    let data = Arc::new(Mutex::new(42i32));
+    let data_clone = Arc::clone(&data);
+
+    let handle = thread::spawn(move || {
+        *data_clone.lock().unwrap() = 100;
+    });
+
+    *data.lock().unwrap() = 200;
+    handle.join().unwrap();
+}
+
+// DO: Use AtomicPtr for lock-free pointer sharing
+fn good_atomic() {
+    let data = Box::into_raw(Box::new(42i32));
+    let atomic_ptr = Arc::new(AtomicPtr::new(data));
+    let atomic_clone = Arc::clone(&atomic_ptr);
+
+    let handle = thread::spawn(move || {
+        let ptr = atomic_clone.load(Ordering::Acquire);
+        // SAFETY: We have exclusive access through atomic operations
+        unsafe { println!("Value: {}", *ptr); }
+    });
+
+    handle.join().unwrap();
+
+    // SAFETY: All threads done, we own the memory
+    unsafe { drop(Box::from_raw(atomic_ptr.load(Ordering::Relaxed))); }
+}
+
+// DO: If you must use raw pointers, ensure exclusive access
+fn good_exclusive() {
+    let mut data = vec![1, 2, 3];
+
+    // Send data ownership to thread, not pointer
+    let handle = thread::spawn(move || {
+        data.push(4);
+        data
+    });
+
+    let data = handle.join().unwrap();
+    println!("{:?}", data);
+}
+```
+
+## When Raw Pointers Across Threads Are Valid
+
+Only with proper synchronization:
+- Through `AtomicPtr` with appropriate memory orderings
+- Protected by a `Mutex` (don't share the pointer, share the Mutex)
+- Using lock-free algorithms with careful memory ordering
+
+## Checklist
+
+- [ ] Does my pointer cross thread boundaries?
+- [ ] Is there synchronization preventing concurrent access?
+- [ ] Can I use a higher-level abstraction (Arc, Mutex)?
+- [ ] If implementing Send/Sync, is thread safety proven?
+
+## Related Rules
+
+- `safety-05`: Consider safety when implementing Send/Sync
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ptr-02-prefer-nonnull.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-02-prefer-nonnull.md
@@ -1,0 +1,114 @@
+---
+id: ptr-02
+original_id: P.UNS.PTR.02
+level: P
+impact: MEDIUM
+---
+
+# Prefer NonNull<T> Over *mut T
+
+## Summary
+
+Use `NonNull<T>` instead of `*mut T` when the pointer should never be null. This enables null pointer optimization and makes the intent clear.
+
+## Rationale
+
+- `NonNull<T>` guarantees non-null at the type level
+- Enables niche optimization: `Option<NonNull<T>>` is the same size as `*mut T`
+- Makes invariants explicit in the type system
+- Covariant over `T` (like `&T`), which is usually what you want
+
+## Bad Example
+
+```rust
+// DON'T: Use *mut when pointer is always non-null
+struct MyBox<T> {
+    ptr: *mut T,  // Invariant: never null, but not enforced
+}
+
+impl<T> MyBox<T> {
+    pub fn new(value: T) -> Self {
+        let ptr = Box::into_raw(Box::new(value));
+        // ptr is guaranteed non-null, but type doesn't show it
+        Self { ptr }
+    }
+
+    pub fn get(&self) -> &T {
+        // Must add null check or document the invariant
+        unsafe { &*self.ptr }
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::ptr::NonNull;
+
+// DO: Use NonNull when pointer is never null
+struct MyBox<T> {
+    ptr: NonNull<T>,  // Type guarantees non-null
+}
+
+impl<T> MyBox<T> {
+    pub fn new(value: T) -> Self {
+        let ptr = Box::into_raw(Box::new(value));
+        // SAFETY: Box::into_raw never returns null
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        Self { ptr }
+    }
+
+    pub fn get(&self) -> &T {
+        // SAFETY: NonNull guarantees ptr is valid
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T> Drop for MyBox<T> {
+    fn drop(&mut self) {
+        // SAFETY: ptr was created from Box::into_raw
+        unsafe { drop(Box::from_raw(self.ptr.as_ptr())); }
+    }
+}
+
+// DO: Niche optimization with Option
+struct OptionalBox<T> {
+    ptr: Option<NonNull<T>>,  // Same size as *mut T!
+}
+```
+
+## NonNull API
+
+```rust
+use std::ptr::NonNull;
+
+// Creating NonNull
+let ptr: NonNull<i32> = NonNull::new(raw_ptr).expect("null pointer");
+let ptr: NonNull<i32> = unsafe { NonNull::new_unchecked(raw_ptr) };
+let ptr: NonNull<i32> = NonNull::dangling();  // For ZSTs or uninitialized
+
+// Using NonNull
+let raw: *mut i32 = ptr.as_ptr();
+let reference: &i32 = unsafe { ptr.as_ref() };
+let mut_ref: &mut i32 = unsafe { ptr.as_mut() };
+
+// Casting
+let ptr: NonNull<u8> = ptr.cast::<u8>();
+```
+
+## When to Use *mut T Instead
+
+- When null is a valid/expected value
+- FFI with C code that may return null
+- When variance matters (NonNull is covariant, sometimes you need invariance)
+
+## Checklist
+
+- [ ] Is my pointer ever null? If no, use NonNull
+- [ ] Do I need null pointer optimization?
+- [ ] Is the variance correct for my use case?
+
+## Related Rules
+
+- `ptr-03`: Use PhantomData for variance and ownership
+- `safety-06`: Don't expose raw pointers in public APIs

--- a/.agents/skills/unsafe-checker/rules/ptr-03-phantomdata.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-03-phantomdata.md
@@ -1,0 +1,125 @@
+---
+id: ptr-03
+original_id: P.UNS.PTR.03
+level: P
+impact: HIGH
+---
+
+# Use PhantomData<T> for Variance and Ownership with Pointer Generics
+
+## Summary
+
+When a struct contains raw pointers but logically owns or borrows the pointed-to data, use `PhantomData<T>` to tell the compiler about the relationship.
+
+## Rationale
+
+Raw pointers don't carry ownership or lifetime information. `PhantomData` lets you:
+- Indicate ownership (for `Drop` check)
+- Control variance (covariant, contravariant, invariant)
+- Participate in lifetime elision
+
+## Bad Example
+
+```rust
+// DON'T: Raw pointer without PhantomData
+struct MyVec<T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+}
+
+// Problems:
+// 1. Compiler doesn't know we "own" the T values
+// 2. T might be incorrectly determined as unused
+// 3. Drop check may allow dangling references
+```
+
+## Good Example
+
+```rust
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+// DO: Use PhantomData to express ownership
+struct MyVec<T> {
+    ptr: NonNull<T>,
+    len: usize,
+    cap: usize,
+    _marker: PhantomData<T>,  // We own T values
+}
+
+// For owned data: PhantomData<T>
+// For borrowed data: PhantomData<&'a T>
+// For mutably borrowed: PhantomData<&'a mut T>
+// For function pointers: PhantomData<fn(T)> (contravariant)
+
+// DO: Express lifetime relationships
+struct Iter<'a, T> {
+    ptr: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,  // Borrows T for 'a
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ptr == self.end {
+            None
+        } else {
+            // SAFETY: ptr < end, so ptr is valid
+            // Lifetime is tied to 'a through PhantomData
+            let current = unsafe { &*self.ptr };
+            self.ptr = unsafe { self.ptr.add(1) };
+            Some(current)
+        }
+    }
+}
+```
+
+## PhantomData Patterns
+
+| Phantom Type | Meaning | Variance |
+|--------------|---------|----------|
+| `PhantomData<T>` | Owns T | Covariant |
+| `PhantomData<&'a T>` | Borrows T for 'a | Covariant in T, covariant in 'a |
+| `PhantomData<&'a mut T>` | Mutably borrows T | Invariant in T, covariant in 'a |
+| `PhantomData<*const T>` | Just has pointer | Covariant |
+| `PhantomData<*mut T>` | Just has pointer | Invariant |
+| `PhantomData<fn(T)>` | Consumes T | Contravariant |
+| `PhantomData<fn() -> T>` | Produces T | Covariant |
+
+## Drop Check
+
+```rust
+use std::marker::PhantomData;
+
+// This tells the compiler that dropping MyVec may drop T values
+struct MyVec<T> {
+    ptr: NonNull<T>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Drop for MyVec<T> {
+    fn drop(&mut self) {
+        // Drop all T values...
+    }
+}
+
+// Without PhantomData<T>, this might compile incorrectly:
+// let x = MyVec::new(&local);
+// drop(local);  // Would be UB if allowed
+// drop(x);      // Tries to access dropped local
+```
+
+## Checklist
+
+- [ ] Does my pointer type logically own the pointed-to data?
+- [ ] Do I need to express a lifetime relationship?
+- [ ] What variance do I need for my generic parameter?
+- [ ] Will the type be dropped, and does it need drop check?
+
+## Related Rules
+
+- `ptr-02`: Prefer NonNull over *mut T
+- `safety-05`: Send/Sync implementation safety

--- a/.agents/skills/unsafe-checker/rules/ptr-04-alignment.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-04-alignment.md
@@ -1,0 +1,117 @@
+---
+id: ptr-04
+original_id: G.UNS.PTR.01
+level: G
+impact: HIGH
+clippy: cast_ptr_alignment
+---
+
+# Do Not Dereference Pointers Cast to Misaligned Types
+
+## Summary
+
+When casting a pointer to a different type, ensure the resulting pointer is properly aligned for the target type.
+
+## Rationale
+
+Misaligned pointer dereferences are undefined behavior on most architectures. Even on architectures that support unaligned access, it may cause performance penalties or subtle bugs.
+
+## Bad Example
+
+```rust
+// DON'T: Cast without checking alignment
+fn bad_cast(bytes: &[u8]) -> u32 {
+    // BAD: bytes might not be aligned for u32
+    let ptr = bytes.as_ptr() as *const u32;
+    unsafe { *ptr }  // UB if misaligned!
+}
+
+// DON'T: Assume struct layout
+#[repr(C)]
+struct Header {
+    flags: u8,
+    value: u32,  // Aligned at offset 4 in the struct
+}
+
+fn bad_field_access(bytes: &[u8]) -> u32 {
+    let header = bytes.as_ptr() as *const Header;
+    // Even if bytes is 4-byte aligned, this might fail
+    // if Header has different alignment than expected
+    unsafe { (*header).value }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use read_unaligned for potentially misaligned data
+fn good_cast(bytes: &[u8]) -> u32 {
+    assert!(bytes.len() >= 4);
+    let ptr = bytes.as_ptr() as *const u32;
+    // SAFETY: We're reading 4 bytes, alignment doesn't matter for read_unaligned
+    unsafe { ptr.read_unaligned() }
+}
+
+// DO: Check alignment before cast
+fn good_aligned_cast(bytes: &[u8]) -> Option<&u32> {
+    if bytes.len() >= 4 && bytes.as_ptr() as usize % std::mem::align_of::<u32>() == 0 {
+        // SAFETY: Checked length and alignment
+        Some(unsafe { &*(bytes.as_ptr() as *const u32) })
+    } else {
+        None
+    }
+}
+
+// DO: Use from_ne_bytes for portable byte conversion
+fn good_from_bytes(bytes: &[u8]) -> u32 {
+    u32::from_ne_bytes(bytes[..4].try_into().unwrap())
+}
+
+// DO: Use bytemuck for safe transmutation
+// use bytemuck::{Pod, Zeroable};
+// let value: u32 = bytemuck::pod_read_unaligned(bytes);
+
+// DO: Use align_to for splitting at alignment boundaries
+fn process_aligned(bytes: &[u8]) {
+    let (prefix, aligned, suffix) = unsafe { bytes.align_to::<u32>() };
+    // prefix and suffix are unaligned portions
+    // aligned is a &[u32] that's properly aligned
+}
+```
+
+## Alignment Check Helpers
+
+```rust
+fn is_aligned<T>(ptr: *const u8) -> bool {
+    ptr as usize % std::mem::align_of::<T>() == 0
+}
+
+/// Align a pointer up to the next aligned address
+fn align_up<T>(ptr: *const u8) -> *const u8 {
+    let align = std::mem::align_of::<T>();
+    let addr = ptr as usize;
+    let aligned = (addr + align - 1) & !(align - 1);
+    aligned as *const u8
+}
+```
+
+## Architecture Notes
+
+| Arch | Misaligned Access |
+|------|-------------------|
+| x86/x64 | Works but slower |
+| ARM | UB, may trap or give wrong results |
+| RISC-V | UB, may trap |
+| WASM | UB |
+
+## Checklist
+
+- [ ] Is my pointer cast changing alignment requirements?
+- [ ] Is the source pointer guaranteed to be aligned?
+- [ ] Should I use read_unaligned instead?
+- [ ] Can I use safe conversion methods (from_ne_bytes)?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/ptr-05-no-const-to-mut.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-05-no-const-to-mut.md
@@ -1,0 +1,120 @@
+---
+id: ptr-05
+original_id: G.UNS.PTR.02
+level: G
+impact: CRITICAL
+clippy: cast_ref_to_mut
+---
+
+# Do Not Manually Convert Immutable Pointer to Mutable
+
+## Summary
+
+Never cast `*const T` to `*mut T` and dereference it to write. This violates aliasing rules and is undefined behavior.
+
+## Rationale
+
+Creating `*const T` from `&T` implies immutability. Other references might exist. Writing through a `*mut T` created from `*const T` creates mutable aliasing, which is UB.
+
+## Bad Example
+
+```rust
+// DON'T: Cast *const to *mut
+fn bad_mutate(value: &i32) {
+    let ptr = value as *const i32 as *mut i32;
+    unsafe { *ptr = 42; }  // UB: Mutating through &
+}
+
+// DON'T: Use transmute to convert
+fn bad_transmute(value: &i32) -> &mut i32 {
+    unsafe { std::mem::transmute(value) }  // UB!
+}
+
+// DON'T: "I know this is the only reference"
+fn bad_claim(value: &i32) {
+    // Even if you "know" there's only one reference,
+    // the compiler assumes & means no mutation
+    let ptr = value as *const i32 as *mut i32;
+    unsafe { *ptr += 1; }  // Still UB - compiler may optimize incorrectly
+}
+```
+
+## Good Example
+
+```rust
+// DO: Take &mut if you need to mutate
+fn good_mutate(value: &mut i32) {
+    *value = 42;
+}
+
+// DO: Use interior mutability
+use std::cell::{Cell, RefCell, UnsafeCell};
+
+struct Mutable {
+    value: Cell<i32>,  // Interior mutability
+}
+
+impl Mutable {
+    fn modify(&self) {
+        self.value.set(42);  // OK: Cell provides interior mutability
+    }
+}
+
+// DO: Use UnsafeCell if you need raw unsafe interior mutability
+struct RawMutable {
+    value: UnsafeCell<i32>,
+}
+
+impl RawMutable {
+    fn modify(&self) {
+        // SAFETY: We ensure exclusive access through external means
+        unsafe { *self.value.get() = 42; }
+    }
+}
+```
+
+## The UnsafeCell Exception
+
+`UnsafeCell<T>` is the ONLY valid way to get `*mut T` from `&self`:
+
+```rust
+use std::cell::UnsafeCell;
+
+pub struct MyMutex<T> {
+    data: UnsafeCell<T>,
+    // ... lock state
+}
+
+impl<T> MyMutex<T> {
+    pub fn lock(&self) -> Guard<'_, T> {
+        // acquire lock...
+
+        // SAFETY: UnsafeCell allows this, lock ensures exclusivity
+        Guard { data: unsafe { &mut *self.data.get() } }
+    }
+}
+```
+
+## Why This Is Always UB
+
+The compiler assumes:
+1. `&T` means no mutation will occur
+2. Multiple `&T` can exist simultaneously
+3. Optimizations can be made based on these assumptions
+
+When you mutate through cast pointer:
+1. Other `&T` references see inconsistent values
+2. Compiler may cache/eliminate reads
+3. Results are unpredictable
+
+## Checklist
+
+- [ ] Am I trying to mutate through `&`?
+- [ ] Should I use `&mut` instead?
+- [ ] Should I use `Cell`, `RefCell`, or `UnsafeCell`?
+- [ ] Is the original type designed for interior mutability?
+
+## Related Rules
+
+- `safety-08`: Mutable return from immutable parameter is wrong
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ptr-06-prefer-cast.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-06-prefer-cast.md
@@ -1,0 +1,110 @@
+---
+id: ptr-06
+original_id: G.UNS.PTR.03
+level: G
+impact: LOW
+clippy: ptr_as_ptr
+---
+
+# Prefer pointer::cast Over `as` for Pointer Casting
+
+## Summary
+
+Use the `cast()` method instead of `as` for pointer type conversions. It's clearer and prevents accidental provenance loss.
+
+## Rationale
+
+- `cast()` only changes the pointed-to type, not pointer properties
+- `as` can accidentally convert to integer and back, losing provenance
+- `cast()` is more explicit about intent
+- Better tooling support (clippy, miri)
+
+## Bad Example
+
+```rust
+// DON'T: Use `as` for pointer casts
+fn bad_cast(ptr: *const u8) -> *const i32 {
+    ptr as *const i32  // Works, but less clear
+}
+
+// DON'T: Accidental provenance loss
+fn bad_roundtrip(ptr: *const u8) -> *const u8 {
+    let addr = ptr as usize;   // Converts to integer
+    addr as *const u8          // Loses provenance information!
+}
+
+// DON'T: Multiple `as` casts in chain
+fn bad_chain(ptr: *const u8) -> *mut i32 {
+    ptr as *mut u8 as *mut i32  // Hard to follow
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use cast() for pointer type changes
+fn good_cast(ptr: *const u8) -> *const i32 {
+    ptr.cast::<i32>()
+}
+
+// DO: Use cast_mut() for const-to-mut (when valid)
+fn good_cast_mut(ptr: *const u8) -> *mut u8 {
+    ptr.cast_mut()  // Only use when mutation is valid!
+}
+
+// DO: Use cast_const() for mut-to-const
+fn good_cast_const(ptr: *mut u8) -> *const u8 {
+    ptr.cast_const()
+}
+
+// DO: Chain casts clearly
+fn good_chain(ptr: *const u8) -> *mut i32 {
+    ptr.cast_mut().cast::<i32>()
+}
+
+// DO: Use with_addr() for address manipulation (nightly)
+#[cfg(feature = "strict_provenance")]
+fn good_provenance(ptr: *const u8, new_addr: usize) -> *const u8 {
+    ptr.with_addr(new_addr)  // Preserves provenance
+}
+```
+
+## Pointer Method Reference
+
+| Method | From | To | Notes |
+|--------|------|-----|-------|
+| `.cast::<U>()` | `*T` | `*U` | Changes pointee type |
+| `.cast_mut()` | `*const T` | `*mut T` | Removes const |
+| `.cast_const()` | `*mut T` | `*const T` | Adds const |
+| `.addr()` | `*T` | `usize` | Gets address (nightly) |
+| `.with_addr(usize)` | `*T` | `*T` | Changes address, keeps provenance |
+| `.map_addr(fn)` | `*T` | `*T` | Transforms address |
+
+## Provenance Considerations
+
+```rust
+// Provenance = permission to access memory
+
+// BAD: Loses provenance
+let ptr: *const u8 = &data as *const u8;
+let addr = ptr as usize;
+let ptr2 = addr as *const u8;  // ptr2 has no provenance!
+
+// GOOD: Preserves provenance (nightly strict_provenance)
+let ptr2 = ptr.with_addr(addr);  // Still has permission
+
+// GOOD: Use expose/from_exposed when provenance must cross integer
+let addr = ptr.expose_addr();  // "Expose" the provenance
+let ptr2 = std::ptr::from_exposed_addr(addr);  // Recover it
+```
+
+## Checklist
+
+- [ ] Am I using `as` where `cast()` would be clearer?
+- [ ] Am I accidentally converting through `usize`?
+- [ ] Do I need to preserve provenance?
+
+## Related Rules
+
+- `ptr-04`: Alignment considerations when casting
+- `ptr-05`: Don't convert const to mut improperly

--- a/.agents/skills/unsafe-checker/rules/safety-01-panic-safety.md
+++ b/.agents/skills/unsafe-checker/rules/safety-01-panic-safety.md
@@ -1,0 +1,113 @@
+---
+id: safety-01
+original_id: P.UNS.SAS.01
+level: P
+impact: CRITICAL
+clippy: panic_in_result_fn
+---
+
+# Be Aware of Memory Safety Issues from Panics
+
+## Summary
+
+Panics in unsafe code can leave data structures in an inconsistent state, leading to undefined behavior when the panic is caught.
+
+## Rationale
+
+When a panic occurs, Rust unwinds the stack and runs destructors. If unsafe code has partially modified data, the destructors may observe invalid state.
+
+## Bad Example
+
+```rust
+// DON'T: Panic can leave Vec in invalid state
+impl<T> MyVec<T> {
+    pub fn push(&mut self, value: T) {
+        if self.len == self.cap {
+            self.grow();  // Might panic during allocation
+        }
+
+        unsafe {
+            // If Clone::clone() panics after incrementing len,
+            // drop will try to drop uninitialized memory
+            self.len += 1;
+            ptr::write(self.ptr.add(self.len - 1), value.clone());
+        }
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Ensure panic safety by ordering operations correctly
+impl<T> MyVec<T> {
+    pub fn push(&mut self, value: T) {
+        if self.len == self.cap {
+            self.grow();
+        }
+
+        unsafe {
+            // Write first, then increment len
+            // If write somehow panics, len is still valid
+            ptr::write(self.ptr.add(self.len), value);
+            self.len += 1;  // Only increment after successful write
+        }
+    }
+}
+
+// DO: Use guards for complex operations
+impl<T: Clone> MyVec<T> {
+    pub fn extend_from_slice(&mut self, slice: &[T]) {
+        self.reserve(slice.len());
+
+        let mut guard = PanicGuard {
+            vec: self,
+            initialized: 0,
+        };
+
+        for item in slice {
+            unsafe {
+                ptr::write(guard.vec.ptr.add(guard.vec.len + guard.initialized), item.clone());
+                guard.initialized += 1;
+            }
+        }
+
+        // Success - update len and forget guard
+        self.len += guard.initialized;
+        std::mem::forget(guard);
+    }
+}
+
+struct PanicGuard<'a, T> {
+    vec: &'a mut MyVec<T>,
+    initialized: usize,
+}
+
+impl<T> Drop for PanicGuard<'_, T> {
+    fn drop(&mut self) {
+        // Clean up partially initialized elements on panic
+        unsafe {
+            for i in 0..self.initialized {
+                ptr::drop_in_place(self.vec.ptr.add(self.vec.len + i));
+            }
+        }
+    }
+}
+```
+
+## Key Patterns
+
+1. **Update bookkeeping after operations**: Increment length only after writing
+2. **Use panic guards**: RAII types that clean up on panic
+3. **Order operations carefully**: Ensure invariants hold if panic occurs at any point
+
+## Checklist
+
+- [ ] What happens if this code panics at each line?
+- [ ] Are all invariants maintained if we unwind from here?
+- [ ] Do I need a panic guard for cleanup?
+
+## Related Rules
+
+- `safety-04`: Avoid double-free from panic safety issues
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-02-verify-invariants.md
+++ b/.agents/skills/unsafe-checker/rules/safety-02-verify-invariants.md
@@ -1,0 +1,90 @@
+---
+id: safety-02
+original_id: P.UNS.SAS.02
+level: P
+impact: CRITICAL
+---
+
+# Unsafe Code Authors Must Verify Safety Invariants
+
+## Summary
+
+When writing unsafe code, you are taking responsibility for upholding all safety invariants that the compiler normally enforces.
+
+## Rationale
+
+Unsafe blocks don't disable safety requirements - they transfer responsibility from the compiler to the programmer. You must manually verify what the compiler normally checks.
+
+## Safety Invariants to Verify
+
+1. **Pointer validity**: Non-null, aligned, points to valid memory
+2. **Aliasing**: No mutable aliasing (two &mut to same memory)
+3. **Initialization**: Memory is initialized before read
+4. **Lifetime**: References don't outlive their referents
+5. **Type validity**: Data matches the expected type's invariants
+6. **Thread safety**: Proper synchronization for concurrent access
+
+## Bad Example
+
+```rust
+// DON'T: Blindly trust inputs
+unsafe fn process(ptr: *const Data, len: usize) {
+    for i in 0..len {
+        // No verification that ptr is valid or len is correct!
+        let item = &*ptr.add(i);
+        process_item(item);
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Document and verify invariants
+/// Processes a slice of Data items.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and aligned for `Data`
+/// - `ptr` must point to `len` consecutive initialized `Data` items
+/// - The memory must not be mutated during this call
+/// - `len * size_of::<Data>()` must not overflow `isize::MAX`
+unsafe fn process(ptr: *const Data, len: usize) {
+    debug_assert!(!ptr.is_null(), "ptr must not be null");
+    debug_assert!(ptr.is_aligned(), "ptr must be aligned");
+
+    for i in 0..len {
+        // SAFETY: Caller guarantees ptr points to len valid items
+        let item = &*ptr.add(i);
+        process_item(item);
+    }
+}
+
+// DO: Provide safe wrapper when possible
+fn process_slice(data: &[Data]) {
+    // SAFETY: slice guarantees all invariants
+    unsafe { process(data.as_ptr(), data.len()) }
+}
+```
+
+## Invariant Documentation Template
+
+```rust
+/// # Safety
+///
+/// The caller must ensure that:
+/// - [List each invariant]
+/// - [Explain why each matters]
+```
+
+## Checklist
+
+- [ ] Have I listed all safety invariants?
+- [ ] Can I prove each invariant holds at the call site?
+- [ ] Have I added debug assertions where possible?
+- [ ] Have I documented invariants in /// # Safety section?
+
+## Related Rules
+
+- `safety-09`: Add SAFETY comment before any unsafe block
+- `safety-10`: Add Safety section in docs for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-03-no-uninit-api.md
+++ b/.agents/skills/unsafe-checker/rules/safety-03-no-uninit-api.md
@@ -1,0 +1,121 @@
+---
+id: safety-03
+original_id: P.UNS.SAS.03
+level: P
+impact: CRITICAL
+clippy: uninit_assumed_init
+---
+
+# Do Not Expose Uninitialized Memory in Public APIs
+
+## Summary
+
+Public APIs must never return or expose uninitialized memory to callers.
+
+## Rationale
+
+Reading uninitialized memory is undefined behavior in Rust. Safe code should never be able to access uninitialized memory through your API.
+
+## Bad Example
+
+```rust
+// DON'T: Expose uninitialized memory
+pub struct Buffer {
+    data: [u8; 1024],
+    len: usize,
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        // BAD: data is uninitialized
+        unsafe {
+            Self {
+                data: std::mem::MaybeUninit::uninit().assume_init(),
+                len: 0,
+            }
+        }
+    }
+
+    // BAD: Returns reference to potentially uninitialized data
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data[..self.len]  // What if len > initialized portion?
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::mem::MaybeUninit;
+
+// DO: Use MaybeUninit properly and only expose initialized data
+pub struct Buffer {
+    data: Box<[MaybeUninit<u8>; 1024]>,
+    len: usize,  // Invariant: data[0..len] is initialized
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        Self {
+            // MaybeUninit doesn't require initialization
+            data: Box::new([MaybeUninit::uninit(); 1024]),
+            len: 0,
+        }
+    }
+
+    pub fn push(&mut self, byte: u8) {
+        if self.len < 1024 {
+            self.data[self.len].write(byte);
+            self.len += 1;
+        }
+    }
+
+    // Only returns initialized portion
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: self.len bytes are initialized (invariant)
+        unsafe {
+            std::slice::from_raw_parts(
+                self.data.as_ptr() as *const u8,
+                self.len
+            )
+        }
+    }
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        // Only drop initialized elements
+        // For u8 this is a no-op, but important for Drop types
+    }
+}
+```
+
+## Patterns for Uninitialized Memory
+
+```rust
+// Pattern 1: MaybeUninit for delayed initialization
+let mut value: MaybeUninit<ExpensiveType> = MaybeUninit::uninit();
+initialize_expensive(&mut value);
+let value = unsafe { value.assume_init() };
+
+// Pattern 2: Vec::with_capacity for growable buffers
+let mut vec = Vec::with_capacity(100);
+// vec.len() is 0, capacity is 100
+// No uninitialized memory is accessible
+
+// Pattern 3: Box::new_uninit (nightly)
+let mut boxed = Box::<[u8; 1024]>::new_uninit();
+boxed.write([0u8; 1024]);
+let boxed = unsafe { boxed.assume_init() };
+```
+
+## Checklist
+
+- [ ] Does my API ever return references to uninitialized memory?
+- [ ] Are length/capacity invariants properly maintained?
+- [ ] Is MaybeUninit used instead of transmute for uninitialized data?
+
+## Related Rules
+
+- `mem-06`: Use MaybeUninit<T> for uninitialized memory
+- `safety-01`: Panic safety with partial initialization

--- a/.agents/skills/unsafe-checker/rules/safety-04-double-free.md
+++ b/.agents/skills/unsafe-checker/rules/safety-04-double-free.md
@@ -1,0 +1,109 @@
+---
+id: safety-04
+original_id: P.UNS.SAS.04
+level: P
+impact: CRITICAL
+---
+
+# Avoid Double-Free from Panic Safety Issues
+
+## Summary
+
+Ensure that resources are not freed twice, especially when panics can occur during operations.
+
+## Rationale
+
+Double-free is undefined behavior. Panics during unsafe operations can cause destructors to run on already-freed or partially-constructed data.
+
+## Bad Example
+
+```rust
+// DON'T: Potential double-free on panic
+impl<T> MyVec<T> {
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;
+            unsafe {
+                // If something panics after this read but before return,
+                // Drop will try to drop this element again
+                Some(ptr::read(self.ptr.add(self.len)))
+            }
+        }
+    }
+}
+
+// DON'T: Double-free with ManuallyDrop misuse
+fn bad_swap<T>(a: &mut T, b: &mut T) {
+    unsafe {
+        let tmp = ptr::read(a);
+        ptr::write(a, ptr::read(b));  // If this panics, tmp leaks
+        ptr::write(b, tmp);
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use std::mem::take or swap
+fn good_swap<T: Default>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b);  // Safe and correct
+}
+
+// DO: Use ManuallyDrop for panic safety
+use std::mem::ManuallyDrop;
+
+impl<T> MyVec<T> {
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;  // Decrement first
+            unsafe {
+                // SAFETY: len was decremented, so this slot won't be
+                // dropped again by Vec's Drop impl
+                Some(ptr::read(self.ptr.add(self.len)))
+            }
+        }
+    }
+}
+
+// DO: Use scopeguard or manual cleanup
+fn safe_operation<T: Clone>(data: &mut [T], source: &[T]) {
+    // Track what we've written for cleanup on panic
+    let mut written = 0;
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        for (i, item) in source.iter().enumerate() {
+            data[i] = item.clone();
+            written = i + 1;
+        }
+    }));
+
+    if result.is_err() {
+        // Clean up on panic (if T needs special handling)
+        // In this case, safe code handles it automatically
+    }
+}
+```
+
+## Patterns to Avoid Double-Free
+
+1. **Decrement length before reading**: Vec's Drop won't touch the read element
+2. **Use ManuallyDrop**: Explicitly control when Drop runs
+3. **Use std::mem::replace/swap**: Safe alternatives for move semantics
+4. **Panic guards**: RAII cleanup on unwind
+
+## Checklist
+
+- [ ] After reading memory, is it marked as "moved"?
+- [ ] Will Drop run on this memory? Should it?
+- [ ] What happens if this code panics at each point?
+- [ ] Are length/count bookkeeping updates ordered correctly?
+
+## Related Rules
+
+- `safety-01`: Panic safety in unsafe code
+- `ptr-01`: Don't share raw pointers across threads

--- a/.agents/skills/unsafe-checker/rules/safety-05-send-sync.md
+++ b/.agents/skills/unsafe-checker/rules/safety-05-send-sync.md
@@ -1,0 +1,113 @@
+---
+id: safety-05
+original_id: P.UNS.SAS.05
+level: P
+impact: CRITICAL
+clippy: non_send_fields_in_send_ty
+---
+
+# Consider Safety When Manually Implementing Auto Traits
+
+## Summary
+
+When manually implementing `Send` or `Sync`, you must ensure thread safety invariants are upheld.
+
+## Rationale
+
+`Send` and `Sync` are unsafe traits because incorrect implementations cause data races, which are undefined behavior. The compiler auto-implements them conservatively, but manual implementations require careful analysis.
+
+## Trait Meanings
+
+- **`Send`**: Safe to transfer ownership to another thread
+- **`Sync`**: Safe to share references (`&T`) between threads (i.e., `&T: Send`)
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe Send/Sync without thread safety
+struct NotThreadSafe {
+    ptr: *mut i32,  // Raw pointers are not Send/Sync
+}
+
+// BAD: This is unsound!
+unsafe impl Send for NotThreadSafe {}
+unsafe impl Sync for NotThreadSafe {}
+
+// DON'T: Rc-like type with unsafe Sync
+struct MyRc<T> {
+    ptr: *mut RcInner<T>,
+}
+
+struct RcInner<T> {
+    count: usize,  // Not atomic!
+    data: T,
+}
+
+// BAD: count is not atomic, concurrent access is UB
+unsafe impl<T: Send> Sync for MyRc<T> {}
+```
+
+## Good Example
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::ptr::NonNull;
+
+// DO: Use atomic operations for thread-safe reference counting
+struct MyArc<T> {
+    ptr: NonNull<ArcInner<T>>,
+}
+
+struct ArcInner<T> {
+    count: AtomicUsize,  // Atomic for thread safety
+    data: T,
+}
+
+// SAFETY: The data is behind atomic reference counting,
+// and T: Send + Sync ensures the data itself is thread-safe
+unsafe impl<T: Send + Sync> Send for MyArc<T> {}
+unsafe impl<T: Send + Sync> Sync for MyArc<T> {}
+
+// DO: Document why it's safe
+/// A thread-safe wrapper around a raw file descriptor.
+///
+/// # Safety
+///
+/// The file descriptor is valid for the lifetime of this struct,
+/// and file descriptors are safe to use from any thread.
+struct ThreadSafeFd {
+    fd: std::os::unix::io::RawFd,
+}
+
+// SAFETY: File descriptors are just integers and can be used
+// from any thread. The actual I/O operations are thread-safe
+// at the OS level.
+unsafe impl Send for ThreadSafeFd {}
+unsafe impl Sync for ThreadSafeFd {}
+```
+
+## Decision Tree
+
+```
+Does your type contain:
+  - Raw pointers? → Probably not auto Send/Sync
+  - Rc/RefCell? → Not Sync (Rc not Send either)
+  - Cell/UnsafeCell? → Not Sync
+  - Interior mutability? → Needs synchronization for Sync
+
+To manually implement:
+  - Send: Can another thread safely drop this?
+  - Sync: Can multiple threads safely call &self methods?
+```
+
+## Checklist
+
+- [ ] Does my type contain any non-Send/Sync fields?
+- [ ] Is interior mutability properly synchronized (Mutex, atomic)?
+- [ ] Would concurrent access cause data races?
+- [ ] Have I documented why the implementation is safe?
+
+## Related Rules
+
+- `ptr-01`: Don't share raw pointers across threads
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-06-no-raw-ptr-api.md
+++ b/.agents/skills/unsafe-checker/rules/safety-06-no-raw-ptr-api.md
@@ -1,0 +1,137 @@
+---
+id: safety-06
+original_id: P.UNS.SAS.06
+level: P
+impact: HIGH
+---
+
+# Do Not Expose Raw Pointers in Public APIs
+
+## Summary
+
+Public APIs should use safe abstractions (references, slices, smart pointers) instead of exposing raw pointers.
+
+## Rationale
+
+Raw pointers bypass Rust's safety guarantees. Exposing them in public APIs forces users into unsafe code and makes it easy to create undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Expose raw pointers in public API
+pub struct Buffer {
+    data: *mut u8,
+    len: usize,
+}
+
+impl Buffer {
+    // BAD: Returns raw pointer
+    pub fn as_ptr(&self) -> *const u8 {
+        self.data
+    }
+
+    // BAD: Takes raw pointer as input
+    pub fn from_ptr(ptr: *mut u8, len: usize) -> Self {
+        Self { data: ptr, len }
+    }
+
+    // BAD: Exposes internal pointer mutably
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.data
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use safe abstractions
+pub struct Buffer {
+    data: Vec<u8>,
+}
+
+impl Buffer {
+    // Returns a safe reference
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    // Takes safe input
+    pub fn from_slice(data: &[u8]) -> Self {
+        Self { data: data.to_vec() }
+    }
+
+    // Mutable access through safe reference
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+}
+
+// DO: If raw pointers are needed, provide unsafe API with documentation
+impl Buffer {
+    /// Returns a pointer to the buffer's data.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is valid for `self.len()` bytes and must not be
+    /// used after the Buffer is dropped or reallocated.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    /// Creates a Buffer from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must point to `len` valid bytes
+    /// - The memory must be allocated with the global allocator
+    /// - Caller transfers ownership of the memory to Buffer
+    pub unsafe fn from_raw_parts(ptr: *mut u8, len: usize, cap: usize) -> Self {
+        Self {
+            data: Vec::from_raw_parts(ptr, len, cap)
+        }
+    }
+}
+```
+
+## Patterns for Safe Pointer APIs
+
+```rust
+// Pattern 1: Use NonNull for internal pointers
+use std::ptr::NonNull;
+
+pub struct MyBox<T> {
+    ptr: NonNull<T>,  // Internal use only
+}
+
+impl<T> MyBox<T> {
+    // Safe public API
+    pub fn get(&self) -> &T {
+        // SAFETY: ptr is always valid while MyBox exists
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+// Pattern 2: Callback-based access
+impl Buffer {
+    // User can work with pointer in controlled context
+    pub fn with_ptr<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(*const u8, usize) -> R,
+    {
+        f(self.data.as_ptr(), self.data.len())
+    }
+}
+```
+
+## Checklist
+
+- [ ] Can this API use references instead of pointers?
+- [ ] Can this API use slices instead of pointer + length?
+- [ ] If pointers are necessary, is the API marked `unsafe`?
+- [ ] Are safety requirements documented?
+
+## Related Rules
+
+- `general-03`: Don't create aliases for unsafe items
+- `safety-10`: Document safety requirements for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-07-unsafe-pair.md
+++ b/.agents/skills/unsafe-checker/rules/safety-07-unsafe-pair.md
@@ -1,0 +1,107 @@
+---
+id: safety-07
+original_id: P.UNS.SAS.07
+level: P
+impact: MEDIUM
+---
+
+# Provide Unsafe Counterparts for Performance Alongside Safe Methods
+
+## Summary
+
+When providing performance-critical operations that skip safety checks, offer both a safe checked version and an unsafe unchecked version.
+
+## Rationale
+
+Users who need maximum performance can opt into unsafe, while others get safety by default. This follows the "safe by default, unsafe opt-in" principle.
+
+## Bad Example
+
+```rust
+// DON'T: Only provide unsafe version
+impl<T> MySlice<T> {
+    /// Gets an element by index.
+    ///
+    /// # Safety
+    /// Index must be in bounds.
+    pub unsafe fn get(&self, index: usize) -> &T {
+        &*self.ptr.add(index)
+    }
+}
+
+// DON'T: Only provide checked version when performance matters
+impl<T> MySlice<T> {
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            Some(unsafe { &*self.ptr.add(index) })
+        } else {
+            None
+        }
+    }
+    // Missing: get_unchecked for performance-critical code
+}
+```
+
+## Good Example
+
+```rust
+// DO: Provide both versions
+impl<T> MySlice<T> {
+    /// Gets an element by index, returning `None` if out of bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            // SAFETY: We just verified index < len
+            Some(unsafe { self.get_unchecked(index) })
+        } else {
+            None
+        }
+    }
+
+    /// Gets an element by index without bounds checking.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        debug_assert!(index < self.len, "index out of bounds");
+        &*self.ptr.add(index)
+    }
+
+    /// Gets an element, panicking if out of bounds.
+    #[inline]
+    pub fn get_or_panic(&self, index: usize) -> &T {
+        assert!(index < self.len, "index {} out of bounds for len {}", index, self.len);
+        // SAFETY: We just asserted index < len
+        unsafe { self.get_unchecked(index) }
+    }
+}
+```
+
+## Standard Library Patterns
+
+| Safe Method | Unsafe Counterpart |
+|-------------|-------------------|
+| `slice.get(i)` | `slice.get_unchecked(i)` |
+| `str.chars().nth(i)` | `str.get_unchecked(range)` |
+| `vec.pop()` | `vec.set_len()` + `ptr::read` |
+| `String::from_utf8()` | `String::from_utf8_unchecked()` |
+
+## Naming Conventions
+
+- Safe: `method_name()`
+- Unsafe: `method_name_unchecked()`
+- Or: `get()` vs `get_unchecked()`
+
+## Checklist
+
+- [ ] Does my safe method have an unsafe counterpart for hot paths?
+- [ ] Does my unsafe method have a safe alternative for normal use?
+- [ ] Are both methods documented with their trade-offs?
+- [ ] Does the unsafe version include debug assertions?
+
+## Related Rules
+
+- `general-02`: Don't blindly use unsafe for performance
+- `safety-09`: Add SAFETY comments

--- a/.agents/skills/unsafe-checker/rules/safety-08-no-mut-from-immut.md
+++ b/.agents/skills/unsafe-checker/rules/safety-08-no-mut-from-immut.md
@@ -1,0 +1,124 @@
+---
+id: safety-08
+original_id: P.UNS.SAS.08
+level: P
+impact: CRITICAL
+clippy: mut_from_ref
+---
+
+# Mutable Return from Immutable Parameter is Wrong
+
+## Summary
+
+A function taking `&self` or `&T` must not return `&mut T` to the same data without interior mutability.
+
+## Rationale
+
+Returning `&mut` from `&` violates Rust's aliasing rules. The caller has an immutable borrow, so they can create additional `&` references. Returning `&mut` creates mutable aliasing, which is undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Return &mut from &self
+struct Container {
+    data: i32,
+}
+
+impl Container {
+    // WRONG: This is undefined behavior!
+    pub fn get_mut(&self) -> &mut i32 {
+        unsafe {
+            // Creating &mut from & is ALWAYS wrong
+            &mut *(&self.data as *const i32 as *mut i32)
+        }
+    }
+}
+
+// DON'T: Transmute & to &mut
+fn bad_transmute<T>(reference: &T) -> &mut T {
+    unsafe { std::mem::transmute(reference) }  // UB!
+}
+```
+
+## Good Example
+
+```rust
+use std::cell::{Cell, RefCell, UnsafeCell};
+
+// DO: Use interior mutability types
+struct Container {
+    data: Cell<i32>,          // For Copy types
+    complex: RefCell<String>, // For non-Copy with runtime checks
+}
+
+impl Container {
+    pub fn get(&self) -> i32 {
+        self.data.get()
+    }
+
+    pub fn set(&self, value: i32) {
+        self.data.set(value);
+    }
+
+    pub fn modify_complex(&self, f: impl FnOnce(&mut String)) {
+        f(&mut self.complex.borrow_mut());
+    }
+}
+
+// DO: Use UnsafeCell for custom interior mutability
+struct MyMutex<T> {
+    locked: std::sync::atomic::AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+impl<T> MyMutex<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        // Acquire lock...
+        MutexGuard { mutex: self }
+    }
+}
+
+struct MutexGuard<'a, T> {
+    mutex: &'a MyMutex<T>,
+}
+
+impl<T> std::ops::DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We hold the lock, so exclusive access is guaranteed
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+```
+
+## The Only Valid Pattern
+
+The ONLY way to get `&mut` from `&` is through `UnsafeCell`:
+
+```rust
+use std::cell::UnsafeCell;
+
+struct ValidInteriorMut {
+    data: UnsafeCell<i32>,
+}
+
+impl ValidInteriorMut {
+    // This is sound ONLY because UnsafeCell opts out of aliasing rules
+    // AND we guarantee exclusive access (e.g., through a lock)
+    pub fn get_mut(&self) -> &mut i32 {
+        // Must ensure no other references exist!
+        unsafe { &mut *self.data.get() }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Am I trying to return &mut from a & method?
+- [ ] If yes, am I using UnsafeCell or a type built on it?
+- [ ] Am I guaranteeing exclusive access before creating &mut?
+- [ ] Would Cell, RefCell, or Mutex solve my problem safely?
+
+## Related Rules
+
+- `ptr-05`: Don't manually convert *const to *mut
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-09-safety-comment.md
+++ b/.agents/skills/unsafe-checker/rules/safety-09-safety-comment.md
@@ -1,0 +1,122 @@
+---
+id: safety-09
+original_id: P.UNS.SAS.09
+level: P
+impact: CRITICAL
+clippy: undocumented_unsafe_blocks
+---
+
+# Add SAFETY Comment Before Any Unsafe Block
+
+## Summary
+
+Every `unsafe` block or `unsafe impl` must have a `// SAFETY:` comment explaining why the operation is safe.
+
+## Rationale
+
+SAFETY comments force the author to think about invariants and help reviewers verify correctness. They serve as documentation for future maintainers.
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe without explanation
+fn get_unchecked(slice: &[i32], index: usize) -> i32 {
+    unsafe { *slice.get_unchecked(index) }
+}
+
+// DON'T: Vague or unhelpful comments
+fn bad_comments(ptr: *const i32) -> i32 {
+    // This is unsafe
+    unsafe { *ptr }
+
+    // Trust me
+    unsafe { *ptr }
+
+    // Safe because I know what I'm doing
+    unsafe { *ptr }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Explain the safety invariant
+fn get_unchecked(slice: &[i32], index: usize) -> i32 {
+    // SAFETY: Caller guarantees index < slice.len()
+    unsafe { *slice.get_unchecked(index) }
+}
+
+// DO: Be specific about what makes it safe
+fn read_header(buffer: &[u8]) -> Header {
+    assert!(buffer.len() >= std::mem::size_of::<Header>());
+
+    // SAFETY:
+    // - buffer.len() >= size_of::<Header>() (asserted above)
+    // - buffer is aligned for u8, which is compatible with any alignment
+    // - Header is #[repr(C)] and has no padding requirements
+    unsafe {
+        std::ptr::read_unaligned(buffer.as_ptr() as *const Header)
+    }
+}
+
+// DO: Document unsafe impl
+struct MySendType(*mut i32);
+
+// SAFETY: The pointer is to thread-local storage that is only accessed
+// from the owning thread. MySendType is only sent when the TLS slot
+// is being transferred between threads with proper synchronization.
+unsafe impl Send for MySendType {}
+
+// DO: Multi-line for complex invariants
+fn complex_operation(data: &mut [u8], ranges: &[(usize, usize)]) {
+    for &(start, end) in ranges {
+        // SAFETY:
+        // 1. All ranges were validated to be within data.len()
+        //    in the calling function `validate_ranges()`
+        // 2. Ranges are non-overlapping (invariant of RangeSet)
+        // 3. We have &mut access to data, so no aliasing
+        unsafe {
+            let ptr = data.as_mut_ptr().add(start);
+            std::ptr::write_bytes(ptr, 0, end - start);
+        }
+    }
+}
+```
+
+## SAFETY Comment Format
+
+```rust
+// SAFETY: <brief explanation>
+
+// Or for complex cases:
+// SAFETY:
+// - Invariant 1: explanation
+// - Invariant 2: explanation
+// - Why this is upheld: explanation
+```
+
+## What to Include
+
+1. **What invariants must hold** for this to be safe
+2. **Why those invariants hold** at this specific call site
+3. **What could go wrong** if the invariants were violated (optional but helpful)
+
+## Clippy Configuration
+
+```toml
+# clippy.toml
+accept-comment-above-statement = true
+accept-comment-above-attributes = true
+```
+
+## Checklist
+
+- [ ] Does every unsafe block have a SAFETY comment?
+- [ ] Does the comment explain WHY it's safe, not just WHAT it does?
+- [ ] Are all relevant invariants mentioned?
+- [ ] Would a reviewer understand the safety argument?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-10`: Add Safety section in docs for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-10-safety-doc.md
+++ b/.agents/skills/unsafe-checker/rules/safety-10-safety-doc.md
@@ -1,0 +1,127 @@
+---
+id: safety-10
+original_id: G.UNS.SAS.01
+level: G
+impact: HIGH
+clippy: missing_safety_doc
+---
+
+# Add Safety Section in Docs for Public Unsafe Functions
+
+## Summary
+
+Public `unsafe` functions must have a `# Safety` section in their documentation explaining the caller's obligations.
+
+## Rationale
+
+Unlike SAFETY comments (which explain why an unsafe block is sound), `# Safety` docs tell callers what they must guarantee. Without this, users cannot safely call the function.
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe function without safety docs
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+
+// DON'T: Safety docs that don't explain requirements
+/// Processes a buffer.
+///
+/// This function is unsafe.  // Not helpful!
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+```
+
+## Good Example
+
+```rust
+/// Processes a buffer of bytes.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+///
+/// - `ptr` is non-null and properly aligned for `u8`
+/// - `ptr` points to at least `len` consecutive, initialized bytes
+/// - The memory referenced by `ptr` is not mutated during this call
+/// - `len` does not exceed `isize::MAX`
+///
+/// # Examples
+///
+/// ```
+/// let data = [1u8, 2, 3, 4];
+/// // SAFETY: data is a valid slice, we pass its pointer and length
+/// unsafe { process_buffer(data.as_ptr(), data.len()) };
+/// ```
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+
+/// Creates a `Vec<T>` from raw parts.
+///
+/// # Safety
+///
+/// This is highly unsafe due to the number of invariants that must
+/// be upheld by the caller:
+///
+/// * `ptr` must have been allocated via the global allocator
+/// * `T` must have the same alignment as the original allocation
+/// * `capacity` must be the capacity the pointer was allocated with
+/// * `length` must be less than or equal to `capacity`
+/// * The first `length` values must be properly initialized
+/// * The allocated memory must not be used elsewhere
+///
+/// Violating these may cause undefined behavior including
+/// use-after-free, double-free, and memory corruption.
+pub unsafe fn from_raw_parts(ptr: *mut T, length: usize, capacity: usize) -> Vec<T> {
+    // ...
+}
+```
+
+## Safety Documentation Template
+
+```rust
+/// Brief description of what the function does.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+///
+/// - Requirement 1: detailed explanation
+/// - Requirement 2: detailed explanation
+///
+/// # Panics (if applicable)
+///
+/// Panics if...
+///
+/// # Examples
+///
+/// ```
+/// // SAFETY: explanation of why this call is safe
+/// unsafe { function_name(...) };
+/// ```
+```
+
+## What to Document
+
+| Category | Example |
+|----------|---------|
+| Pointer validity | "ptr must be non-null and aligned" |
+| Memory state | "must point to initialized memory" |
+| Aliasing | "no other references to this memory may exist" |
+| Lifetime | "pointer must be valid for the duration of the call" |
+| Thread safety | "must not be called concurrently with..." |
+| Invariants | "len must not exceed isize::MAX" |
+
+## Checklist
+
+- [ ] Does the function have a `# Safety` section?
+- [ ] Are ALL caller obligations listed?
+- [ ] Is each requirement specific and verifiable?
+- [ ] Does the example show correct usage with SAFETY comment?
+
+## Related Rules
+
+- `safety-09`: SAFETY comments for unsafe blocks
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-11-assert-not-debug.md
+++ b/.agents/skills/unsafe-checker/rules/safety-11-assert-not-debug.md
@@ -1,0 +1,105 @@
+---
+id: safety-11
+original_id: G.UNS.SAS.02
+level: G
+impact: MEDIUM
+clippy: debug_assert_with_mut_call
+---
+
+# Use assert! Instead of debug_assert! in Unsafe Functions
+
+## Summary
+
+In `unsafe` functions or functions containing unsafe blocks, prefer `assert!` over `debug_assert!` for checking safety invariants.
+
+## Rationale
+
+`debug_assert!` is compiled out in release builds. If an invariant is important enough to check for safety, it should be checked in all builds to catch violations.
+
+## Bad Example
+
+```rust
+// DON'T: Use debug_assert for safety-critical checks
+pub unsafe fn get_unchecked(slice: &[i32], index: usize) -> &i32 {
+    debug_assert!(index < slice.len());  // Gone in release!
+    &*slice.as_ptr().add(index)
+}
+
+// DON'T: Rely on debug_assert for FFI safety
+pub unsafe fn call_c_function(ptr: *const Data) {
+    debug_assert!(!ptr.is_null());  // Won't catch bugs in release
+    ffi::process_data(ptr);
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use assert! for safety checks (when performance allows)
+pub unsafe fn get_unchecked(slice: &[i32], index: usize) -> &i32 {
+    assert!(index < slice.len(), "index {} out of bounds for len {}", index, slice.len());
+    &*slice.as_ptr().add(index)
+}
+
+// DO: Use debug_assert when CALLER is responsible
+/// # Safety
+/// index must be less than slice.len()
+pub unsafe fn get_unchecked_fast(slice: &[i32], index: usize) -> &i32 {
+    // Caller is responsible; debug_assert just helps catch bugs during development
+    debug_assert!(index < slice.len());
+    &*slice.as_ptr().add(index)
+}
+
+// DO: Use assert for internal safety, debug_assert for caller obligations
+pub fn get_checked(slice: &[i32], index: usize) -> Option<&i32> {
+    if index < slice.len() {
+        // SAFETY: We just checked index < len
+        // debug_assert is fine here because the if-check is the real guard
+        Some(unsafe {
+            debug_assert!(index < slice.len()); // Redundant, just for documentation
+            &*slice.as_ptr().add(index)
+        })
+    } else {
+        None
+    }
+}
+```
+
+## When to Use Each
+
+| Assertion | Use When |
+|-----------|----------|
+| `assert!` | Invariant is not already checked; function is called with untrusted input |
+| `debug_assert!` | Invariant is the caller's responsibility (documented in `# Safety`); performance-critical |
+| No assert | Invariant is enforced by types or prior checks in the same function |
+
+## Hybrid Approach
+
+```rust
+// Use cfg to have both safety and performance
+pub unsafe fn process(slice: &[u8], index: usize) {
+    // Always check in tests and debug
+    #[cfg(any(test, debug_assertions))]
+    assert!(index < slice.len());
+
+    // Optional: paranoid mode for production
+    #[cfg(feature = "paranoid")]
+    assert!(index < slice.len());
+
+    // SAFETY: Caller guarantees index < len (checked in debug)
+    let ptr = slice.as_ptr().add(index);
+    // ...
+}
+```
+
+## Checklist
+
+- [ ] Is this a safety-critical invariant?
+- [ ] Who is responsible for upholding it (caller or this function)?
+- [ ] Can the assertion be optimized away when provably true?
+- [ ] What's the performance impact of the assertion?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-09`: SAFETY comments

--- a/.agents/skills/unsafe-checker/rules/union-01-avoid-except-ffi.md
+++ b/.agents/skills/unsafe-checker/rules/union-01-avoid-except-ffi.md
@@ -1,0 +1,117 @@
+---
+id: union-01
+original_id: P.UNS.UNI.01
+level: P
+impact: HIGH
+---
+
+# Avoid Union Except for C Interop
+
+## Summary
+
+Only use `union` for FFI with C code. For Rust-only code, use `enum` with explicit tags.
+
+## Rationale
+
+- Unions require unsafe to read (any field access is unsafe)
+- Easy to read wrong field, causing undefined behavior
+- Enums are type-safe and the compiler tracks the active variant
+- Unions don't run destructors properly
+
+## Bad Example
+
+```rust
+// DON'T: Use union for space optimization in Rust-only code
+union IntOrFloat {
+    i: i32,
+    f: f32,
+}
+
+fn bad_usage() {
+    let mut u = IntOrFloat { i: 42 };
+
+    // BAD: Reading wrong field is UB
+    let f = unsafe { u.f };  // UB if i was the last written field
+}
+
+// DON'T: Use union for variant types
+union Variant {
+    string: std::mem::ManuallyDrop<String>,
+    number: i64,
+}
+
+// Problems:
+// 1. Must manually track which variant is active
+// 2. Must manually call drop on String variant
+// 3. Easy to have memory leaks or double-free
+```
+
+## Good Example
+
+```rust
+// DO: Use enum for variant types in Rust
+enum Variant {
+    String(String),
+    Number(i64),
+}
+
+// Compiler tracks active variant, runs correct destructor
+
+// DO: Use union only for C FFI
+#[repr(C)]
+union CUnion {
+    i: i32,
+    f: f32,
+}
+
+// When interfacing with C code that uses this union
+extern "C" {
+    fn c_function_returns_union() -> CUnion;
+    fn c_function_takes_union(u: CUnion);
+}
+
+// DO: Wrap in safe API with explicit variant tracking
+#[repr(C)]
+pub struct SafeUnion {
+    tag: u8,
+    data: CUnion,
+}
+
+impl SafeUnion {
+    pub fn as_int(&self) -> Option<i32> {
+        if self.tag == 0 {
+            // SAFETY: Tag indicates integer variant is active
+            Some(unsafe { self.data.i })
+        } else {
+            None
+        }
+    }
+}
+```
+
+## When Union Is Appropriate
+
+1. **C FFI**: Matching C union layout for interoperability
+2. **MaybeUninit**: The standard library uses union internally
+3. **Very low-level optimization**: Only after profiling and careful safety analysis
+
+## Alternatives to Union
+
+| Use Case | Instead of Union | Use |
+|----------|-----------------|-----|
+| Variant types | union + tag | `enum` |
+| Optional value | union + bool | `Option<T>` |
+| Type punning | union | `transmute` or `from_ne_bytes` |
+| Uninitialized memory | union | `MaybeUninit<T>` |
+
+## Checklist
+
+- [ ] Is this for C FFI? If not, use enum
+- [ ] If union is necessary, is there a tag tracking active variant?
+- [ ] Are destructors handled correctly for Drop types?
+- [ ] Is the union #[repr(C)] for FFI?
+
+## Related Rules
+
+- `union-02`: Don't use union variants across lifetimes
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/union-02-no-cross-lifetime.md
+++ b/.agents/skills/unsafe-checker/rules/union-02-no-cross-lifetime.md
@@ -1,0 +1,121 @@
+---
+id: union-02
+original_id: P.UNS.UNI.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Use Union Variants Across Different Lifetimes
+
+## Summary
+
+Do not write to one union field and read from another field that has a different lifetime or references data with a different lifetime.
+
+## Rationale
+
+Union fields share the same memory. If one field stores a reference with lifetime `'a` and you read it as a reference with lifetime `'b`, you bypass lifetime checking and can create dangling references.
+
+## Bad Example
+
+```rust
+// DON'T: Extend lifetime through union
+union LifetimeBypass<'a, 'b> {
+    short: &'a str,
+    long: &'b str,
+}
+
+fn bad_lifetime_extension<'a, 'b>(short: &'a str) -> &'b str {
+    let u = LifetimeBypass { short };
+    // BAD: Reading with different lifetime is UB
+    unsafe { u.long }
+}
+
+fn exploit() {
+    let long_ref: &'static str;
+    {
+        let temp = String::from("temporary");
+        // Extend local reference to 'static - dangling pointer!
+        long_ref = bad_lifetime_extension(&temp);
+    }
+    // temp is dropped, long_ref is dangling
+    println!("{}", long_ref);  // UB: use after free
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use same lifetime for all reference fields
+union SafeUnion<'a> {
+    str_ref: &'a str,
+    bytes_ref: &'a [u8],
+}
+
+fn safe_conversion<'a>(s: &'a str) -> &'a [u8] {
+    let u = SafeUnion { str_ref: s };
+    // SAFETY: Both fields have same lifetime 'a
+    // AND str and [u8] have compatible representations
+    unsafe { u.bytes_ref }
+}
+
+// Better: Just use as_bytes()
+fn better_conversion(s: &str) -> &[u8] {
+    s.as_bytes()
+}
+
+// DO: Use MaybeUninit for delayed initialization, not lifetime tricks
+use std::mem::MaybeUninit;
+
+fn delayed_init<T>(init: impl FnOnce() -> T) -> T {
+    let mut value: MaybeUninit<T> = MaybeUninit::uninit();
+    value.write(init());
+    unsafe { value.assume_init() }
+}
+```
+
+## Why This Is Dangerous
+
+The Rust lifetime system prevents use-after-free by tracking how long references are valid. Unions can subvert this:
+
+```
+Memory: [pointer to "hello"]
+
+Union as 'short: points to stack memory (valid during function)
+Union as 'long:  claims to point to valid memory forever
+
+Reality: After function returns, pointer is dangling
+```
+
+## Safe Union Patterns
+
+```rust
+// Pattern 1: All fields have same lifetime
+union SameLifetime<'a, T, U> {
+    a: &'a T,
+    b: &'a U,
+}
+
+// Pattern 2: No references at all
+#[repr(C)]
+union NoRefs {
+    i: i32,
+    f: f32,
+}
+
+// Pattern 3: Use ManuallyDrop for owned values (careful with Drop!)
+union OwnedUnion {
+    s: std::mem::ManuallyDrop<String>,
+    v: std::mem::ManuallyDrop<Vec<u8>>,
+}
+```
+
+## Checklist
+
+- [ ] Do all reference fields have the same lifetime parameter?
+- [ ] Am I trying to extend a lifetime through union? (If yes, stop!)
+- [ ] For owned types, am I handling Drop correctly?
+
+## Related Rules
+
+- `union-01`: Avoid union except for C interop
+- `safety-02`: Verify safety invariants

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +30,27 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -56,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -75,6 +116,251 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex 0.12.1",
+ "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap 2.13.0",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+dependencies = [
+ "bitflags",
+ "serde_core",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-select"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -92,16 +378,215 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async_cell"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
+dependencies = [
+ "loom",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bstr"
@@ -121,20 +606,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -148,6 +665,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -181,7 +708,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -197,16 +724,948 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "datafusion"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea28305c211e3541c9cfcf06a23d0d8c7c824b4502ed1fdf0a6ff4ad24ee531c"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.2",
+ "regex",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ab99b6df5f60a6ddbc515e4c05caee1192d395cf3cb67ce5d1c17e3c9b9b74"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ae3d14912c0d779ada98d30dc60f3244f3c26c2446b87394629ea5c076a31c"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2df29b9592a5d55b8238eaf67d2f21963d5a08cd1a8b7670134405206caabd"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-ipc",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "libc",
+ "log",
+ "object_store",
+ "paste",
+ "sqlparser",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42639baa0049d5fffd7e283504b9b5e7b9b2e7a2dea476eed60ab0d40d999b85"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25951b617bb22a9619e1520450590cb2004bfcad10bcb396b961f4a1a10dcec5"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b28226960ba99c50d78ac6f736ebe09eb5cb3bb9bb58194266278000ca41f"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f538b57b052a678b1ce860181c65d3ace5a8486312dc50b41c01dd585a773a51"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fbc1d32b1b03c9734e27c0c5f041232b68621c8455f22769838634750a196c"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6450dc702b3d39e8ced54c3356abb453bd2f3cea86d90d555a4b92f7a38462"
+
+[[package]]
+name = "datafusion-execution"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66a02fa601de49da5181dbdcf904a18b16a184db2b31f5e5534552ea2d5e660"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.2",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf59a9b308a1a07dc2eb2f85e6366bc0226dc390b40f3aa0a72d79f1cfe2465"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99eac4c6538c708638db43e7a3bd88e0e57955ddb722d420fb9a6d38dfc28f"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11aa2c492ac046397b36d57c62a72982aad306495bbcbcdbcabd424d4a2fe245"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "blake2",
+ "blake3",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "md-5",
+ "num-traits",
+ "rand 0.9.2",
+ "regex",
+ "sha2",
+ "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325a00081898945d48d6194d9ca26120e523c993be3bb7c084061a5a2a72e787"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "half",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809bbcb1e0dbec5d0ce30d493d135aea7564f1ba4550395f7f94321223df2dae"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ebaa5d7024ef45973e0a7db1e9aeaa647936496f4d4061c0448f23d77d6320"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60eab6f39df9ee49a2c7fa38eddc01fa0086ee31b29c7d19f38e72f479609752"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00b2c15e342a90e65a846199c9e49293dd09fe1bcd63d8be2544604892f7eb8"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493e2e1d1f4753dfc139a5213f1b5d0b97eea46a82d9bda3c7908aa96981b74b"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba01c55ade8278a791b429f7bf5cb1de64de587a342d084b18245edfae7096e2"
+dependencies = [
+ "datafusion-doc",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a80c6dfbba6a2163a9507f6353ac78c69d8deb26232c9e419160e58ff7c3e047"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3a86264bb9163e7360b6622e789bc7fcbb43672e78a8493f0bc369a41a57c6"
+dependencies = [
+ "ahash",
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "parking_lot",
+ "paste",
+ "petgraph",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5e00e524ac33500be6c5eeac940bd3f6b984ba9b7df0cd5f6c34a8a2cc4d6b"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae769ea5d688b4e74e9be5cad6f9d9f295b540825355868a3ab942380dd97ce"
+dependencies = [
+ "ahash",
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3588753ab2b47b0e43cd823fe5e7944df6734dabd6dafb72e2cc1c2a22f1944"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79949cbb109c2a45c527bfe0d956b9f2916807c05d4d2e66f3fd0af827ac2b61"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "log",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6434e2ee8a39d04b95fed688ff34dc251af6e4a0c2e1714716b6e3846690d589"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91efb8302b4877d499c37e9a71886b90236ab27d9cc42fd51112febf341abd6"
+dependencies = [
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "52.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f01eef7bcf4d00e87305b55f1b75792384e130fe0258bac02cd48378ae5ff87"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "indexmap 2.13.0",
+ "log",
+ "regex",
+ "sqlparser",
+]
+
+[[package]]
+name = "deepsize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb987ec36f6bf7bfbea3f928b75590b736fc42af8e54d97592481351b2b96c"
+dependencies = [
+ "deepsize_derive",
+]
+
+[[package]]
+name = "deepsize_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990101d41f3bc8c1a45641024377ee284ecc338e5ecf3ea0f0e236d897c72796"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -221,8 +1680,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "ethnum"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -237,6 +1735,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,10 +1770,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forgeplan-cli"
@@ -262,6 +1798,7 @@ dependencies = [
  "forgeplan-core",
  "predicates",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -269,13 +1806,203 @@ name = "forgeplan-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrow-array",
+ "arrow-schema",
+ "async-trait",
  "chrono",
+ "futures",
+ "lancedb",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fsst"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a32ddfc5478379cd1782bdd9d7d1411063f563e5b338fc73bafe5916451a5b9d"
+dependencies = [
+ "arrow-array",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "fst"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+dependencies = [
+ "utf8-ranges",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -286,10 +2013,59 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -297,7 +2073,9 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -305,12 +2083,151 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperloglogplus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -337,10 +2254,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -355,16 +2391,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -377,10 +2498,653 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonb"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a901f06163d352fbe41c3c2ff5e08b75330a003cc941e988fb501022f5421e6"
+dependencies = [
+ "byteorder",
+ "ethnum",
+ "fast-float2",
+ "itoa",
+ "jiff",
+ "nom 8.0.0",
+ "num-traits",
+ "ordered-float",
+ "rand 0.9.2",
+ "ryu",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "lance"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c5ce428fda0721f5c48bfde17a1921c4da2d2142b2f46a16c89abf5fce8003"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "async_cell",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crossbeam-skiplist",
+ "dashmap",
+ "datafusion",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "deepsize",
+ "either",
+ "futures",
+ "half",
+ "humantime",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-table",
+ "log",
+ "moka",
+ "object_store",
+ "permutation",
+ "pin-project",
+ "prost",
+ "prost-types",
+ "rand 0.9.2",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.0",
+ "tantivy",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-arrow"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fdaf99863fa0d631e422881e88be4837d8b82f36a87143d723a9d285acec4b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "half",
+ "jsonb",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-bitpacking"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866b1634d38d94e8ab86fbcf238ac82dc8a5f72a4a6a90525f29899772e7cc7f"
+dependencies = [
+ "arrayref",
+ "paste",
+ "seq-macro",
+]
+
+[[package]]
+name = "lance-core"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c29f4e48c201c2806fe6ae117b65d0287eda236acd07357b556a54b0d5c5a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "datafusion-common",
+ "datafusion-sql",
+ "deepsize",
+ "futures",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "libc",
+ "log",
+ "mock_instant",
+ "moka",
+ "num_cpus",
+ "object_store",
+ "pin-project",
+ "prost",
+ "rand 0.9.2",
+ "roaring",
+ "serde_json",
+ "snafu 0.9.0",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-datafusion"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ccc72695473f4207df4c6df3b347a63e84c32c0bc36bf42a7d86e8a7c0c67e2"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "futures",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datagen",
+ "log",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "snafu 0.9.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-datagen"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe84d76944acd834ded14d7562663af995556e0c6594f4b4ac69b0183f99c1a"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "futures",
+ "half",
+ "hex",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rand_xoshiro",
+ "random_word",
+]
+
+[[package]]
+name = "lance-encoding"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1007242188e5d53c98717e7f2cb340dc80eb9c94c2b935587598919b3a36bd"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "bytemuck",
+ "byteorder",
+ "bytes",
+ "fsst",
+ "futures",
+ "hex",
+ "hyperloglogplus",
+ "itertools 0.13.0",
+ "lance-arrow",
+ "lance-bitpacking",
+ "lance-core",
+ "log",
+ "lz4",
+ "num-traits",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "snafu 0.9.0",
+ "strum",
+ "tokio",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+]
+
+[[package]]
+name = "lance-file"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f80088e418941f39cf5599d166ae1a6ef498cc2d967652a0692477d4871a9277"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "datafusion-common",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-encoding",
+ "lance-io",
+ "log",
+ "num-traits",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "snafu 0.9.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "lance-index"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0011daf1ddde99becffd2ae235ad324576736a526c54ffbc4d7e583872f1215"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-channel",
+ "async-recursion",
+ "async-trait",
+ "bitpacking",
+ "bitvec",
+ "bytes",
+ "crossbeam-queue",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-sql",
+ "deepsize",
+ "dirs",
+ "fst",
+ "futures",
+ "half",
+ "itertools 0.13.0",
+ "jsonb",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-io",
+ "lance-linalg",
+ "lance-table",
+ "libm",
+ "log",
+ "ndarray",
+ "num-traits",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "rand_distr 0.5.1",
+ "rangemap",
+ "rayon",
+ "roaring",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "snafu 0.9.0",
+ "tantivy",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "twox-hash",
+ "uuid",
+]
+
+[[package]]
+name = "lance-io"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa8a74e93753d19a27ce3adaeb99e31227df13ad5926dd43572be76b43dd284"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "async-recursion",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "http",
+ "lance-arrow",
+ "lance-core",
+ "lance-namespace",
+ "log",
+ "object_store",
+ "path_abs",
+ "pin-project",
+ "prost",
+ "rand 0.9.2",
+ "serde",
+ "snafu 0.9.0",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "lance-linalg"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d8da8f6b8dd37ab3b8199896ee265817f86232e3727c0b0eeb3c9093b64d9"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "cc",
+ "deepsize",
+ "half",
+ "lance-arrow",
+ "lance-core",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-namespace"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f176e427d9c35938d8a7097876114bc35dfd280b06077779753f2effe3e86aab"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "lance-core",
+ "lance-namespace-reqwest-client",
+ "snafu 0.9.0",
+]
+
+[[package]]
+name = "lance-namespace-impls"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663c32086ecfab311acb0813c65a4bb352a5b648ccf8b513c24697ce8d412039"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "lance",
+ "lance-core",
+ "lance-index",
+ "lance-io",
+ "lance-namespace",
+ "lance-table",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "serde_json",
+ "snafu 0.9.0",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "lance-namespace-reqwest-client"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9008f9825066088178c10599130c8bb0b9c79a39a479e8c51201620c43864a"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "lance-table"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa189b3081481a97b64cf1161297947a63b8adb941b1950989d0269858703a43"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "deepsize",
+ "futures",
+ "lance-arrow",
+ "lance-core",
+ "lance-file",
+ "lance-io",
+ "log",
+ "object_store",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "rand 0.9.2",
+ "rangemap",
+ "roaring",
+ "semver",
+ "serde",
+ "serde_json",
+ "snafu 0.9.0",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lance-testing"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79a6f4ab0788ee82893bac5de4ff0d0d88bba96de87db4b6e18b1883616d4dbe"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "lance-arrow",
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "lancedb"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79dd30fddeb0f21d090c502f937aa4862b5a352e74c47e35c6c76fec9f31534"
+dependencies = [
+ "ahash",
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-sql",
+ "futures",
+ "half",
+ "lance",
+ "lance-arrow",
+ "lance-core",
+ "lance-datafusion",
+ "lance-datagen",
+ "lance-encoding",
+ "lance-file",
+ "lance-index",
+ "lance-io",
+ "lance-linalg",
+ "lance-namespace",
+ "lance-namespace-impls",
+ "lance-table",
+ "lance-testing",
+ "lazy_static",
+ "log",
+ "moka",
+ "num-traits",
+ "object_store",
+ "pin-project",
+ "rand 0.9.2",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "snafu 0.8.9",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -389,10 +3153,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -401,10 +3201,237 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "once_cell",
+ "rawpointer",
+ "thread-tree",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mock_instant"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce6dd36094cac388f119d2e9dc82dc730ef91c32a6222170d630e5414b956e6"
+
+[[package]]
+name = "moka"
+version = "0.12.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -413,12 +3440,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
 ]
 
 [[package]]
@@ -432,6 +3537,208 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "permutation"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -470,7 +3777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -480,6 +3787,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -493,9 +3906,194 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "random_word"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
+dependencies = [
+ "ahash",
+ "brotli",
+ "paste",
+ "rand 0.9.2",
+ "unicase",
+]
+
+[[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "regex"
@@ -527,6 +4125,113 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,8 +4240,55 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -552,10 +4304,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -584,7 +4419,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -601,16 +4436,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -620,10 +4529,189 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
+dependencies = [
+ "snafu-derive 0.9.0",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -637,16 +4725,194 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tantivy"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "hyperloglogplus",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex 0.11.6",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
+dependencies = [
+ "nom 7.1.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
+dependencies = [
+ "murmurhash32",
+ "rand_distr 0.4.3",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -672,14 +4938,309 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "thread-tree"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbd370cb847953a25954d9f63e14824a36113f8c72eecf6eccef5dc4b45d630"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -694,10 +5255,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -707,6 +5322,31 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -740,6 +5380,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +5412,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -788,9 +5442,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -801,9 +5468,60 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -826,7 +5544,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -837,7 +5555,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -866,12 +5584,168 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -901,9 +5775,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -919,7 +5793,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -932,7 +5806,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -951,7 +5825,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -962,7 +5836,159 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ serde_yaml = "0.9"
 thiserror = "2"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1", features = ["full"] }
+lancedb = "0.27"
+arrow = { version = "57", default-features = false }
+arrow-array = "57"
+arrow-schema = "57"
+futures = "0.3"
+async-trait = "0.1"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -13,6 +13,7 @@ forgeplan-core = { path = "../forgeplan-core" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/forgeplan-cli/src/commands/graph.rs
+++ b/crates/forgeplan-cli/src/commands/graph.rs
@@ -1,12 +1,12 @@
 use forgeplan_core::graph;
 use forgeplan_core::workspace;
 
-pub fn run() -> anyhow::Result<()> {
+pub async fn run() -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
 
-    let edges = graph::build_edges(&ws)?;
+    let edges = graph::build_edges(&ws).await?;
     let mermaid = graph::render_mermaid(&edges);
 
     println!("{}", mermaid);

--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use forgeplan_core::workspace::{find_workspace, init_workspace, FORGEPLAN_DIR};
 
-pub fn run(force: bool) -> Result<()> {
+pub async fn run(force: bool) -> Result<()> {
     let cwd = env::current_dir()?;
 
     // Check if already initialized

--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::fs;
 
 use anyhow::Result;
 
@@ -16,7 +15,7 @@ pub async fn run(force: bool) -> Result<()> {
             return Ok(());
         }
         // Remove existing workspace for reinit
-        fs::remove_dir_all(&existing)?;
+        tokio::fs::remove_dir_all(&existing).await?;
         println!("  Removed existing {}", existing.display());
     }
 

--- a/crates/forgeplan-cli/src/commands/link.rs
+++ b/crates/forgeplan-cli/src/commands/link.rs
@@ -2,7 +2,7 @@ use forgeplan_core::artifact::store;
 use forgeplan_core::link;
 use forgeplan_core::workspace;
 
-pub fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Result<()> {
+pub async fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -11,7 +11,7 @@ pub fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Result<(
     let relation = link::normalize_relation(relation)?;
 
     // Find source artifact
-    let artifacts = store::list_artifacts(&ws)?;
+    let artifacts = store::list_artifacts(&ws).await?;
     let source = artifacts
         .iter()
         .find(|a| a.id.eq_ignore_ascii_case(source_id))
@@ -29,7 +29,7 @@ pub fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Result<(
     }
 
     // Add link
-    link::add_link(&source.path, target_id, &relation)?;
+    link::add_link(&source.path, target_id, &relation).await?;
 
     println!(
         "Linked: {} --{}--> {}",

--- a/crates/forgeplan-cli/src/commands/list.rs
+++ b/crates/forgeplan-cli/src/commands/list.rs
@@ -5,12 +5,12 @@ use anyhow::Result;
 use forgeplan_core::artifact::store::list_artifacts;
 use forgeplan_core::workspace::find_workspace;
 
-pub fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Result<()> {
+pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Result<()> {
     let cwd = env::current_dir()?;
     let workspace = find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
 
-    let mut artifacts = list_artifacts(&workspace)?;
+    let mut artifacts = list_artifacts(&workspace).await?;
 
     // Apply filters
     if let Some(kind) = kind_filter {

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -9,7 +9,7 @@ use forgeplan_core::artifact::types::ArtifactKind;
 use forgeplan_core::template::{get_embedded_template, render_template};
 use forgeplan_core::workspace::{find_workspace, load_config};
 
-pub fn run(kind_str: &str, title: &str) -> Result<()> {
+pub async fn run(kind_str: &str, title: &str) -> Result<()> {
     let kind = parse_kind(kind_str)?;
 
     let cwd = env::current_dir()?;
@@ -17,7 +17,7 @@ pub fn run(kind_str: &str, title: &str) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
 
     let config = load_config(&workspace)?;
-    let id = next_id(&workspace, &kind, config.id_digits)?;
+    let id = next_id(&workspace, &kind, config.id_digits).await?;
     let slug = slugify(title);
 
     // The kind string used for template lookup (lowercase, CLI-style name)
@@ -47,12 +47,6 @@ pub fn run(kind_str: &str, title: &str) -> Result<()> {
     rendered = rendered.replace("YYYY-MM-DD", &today);
 
     // Replace full ID patterns like PRD-{NNN} that may remain after render
-    // (render_template already handles {NNN}, but the prefix-qualified pattern
-    // e.g. "PRD-001" is produced naturally from "PRD-{NNN}" -> "PRD-001")
-    // So this should already work. But let's also replace the heading pattern.
-    // The heading "# PRD-001: {Product Area / Feature Name}" needs title substitution.
-    // The template renders {NNN} to the number, producing "# PRD-001: ..."
-    // We replace the boilerplate heading hint with the actual title.
     let heading_pattern = format!("# {}-{}: ", prefix, nnn);
     if let Some(pos) = rendered.find(&heading_pattern) {
         // Find the end of that line

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::env;
-use std::fs;
-
 use anyhow::{Context, Result};
 
 use forgeplan_core::artifact::store::{kind_dir, next_id, slugify};
@@ -64,11 +62,11 @@ pub async fn run(kind_str: &str, title: &str) -> Result<()> {
 
     // Write file
     let dir = workspace.join(kind_dir(&kind));
-    fs::create_dir_all(&dir)?;
+    tokio::fs::create_dir_all(&dir).await?;
     let filename = format!("{}-{}.md", id, slug);
     let filepath = dir.join(&filename);
 
-    fs::write(&filepath, &rendered)
+    tokio::fs::write(&filepath, &rendered).await
         .with_context(|| format!("Failed to write {}", filepath.display()))?;
 
     println!("  Created: {}", filepath.display());

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -4,14 +4,14 @@ use forgeplan_core::link;
 use forgeplan_core::scoring::reff::{self, EvidenceItem, EvidenceType, Verdict};
 use forgeplan_core::workspace;
 
-pub fn run(id: Option<&str>) -> anyhow::Result<()> {
+pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
 
     let target_id = id.ok_or_else(|| anyhow::anyhow!("Usage: forgeplan score <ID>"))?;
 
-    let artifacts = store::list_artifacts(&ws)?;
+    let artifacts = store::list_artifacts(&ws).await?;
 
     // Find the target artifact
     let target = artifacts

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -19,7 +19,7 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
         .find(|a| a.id.eq_ignore_ascii_case(target_id))
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' not found", target_id))?;
 
-    let content = std::fs::read_to_string(&target.path)?;
+    let content = tokio::fs::read_to_string(&target.path).await?;
     let (fm, _) = frontmatter::parse_frontmatter(&content)?;
 
     // Collect evidence from linked EvidencePack artifacts
@@ -38,7 +38,7 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
             continue;
         }
 
-        let ev_content = std::fs::read_to_string(&artifact.path)?;
+        let ev_content = tokio::fs::read_to_string(&artifact.path).await?;
         let ev_fm = match frontmatter::parse_frontmatter(&ev_content) {
             Ok((fm, _)) => fm,
             Err(_) => continue,

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -1,12 +1,12 @@
 use forgeplan_core::search;
 use forgeplan_core::workspace;
 
-pub fn run(query: &str, kind: Option<&str>) -> anyhow::Result<()> {
+pub async fn run(query: &str, kind: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
 
-    let hits = search::search(&ws, query, kind)?;
+    let hits = search::search(&ws, query, kind).await?;
 
     if hits.is_empty() {
         println!("No results for \"{}\"", query);

--- a/crates/forgeplan-cli/src/commands/stale.rs
+++ b/crates/forgeplan-cli/src/commands/stale.rs
@@ -1,12 +1,12 @@
 use forgeplan_core::stale;
 use forgeplan_core::workspace;
 
-pub fn run() -> anyhow::Result<()> {
+pub async fn run() -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
 
-    let stale_artifacts = stale::find_stale(&ws)?;
+    let stale_artifacts = stale::find_stale(&ws).await?;
 
     if stale_artifacts.is_empty() {
         println!("No stale artifacts found. All valid_until dates are current.");

--- a/crates/forgeplan-cli/src/commands/status.rs
+++ b/crates/forgeplan-cli/src/commands/status.rs
@@ -6,13 +6,13 @@ use anyhow::Result;
 use forgeplan_core::artifact::store::list_artifacts;
 use forgeplan_core::workspace::{find_workspace, load_config};
 
-pub fn run() -> Result<()> {
+pub async fn run() -> Result<()> {
     let cwd = env::current_dir()?;
     let workspace = find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
 
     let config = load_config(&workspace)?;
-    let artifacts = list_artifacts(&workspace)?;
+    let artifacts = list_artifacts(&workspace).await?;
 
     // Count by kind
     let mut by_kind: BTreeMap<String, u32> = BTreeMap::new();

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -36,7 +36,7 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
     let mut total_passed = 0;
 
     for artifact in &to_validate {
-        let content = std::fs::read_to_string(&artifact.path)?;
+        let content = tokio::fs::read_to_string(&artifact.path).await?;
         let (fm, body) = frontmatter::parse_frontmatter(&content)?;
 
         let kind = parse_kind(&artifact.kind);

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -4,12 +4,12 @@ use forgeplan_core::artifact::types::{ArtifactKind, Mode};
 use forgeplan_core::validation::{self, Severity, ValidationResult};
 use forgeplan_core::workspace;
 
-pub fn run(id: Option<&str>) -> anyhow::Result<()> {
+pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
 
-    let artifacts = store::list_artifacts(&ws)?;
+    let artifacts = store::list_artifacts(&ws).await?;
     if artifacts.is_empty() {
         println!("No artifacts found.");
         return Ok(());

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -70,27 +70,28 @@ enum Commands {
     Stale,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { force } => commands::init::run(force),
-        Commands::New { kind, title } => commands::new::run(&kind, &title),
+        Commands::Init { force } => commands::init::run(force).await,
+        Commands::New { kind, title } => commands::new::run(&kind, &title).await,
         Commands::List { r#type, status } => {
-            commands::list::run(r#type.as_deref(), status.as_deref())
+            commands::list::run(r#type.as_deref(), status.as_deref()).await
         }
-        Commands::Status => commands::status::run(),
-        Commands::Validate { id } => commands::validate::run(id.as_deref()),
-        Commands::Score { id } => commands::score::run(id.as_deref()),
+        Commands::Status => commands::status::run().await,
+        Commands::Validate { id } => commands::validate::run(id.as_deref()).await,
+        Commands::Score { id } => commands::score::run(id.as_deref()).await,
         Commands::Link {
             source,
             target,
             relation,
-        } => commands::link::run(&source, &target, &relation),
-        Commands::Graph => commands::graph::run(),
+        } => commands::link::run(&source, &target, &relation).await,
+        Commands::Graph => commands::graph::run().await,
         Commands::Search { query, r#type } => {
-            commands::search::run(&query, r#type.as_deref())
+            commands::search::run(&query, r#type.as_deref()).await
         }
-        Commands::Stale => commands::stale::run(),
+        Commands::Stale => commands::stale::run().await,
     }
 }

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -12,6 +12,12 @@ thiserror.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 regex = "1"
+tokio.workspace = true
+lancedb.workspace = true
+arrow-array.workspace = true
+arrow-schema.workspace = true
+futures.workspace = true
+async-trait.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/forgeplan-core/src/artifact/store.rs
+++ b/crates/forgeplan-core/src/artifact/store.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::artifact::frontmatter::{self, Frontmatter};
@@ -32,17 +31,15 @@ pub fn kind_dir(kind: &ArtifactKind) -> &'static str {
 
 /// Find the next sequential ID for a given kind in workspace.
 /// Scans existing files, extracts the numeric part, returns max + 1.
-pub fn next_id(workspace: &Path, kind: &ArtifactKind, digits: u32) -> anyhow::Result<String> {
+pub async fn next_id(workspace: &Path, kind: &ArtifactKind, digits: u32) -> anyhow::Result<String> {
     let dir = workspace.join(kind_dir(kind));
-    // The prefix like "PRD", "RFC" etc (without trailing dash)
     let kind_prefix = kind.prefix().trim_end_matches('-').to_uppercase();
 
     let mut max_num: u32 = 0;
     if dir.exists() {
-        for entry in fs::read_dir(&dir)? {
-            let entry = entry?;
+        let mut read_dir = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
             let name = entry.file_name().to_string_lossy().to_string();
-            // Extract number from filenames like PRD-001-title.md
             if let Some(rest) = name.to_uppercase().strip_prefix(&format!("{}-", kind_prefix)) {
                 if let Some(num_str) = rest.split('-').next() {
                     if let Ok(num) = num_str.parse::<u32>() {
@@ -75,20 +72,20 @@ pub fn slugify(title: &str) -> String {
 }
 
 /// List all artifacts in the workspace, reading only frontmatter.
-pub fn list_artifacts(workspace: &Path) -> anyhow::Result<Vec<ArtifactSummary>> {
+pub async fn list_artifacts(workspace: &Path) -> anyhow::Result<Vec<ArtifactSummary>> {
     let mut results = Vec::new();
     for dir_name in crate::workspace::ARTIFACT_DIRS {
         let dir = workspace.join(dir_name);
         if !dir.exists() {
             continue;
         }
-        for entry in fs::read_dir(&dir)? {
-            let entry = entry?;
+        let mut read_dir = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
             let path = entry.path();
             if path.extension().map_or(true, |e| e != "md") {
                 continue;
             }
-            let content = fs::read_to_string(&path)?;
+            let content = tokio::fs::read_to_string(&path).await?;
             if let Ok((fm, _body)) = frontmatter::parse_frontmatter(&content) {
                 let id = fm_string(&fm, "id");
                 let title = fm_string(&fm, "title");

--- a/crates/forgeplan-core/src/db/convert.rs
+++ b/crates/forgeplan-core/src/db/convert.rs
@@ -104,12 +104,12 @@ fn get_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String> {
     }
 }
 
-fn make_null_embedding_col(len: usize) -> Arc<dyn Array> {
+pub(crate) fn make_null_embedding_col(len: usize) -> Arc<dyn Array> {
     use arrow_array::FixedSizeListArray;
     use arrow_schema::Field;
 
     let item_field = Arc::new(Field::new("item", arrow_schema::DataType::Float32, true));
-    Arc::new(FixedSizeListArray::new_null(item_field, 384, len))
+    Arc::new(FixedSizeListArray::new_null(item_field, schema::EMBEDDING_DIM, len))
 }
 
 #[cfg(test)]

--- a/crates/forgeplan-core/src/db/convert.rs
+++ b/crates/forgeplan-core/src/db/convert.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+
+use arrow_array::{Array, Float64Array, RecordBatch, StringArray};
+use arrow_schema::Schema;
+
+use crate::artifact::store::ArtifactSummary;
+use crate::db::schema;
+use crate::db::store::NewArtifact;
+
+/// Convert a NewArtifact into an Arrow RecordBatch using the artifacts schema.
+///
+/// The embedding column is set to null (no vector computed at creation time).
+pub fn artifact_to_batch(artifact: &NewArtifact, now: &str) -> anyhow::Result<RecordBatch> {
+    let schema = schema::artifacts_schema();
+    artifact_to_batch_with_schema(artifact, now, &schema)
+}
+
+pub(crate) fn artifact_to_batch_with_schema(
+    artifact: &NewArtifact,
+    now: &str,
+    schema: &Arc<Schema>,
+) -> anyhow::Result<RecordBatch> {
+    let embedding_col = make_null_embedding_col(1);
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![artifact.id.as_str()])),
+            Arc::new(StringArray::from(vec![artifact.kind.as_str()])),
+            Arc::new(StringArray::from(vec![artifact.status.as_str()])),
+            Arc::new(StringArray::from(vec![artifact.title.as_str()])),
+            Arc::new(arrow_array::LargeStringArray::from(vec![
+                artifact.body.as_str()
+            ])),
+            Arc::new(StringArray::from(vec![artifact.depth.as_str()])),
+            Arc::new(StringArray::from(vec![artifact.author.as_deref()])),
+            Arc::new(StringArray::from(vec![artifact.parent_epic.as_deref()])),
+            Arc::new(Float64Array::from(vec![0.0f64])),
+            Arc::new(StringArray::from(vec![artifact.valid_until.as_deref()])),
+            Arc::new(StringArray::from(vec![now])),
+            Arc::new(StringArray::from(vec![now])),
+            embedding_col,
+        ],
+    )?;
+    Ok(batch)
+}
+
+/// Extract ArtifactSummary values from all rows in a RecordBatch.
+pub fn batch_to_artifacts(batch: &RecordBatch) -> anyhow::Result<Vec<ArtifactSummary>> {
+    let mut results = Vec::new();
+    for row in 0..batch.num_rows() {
+        if let Some(summary) = extract_summary(batch, row) {
+            results.push(summary);
+        }
+    }
+    Ok(results)
+}
+
+/// Build a one-row RecordBatch for a relation record.
+pub fn relation_to_batch(
+    source: &str,
+    target: &str,
+    relation: &str,
+    now: &str,
+) -> anyhow::Result<RecordBatch> {
+    let schema = schema::relations_schema();
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![source])),
+            Arc::new(StringArray::from(vec![target])),
+            Arc::new(StringArray::from(vec![relation])),
+            Arc::new(StringArray::from(vec![now])),
+        ],
+    )?;
+    Ok(batch)
+}
+
+fn extract_summary(batch: &RecordBatch, row: usize) -> Option<ArtifactSummary> {
+    let id = get_string(batch, "id", row)?;
+    let title = get_string(batch, "title", row).unwrap_or_default();
+    let kind = get_string(batch, "kind", row).unwrap_or_default();
+    let status = get_string(batch, "status", row).unwrap_or_default();
+
+    Some(ArtifactSummary {
+        id,
+        title,
+        kind,
+        status,
+        path: std::path::PathBuf::new(),
+    })
+}
+
+fn get_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String> {
+    let array = batch.column_by_name(col)?;
+    if let Some(arr) = array.as_any().downcast_ref::<StringArray>() {
+        if arr.is_null(row) {
+            None
+        } else {
+            Some(arr.value(row).to_string())
+        }
+    } else {
+        None
+    }
+}
+
+fn make_null_embedding_col(len: usize) -> Arc<dyn Array> {
+    use arrow_array::FixedSizeListArray;
+    use arrow_schema::Field;
+
+    let item_field = Arc::new(Field::new("item", arrow_schema::DataType::Float32, true));
+    Arc::new(FixedSizeListArray::new_null(item_field, 384, len))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::store::NewArtifact;
+
+    fn sample_artifact() -> NewArtifact {
+        NewArtifact {
+            id: "PRD-001".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Test PRD".to_string(),
+            body: "## Summary\n\nTest.".to_string(),
+            depth: "standard".to_string(),
+            author: Some("alice".to_string()),
+            parent_epic: None,
+            valid_until: None,
+        }
+    }
+
+    #[test]
+    fn artifact_to_batch_has_correct_row_count() {
+        let artifact = sample_artifact();
+        let batch = artifact_to_batch(&artifact, "2026-01-01T00:00:00Z").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+    }
+
+    #[test]
+    fn artifact_to_batch_contains_id_and_kind() {
+        let artifact = sample_artifact();
+        let batch = artifact_to_batch(&artifact, "2026-01-01T00:00:00Z").unwrap();
+        let id_col = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        assert_eq!(id_col.value(0), "PRD-001");
+
+        let kind_col = batch
+            .column_by_name("kind")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        assert_eq!(kind_col.value(0), "prd");
+    }
+
+    #[test]
+    fn batch_to_artifacts_round_trips_summary() {
+        let artifact = sample_artifact();
+        let batch = artifact_to_batch(&artifact, "2026-01-01T00:00:00Z").unwrap();
+        let summaries = batch_to_artifacts(&batch).unwrap();
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "PRD-001");
+        assert_eq!(summaries[0].kind, "prd");
+        assert_eq!(summaries[0].status, "draft");
+        assert_eq!(summaries[0].title, "Test PRD");
+    }
+
+    #[test]
+    fn relation_to_batch_has_correct_columns() {
+        let batch =
+            relation_to_batch("PRD-001", "RFC-001", "informs", "2026-01-01T00:00:00Z").unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        let src_col = batch
+            .column_by_name("source_id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        assert_eq!(src_col.value(0), "PRD-001");
+
+        let tgt_col = batch
+            .column_by_name("target_id")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        assert_eq!(tgt_col.value(0), "RFC-001");
+    }
+
+    #[test]
+    fn artifact_to_batch_nullable_author_is_null_when_none() {
+        let mut artifact = sample_artifact();
+        artifact.author = None;
+        let batch = artifact_to_batch(&artifact, "2026-01-01T00:00:00Z").unwrap();
+        let author_col = batch
+            .column_by_name("author")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+            .unwrap();
+        assert!(author_col.is_null(0));
+    }
+}

--- a/crates/forgeplan-core/src/db/mod.rs
+++ b/crates/forgeplan-core/src/db/mod.rs
@@ -1,0 +1,3 @@
+pub mod convert;
+pub mod schema;
+pub mod store;

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use arrow_schema::{DataType, Field, Schema};
 
+/// Embedding vector dimension (BGE-M3 / all-MiniLM-L6-v2).
+/// Referenced from schema, store, and convert modules.
+pub const EMBEDDING_DIM: i32 = 384;
+
 /// Arrow schema for the `artifacts` table.
 ///
 /// Columns:
@@ -36,7 +40,7 @@ pub fn artifacts_schema() -> Arc<Schema> {
             "embedding",
             DataType::FixedSizeList(
                 Arc::new(Field::new("item", DataType::Float32, true)),
-                384,
+                EMBEDDING_DIM,
             ),
             true,
         ),
@@ -124,7 +128,7 @@ mod tests {
         assert!(emb.is_nullable());
         match emb.data_type() {
             DataType::FixedSizeList(inner, size) => {
-                assert_eq!(*size, 384);
+                assert_eq!(*size, EMBEDDING_DIM);
                 assert_eq!(*inner.data_type(), DataType::Float32);
             }
             _ => panic!("embedding should be FixedSizeList"),

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use arrow_schema::{DataType, Field, Schema};
+
+/// Arrow schema for the `artifacts` table.
+///
+/// Columns:
+/// - id          Utf8 (not null) — PK: "PRD-001", "RFC-002"
+/// - kind        Utf8 (not null) — "prd", "rfc", "adr", "epic", etc.
+/// - status      Utf8 (not null) — "draft", "active", "superseded"
+/// - title       Utf8 (not null) — human-readable title
+/// - body        LargeUtf8 (not null) — markdown content (after ---)
+/// - depth       Utf8 (not null) — "tactical", "standard", "deep"
+/// - author      Utf8 (nullable) — author name
+/// - parent_epic Utf8 (nullable) — FK: parent epic ID
+/// - r_eff_score Float64 (not null) — cached R_eff score
+/// - valid_until Utf8 (nullable) — ISO date for evidence decay
+/// - created_at  Utf8 (not null) — ISO datetime
+/// - updated_at  Utf8 (not null) — ISO datetime
+/// - embedding   FixedSizeList(384, Float32) (nullable) — vector for semantic search
+pub fn artifacts_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("status", DataType::Utf8, false),
+        Field::new("title", DataType::Utf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("depth", DataType::Utf8, false),
+        Field::new("author", DataType::Utf8, true),
+        Field::new("parent_epic", DataType::Utf8, true),
+        Field::new("r_eff_score", DataType::Float64, false),
+        Field::new("valid_until", DataType::Utf8, true),
+        Field::new("created_at", DataType::Utf8, false),
+        Field::new("updated_at", DataType::Utf8, false),
+        Field::new(
+            "embedding",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                384,
+            ),
+            true,
+        ),
+    ]))
+}
+
+/// Arrow schema for the `evidence` table.
+///
+/// Columns:
+/// - id               Utf8 (not null) — PK: "EVID-001"
+/// - artifact_id      Utf8 (not null) — FK: linked artifact
+/// - evidence_type    Utf8 (not null) — "measurement", "test", etc.
+/// - verdict          Utf8 (not null) — "supports", "weakens", "refutes"
+/// - congruence_level Int32 (not null) — 0-3
+/// - valid_until      Utf8 (nullable) — ISO date
+/// - content          Utf8 (not null) — evidence description
+/// - created_at       Utf8 (not null) — ISO datetime
+pub fn evidence_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("artifact_id", DataType::Utf8, false),
+        Field::new("evidence_type", DataType::Utf8, false),
+        Field::new("verdict", DataType::Utf8, false),
+        Field::new("congruence_level", DataType::Int32, false),
+        Field::new("valid_until", DataType::Utf8, true),
+        Field::new("content", DataType::Utf8, false),
+        Field::new("created_at", DataType::Utf8, false),
+    ]))
+}
+
+/// Arrow schema for the `relations` table.
+///
+/// Columns:
+/// - source_id     Utf8 (not null) — FK: source artifact
+/// - target_id     Utf8 (not null) — FK: target artifact
+/// - relation_type Utf8 (not null) — "informs", "based_on", "supersedes"
+/// - created_at    Utf8 (not null) — ISO datetime
+pub fn relations_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("source_id", DataType::Utf8, false),
+        Field::new("target_id", DataType::Utf8, false),
+        Field::new("relation_type", DataType::Utf8, false),
+        Field::new("created_at", DataType::Utf8, false),
+    ]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifacts_schema_has_required_columns() {
+        let schema = artifacts_schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"id"));
+        assert!(names.contains(&"kind"));
+        assert!(names.contains(&"status"));
+        assert!(names.contains(&"title"));
+        assert!(names.contains(&"body"));
+        assert!(names.contains(&"r_eff_score"));
+        assert!(names.contains(&"embedding"));
+        assert!(names.contains(&"created_at"));
+        assert!(names.contains(&"updated_at"));
+    }
+
+    #[test]
+    fn artifacts_schema_nullable_fields() {
+        let schema = artifacts_schema();
+        let nullable: Vec<&str> = schema
+            .fields()
+            .iter()
+            .filter(|f| f.is_nullable())
+            .map(|f| f.name().as_str())
+            .collect();
+        assert!(nullable.contains(&"author"));
+        assert!(nullable.contains(&"parent_epic"));
+        assert!(nullable.contains(&"valid_until"));
+        assert!(nullable.contains(&"embedding"));
+    }
+
+    #[test]
+    fn artifacts_schema_embedding_type() {
+        let schema = artifacts_schema();
+        let emb = schema.field_with_name("embedding").unwrap();
+        assert!(emb.is_nullable());
+        match emb.data_type() {
+            DataType::FixedSizeList(inner, size) => {
+                assert_eq!(*size, 384);
+                assert_eq!(*inner.data_type(), DataType::Float32);
+            }
+            _ => panic!("embedding should be FixedSizeList"),
+        }
+    }
+
+    #[test]
+    fn evidence_schema_has_required_columns() {
+        let schema = evidence_schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"id"));
+        assert!(names.contains(&"artifact_id"));
+        assert!(names.contains(&"verdict"));
+        assert!(names.contains(&"congruence_level"));
+    }
+
+    #[test]
+    fn relations_schema_has_required_columns() {
+        let schema = relations_schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"source_id"));
+        assert!(names.contains(&"target_id"));
+        assert!(names.contains(&"relation_type"));
+        assert!(names.contains(&"created_at"));
+    }
+}

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use arrow_schema::{DataType, Field, Schema};
 
-/// Embedding vector dimension (BGE-M3 / all-MiniLM-L6-v2).
+/// Embedding vector dimension — BGE-M3 full-size (ADR-005).
 /// Referenced from schema, store, and convert modules.
-pub const EMBEDDING_DIM: i32 = 384;
+pub const EMBEDDING_DIM: i32 = 1024;
 
 /// Arrow schema for the `artifacts` table.
 ///

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -10,7 +10,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::Table;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::schema;
+use crate::db::{convert, schema};
 
 /// Filter for listing artifacts.
 #[derive(Debug, Default)]
@@ -46,7 +46,7 @@ impl LanceStore {
     /// Connect to an existing LanceDB workspace (tables must already exist).
     pub async fn open(workspace_path: &Path) -> anyhow::Result<Self> {
         let lance_dir = workspace_path.join("lance");
-        let db = lancedb::connect(lance_dir.to_str().unwrap()).execute().await?;
+        let db = lancedb::connect(lance_dir.to_str().ok_or_else(|| anyhow::anyhow!("LanceDB path contains non-UTF-8 characters: {:?}", lance_dir))?).execute().await?;
 
         let artifacts = db.open_table("artifacts").execute().await?;
         let evidence = db.open_table("evidence").execute().await?;
@@ -65,7 +65,7 @@ impl LanceStore {
         let lance_dir = workspace_path.join("lance");
         tokio::fs::create_dir_all(&lance_dir).await?;
 
-        let db = lancedb::connect(lance_dir.to_str().unwrap()).execute().await?;
+        let db = lancedb::connect(lance_dir.to_str().ok_or_else(|| anyhow::anyhow!("LanceDB path contains non-UTF-8 characters: {:?}", lance_dir))?).execute().await?;
         let existing_tables = db.table_names().execute().await?;
 
         // Create artifacts table if not present
@@ -103,32 +103,13 @@ impl LanceStore {
 
     /// Insert a new artifact, returning its ID.
     pub async fn create_artifact(&self, artifact: &NewArtifact) -> anyhow::Result<String> {
+        // Guard: check for duplicate ID
+        if self.get_artifact(&artifact.id).await?.is_some() {
+            anyhow::bail!("Artifact '{}' already exists", artifact.id);
+        }
+
         let now = Utc::now().to_rfc3339();
-        let schema = schema::artifacts_schema();
-
-        // Build null FixedSizeList(384) column for embedding
-        let embedding_col = make_null_embedding_col(1);
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec![artifact.id.as_str()])),
-                Arc::new(StringArray::from(vec![artifact.kind.as_str()])),
-                Arc::new(StringArray::from(vec![artifact.status.as_str()])),
-                Arc::new(StringArray::from(vec![artifact.title.as_str()])),
-                Arc::new(arrow_array::LargeStringArray::from(vec![
-                    artifact.body.as_str()
-                ])),
-                Arc::new(StringArray::from(vec![artifact.depth.as_str()])),
-                Arc::new(StringArray::from(vec![artifact.author.as_deref()])),
-                Arc::new(StringArray::from(vec![artifact.parent_epic.as_deref()])),
-                Arc::new(Float64Array::from(vec![0.0f64])),
-                Arc::new(StringArray::from(vec![artifact.valid_until.as_deref()])),
-                Arc::new(StringArray::from(vec![now.as_str()])),
-                Arc::new(StringArray::from(vec![now.as_str()])),
-                embedding_col,
-            ],
-        )?;
+        let batch = convert::artifact_to_batch(artifact, &now)?;
 
         self.artifacts.add(vec![batch]).execute().await?;
         Ok(artifact.id.clone())
@@ -196,7 +177,7 @@ impl LanceStore {
         &self,
         id: &str,
         status: Option<&str>,
-        _title: Option<&str>,
+        title: Option<&str>,
     ) -> anyhow::Result<()> {
         let now = Utc::now().to_rfc3339();
         let predicate = format!("id = '{}'", id.replace('\'', "''"));
@@ -207,6 +188,9 @@ impl LanceStore {
             .column("updated_at", &format!("'{}'", now));
         if let Some(s) = status {
             builder = builder.column("status", &format!("'{}'", s.replace('\'', "''")));
+        }
+        if let Some(t) = title {
+            builder = builder.column("title", &format!("'{}'", t.replace('\'', "''")));
         }
         builder.execute().await?;
         Ok(())
@@ -219,25 +203,27 @@ impl LanceStore {
         Ok(())
     }
 
-    /// Add a relation between two artifacts.
+    /// Add a relation between two artifacts. Rejects duplicates.
     pub async fn add_relation(
         &self,
         source: &str,
         target: &str,
         relation: &str,
     ) -> anyhow::Result<()> {
-        let now = Utc::now().to_rfc3339();
-        let schema = schema::relations_schema();
+        // Dedup: check if relation already exists
+        let existing = self.get_relations(source).await?;
+        let duplicate = existing.iter().any(|(t, r)| {
+            t.eq_ignore_ascii_case(target) && r == relation
+        });
+        if duplicate {
+            anyhow::bail!(
+                "Relation already exists: {} --{}--> {}",
+                source, relation, target
+            );
+        }
 
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec![source])),
-                Arc::new(StringArray::from(vec![target])),
-                Arc::new(StringArray::from(vec![relation])),
-                Arc::new(StringArray::from(vec![now.as_str()])),
-            ],
-        )?;
+        let now = Utc::now().to_rfc3339();
+        let batch = convert::relation_to_batch(source, target, relation, &now)?;
 
         self.relations.add(vec![batch]).execute().await?;
         Ok(())
@@ -321,15 +307,6 @@ fn get_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String> {
     }
 }
 
-/// Build a null FixedSizeList(384, Float32) array of length `len`.
-fn make_null_embedding_col(len: usize) -> Arc<dyn Array> {
-    use arrow_array::FixedSizeListArray;
-    use arrow_schema::Field;
-
-    let item_field = Arc::new(Field::new("item", arrow_schema::DataType::Float32, true));
-    Arc::new(FixedSizeListArray::new_null(item_field, 384, len))
-}
-
 /// Create an empty RecordBatch for artifacts (used when initializing tables).
 fn empty_artifacts_batch(
     schema: Arc<arrow_schema::Schema>,
@@ -349,7 +326,7 @@ fn empty_artifacts_batch(
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
-            make_null_embedding_col(0),
+            convert::make_null_embedding_col(0),
         ],
     )
 }

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -1,0 +1,514 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow_array::{Array, Float64Array, Int32Array, RecordBatch, StringArray};
+use arrow_schema::ArrowError;
+use chrono::Utc;
+use futures::StreamExt;
+use lancedb::connection::Connection;
+use lancedb::query::{ExecutableQuery, QueryBase};
+use lancedb::Table;
+
+use crate::artifact::store::ArtifactSummary;
+use crate::db::schema;
+
+/// Filter for listing artifacts.
+#[derive(Debug, Default)]
+pub struct ArtifactFilter {
+    pub kind: Option<String>,
+    pub status: Option<String>,
+}
+
+/// Minimal artifact data for creation.
+#[derive(Debug)]
+pub struct NewArtifact {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub title: String,
+    pub body: String,
+    pub depth: String,
+    pub author: Option<String>,
+    pub parent_epic: Option<String>,
+    pub valid_until: Option<String>,
+}
+
+/// LanceDB-backed artifact store.
+pub struct LanceStore {
+    _db: Connection,
+    artifacts: Table,
+    #[allow(dead_code)]
+    evidence: Table,
+    relations: Table,
+}
+
+impl LanceStore {
+    /// Connect to an existing LanceDB workspace (tables must already exist).
+    pub async fn open(workspace_path: &Path) -> anyhow::Result<Self> {
+        let lance_dir = workspace_path.join("lance");
+        let db = lancedb::connect(lance_dir.to_str().unwrap()).execute().await?;
+
+        let artifacts = db.open_table("artifacts").execute().await?;
+        let evidence = db.open_table("evidence").execute().await?;
+        let relations = db.open_table("relations").execute().await?;
+
+        Ok(Self {
+            _db: db,
+            artifacts,
+            evidence,
+            relations,
+        })
+    }
+
+    /// Create tables if they don't exist, then open the store.
+    pub async fn init(workspace_path: &Path) -> anyhow::Result<Self> {
+        let lance_dir = workspace_path.join("lance");
+        tokio::fs::create_dir_all(&lance_dir).await?;
+
+        let db = lancedb::connect(lance_dir.to_str().unwrap()).execute().await?;
+        let existing_tables = db.table_names().execute().await?;
+
+        // Create artifacts table if not present
+        if !existing_tables.contains(&"artifacts".to_string()) {
+            let schema = schema::artifacts_schema();
+            let batch = empty_artifacts_batch(schema.clone())?;
+            db.create_table("artifacts", vec![batch]).execute().await?;
+        }
+
+        // Create evidence table if not present
+        if !existing_tables.contains(&"evidence".to_string()) {
+            let schema = schema::evidence_schema();
+            let batch = empty_evidence_batch(schema.clone())?;
+            db.create_table("evidence", vec![batch]).execute().await?;
+        }
+
+        // Create relations table if not present
+        if !existing_tables.contains(&"relations".to_string()) {
+            let schema = schema::relations_schema();
+            let batch = empty_relations_batch(schema.clone())?;
+            db.create_table("relations", vec![batch]).execute().await?;
+        }
+
+        let artifacts = db.open_table("artifacts").execute().await?;
+        let evidence = db.open_table("evidence").execute().await?;
+        let relations = db.open_table("relations").execute().await?;
+
+        Ok(Self {
+            _db: db,
+            artifacts,
+            evidence,
+            relations,
+        })
+    }
+
+    /// Insert a new artifact, returning its ID.
+    pub async fn create_artifact(&self, artifact: &NewArtifact) -> anyhow::Result<String> {
+        let now = Utc::now().to_rfc3339();
+        let schema = schema::artifacts_schema();
+
+        // Build null FixedSizeList(384) column for embedding
+        let embedding_col = make_null_embedding_col(1);
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![artifact.id.as_str()])),
+                Arc::new(StringArray::from(vec![artifact.kind.as_str()])),
+                Arc::new(StringArray::from(vec![artifact.status.as_str()])),
+                Arc::new(StringArray::from(vec![artifact.title.as_str()])),
+                Arc::new(arrow_array::LargeStringArray::from(vec![
+                    artifact.body.as_str()
+                ])),
+                Arc::new(StringArray::from(vec![artifact.depth.as_str()])),
+                Arc::new(StringArray::from(vec![artifact.author.as_deref()])),
+                Arc::new(StringArray::from(vec![artifact.parent_epic.as_deref()])),
+                Arc::new(Float64Array::from(vec![0.0f64])),
+                Arc::new(StringArray::from(vec![artifact.valid_until.as_deref()])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+                embedding_col,
+            ],
+        )?;
+
+        self.artifacts.add(vec![batch]).execute().await?;
+        Ok(artifact.id.clone())
+    }
+
+    /// Get a single artifact by ID. Returns None if not found.
+    pub async fn get_artifact(&self, id: &str) -> anyhow::Result<Option<ArtifactSummary>> {
+        let filter = format!("id = '{}'", id.replace('\'', "''"));
+        let batches = collect_batches(
+            self.artifacts
+                .query()
+                .only_if(filter)
+                .execute()
+                .await?,
+        )
+        .await?;
+
+        for batch in &batches {
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            if let Some(summary) = extract_summary(batch, 0) {
+                return Ok(Some(summary));
+            }
+        }
+        Ok(None)
+    }
+
+    /// List artifacts with optional kind/status filter.
+    pub async fn list_artifacts(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactSummary>> {
+        let mut query = self.artifacts.query();
+
+        if let Some(f) = filter {
+            let mut conditions = Vec::new();
+            if let Some(kind) = &f.kind {
+                conditions.push(format!("kind = '{}'", kind.replace('\'', "''")));
+            }
+            if let Some(status) = &f.status {
+                conditions.push(format!("status = '{}'", status.replace('\'', "''")));
+            }
+            if !conditions.is_empty() {
+                query = query.only_if(conditions.join(" AND "));
+            }
+        }
+
+        let batches = collect_batches(query.execute().await?).await?;
+
+        let mut results = Vec::new();
+        for batch in &batches {
+            for row in 0..batch.num_rows() {
+                if let Some(summary) = extract_summary(batch, row) {
+                    results.push(summary);
+                }
+            }
+        }
+        results.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(results)
+    }
+
+    /// Update artifact updated_at (and optionally status/title).
+    pub async fn update_artifact(
+        &self,
+        id: &str,
+        status: Option<&str>,
+        _title: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let predicate = format!("id = '{}'", id.replace('\'', "''"));
+        let mut builder = self
+            .artifacts
+            .update()
+            .only_if(predicate)
+            .column("updated_at", &format!("'{}'", now));
+        if let Some(s) = status {
+            builder = builder.column("status", &format!("'{}'", s.replace('\'', "''")));
+        }
+        builder.execute().await?;
+        Ok(())
+    }
+
+    /// Delete an artifact by ID.
+    pub async fn delete_artifact(&self, id: &str) -> anyhow::Result<()> {
+        let predicate = format!("id = '{}'", id.replace('\'', "''"));
+        self.artifacts.delete(&predicate).await?;
+        Ok(())
+    }
+
+    /// Add a relation between two artifacts.
+    pub async fn add_relation(
+        &self,
+        source: &str,
+        target: &str,
+        relation: &str,
+    ) -> anyhow::Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let schema = schema::relations_schema();
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec![source])),
+                Arc::new(StringArray::from(vec![target])),
+                Arc::new(StringArray::from(vec![relation])),
+                Arc::new(StringArray::from(vec![now.as_str()])),
+            ],
+        )?;
+
+        self.relations.add(vec![batch]).execute().await?;
+        Ok(())
+    }
+
+    /// Get all relations for an artifact (as source).
+    /// Returns Vec<(target_id, relation_type)>.
+    pub async fn get_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        let filter = format!("source_id = '{}'", id.replace('\'', "''"));
+        let batches = collect_batches(
+            self.relations
+                .query()
+                .only_if(filter)
+                .execute()
+                .await?,
+        )
+        .await?;
+
+        let mut results = Vec::new();
+        for batch in &batches {
+            let target_col = batch
+                .column_by_name("target_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let rel_col = batch
+                .column_by_name("relation_type")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
+            if let (Some(targets), Some(rels)) = (target_col, rel_col) {
+                for i in 0..batch.num_rows() {
+                    if !targets.is_null(i) && !rels.is_null(i) {
+                        results.push((
+                            targets.value(i).to_string(),
+                            rels.value(i).to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(results)
+    }
+}
+
+/// Collect a stream of RecordBatches into a Vec.
+async fn collect_batches(
+    stream: lancedb::arrow::SendableRecordBatchStream,
+) -> anyhow::Result<Vec<RecordBatch>> {
+    let mut batches = Vec::new();
+    let mut stream = std::pin::pin!(stream);
+    while let Some(result) = stream.next().await {
+        batches.push(result?);
+    }
+    Ok(batches)
+}
+
+/// Extract an ArtifactSummary from a RecordBatch row.
+fn extract_summary(batch: &RecordBatch, row: usize) -> Option<ArtifactSummary> {
+    let id = get_string(batch, "id", row)?;
+    let title = get_string(batch, "title", row).unwrap_or_default();
+    let kind = get_string(batch, "kind", row).unwrap_or_default();
+    let status = get_string(batch, "status", row).unwrap_or_default();
+
+    Some(ArtifactSummary {
+        id,
+        title,
+        kind,
+        status,
+        path: std::path::PathBuf::new(), // LanceDB store doesn't use file paths
+    })
+}
+
+fn get_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String> {
+    let array = batch.column_by_name(col)?;
+    if let Some(arr) = array.as_any().downcast_ref::<StringArray>() {
+        if arr.is_null(row) {
+            None
+        } else {
+            Some(arr.value(row).to_string())
+        }
+    } else {
+        None
+    }
+}
+
+/// Build a null FixedSizeList(384, Float32) array of length `len`.
+fn make_null_embedding_col(len: usize) -> Arc<dyn Array> {
+    use arrow_array::FixedSizeListArray;
+    use arrow_schema::Field;
+
+    let item_field = Arc::new(Field::new("item", arrow_schema::DataType::Float32, true));
+    Arc::new(FixedSizeListArray::new_null(item_field, 384, len))
+}
+
+/// Create an empty RecordBatch for artifacts (used when initializing tables).
+fn empty_artifacts_batch(
+    schema: Arc<arrow_schema::Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(arrow_array::LargeStringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
+            Arc::new(Float64Array::from(Vec::<f64>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            make_null_embedding_col(0),
+        ],
+    )
+}
+
+/// Create an empty RecordBatch for evidence.
+fn empty_evidence_batch(
+    schema: Arc<arrow_schema::Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(Int32Array::from(Vec::<i32>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+        ],
+    )
+}
+
+/// Create an empty RecordBatch for relations.
+fn empty_relations_batch(
+    schema: Arc<arrow_schema::Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<&str>::new())),
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn make_store(tmp: &TempDir) -> LanceStore {
+        let ws = tmp.path().join(".forgeplan");
+        LanceStore::init(&ws).await.unwrap()
+    }
+
+    fn sample_artifact(id: &str) -> NewArtifact {
+        NewArtifact {
+            id: id.to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: format!("Test PRD {}", id),
+            body: "## Summary\n\nTest body content.".to_string(),
+            depth: "standard".to_string(),
+            author: Some("test-author".to_string()),
+            parent_epic: None,
+            valid_until: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn init_creates_tables() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let store = LanceStore::init(&ws).await.unwrap();
+
+        // Should be able to list (empty) artifacts without error
+        let artifacts = store.list_artifacts(None).await.unwrap();
+        assert!(artifacts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_and_get_artifact() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        let artifact = sample_artifact("PRD-001");
+        let id = store.create_artifact(&artifact).await.unwrap();
+        assert_eq!(id, "PRD-001");
+
+        let retrieved = store.get_artifact("PRD-001").await.unwrap();
+        assert!(retrieved.is_some());
+        let summary = retrieved.unwrap();
+        assert_eq!(summary.id, "PRD-001");
+        assert_eq!(summary.kind, "prd");
+        assert_eq!(summary.status, "draft");
+    }
+
+    #[tokio::test]
+    async fn get_nonexistent_artifact_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        let result = store.get_artifact("MISSING-999").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_artifacts_returns_all() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        store.create_artifact(&sample_artifact("PRD-001")).await.unwrap();
+        store.create_artifact(&sample_artifact("PRD-002")).await.unwrap();
+
+        let list = store.list_artifacts(None).await.unwrap();
+        assert_eq!(list.len(), 2);
+        // sorted by id
+        assert_eq!(list[0].id, "PRD-001");
+        assert_eq!(list[1].id, "PRD-002");
+    }
+
+    #[tokio::test]
+    async fn list_artifacts_with_kind_filter() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        store.create_artifact(&sample_artifact("PRD-001")).await.unwrap();
+
+        let mut rfc = sample_artifact("RFC-001");
+        rfc.kind = "rfc".to_string();
+        store.create_artifact(&rfc).await.unwrap();
+
+        let filter = ArtifactFilter {
+            kind: Some("prd".to_string()),
+            status: None,
+        };
+        let list = store.list_artifacts(Some(&filter)).await.unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "PRD-001");
+    }
+
+    #[tokio::test]
+    async fn delete_artifact() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        store.create_artifact(&sample_artifact("PRD-001")).await.unwrap();
+        store.delete_artifact("PRD-001").await.unwrap();
+
+        let result = store.get_artifact("PRD-001").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn add_and_get_relations() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        store.add_relation("PRD-001", "RFC-001", "informs").await.unwrap();
+        store.add_relation("PRD-001", "ADR-001", "based_on").await.unwrap();
+
+        let relations = store.get_relations("PRD-001").await.unwrap();
+        assert_eq!(relations.len(), 2);
+
+        let targets: Vec<&str> = relations.iter().map(|(t, _)| t.as_str()).collect();
+        assert!(targets.contains(&"RFC-001"));
+        assert!(targets.contains(&"ADR-001"));
+    }
+}

--- a/crates/forgeplan-core/src/graph/mod.rs
+++ b/crates/forgeplan-core/src/graph/mod.rs
@@ -14,12 +14,12 @@ pub struct Edge {
 }
 
 /// Build all edges by scanning all artifacts in the workspace.
-pub fn build_edges(workspace: &Path) -> anyhow::Result<Vec<Edge>> {
-    let artifacts = store::list_artifacts(workspace)?;
+pub async fn build_edges(workspace: &Path) -> anyhow::Result<Vec<Edge>> {
+    let artifacts = store::list_artifacts(workspace).await?;
     let mut edges = Vec::new();
 
     for artifact in &artifacts {
-        let content = std::fs::read_to_string(&artifact.path)?;
+        let content = tokio::fs::read_to_string(&artifact.path).await?;
         if let Ok((fm, _)) = frontmatter::parse_frontmatter(&content) {
             let links = link::list_links(&fm);
             for (target, relation) in links {

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod artifact;
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod graph;
 pub mod link;

--- a/crates/forgeplan-core/src/link/mod.rs
+++ b/crates/forgeplan-core/src/link/mod.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::Path;
 
 use crate::artifact::frontmatter::{self, Frontmatter};
@@ -6,14 +5,14 @@ use crate::error::ForgeplanError;
 
 /// Add a typed link to an artifact's frontmatter.
 /// Writes the updated file back to disk.
-pub fn add_link(
+pub async fn add_link(
     artifact_path: &Path,
     target_id: &str,
     relation: &str,
 ) -> anyhow::Result<()> {
     // Normalize target to uppercase for consistent storage and dedup
     let target_id = target_id.to_uppercase();
-    let content = fs::read_to_string(artifact_path)?;
+    let content = tokio::fs::read_to_string(artifact_path).await?;
     let (mut fm, body) = frontmatter::parse_frontmatter(&content)?;
 
     // Get or create links array
@@ -57,7 +56,7 @@ pub fn add_link(
     }
 
     let output = frontmatter::render_frontmatter(&fm, &body)?;
-    fs::write(artifact_path, output)?;
+    tokio::fs::write(artifact_path, output).await?;
     Ok(())
 }
 
@@ -178,11 +177,11 @@ links:
         path
     }
 
-    #[test]
-    fn add_link_creates_link_entry() {
+    #[tokio::test]
+    async fn add_link_creates_link_entry() {
         let tmp = TempDir::new().unwrap();
         let path = make_artifact(tmp.path(), "PRD-001", "");
-        add_link(&path, "RFC-001", "informs").unwrap();
+        add_link(&path, "RFC-001", "informs").await.unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
         let (fm, _) = crate::artifact::frontmatter::parse_frontmatter(&content).unwrap();
@@ -192,11 +191,11 @@ links:
         assert_eq!(links[0].1, "informs");
     }
 
-    #[test]
-    fn add_link_writes_target_uppercase() {
+    #[tokio::test]
+    async fn add_link_writes_target_uppercase() {
         let tmp = TempDir::new().unwrap();
         let path = make_artifact(tmp.path(), "PRD-001", "");
-        add_link(&path, "rfc-001", "informs").unwrap();
+        add_link(&path, "rfc-001", "informs").await.unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
         let (fm, _) = crate::artifact::frontmatter::parse_frontmatter(&content).unwrap();
@@ -204,13 +203,13 @@ links:
         assert_eq!(links[0].0, "RFC-001");
     }
 
-    #[test]
-    fn add_link_detects_case_insensitive_duplicate() {
+    #[tokio::test]
+    async fn add_link_detects_case_insensitive_duplicate() {
         let tmp = TempDir::new().unwrap();
         let path = make_artifact(tmp.path(), "PRD-001", "");
-        add_link(&path, "RFC-001", "informs").unwrap();
+        add_link(&path, "RFC-001", "informs").await.unwrap();
         // Adding duplicate with different case should fail
-        let err = add_link(&path, "rfc-001", "informs").unwrap_err();
+        let err = add_link(&path, "rfc-001", "informs").await.unwrap_err();
         assert!(err.to_string().contains("RFC-001") || err.to_string().contains("already"));
     }
 }

--- a/crates/forgeplan-core/src/search/mod.rs
+++ b/crates/forgeplan-core/src/search/mod.rs
@@ -20,7 +20,7 @@ pub struct MatchContext {
 }
 
 /// Search all artifacts for a keyword pattern (case-insensitive regex grep).
-pub fn search(
+pub async fn search(
     workspace: &Path,
     query: &str,
     kind_filter: Option<&str>,
@@ -29,7 +29,7 @@ pub fn search(
         .case_insensitive(true)
         .build()?;
 
-    let artifacts = store::list_artifacts(workspace)?;
+    let artifacts = store::list_artifacts(workspace).await?;
     let mut hits = Vec::new();
 
     for artifact in artifacts {
@@ -40,7 +40,7 @@ pub fn search(
             }
         }
 
-        let content = std::fs::read_to_string(&artifact.path)?;
+        let content = tokio::fs::read_to_string(&artifact.path).await?;
         let (_fm, body) = match frontmatter::parse_frontmatter(&content) {
             Ok(result) => result,
             Err(_) => continue,
@@ -103,60 +103,60 @@ mod tests {
         fs::write(ws.join(subdir).join(filename), content).unwrap();
     }
 
-    #[test]
-    fn search_finds_match_in_title() {
+    #[tokio::test]
+    async fn search_finds_match_in_title() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         write_artifact(&ws, "prds", "PRD-001-auth.md", "PRD-001", "prd", "Authentication System", "Some body content.");
 
-        let hits = search(&ws, "authentication", None).unwrap();
+        let hits = search(&ws, "authentication", None).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].artifact.id, "PRD-001");
         assert!(hits[0].matches.iter().any(|m| m.line.contains("[title]")));
     }
 
-    #[test]
-    fn search_finds_match_in_body() {
+    #[tokio::test]
+    async fn search_finds_match_in_body() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         write_artifact(&ws, "rfcs", "RFC-001-search.md", "RFC-001", "rfc", "Search Feature", "Implement full-text search with LanceDB.");
 
-        let hits = search(&ws, "lancedb", None).unwrap();
+        let hits = search(&ws, "lancedb", None).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].artifact.id, "RFC-001");
         assert!(hits[0].matches.iter().any(|m| m.line_number > 0));
     }
 
-    #[test]
-    fn search_is_case_insensitive() {
+    #[tokio::test]
+    async fn search_is_case_insensitive() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         write_artifact(&ws, "prds", "PRD-002-perf.md", "PRD-002", "prd", "Performance Goals", "NFR requirements here.");
 
-        let hits = search(&ws, "PERFORMANCE", None).unwrap();
+        let hits = search(&ws, "PERFORMANCE", None).await.unwrap();
         assert_eq!(hits.len(), 1);
     }
 
-    #[test]
-    fn search_applies_kind_filter() {
+    #[tokio::test]
+    async fn search_applies_kind_filter() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         write_artifact(&ws, "prds", "PRD-001-x.md", "PRD-001", "prd", "Shared Keyword", "");
         write_artifact(&ws, "rfcs", "RFC-001-x.md", "RFC-001", "rfc", "Shared Keyword", "");
 
         // Filter to only rfcs
-        let hits = search(&ws, "shared keyword", Some("rfc")).unwrap();
+        let hits = search(&ws, "shared keyword", Some("rfc")).await.unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].artifact.kind, "rfc");
     }
 
-    #[test]
-    fn search_returns_empty_when_no_match() {
+    #[tokio::test]
+    async fn search_returns_empty_when_no_match() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         write_artifact(&ws, "prds", "PRD-001-x.md", "PRD-001", "prd", "Title Here", "Body here.");
 
-        let hits = search(&ws, "nonexistent-term-xyz", None).unwrap();
+        let hits = search(&ws, "nonexistent-term-xyz", None).await.unwrap();
         assert!(hits.is_empty());
     }
 }

--- a/crates/forgeplan-core/src/stale/mod.rs
+++ b/crates/forgeplan-core/src/stale/mod.rs
@@ -14,13 +14,13 @@ pub struct StaleArtifact {
 }
 
 /// Find all artifacts where valid_until has passed.
-pub fn find_stale(workspace: &Path) -> anyhow::Result<Vec<StaleArtifact>> {
+pub async fn find_stale(workspace: &Path) -> anyhow::Result<Vec<StaleArtifact>> {
     let today = Utc::now().date_naive();
-    let artifacts = store::list_artifacts(workspace)?;
+    let artifacts = store::list_artifacts(workspace).await?;
     let mut stale = Vec::new();
 
     for artifact in artifacts {
-        let content = std::fs::read_to_string(&artifact.path)?;
+        let content = tokio::fs::read_to_string(&artifact.path).await?;
         let (fm, _) = match frontmatter::parse_frontmatter(&content) {
             Ok(result) => result,
             Err(_) => continue,
@@ -80,43 +80,43 @@ mod tests {
         fs::write(ws.join(subdir).join(filename), content).unwrap();
     }
 
-    #[test]
-    fn find_stale_no_stale_artifacts() {
+    #[tokio::test]
+    async fn find_stale_no_stale_artifacts() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         // Artifact with no valid_until — not stale
         write_artifact_with_expiry(&ws, "prds", "PRD-001.md", "PRD-001", None);
 
-        let stale = find_stale(&ws).unwrap();
+        let stale = find_stale(&ws).await.unwrap();
         assert!(stale.is_empty());
     }
 
-    #[test]
-    fn find_stale_expired_artifact() {
+    #[tokio::test]
+    async fn find_stale_expired_artifact() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         // valid_until in the past
         write_artifact_with_expiry(&ws, "prds", "PRD-001.md", "PRD-001", Some("2020-01-01"));
 
-        let stale = find_stale(&ws).unwrap();
+        let stale = find_stale(&ws).await.unwrap();
         assert_eq!(stale.len(), 1);
         assert_eq!(stale[0].artifact.id, "PRD-001");
         assert!(stale[0].days_expired > 0);
     }
 
-    #[test]
-    fn find_stale_future_valid_until_not_stale() {
+    #[tokio::test]
+    async fn find_stale_future_valid_until_not_stale() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         // valid_until far in the future
         write_artifact_with_expiry(&ws, "prds", "PRD-001.md", "PRD-001", Some("2099-12-31"));
 
-        let stale = find_stale(&ws).unwrap();
+        let stale = find_stale(&ws).await.unwrap();
         assert!(stale.is_empty());
     }
 
-    #[test]
-    fn find_stale_sorted_by_days_expired_descending() {
+    #[tokio::test]
+    async fn find_stale_sorted_by_days_expired_descending() {
         let tmp = TempDir::new().unwrap();
         let ws = setup_workspace(&tmp);
         // PRD-001 expired longer ago
@@ -124,7 +124,7 @@ mod tests {
         // PRD-002 expired more recently
         write_artifact_with_expiry(&ws, "rfcs", "RFC-001.md", "RFC-001", Some("2020-01-01"));
 
-        let stale = find_stale(&ws).unwrap();
+        let stale = find_stale(&ws).await.unwrap();
         assert_eq!(stale.len(), 2);
         // First element should have more days_expired (older expiry)
         assert!(stale[0].days_expired >= stale[1].days_expired);

--- a/docs/adrs/ADR-004-async-tokio-runtime.md
+++ b/docs/adrs/ADR-004-async-tokio-runtime.md
@@ -1,0 +1,85 @@
+---
+id: ADR-004
+title: "Full async (tokio) вместо sync CLI"
+status: Accepted
+depth: standard
+valid_until: 2027-03-22
+problem_ref: ""
+created: 2026-03-22
+updated: 2026-03-22
+---
+
+# ADR-004: Full async (tokio) вместо sync CLI
+
+## Context
+
+Phase 3D: интеграция LanceDB как primary storage. LanceDB Rust SDK полностью async (tokio). Нужно решить: конвертировать весь CLI в async или использовать sync wrapper.
+
+Текущий CLI полностью sync (97 тестов). LanceDB API: `db.connect().execute().await`, `table.query().execute().await`, `table.add(reader).execute().await` — всё async.
+
+## Decision
+
+**Full async migration**: весь core становится async, CLI использует `#[tokio::main]`.
+
+**Selected**: tokio runtime + async fn в core + async tests
+
+**Why Selected**: Чистая архитектура без sync/async boundary. Готовность к Phase 4 (Tauri 2.0 — тоже async). Нет риска nested runtime panic.
+
+## Alternatives Considered
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| Full async (tokio) | **Chosen** | Чистая архитектура, Tauri-ready, нет nested runtime |
+| Sync wrapper (block_on) | Rejected | Nested runtime panic при вызове из async контекста (Tauri). Скрытая сложность |
+| Async only for DB layer | Rejected | Sync/async boundary в каждой команде. Сложный тестинг |
+
+## Consequences
+
+### Positive
+- Единая async модель во всём проекте
+- LanceDB API используется напрямую (нет обёрток)
+- Готовность к Tauri 2.0 (async IPC commands)
+- tokio::fs для параллельного I/O (list_artifacts на большом workspace)
+- Тесты с `#[tokio::test]` — стандартный async testing
+
+### Negative (trade-offs)
+- Все 97 тестов нужно обновить (async fn + .await)
+- tokio в зависимостях увеличивает compile time (~30s)
+- Binary size +~500KB (tokio runtime)
+- Простые функции (find_workspace, parse_frontmatter) остаются sync — нужна дисциплина
+
+### Risks
+- Compile time увеличится из-за tokio + arrow + lancedb (~2-3 min full build)
+- Новые разработчики должны знать async Rust
+
+## Invariants
+
+- I/O-heavy функции (store CRUD, search, graph) — ДОЛЖНЫ быть async
+- Pure computation (validation, scoring, frontmatter parsing) — ДОЛЖНЫ остаться sync
+- CLI entry point — `#[tokio::main]` (multi-threaded runtime)
+- Тесты — `#[tokio::test]` для async, `#[test]` для sync
+- Integration tests (assert_cmd) — НЕ меняются (тестируют binary, не library)
+
+## Evidence Requirements
+
+- Все 97 тестов проходят после миграции
+- Binary size < 15MB (NFR-002) после добавления tokio + lancedb + arrow
+- Startup time < 100ms (NFR-001) — tokio runtime не должен замедлять
+
+## Valid Until
+
+**Дата**: 2027-03-22
+
+**Refresh Triggers**:
+- Появление sync-only embedded DB лучше LanceDB
+- Tauri откажется от async в пользу sync
+- tokio runtime станет несовместим с целевыми платформами
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|----------|------|----------|
+| RFC-003 | RFC | based_on (LanceDB integration) |
+| ADR-002 | ADR | informs (LanceDB выбран, требует async) |
+| PRD-001 | PRD | informs |
+| EPIC-001 | Epic | parent |

--- a/docs/adrs/ADR-005-fastembed-bge-m3-1024.md
+++ b/docs/adrs/ADR-005-fastembed-bge-m3-1024.md
@@ -1,0 +1,93 @@
+---
+id: ADR-005
+title: "fastembed-rs + BGE-M3 (1024-dim) вместо ort + BGE-M3 (384-dim)"
+status: Accepted
+depth: standard
+valid_until: 2027-03-22
+problem_ref: ""
+created: 2026-03-22
+updated: 2026-03-22
+---
+
+# ADR-005: fastembed-rs + BGE-M3 (1024-dim) вместо ort + BGE-M3 (384-dim)
+
+## Context
+
+Phase 4 требует semantic search по артефактам. VISION.md указывает `ort (ONNX Runtime)` с `BGE-M3` на 384 dimensions. Исследование показало, что:
+1. `fastembed-rs` (от Qdrant) даёт drop-in support для BGE-M3 + BGE-Reranker-v2 без ручного ONNX export
+2. BGE-M3 поддерживает 1024-dim (полноразмерные) — лучшее качество retrieval
+3. Reranking (BGE-Reranker-v2-M3) доступен из коробки — нет в `ort` без ручной работы
+
+## Decision
+
+**Selected**: `fastembed-rs` с BGE-M3 full-size (1024-dim) + BGE-Reranker-v2-M3.
+
+**Why Selected**: Production-ready crate (Qdrant backed), zero-config tokenization, auto-download моделей с HF Hub, поддержка квантизации, reranker из коробки. 1024-dim даёт лучшее качество семантического поиска чем 384-dim.
+
+## Alternatives Considered
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| `ort` + manual ONNX export (384-dim) | Rejected | Нужен Python для ONNX export, нет reranker, больше boilerplate |
+| `fastembed-rs` + BGE-M3 (384-dim) | Rejected | Работает, но 1024-dim даёт лучший recall при незначительном увеличении storage |
+| `fastembed-rs` + BGE-M3 (1024-dim) | **Chosen** | Best quality, zero-config, reranker included |
+| `candle` (HuggingFace Rust ML) | Rejected | Нет built-in BGE-M3, нужен custom code, меньше production evidence |
+| `rust-bert` | Rejected | Legacy, нет BGE support |
+
+## Consequences
+
+### Positive
+- 100% Rust — нет Python dependency
+- Drop-in BGE-M3 + Reranker-v2 через enum variants
+- Auto-download с HF Hub, кэширование в `~/.cache/huggingface/`
+- Квантизованные варианты для edge deployment (~350MB vs 1.2GB)
+- 3-5x быстрее Python (ONNX Runtime backend)
+- 1024-dim = лучший recall на MTEB benchmarks
+
+### Negative (trade-offs)
+- Binary size +~25 MB (ONNX Runtime libs) — нужен feature flag
+- Model size ~600-1200 MB (загружается при первом использовании)
+- NFR-002 (< 15MB binary) → semantic-search = optional feature
+- EMBEDDING_DIM 384 → 1024 — breaking change для существующих LanceDB таблиц
+- LanceDB `FixedSizeList(1024)` — больше storage на артефакт
+
+### Risks
+- fastembed-rs API изменится (pre-1.0 crate) → pin version
+- Модель удалена с HF Hub → bundle или зеркало
+- 1024-dim слишком медленный на слабых машинах → fallback к quantized model
+
+## Invariants
+
+- `fastembed-rs` используется ТОЛЬКО через feature flag `semantic-search`
+- Без feature flag — CLI работает без embedding модели (binary < 15MB)
+- EMBEDDING_DIM = 1024 (full BGE-M3)
+- Модели загружаются при первом `forgeplan search --semantic`, не при `forgeplan init`
+- Reranker используется для `forgeplan search` с `--rerank` flag
+- Embedding dimension записан как константа `EMBEDDING_DIM` в `db/schema.rs`
+
+## Evidence Requirements
+
+- fastembed-rs компилируется в Forgeplan workspace
+- Embedding generation < 500ms для одного артефакта (среднего размера ~500 слов)
+- Vector search < 200ms на 1000 артефактах с LanceDB ANN
+- Reranking top-10 results < 1s
+- Binary size с feature flag < 40MB (без ONNX: < 15MB)
+
+## Valid Until
+
+**Дата**: 2027-03-22
+
+**Refresh Triggers**:
+- fastembed-rs прекратит поддержку
+- Появится лучшая multilingual embedding модель для Rust
+- ONNX Runtime заменится на другой backend (WGPU, Metal)
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|----------|------|----------|
+| SPEC-001 | Spec | updates (embedding dimension 384 → 1024) |
+| RFC-003 | RFC | informs (LanceDB integration) |
+| ADR-002 | ADR | extends (LanceDB + vectors) |
+| EPIC-001 | Epic | parent |
+| VISION.md | Doc | updates (ort → fastembed) |

--- a/docs/rfcs/RFC-003-lancedb-integration.md
+++ b/docs/rfcs/RFC-003-lancedb-integration.md
@@ -14,9 +14,9 @@ depth: deep
 ## Progress
 
 ```
-Phase D  ░░░░░░░░░░░░░░░░░░░░░░░░  0/5   (  0%)  LanceDB Integration
+Phase D  ████████████████░░░░░░░░  3/5   ( 60%)  LanceDB Integration
 ─────────────────────────────────────────────────
-TOTAL                               0/5   (  0%)
+TOTAL                               3/5   ( 60%)
 ```
 
 ---
@@ -311,9 +311,9 @@ forgeplan init --migrate (existing workspace):
 ## Implementation Phases
 
 ### Phase D: LanceDB Integration
-- [ ] **D.1** Async migration — tokio runtime, async core functions, async tests
-- [ ] **D.2** LanceDB db module — schema, connect, create tables
-- [ ] **D.3** ArtifactStore trait + LanceStore implementation (CRUD)
+- [x] **D.1** Async migration — tokio runtime, async core functions, async tests
+- [x] **D.2** LanceDB db module — schema, connect, create tables
+- [x] **D.3** ArtifactStore trait + LanceStore implementation (CRUD + convert)
 - [ ] **D.4** Markdown projection — write LanceDB → render markdown
 - [ ] **D.5** Command migration — all 10 CLI commands use LanceStore
 

--- a/docs/rfcs/RFC-003-lancedb-integration.md
+++ b/docs/rfcs/RFC-003-lancedb-integration.md
@@ -1,0 +1,332 @@
+---
+id: RFC-003
+title: "LanceDB Integration — async storage, schema, migration"
+status: Draft
+author: explosovebit
+created: 2026-03-21
+updated: 2026-03-21
+prd: PRD-001
+depth: deep
+---
+
+# RFC-003: LanceDB Integration
+
+## Progress
+
+```
+Phase D  ░░░░░░░░░░░░░░░░░░░░░░░░  0/5   (  0%)  LanceDB Integration
+─────────────────────────────────────────────────
+TOTAL                               0/5   (  0%)
+```
+
+---
+
+## Summary
+
+Интеграция LanceDB как primary storage для Forgeplan CLI. Все CRUD операции через LanceDB, markdown файлы = git-tracked projections. Async runtime (tokio) для всего core. Адаптация quint-code schema.sql (9 таблиц → 3 LanceDB таблицы).
+
+## Motivation
+
+ADR-002 определяет LanceDB = source of truth. Текущий file-based store работает, но не поддерживает:
+- Structured queries (filter by kind + status + date range)
+- Vector search (semantic similarity между артефактами)
+- Atomic operations (concurrent read/write safety)
+- Evidence → Artifact relationships через foreign keys
+
+Без LanceDB: search = regex grep (O(n) scan), нет semantic search, нет structured queries, нет Phase 4 (Desktop App с rich queries).
+
+## Goals
+
+- Определить LanceDB schema (3 таблицы: artifacts, evidence, relations)
+- Описать async migration path (sync → tokio)
+- Определить ArtifactStore trait (абстракция над storage backend)
+- Описать markdown projection pipeline (LanceDB write → markdown render)
+- Обратная совместимость: `forgeplan init` мигрирует существующие markdown файлы
+
+## Non-Goals
+
+- Vector embeddings / semantic search (Phase 4, requires ONNX)
+- Desktop App integration (Phase 4, Tauri)
+- MCP server (Phase 5)
+- Migration tool для v0.1.0 → v0.2.0 workspaces (отдельная задача)
+
+---
+
+## Options Considered
+
+### Option A: Full async migration (выбран)
+
+**Description**: Весь core становится async. tokio runtime. LanceDB = primary store. Markdown = projection.
+
+**Pros**: Чистая архитектура. Готовность к Phase 4 (Tauri async). Нет sync/async boundary проблем.
+
+**Cons**: Ломает все 97 тестов (нужен `#[tokio::test]`). Увеличивает compile time.
+
+### Option B: Sync wrapper вокруг async
+
+**Description**: LanceDB вызывается через `tokio::runtime::Runtime::block_on()` из sync кода.
+
+**Pros**: Минимальные изменения в существующем коде.
+
+**Cons**: Nested runtime panic. Плохой DX. Не работает с Tauri (который тоже async).
+
+### Option C: LanceDB только для search, file store для CRUD
+
+**Description**: File store остаётся primary. LanceDB = read-only index для search.
+
+**Pros**: Минимальные изменения. Инкрементально.
+
+**Cons**: Два source of truth. Sync проблемы. Не соответствует ADR-002.
+
+## Trade-off Analysis
+
+| Критерий | Full async (A) | Sync wrapper (B) | Search-only (C) |
+|----------|---------------|-------------------|-----------------|
+| ADR-002 compliance | Full | Partial | No |
+| Code changes | High | Low | Low |
+| Tauri readiness | Yes | No (nested runtime) | No |
+| Correctness | Best | Runtime panics | Dual source |
+| Future maintenance | Simple | Complex | Complex |
+
+---
+
+## Proposed Direction
+
+**Option A: Full async migration**. Соответствует ADR-002, готовит к Phase 4 (Tauri), чистая архитектура.
+
+---
+
+## Architecture
+
+### LanceDB Schema (3 таблицы)
+
+Адаптация quint-code schema.sql (9 таблиц) → 3 LanceDB таблицы. Quint-code таблицы `work_records`, `audit_log`, `waivers`, `predictions`, `fpf_state`, `characteristics` не нужны для MVP CLI.
+
+#### Table: `artifacts`
+
+```
+┌─────────────┬───────────────────┬───────────────────────────────────┐
+│ Column       │ Type              │ Description                       │
+├─────────────┼───────────────────┼───────────────────────────────────┤
+│ id          │ Utf8              │ PK: "PRD-001", "RFC-002"          │
+│ kind        │ Utf8              │ "prd", "rfc", "adr", "epic", etc. │
+│ status      │ Utf8              │ "draft", "active", "superseded"   │
+│ title       │ Utf8              │ Human-readable title              │
+│ body        │ Utf8 (Large)      │ Markdown content (after ---)      │
+│ depth       │ Utf8              │ "tactical", "standard", "deep"    │
+│ author      │ Utf8 (nullable)   │ Author name                       │
+│ parent_epic │ Utf8 (nullable)   │ FK: parent epic ID                │
+│ r_eff_score │ Float64           │ Cached R_eff score                │
+│ valid_until │ Utf8 (nullable)   │ ISO date for evidence decay       │
+│ created_at  │ Utf8              │ ISO datetime                      │
+│ updated_at  │ Utf8              │ ISO datetime                      │
+│ embedding   │ FixedSizeList(384)│ Vector for semantic search        │
+└─────────────┴───────────────────┴───────────────────────────────────┘
+```
+
+#### Table: `evidence`
+
+```
+┌──────────────────┬───────────────┬──────────────────────────────────┐
+│ Column            │ Type          │ Description                      │
+├──────────────────┼───────────────┼──────────────────────────────────┤
+│ id               │ Utf8          │ PK: "EVID-001"                   │
+│ artifact_id      │ Utf8          │ FK: linked artifact              │
+│ evidence_type    │ Utf8          │ "measurement", "test", etc.      │
+│ verdict          │ Utf8          │ "supports", "weakens", "refutes" │
+│ congruence_level │ Int32         │ 0-3                              │
+│ valid_until      │ Utf8 (null)   │ ISO date                         │
+│ content          │ Utf8          │ Evidence description             │
+│ created_at       │ Utf8          │ ISO datetime                     │
+└──────────────────┴───────────────┴──────────────────────────────────┘
+```
+
+#### Table: `relations`
+
+```
+┌────────────────┬──────────┬───────────────────────────────────────┐
+│ Column          │ Type     │ Description                           │
+├────────────────┼──────────┼───────────────────────────────────────┤
+│ source_id      │ Utf8     │ FK: source artifact                   │
+│ target_id      │ Utf8     │ FK: target artifact                   │
+│ relation_type  │ Utf8     │ "informs", "based_on", "supersedes"   │
+│ created_at     │ Utf8     │ ISO datetime                          │
+└────────────────┴──────────┴───────────────────────────────────────┘
+```
+
+### Async Migration
+
+```rust
+// Before (sync):
+pub fn list_artifacts(workspace: &Path) -> anyhow::Result<Vec<ArtifactSummary>>
+
+// After (async):
+pub async fn list_artifacts(db: &Database) -> anyhow::Result<Vec<ArtifactSummary>>
+
+// CLI main:
+#[tokio::main]
+async fn main() -> anyhow::Result<()> { ... }
+
+// Tests:
+#[tokio::test]
+async fn test_list_artifacts() { ... }
+```
+
+### ArtifactStore Trait (abstraction)
+
+```rust
+#[async_trait]
+pub trait ArtifactStore {
+    async fn create(&self, artifact: &NewArtifact) -> Result<ArtifactSummary>;
+    async fn get(&self, id: &str) -> Result<Option<Artifact>>;
+    async fn list(&self, filter: &ArtifactFilter) -> Result<Vec<ArtifactSummary>>;
+    async fn update(&self, id: &str, update: &ArtifactUpdate) -> Result<()>;
+    async fn delete(&self, id: &str) -> Result<()>;
+    async fn add_link(&self, source: &str, target: &str, relation: &str) -> Result<()>;
+    async fn get_links(&self, id: &str) -> Result<Vec<Link>>;
+    async fn search(&self, query: &str, kind: Option<&str>) -> Result<Vec<SearchHit>>;
+}
+```
+
+### LanceDB Store Implementation
+
+```rust
+pub struct LanceStore {
+    db: Database,
+    artifacts_table: Table,
+    evidence_table: Table,
+    relations_table: Table,
+    workspace_path: PathBuf,  // for markdown projections
+}
+
+impl LanceStore {
+    pub async fn open(workspace: &Path) -> Result<Self> {
+        let lance_dir = workspace.join("lance");
+        let db = lancedb::connect(lance_dir.to_str().unwrap()).execute().await?;
+        // Open or create tables...
+        Ok(Self { db, ... })
+    }
+}
+```
+
+### Markdown Projection Pipeline
+
+```
+User: forgeplan new prd "Feature X"
+  → LanceStore::create(artifact)
+    → Insert into LanceDB artifacts table
+    → Render markdown: frontmatter (from record) + body (from template)
+    → Write to .forgeplan/prds/PRD-001-feature-x.md
+    → Return ArtifactSummary
+
+User: forgeplan list
+  → LanceStore::list(filter)
+    → SELECT id, kind, status, title FROM artifacts WHERE ...
+    → Return Vec<ArtifactSummary> (no file I/O!)
+
+User: forgeplan validate PRD-001
+  → LanceStore::get("PRD-001")
+    → SELECT * FROM artifacts WHERE id = 'PRD-001'
+    → Return Artifact with body
+    → validate(body, frontmatter, kind, depth)
+```
+
+### Data Flow
+
+```
+                    ┌─────────────┐
+                    │  CLI Layer   │
+                    │  (clap)      │
+                    └──────┬──────┘
+                           │
+                    ┌──────▼──────┐
+                    │  Core Layer  │
+                    │  (async)     │
+                    └──────┬──────┘
+                           │
+                ┌──────────▼──────────┐
+                │    ArtifactStore     │ ← trait
+                │    (LanceStore)      │ ← impl
+                └──────────┬──────────┘
+                           │
+              ┌────────────▼────────────┐
+              │         LanceDB         │
+              │  .forgeplan/lance/      │
+              │  (Arrow columnar)       │
+              └────────────┬────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │   Markdown Projection    │
+              │  .forgeplan/prds/*.md    │
+              │  (git-tracked, read-only)│
+              └─────────────────────────┘
+```
+
+### Migration: existing workspace → LanceDB
+
+```
+forgeplan init (new workspace):
+  → Create .forgeplan/lance/ + tables
+  → Create .forgeplan/prds/, rfcs/, etc. (empty, for projections)
+
+forgeplan init --migrate (existing workspace):
+  → Scan .forgeplan/prds/*.md, rfcs/*.md, etc.
+  → Parse frontmatter + body from each
+  → Insert into LanceDB artifacts table
+  → Parse links from frontmatter → insert into relations table
+  → Mark migration complete in config.yaml (storage_version: 2)
+```
+
+### Directory Structure (updated)
+
+```
+.forgeplan/
+├── config.yaml          ← storage_version: 2
+├── lance/               ← LanceDB (gitignore)
+│   ├── artifacts.lance/
+│   ├── evidence.lance/
+│   └── relations.lance/
+├── prds/                ← markdown projections (git-tracked)
+├── epics/
+├── specs/
+├── rfcs/
+├── adrs/
+├── problems/
+├── solutions/
+├── evidence/
+├── notes/
+└── refresh/
+```
+
+---
+
+## Risks & Open Questions
+
+- **Risk**: LanceDB crate compile time — arrow + tokio = heavy. Mitigated: workspace dependency dedup.
+- **Risk**: LanceDB API stability — SDK not 1.0 yet. Mitigated: pin version, ArtifactStore trait for swapability.
+- **Risk**: Binary size increase (arrow + tokio). Mitigated: check NFR-002 (< 15MB) after integration.
+- **Open**: embedding column — fill with zeros initially, populate when ONNX added (Phase 4)?
+- **Open**: .forgeplan/lance/ в .gitignore? Да — LanceDB files не для git, markdown projections — для git.
+
+## Implementation Phases
+
+### Phase D: LanceDB Integration
+- [ ] **D.1** Async migration — tokio runtime, async core functions, async tests
+- [ ] **D.2** LanceDB db module — schema, connect, create tables
+- [ ] **D.3** ArtifactStore trait + LanceStore implementation (CRUD)
+- [ ] **D.4** Markdown projection — write LanceDB → render markdown
+- [ ] **D.5** Command migration — all 10 CLI commands use LanceStore
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|----------|------|----------|
+| PRD-001 | PRD | based_on |
+| RFC-001 | RFC | extends |
+| RFC-002 | RFC | extends |
+| ADR-002 | ADR | implements (LanceDB decision) |
+| EPIC-001 | Epic | parent |
+
+---
+
+> **Next step**: D.1 — Async migration (tokio runtime, convert core to async, fix all tests).

--- a/docs/specs/SPEC-001-storage-contracts.md
+++ b/docs/specs/SPEC-001-storage-contracts.md
@@ -1,0 +1,403 @@
+---
+id: SPEC-001
+title: "Storage Contracts — LanceDB schema, ArtifactStore API, DTOs"
+status: Draft
+author: explosovebit
+created: 2026-03-22
+updated: 2026-03-22
+prd: PRD-001
+rfc: RFC-003
+depth: deep
+spec_type: data_model
+---
+
+# SPEC-001: Storage Contracts
+
+## Summary
+
+Формальная спецификация контрактов между слоями Forgeplan: Arrow schemas для LanceDB таблиц, `ArtifactStore` trait API, domain types (DTOs), conversion rules. Это контракт — изменения только через delta-spec.
+
+---
+
+## Data Models
+
+### 1. Domain Types (DTOs)
+
+#### ArtifactId (Newtype)
+
+```rust
+/// Type-safe artifact identifier. Format: "{KIND}-{NNN}" (e.g., "PRD-001", "RFC-002").
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ArtifactId(String);
+
+impl ArtifactId {
+    pub fn new(kind: &ArtifactKind, num: u32, digits: u32) -> Self;
+    pub fn parse(s: &str) -> Result<Self>;  // validates format
+    pub fn as_str(&self) -> &str;
+    pub fn kind(&self) -> Option<ArtifactKind>;  // extract from prefix
+    pub fn number(&self) -> Option<u32>;          // extract numeric part
+}
+
+impl Display for ArtifactId { /* "PRD-001" */ }
+impl From<String> for ArtifactId { /* unchecked */ }
+impl From<&str> for ArtifactId { /* unchecked */ }
+```
+
+**Validation**: Uppercase prefix + dash + zero-padded digits. Regex: `^[A-Z]+-\d{3,}$`
+
+#### ArtifactRecord (full domain object)
+
+```rust
+/// Complete artifact with all fields. Used for get() and storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactRecord {
+    pub id: ArtifactId,
+    pub kind: ArtifactKind,
+    pub status: Status,
+    pub title: String,
+    pub body: String,
+
+    #[serde(default)]
+    pub depth: Option<Mode>,
+
+    #[serde(default)]
+    pub author: Option<String>,
+
+    #[serde(default)]
+    pub parent_epic: Option<String>,
+
+    #[serde(default)]
+    pub r_eff_score: f64,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+
+    pub created_at: String,  // ISO 8601
+    pub updated_at: String,  // ISO 8601
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<Vec<f32>>,  // 384-dim, None until Phase 4
+}
+```
+
+#### NewArtifact (create DTO)
+
+```rust
+/// Input for creating a new artifact. ID is auto-generated.
+pub struct NewArtifact {
+    pub kind: ArtifactKind,
+    pub title: String,
+    pub body: String,
+    pub depth: Option<Mode>,
+    pub author: Option<String>,
+    pub parent_epic: Option<String>,
+}
+```
+
+#### ArtifactSummary (list DTO)
+
+```rust
+/// Lightweight projection for list/search results. No body, no embedding.
+#[derive(Debug, Clone)]
+pub struct ArtifactSummary {
+    pub id: ArtifactId,
+    pub title: String,
+    pub kind: String,
+    pub status: String,
+    pub depth: Option<String>,
+    pub r_eff_score: f64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+```
+
+#### ArtifactFilter (query DTO)
+
+```rust
+/// Filter criteria for list queries.
+#[derive(Debug, Clone, Default)]
+pub struct ArtifactFilter {
+    pub kind: Option<String>,
+    pub status: Option<String>,
+    pub parent_epic: Option<String>,
+}
+```
+
+#### ArtifactUpdate (update DTO)
+
+```rust
+/// Partial update. Only non-None fields are applied.
+pub struct ArtifactUpdate {
+    pub status: Option<Status>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub r_eff_score: Option<f64>,
+    pub valid_until: Option<String>,
+}
+```
+
+---
+
+### 2. Arrow Schemas (LanceDB)
+
+#### artifacts table
+
+| # | Column | Arrow Type | Nullable | Description |
+|---|--------|-----------|----------|-------------|
+| 0 | `id` | `Utf8` | NO | PK: "PRD-001" |
+| 1 | `kind` | `Utf8` | NO | "prd", "rfc", "adr" |
+| 2 | `status` | `Utf8` | NO | "draft", "active", "superseded" |
+| 3 | `title` | `Utf8` | NO | Human-readable title |
+| 4 | `body` | `LargeUtf8` | NO | Markdown content |
+| 5 | `depth` | `Utf8` | YES | "tactical", "standard", "deep" |
+| 6 | `author` | `Utf8` | YES | Author name |
+| 7 | `parent_epic` | `Utf8` | YES | FK: parent epic ID |
+| 8 | `r_eff_score` | `Float64` | NO | Cached R_eff (default 0.0) |
+| 9 | `valid_until` | `Utf8` | YES | ISO date "2027-03-22" |
+| 10 | `created_at` | `Utf8` | NO | ISO datetime |
+| 11 | `updated_at` | `Utf8` | NO | ISO datetime |
+| 12 | `embedding` | `FixedSizeList(384, Float32)` | YES | Semantic vector (None until Phase 4) |
+
+```rust
+pub fn artifacts_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("status", DataType::Utf8, false),
+        Field::new("title", DataType::Utf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("depth", DataType::Utf8, true),
+        Field::new("author", DataType::Utf8, true),
+        Field::new("parent_epic", DataType::Utf8, true),
+        Field::new("r_eff_score", DataType::Float64, false),
+        Field::new("valid_until", DataType::Utf8, true),
+        Field::new("created_at", DataType::Utf8, false),
+        Field::new("updated_at", DataType::Utf8, false),
+        Field::new("embedding",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                384  // i32!
+            ),
+            true,  // nullable — None until ONNX embeddings added
+        ),
+    ])
+}
+```
+
+#### evidence table
+
+| # | Column | Arrow Type | Nullable | Description |
+|---|--------|-----------|----------|-------------|
+| 0 | `id` | `Utf8` | NO | PK: "EVID-001" |
+| 1 | `artifact_id` | `Utf8` | NO | FK: linked artifact |
+| 2 | `evidence_type` | `Utf8` | NO | "measurement", "test", "benchmark", "audit" |
+| 3 | `verdict` | `Utf8` | NO | "supports", "weakens", "refutes" |
+| 4 | `congruence_level` | `Int32` | NO | 0-3 |
+| 5 | `valid_until` | `Utf8` | YES | ISO date |
+| 6 | `content` | `Utf8` | NO | Description |
+| 7 | `created_at` | `Utf8` | NO | ISO datetime |
+
+#### relations table
+
+| # | Column | Arrow Type | Nullable | Description |
+|---|--------|-----------|----------|-------------|
+| 0 | `source_id` | `Utf8` | NO | FK: source artifact |
+| 1 | `target_id` | `Utf8` | NO | FK: target artifact |
+| 2 | `relation_type` | `Utf8` | NO | "informs", "based_on", "supersedes", "contradicts", "refines" |
+| 3 | `created_at` | `Utf8` | NO | ISO datetime |
+
+---
+
+## API Contracts
+
+### ArtifactStore Trait
+
+```rust
+/// Storage abstraction — swappable backend (LanceDB, in-memory, file-based).
+#[async_trait]
+pub trait ArtifactStore: Send + Sync {
+    /// Create artifact, auto-generate ID. Returns the generated ID.
+    async fn create(&self, artifact: &NewArtifact) -> Result<ArtifactId>;
+
+    /// Get full artifact by ID. Returns None if not found.
+    async fn get(&self, id: &str) -> Result<Option<ArtifactRecord>>;
+
+    /// List artifacts with optional filter. Returns summaries (no body).
+    async fn list(&self, filter: &ArtifactFilter) -> Result<Vec<ArtifactSummary>>;
+
+    /// Update artifact fields. Only non-None fields in ArtifactUpdate are applied.
+    async fn update(&self, id: &str, update: &ArtifactUpdate) -> Result<()>;
+
+    /// Delete artifact by ID.
+    async fn delete(&self, id: &str) -> Result<()>;
+
+    /// Add typed relationship between two artifacts.
+    async fn add_link(&self, source: &str, target: &str, relation: &str) -> Result<()>;
+
+    /// Get all outgoing links from an artifact. Returns Vec<(target_id, relation)>.
+    async fn get_links(&self, id: &str) -> Result<Vec<(String, String)>>;
+
+    /// Get next sequential ID for a kind. E.g., "PRD-004" if 3 PRDs exist.
+    async fn next_id(&self, kind: &ArtifactKind) -> Result<ArtifactId>;
+
+    /// Count artifacts by kind and status.
+    async fn count(&self, filter: &ArtifactFilter) -> Result<usize>;
+}
+```
+
+**Invariants**:
+- `create()` MUST auto-generate monotonically increasing IDs per kind
+- `create()` MUST write markdown projection after LanceDB insert
+- `get()` returns from LanceDB, NOT from markdown files
+- `list()` returns `ArtifactSummary` (no body, no embedding) for performance
+- `add_link()` MUST normalize target to uppercase
+- `add_link()` MUST reject duplicates (case-insensitive)
+- All methods MUST validate ID format before `.only_if()` (SQL injection prevention)
+
+### LanceStoreBuilder
+
+```rust
+pub struct LanceStoreBuilder {
+    workspace: Option<PathBuf>,
+    embedding_dim: i32,  // default: 384
+}
+
+impl LanceStoreBuilder {
+    pub fn new() -> Self;
+    pub fn workspace(self, path: impl Into<PathBuf>) -> Self;
+    pub fn embedding_dim(self, dim: i32) -> Self;
+    pub async fn build(self) -> Result<LanceStore>;
+    pub async fn open_existing(self) -> Result<LanceStore>;  // fails if tables don't exist
+}
+```
+
+**Invariants**:
+- `build()` creates tables if they don't exist (idempotent)
+- `open_existing()` fails with `ForgeplanError::WorkspaceNotFound` if no lance/ directory
+- `.forgeplan/lance/` directory is created by `build()`, not by workspace init
+
+### LanceStore
+
+```rust
+#[derive(Clone)]  // Clone = Arc bump, cheap
+pub struct LanceStore {
+    inner: Arc<LanceStoreInner>,
+}
+
+struct LanceStoreInner {
+    db: lancedb::Database,
+    artifacts: lancedb::Table,
+    evidence: lancedb::Table,
+    relations: lancedb::Table,
+    workspace: PathBuf,
+    embedding_dim: i32,
+}
+
+impl ArtifactStore for LanceStore { /* ... */ }
+```
+
+---
+
+## Validation Rules
+
+### Field Constraints
+
+| Field | Constraint |
+|-------|-----------|
+| `id` | Regex: `^[A-Z]+-\d{3,}$` |
+| `kind` | One of: prd, epic, spec, rfc, adr, note, problem, solution, evidence, refresh |
+| `status` | One of: draft, active, superseded, deprecated, refresh_due |
+| `depth` | One of: note, tactical, standard, deep (nullable) |
+| `congruence_level` | 0..=3 |
+| `relation_type` | One of: informs, based_on, supersedes, contradicts, refines |
+| `r_eff_score` | 0.0..=1.0 |
+| `embedding` | Exactly 384 f32 values, or None |
+
+### SQL Injection Prevention
+
+IDs used in `.only_if()` MUST be sanitized:
+
+```rust
+fn sanitize_id(id: &str) -> Result<&str> {
+    if id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+        Ok(id)
+    } else {
+        Err(ForgeplanError::ArtifactNotFound(id.to_string()))
+    }
+}
+```
+
+---
+
+## Events / Side Effects
+
+| Operation | Side Effect |
+|-----------|-------------|
+| `create()` | Insert into `artifacts` table → render markdown → write to `.forgeplan/{kind}s/{id}-{slug}.md` |
+| `update()` | Update LanceDB record → re-render markdown → overwrite `.md` file |
+| `delete()` | Delete from LanceDB → delete `.md` file |
+| `add_link()` | Insert into `relations` table → update source artifact's `.md` frontmatter `links:` |
+
+### Markdown Projection Format
+
+```yaml
+---
+id: PRD-001
+title: "Feature X"
+kind: prd
+status: Draft
+depth: standard
+author: explosovebit
+created: 2026-03-22
+updated: 2026-03-22
+links:
+  - target: RFC-001
+    relation: informs
+---
+
+[body content from LanceDB]
+```
+
+---
+
+## Conversion Rules
+
+### Domain → Arrow (write path)
+
+| Domain Type | Arrow Type | Conversion |
+|-------------|-----------|------------|
+| `ArtifactId` | `StringArray` | `.as_str().to_string()` |
+| `ArtifactKind` | `StringArray` | serde snake_case: `Prd` → `"prd"` |
+| `Status` | `StringArray` | serde snake_case: `Draft` → `"draft"` |
+| `Option<String>` | `StringArray` (nullable) | `Some(s)` → value, `None` → null |
+| `f64` | `Float64Array` | direct |
+| `Option<Vec<f32>>` | `FixedSizeListArray` (nullable) | `None` → null row |
+
+### Arrow → Domain (read path)
+
+| Arrow Column | Domain Type | Conversion |
+|--------------|-------------|------------|
+| `StringArray[i]` | `String` | `.value(i).to_string()` |
+| `StringArray[i]` (nullable) | `Option<String>` | `.is_null(i)` check |
+| `Float64Array[i]` | `f64` | `.value(i)` |
+| `FixedSizeListArray[i]` | `Option<Vec<f32>>` | `.is_null(i)`, then `.as_primitive::<Float32Type>().values().to_vec()` |
+
+---
+
+## Versioning
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-03-22 | Initial: 3 tables, ArtifactStore trait, 6 DTOs |
+
+---
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|----------|------|----------|
+| PRD-001 | PRD | based_on |
+| RFC-003 | RFC | implements |
+| ADR-002 | ADR | informs (LanceDB decision) |
+| ADR-004 | ADR | informs (async decision) |
+| EPIC-001 | Epic | parent |

--- a/docs/specs/SPEC-001-storage-contracts.md
+++ b/docs/specs/SPEC-001-storage-contracts.md
@@ -5,6 +5,7 @@ status: Draft
 author: explosovebit
 created: 2026-03-22
 updated: 2026-03-22
+delta: "v1.1: EMBEDDING_DIM 384→1024 (ADR-005), fastembed-rs"
 prd: PRD-001
 rfc: RFC-003
 depth: deep
@@ -76,7 +77,7 @@ pub struct ArtifactRecord {
     pub updated_at: String,  // ISO 8601
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub embedding: Option<Vec<f32>>,  // 384-dim, None until Phase 4
+    pub embedding: Option<Vec<f32>>,  // 1024-dim, None until Phase 4
 }
 ```
 
@@ -156,7 +157,7 @@ pub struct ArtifactUpdate {
 | 9 | `valid_until` | `Utf8` | YES | ISO date "2027-03-22" |
 | 10 | `created_at` | `Utf8` | NO | ISO datetime |
 | 11 | `updated_at` | `Utf8` | NO | ISO datetime |
-| 12 | `embedding` | `FixedSizeList(384, Float32)` | YES | Semantic vector (None until Phase 4) |
+| 12 | `embedding` | `FixedSizeList(1024, Float32)` | YES | Semantic vector (None until Phase 4) |
 
 ```rust
 pub fn artifacts_schema() -> Schema {
@@ -176,7 +177,7 @@ pub fn artifacts_schema() -> Schema {
         Field::new("embedding",
             DataType::FixedSizeList(
                 Arc::new(Field::new("item", DataType::Float32, true)),
-                384  // i32!
+                1024  // i32! Full BGE-M3 (ADR-005)
             ),
             true,  // nullable — None until ONNX embeddings added
         ),
@@ -311,7 +312,7 @@ impl ArtifactStore for LanceStore { /* ... */ }
 | `congruence_level` | 0..=3 |
 | `relation_type` | One of: informs, based_on, supersedes, contradicts, refines |
 | `r_eff_score` | 0.0..=1.0 |
-| `embedding` | Exactly 384 f32 values, or None |
+| `embedding` | Exactly 1024 f32 values, or None (BGE-M3 full, ADR-005) |
 
 ### SQL Injection Prevention
 
@@ -389,6 +390,7 @@ links:
 | Version | Date | Changes |
 |---------|------|---------|
 | 1.0 | 2026-03-22 | Initial: 3 tables, ArtifactStore trait, 6 DTOs |
+| 1.1 | 2026-03-22 | MODIFIED: EMBEDDING_DIM 384→1024 (ADR-005). MODIFIED: ort→fastembed-rs. ADDED: reranker support. |
 
 ---
 

--- a/research/RUST-ARCHITECTURE-PATTERNS.md
+++ b/research/RUST-ARCHITECTURE-PATTERNS.md
@@ -1,0 +1,257 @@
+# Rust Architecture Patterns — Research Report
+
+> Extracted from 3 reference projects: edgequake, jan, graphrag-rs
+> Date: 2026-03-22
+> Purpose: Inform Forgeplan LanceDB integration (RFC-003)
+
+---
+
+## Synthesis: Best Patterns for Forgeplan
+
+### 1. Storage Abstraction: Trait-Based (from graphrag-rs)
+
+```rust
+#[async_trait]
+pub trait ArtifactStore: Send + Sync {
+    async fn create(&self, artifact: &NewArtifact) -> Result<ArtifactSummary>;
+    async fn get(&self, id: &str) -> Result<Option<Artifact>>;
+    async fn list(&self, filter: &ArtifactFilter) -> Result<Vec<ArtifactSummary>>;
+    async fn update(&self, id: &str, update: &ArtifactUpdate) -> Result<()>;
+    async fn delete(&self, id: &str) -> Result<()>;
+    async fn search(&self, query: &str, kind: Option<&str>) -> Result<Vec<SearchHit>>;
+}
+```
+
+**Source**: graphrag-rs VectorStore trait (42 lines) — clean, async, Send + Sync bounds.
+**Why**: Allows swapping LanceDB for in-memory store in tests, or future SQLite fallback.
+
+### 2. LanceDB Patterns (from graphrag-rs)
+
+#### Table Init: try open, else create
+```rust
+let table = match db.open_table("artifacts").execute().await {
+    Ok(table) => table,
+    Err(_) => {
+        let empty = create_empty_batch(schema.clone())?;
+        db.create_table("artifacts", empty).execute().await?
+    }
+};
+```
+
+#### RecordBatch Construction
+```rust
+let batch = RecordBatch::try_new(
+    schema.clone(),
+    vec![
+        Arc::new(StringArray::from(vec![id])),
+        Arc::new(StringArray::from(vec![title])),
+        Arc::new(Float64Array::from(vec![r_eff_score])),
+        Arc::new(FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+            vec![Some(embedding.iter().map(|&v| Some(v)).collect())],
+            384, // dimension as i32
+        )),
+    ],
+)?;
+```
+
+#### Query Patterns
+```rust
+// By ID (SQL filter)
+table.query().only_if(format!("id = '{}'", id)).execute().await?
+
+// Vector search
+table.query().limit(k).nearest_to(query_vec).execute().await?
+
+// Stream collection
+.try_collect::<Vec<RecordBatch>>().await?
+```
+
+#### Gotchas
+- `.limit()` BEFORE `.nearest_to()` (order matters!)
+- FixedSizeList size is **i32**, not usize
+- Schema from `.schema().await` (not hardcoded per operation)
+- `.only_if()` vulnerable to injection — validate IDs!
+
+### 3. Error Handling: thiserror Enum (from edgequake)
+
+```rust
+#[derive(Error, Debug)]
+pub enum ForgeplanError {
+    #[error("workspace not found: run `forgeplan init` first")]
+    WorkspaceNotFound,
+    #[error("artifact not found: {0}")]
+    ArtifactNotFound(String),
+    #[error("storage error: {0}")]
+    Storage(String),
+    #[error("validation failed: {0} error(s)")]
+    ValidationFailed(usize),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Arrow(#[from] arrow::error::ArrowError),
+    #[error(transparent)]
+    Lance(#[from] lancedb::Error),
+}
+
+impl ForgeplanError {
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Storage(_))
+    }
+}
+```
+
+### 4. Client/Store: Arc<Inner> + Builder (from edgequake + jan)
+
+```rust
+#[derive(Clone)]
+pub struct LanceStore {
+    inner: Arc<LanceStoreInner>,
+}
+
+struct LanceStoreInner {
+    db: lancedb::Database,
+    artifacts: lancedb::Table,
+    evidence: lancedb::Table,
+    relations: lancedb::Table,
+    workspace: PathBuf,
+}
+
+impl LanceStore {
+    pub fn builder() -> LanceStoreBuilder { ... }
+}
+
+pub struct LanceStoreBuilder {
+    workspace: Option<PathBuf>,
+    embedding_dim: usize,
+}
+
+impl LanceStoreBuilder {
+    pub fn workspace(mut self, path: impl Into<PathBuf>) -> Self { ... }
+    pub fn embedding_dim(mut self, dim: usize) -> Self { ... }
+    pub async fn build(self) -> Result<LanceStore> { ... }
+}
+```
+
+### 5. Newtype IDs (from graphrag-rs)
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ArtifactId(String);
+
+impl ArtifactId {
+    pub fn new(kind: &ArtifactKind, num: u32, digits: u32) -> Self {
+        Self(format!("{}-{:0>width$}", kind.prefix().trim_end_matches('-').to_uppercase(), num, width = digits as usize))
+    }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+impl Display for ArtifactId { ... }
+impl From<String> for ArtifactId { ... }
+impl From<&str> for ArtifactId { ... }
+```
+
+### 6. Feature Flags (from jan + graphrag-rs)
+
+```toml
+[features]
+default = ["file-store"]
+file-store = []                    # Current file-based storage
+lancedb = ["dep:lancedb", "dep:arrow", "dep:arrow-array", "dep:arrow-schema"]
+semantic-search = ["lancedb", "dep:ort"]  # Phase 4
+desktop = ["dep:tauri"]            # Phase 4
+mcp = ["dep:rmcp"]                 # Phase 5
+```
+
+### 7. Serde Patterns (from edgequake)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactRecord {
+    pub id: ArtifactId,
+    pub kind: ArtifactKind,
+    pub status: Status,
+    pub title: String,
+    pub body: String,
+
+    #[serde(default)]
+    pub author: Option<String>,
+
+    #[serde(default)]
+    pub depth: Option<Mode>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub links: Vec<Link>,
+}
+```
+
+### 8. Async Test Patterns (from all 3)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn setup_store() -> (TempDir, LanceStore) {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceStore::builder()
+            .workspace(tmp.path())
+            .embedding_dim(384)
+            .build()
+            .await
+            .unwrap();
+        (tmp, store)
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get() {
+        let (_tmp, store) = setup_store().await;
+        let id = store.create(&NewArtifact { ... }).await.unwrap();
+        let artifact = store.get(id.as_str()).await.unwrap();
+        assert!(artifact.is_some());
+    }
+}
+```
+
+### 9. Markdown Projection (Forgeplan-specific)
+
+```rust
+impl LanceStore {
+    /// After writing to LanceDB, render markdown projection
+    async fn project_to_markdown(&self, artifact: &Artifact) -> Result<()> {
+        let dir = self.workspace.join(kind_dir(&artifact.kind));
+        let filename = format!("{}-{}.md", artifact.id, slugify(&artifact.title));
+        let content = render_frontmatter_and_body(artifact)?;
+        tokio::fs::write(dir.join(filename), content).await?;
+        Ok(())
+    }
+}
+```
+
+---
+
+## Decision Matrix: What to Adopt
+
+| Pattern | Source | Adopt? | Priority |
+|---------|--------|--------|----------|
+| ArtifactStore trait (async) | graphrag-rs | YES | P0 |
+| LanceDB RecordBatch patterns | graphrag-rs | YES | P0 |
+| thiserror enum + is_retryable | edgequake | YES | P0 |
+| Arc<Inner> + Builder | edgequake | YES | P0 |
+| Newtype ArtifactId | graphrag-rs | YES | P1 |
+| Feature flags (lancedb/desktop) | jan + graphrag | YES | P1 |
+| Serde skip_serializing_if | edgequake | YES | P1 |
+| TypedBuilder (compile-time) | graphrag-rs | NO (over-eng) | — |
+| Plugin architecture | jan | NO (Phase 4) | — |
+| wiremock for HTTP tests | edgequake | NO (no HTTP) | — |
+
+---
+
+## References
+
+- edgequake SDK: `sources/edgequake/sdks/rust/` (~1800 LOC)
+- jan: `sources/jan/` (monolithic + plugins)
+- graphrag-rs: `sources/graphrag-rs/` (8 crates, `graphrag-core/src/persistence/lance.rs` = 521 LOC)

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,180 @@
+{
+  "version": 1,
+  "skills": {
+    "coding-guidelines": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "0742312a0de5eb6bd84e093c1815b1db98126130b92713ea5fc2cf902338aa3b"
+    },
+    "domain-cli": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "88a6efe282b5105161c8ddb320f09ca0ffed19323fe403dfa7adb4aaa708b8dc"
+    },
+    "domain-cloud-native": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "10a6e60e8d2a1b977fc5d5935976c17b498335ee2f19255438e45fd15a8811bc"
+    },
+    "domain-embedded": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "3d32e5d2d602f775f4a3d6bc0222d56526ec0dbc882771c80430dffdc2be6dd2"
+    },
+    "domain-fintech": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "c2fbfc41eafd81d828dead9f6988e63a544697d6961e673e563d08d47b7a17f5"
+    },
+    "domain-iot": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "4a8aaf6e1bebbd1984faf04e6dc0cb3b309409628b090ce72b63c807e9b76e4e"
+    },
+    "domain-ml": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "e53c7de1916555fe903c40270208a88e2350f8e5c2f81c5115059ccf4278cca1"
+    },
+    "domain-web": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "dd853ce97875f139da437df6e09eaca8b326931a98f3eb8dc02669670c12161d"
+    },
+    "m01-ownership": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "69f57ede558e32e703e468ef5328f5bcc6610adff9d99b49984a5b3507d31b5b"
+    },
+    "m02-resource": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "b79e4a7702adb7c7622dfab7818dd81710352d448d285885946652e5dc73fd5b"
+    },
+    "m03-mutability": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "78eb8bc5e8b9bbeb5a59375b74b773c8fe824bb1644fa0fb77e99a1255a272ab"
+    },
+    "m04-zero-cost": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "8bc6733618b217b608fe5011f4c74b7ceb8c0765ba60702e30fa8fa4824584f2"
+    },
+    "m05-type-driven": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "06a52b0f35951cd01e21b2906917061f3994ece6b8c6b055dca65bbe14820283"
+    },
+    "m06-error-handling": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "e6639bd5913e63bd8315f7b36f5dd22a029cae2404135a75ac24c0627a93e4e5"
+    },
+    "m07-concurrency": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "6ff3b31bae02e84238a75845008150122071ba449b23edb9ea8a50e3635fffb7"
+    },
+    "m09-domain": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "ce0ed9b5b5c12775c6c04423c79c8a542638629237ad2447a3c6569accf1a15a"
+    },
+    "m10-performance": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "c0e093f630ec71079aa7a138af376821e3cc24dfb129f7162e82d854e26a1087"
+    },
+    "m11-ecosystem": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "7ac5dd7206c339379d0aafe304a473a2e54465374be269ffc97d9e615325fc69"
+    },
+    "m12-lifecycle": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "e360c0db5b5bf8e47d418e0a4a6ce33de7725b40eb126e6266f9fedfbccff291"
+    },
+    "m13-domain-error": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "fc90102a877b830f24735d649c5042ad74423e04ed64f1f1e44df776c7880932"
+    },
+    "m14-mental-model": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "6c53f050376c04a4abb5edce769a7052d93f605cc06299e657d9fce5b01edbab"
+    },
+    "m15-anti-pattern": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "d9f5d80bd2ab49f063a61d90a96100298788ea0e1e5bd5e917be3c7e124078a2"
+    },
+    "meta-cognition-parallel": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "6e3006df76c15c95d64b2b52a39735ec14c6eb398192b3129aebda6fa923fd2f"
+    },
+    "rust-call-graph": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "0999fbe783c81b87ba1dc1347758bd87b5880dca0d66c69be53bbac133a4c888"
+    },
+    "rust-code-navigator": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "c5c5b9521be30a3b5a3d6fa122bf9df809af3b28760e06fa317d6afab5bb3939"
+    },
+    "rust-daily": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "016d958078944cba2cbd3a7beff9c328abd22aebd9f3206c95fdaedac4d7103a"
+    },
+    "rust-deps-visualizer": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "b7cb6cbb693df52c43cae43149469ba44b05ad0747c5826c3d65f5e4b4ad3d74"
+    },
+    "rust-learner": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "12e6434334fc6f131f09f35cbb53871d0d4c753fd404c1337e9c48ad5a9a1dbf"
+    },
+    "rust-refactor-helper": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "614d54b2b16a57965412a3fff048c6d36e6f1535fcbb9ac2cf71e7a987e5a119"
+    },
+    "rust-router": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "ff5616fc8a0ef0d9434f1041e5128eb0f381d3484921ee8bfd009d64ad57045b"
+    },
+    "rust-skill-creator": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "0314bb7b61f6e7be24a498b7fb45969f78924e81c2f74723badb056724697119"
+    },
+    "rust-skills": {
+      "source": "leonardomso/rust-skills",
+      "sourceType": "github",
+      "computedHash": "46bd078eef99d07cf5544129e24f917646a39cda58672233c559d3fa6af68369"
+    },
+    "rust-symbol-analyzer": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "1e6b2fd668a9a9574b89cf90797bcd825636163d0f3b5fc9e678fd71ce4869b9"
+    },
+    "rust-trait-explorer": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "2feac2b9bb17689a7227fcae62c8a20351bb5afb271a47d49c27ba87ba9e7e26"
+    },
+    "unsafe-checker": {
+      "source": "actionbook/rust-skills",
+      "sourceType": "github",
+      "computedHash": "b76d79853846ea40ad42092c61de26da4561299b176768599751d5bcc13cf5db"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Async migration** (ADR-004): all I/O functions → tokio::fs, CLI #[tokio::main]
- **LanceDB storage** (RFC-003): db/ module with schema, store (Arc<Inner>), convert
- **ADR-005**: fastembed-rs + BGE-M3 1024-dim + Reranker-v2
- **SPEC-001**: Storage contracts (3 Arrow schemas, ArtifactStore trait, 6 DTOs)
- **Research**: Architecture patterns from edgequake + jan + graphrag-rs
- **Code review**: 8 findings fixed (3 Critical, 5 Important)
- **106 tests** pass

## Architecture (from research)

| Pattern | Source | Applied |
|---------|--------|---------|
| ArtifactStore async trait | graphrag-rs | db/store.rs |
| Arc<Inner> + Builder | edgequake | LanceStore |
| LanceDB RecordBatch | graphrag-rs | db/convert.rs |
| EMBEDDING_DIM const | graphrag-rs | db/schema.rs (1024) |
| thiserror domain errors | edgequake | error.rs |
| Feature flags | jan+graphrag | Cargo.toml |

## Files Changed

| Area | Files | What |
|------|-------|------|
| db/ (NEW) | schema.rs, store.rs, convert.rs, mod.rs | LanceDB storage module |
| async | all commands, store, search, stale, link, graph | tokio::fs migration |
| docs | ADR-004, ADR-005, SPEC-001, RFC-003, research/ | Full methodology coverage |

## Methodology Compliance

```
EPIC-001 → PRD-001 (ЧТО) → SPEC-001 v1.1 (КОНТРАКТЫ) → RFC-003 (КАК) → ADR-004+005 (ПОЧЕМУ)
```

## Test plan

- [x] `cargo test` — 106 tests pass
- [x] Code review: 8 findings fixed
- [x] Async: no blocking std::fs in async handlers
- [x] LanceDB: CRUD + relations + query tests
- [x] Arrow: correct FixedSizeList(1024, Float32)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs: RFC-003, ADR-004, ADR-005, SPEC-001, EPIC-001