### PR TITLE
[Phase 4.5+4.6] Evidence Decay + Depth Calibration

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 - [x] Phase 4.1: MCP server — `forgeplan serve` (rmcp crate, expose all 11 commands as tools)
 - [x] RFC-004: MCP Server Architecture — document design decisions
 - [x] ADR-006: Full LanceDB primary (no file fallback) — document decision
-- [ ] Update RFC-003 progress to 100%
+- [x] Update RFC-003 progress to 100%
 
 ### P1 (Phase 4 — AI Features)
 - [ ] LLM integration — generate PRD from description

--- a/crates/forgeplan-cli/src/commands/calibrate.rs
+++ b/crates/forgeplan-cli/src/commands/calibrate.rs
@@ -1,0 +1,93 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::depth;
+use forgeplan_core::workspace;
+
+pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let records = store.list_records(None).await?;
+
+    if records.is_empty() {
+        println!("No artifacts found.");
+        return Ok(());
+    }
+
+    let to_check: Vec<_> = if let Some(target_id) = id {
+        let upper = target_id.to_uppercase();
+        records
+            .into_iter()
+            .filter(|r| r.id.to_uppercase() == upper)
+            .collect()
+    } else {
+        records
+    };
+
+    if to_check.is_empty() {
+        if let Some(target_id) = id {
+            anyhow::bail!("Artifact '{}' not found", target_id);
+        }
+    }
+
+    let mut escalations = 0;
+
+    for record in &to_check {
+        let link_count = store.get_relations(&record.id).await.unwrap_or_default().len();
+        let result = depth::suggest_depth(record, link_count);
+
+        if id.is_some() || result.escalation_needed {
+            println!();
+            println!(
+                "{} \"{}\"",
+                result.artifact_id, result.artifact_title
+            );
+            println!("{}", "─".repeat(50));
+            println!(
+                "  Current:   {:?}",
+                result.current_depth
+            );
+            println!(
+                "  Suggested: {:?}{}",
+                result.suggested_depth,
+                if result.escalation_needed {
+                    " ⬆ ESCALATION"
+                } else {
+                    ""
+                }
+            );
+
+            if !result.signals.is_empty() {
+                println!("  Signals:");
+                for s in &result.signals {
+                    println!(
+                        "    {:?} → {} ({})",
+                        s.minimum_depth, s.name, s.value
+                    );
+                }
+            }
+
+            if result.escalation_needed {
+                escalations += 1;
+            }
+        }
+    }
+
+    if id.is_none() {
+        println!();
+        if escalations > 0 {
+            println!(
+                "{} artifact(s) need depth escalation.",
+                escalations
+            );
+        } else {
+            println!("All artifacts are at appropriate depth levels.");
+        }
+    }
+
+    println!();
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/decay.rs
+++ b/crates/forgeplan-cli/src/commands/decay.rs
@@ -1,0 +1,49 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::scoring::decay;
+use forgeplan_core::workspace;
+
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let entries = decay::decay_report(&store).await?;
+
+    if entries.is_empty() {
+        println!("No evidence decay detected. All linked evidence is current.");
+        return Ok(());
+    }
+
+    println!(
+        "Evidence Decay Report — {} artifact(s) affected:\n",
+        entries.len()
+    );
+
+    for entry in &entries {
+        let drop = entry.fresh_r_eff - entry.current_r_eff;
+        println!(
+            "  {} \"{}\"",
+            entry.artifact_id, entry.artifact_title
+        );
+        println!(
+            "    R_eff: {:.2} → {:.2} (drop: {:.2})",
+            entry.fresh_r_eff, entry.current_r_eff, drop
+        );
+
+        for ev in &entry.expired_evidence {
+            println!(
+                "    ⚠ {} expired {} ({} days ago, score={:.1})",
+                ev.id, ev.valid_until, ev.days_expired, ev.individual_score
+            );
+        }
+        println!();
+    }
+
+    println!("Hint: Create a RefreshReport to re-evaluate stale evidence:");
+    println!("  forgeplan new refresh \"Re-evaluate <artifact>\"");
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -1,3 +1,5 @@
+pub mod calibrate;
+pub mod decay;
 pub mod graph;
 pub mod init;
 pub mod link;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -73,6 +73,13 @@ enum Commands {
         /// Artifact ID (shows all if omitted)
         id: Option<String>,
     },
+    /// Show evidence decay impact on R_eff scores
+    Decay,
+    /// Suggest depth level (Tactical/Standard/Deep/Critical) based on artifact content
+    Calibrate {
+        /// Artifact ID (checks all if omitted)
+        id: Option<String>,
+    },
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -101,6 +108,8 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Stale => commands::stale::run().await,
         Commands::Progress { id } => commands::progress::run(id.as_deref()).await,
+        Commands::Decay => commands::decay::run().await,
+        Commands::Calibrate { id } => commands::calibrate::run(id.as_deref()).await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-core/src/depth/mod.rs
+++ b/crates/forgeplan-core/src/depth/mod.rs
@@ -1,0 +1,238 @@
+use crate::artifact::types::Mode;
+use crate::db::store::ArtifactRecord;
+
+/// Result of depth calibration for a single artifact.
+#[derive(Debug, Clone)]
+pub struct CalibrationResult {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub current_depth: String,
+    pub suggested_depth: Mode,
+    pub signals: Vec<DepthSignal>,
+    pub escalation_needed: bool,
+}
+
+/// A signal that contributed to the depth suggestion.
+#[derive(Debug, Clone)]
+pub struct DepthSignal {
+    pub name: String,
+    pub value: String,
+    pub minimum_depth: Mode,
+}
+
+/// Suggest depth level for an artifact based on heuristic analysis of its content.
+pub fn suggest_depth(record: &ArtifactRecord, link_count: usize) -> CalibrationResult {
+    let mut signals = Vec::new();
+    let body_lower = record.body.to_lowercase();
+
+    // Signal 1: Functional Requirements count
+    let fr_count = record
+        .body
+        .lines()
+        .filter(|l| {
+            let t = l.trim();
+            t.starts_with("- [") || t.starts_with("* [")
+        })
+        .count();
+
+    if fr_count > 10 {
+        signals.push(DepthSignal {
+            name: "functional_requirements".into(),
+            value: format!("{fr_count} items"),
+            minimum_depth: Mode::Deep,
+        });
+    } else if fr_count > 3 {
+        signals.push(DepthSignal {
+            name: "functional_requirements".into(),
+            value: format!("{fr_count} items"),
+            minimum_depth: Mode::Standard,
+        });
+    }
+
+    // Signal 2: Security / Breaking Changes sections → auto-escalate
+    let has_security = body_lower.contains("## security")
+        || body_lower.contains("## compliance")
+        || body_lower.contains("## authentication")
+        || body_lower.contains("security considerations");
+
+    if has_security {
+        signals.push(DepthSignal {
+            name: "security_section".into(),
+            value: "present".into(),
+            minimum_depth: Mode::Deep,
+        });
+    }
+
+    let has_breaking = body_lower.contains("breaking change")
+        || body_lower.contains("## migration")
+        || body_lower.contains("backwards compatibility");
+
+    if has_breaking {
+        signals.push(DepthSignal {
+            name: "breaking_changes".into(),
+            value: "detected".into(),
+            minimum_depth: Mode::Deep,
+        });
+    }
+
+    // Signal 3: Link count → impact proxy
+    if link_count > 5 {
+        signals.push(DepthSignal {
+            name: "dependency_links".into(),
+            value: format!("{link_count} links"),
+            minimum_depth: Mode::Deep,
+        });
+    } else if link_count > 2 {
+        signals.push(DepthSignal {
+            name: "dependency_links".into(),
+            value: format!("{link_count} links"),
+            minimum_depth: Mode::Standard,
+        });
+    }
+
+    // Signal 4: Parent epic → part of strategy
+    if record.parent_epic.as_ref().is_some_and(|p| !p.is_empty()) {
+        signals.push(DepthSignal {
+            name: "parent_epic".into(),
+            value: record.parent_epic.clone().unwrap_or_default(),
+            minimum_depth: Mode::Standard,
+        });
+    }
+
+    // Signal 5: Body complexity (section count)
+    let section_count = record
+        .body
+        .lines()
+        .filter(|l| l.starts_with("## "))
+        .count();
+
+    if section_count > 8 {
+        signals.push(DepthSignal {
+            name: "section_count".into(),
+            value: format!("{section_count} sections"),
+            minimum_depth: Mode::Deep,
+        });
+    } else if section_count > 4 {
+        signals.push(DepthSignal {
+            name: "section_count".into(),
+            value: format!("{section_count} sections"),
+            minimum_depth: Mode::Standard,
+        });
+    }
+
+    // Signal 6: Body length
+    let line_count = record.body.lines().count();
+    if line_count > 200 {
+        signals.push(DepthSignal {
+            name: "body_length".into(),
+            value: format!("{line_count} lines"),
+            minimum_depth: Mode::Deep,
+        });
+    } else if line_count > 50 {
+        signals.push(DepthSignal {
+            name: "body_length".into(),
+            value: format!("{line_count} lines"),
+            minimum_depth: Mode::Standard,
+        });
+    }
+
+    // Determine suggested depth = max(all signal minimums)
+    let suggested = signals
+        .iter()
+        .map(|s| &s.minimum_depth)
+        .max_by_key(|m| depth_rank(m))
+        .cloned()
+        .unwrap_or(Mode::Tactical);
+
+    let current = record.depth.parse::<Mode>().unwrap_or(Mode::Standard);
+    let escalation_needed = depth_rank(&suggested) > depth_rank(&current);
+
+    CalibrationResult {
+        artifact_id: record.id.clone(),
+        artifact_title: record.title.clone(),
+        current_depth: record.depth.clone(),
+        suggested_depth: suggested,
+        signals,
+        escalation_needed,
+    }
+}
+
+fn depth_rank(mode: &Mode) -> u8 {
+    match mode {
+        Mode::Note => 0,
+        Mode::Tactical => 1,
+        Mode::Standard => 2,
+        Mode::Deep => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::store::ArtifactRecord;
+
+    fn make_record(body: &str, depth: &str, parent_epic: Option<&str>) -> ArtifactRecord {
+        ArtifactRecord {
+            id: "TEST-001".into(),
+            kind: "prd".into(),
+            status: "draft".into(),
+            title: "Test Artifact".into(),
+            body: body.into(),
+            depth: depth.into(),
+            author: None,
+            parent_epic: parent_epic.map(|s| s.into()),
+            r_eff_score: 0.0,
+            valid_until: None,
+            created_at: "2026-01-01T00:00:00".into(),
+            updated_at: "2026-01-01T00:00:00".into(),
+        }
+    }
+
+    #[test]
+    fn minimal_artifact_suggests_tactical() {
+        let record = make_record("# Simple note\nJust a thought.", "tactical", None);
+        let result = suggest_depth(&record, 0);
+        assert_eq!(result.suggested_depth, Mode::Tactical);
+        assert!(!result.escalation_needed);
+    }
+
+    #[test]
+    fn security_section_escalates_to_deep() {
+        let record = make_record(
+            "# Auth Design\n## Security\nMust handle OIDC.\n## Implementation\nTBD.",
+            "standard",
+            None,
+        );
+        let result = suggest_depth(&record, 0);
+        assert_eq!(result.suggested_depth, Mode::Deep);
+        assert!(result.escalation_needed);
+    }
+
+    #[test]
+    fn many_links_escalates() {
+        let record = make_record("# Feature\n## Summary\nDoes things.", "tactical", None);
+        let result = suggest_depth(&record, 6);
+        assert_eq!(result.suggested_depth, Mode::Deep);
+        assert!(result.escalation_needed);
+    }
+
+    #[test]
+    fn parent_epic_at_least_standard() {
+        let record = make_record("# Task\nSmall fix.", "tactical", Some("EPIC-001"));
+        let result = suggest_depth(&record, 0);
+        assert_eq!(result.suggested_depth, Mode::Standard);
+        assert!(result.escalation_needed);
+    }
+
+    #[test]
+    fn already_deep_no_escalation() {
+        let record = make_record(
+            "# Complex\n## Security\nImportant.\n## Migration\nBreaking.",
+            "deep",
+            None,
+        );
+        let result = suggest_depth(&record, 3);
+        assert_eq!(result.suggested_depth, Mode::Deep);
+        assert!(!result.escalation_needed);
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod artifact;
 pub mod config;
 pub mod db;
+pub mod depth;
 pub mod error;
 pub mod graph;
 pub mod link;

--- a/crates/forgeplan-core/src/scoring/decay.rs
+++ b/crates/forgeplan-core/src/scoring/decay.rs
@@ -1,0 +1,199 @@
+use chrono::{NaiveDateTime, Utc};
+
+use crate::db::store::{ArtifactFilter, ArtifactRecord, LanceStore};
+use crate::scoring::reff::{self, EvidenceItem, EvidenceType, Verdict};
+
+/// A single artifact's decay report — shows R_eff impact of expired evidence.
+#[derive(Debug, Clone)]
+pub struct DecayEntry {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub current_r_eff: f64,
+    pub fresh_r_eff: f64,
+    pub expired_evidence: Vec<ExpiredEvidence>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExpiredEvidence {
+    pub id: String,
+    pub valid_until: String,
+    pub days_expired: i64,
+    pub individual_score: f64,
+}
+
+/// Build decay report: for each artifact with linked evidence, compare
+/// current R_eff (with expiry) vs fresh R_eff (as if all evidence were valid).
+pub async fn decay_report(store: &LanceStore) -> anyhow::Result<Vec<DecayEntry>> {
+    let all_records = store.list_records(None).await?;
+    let evidence_filter = ArtifactFilter {
+        kind: Some("evidence".to_string()),
+        status: None,
+    };
+    let evidence_records = store.list_records(Some(&evidence_filter)).await?;
+
+    if evidence_records.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let now = Utc::now().naive_utc();
+    let mut entries = Vec::new();
+
+    for record in &all_records {
+        if record.kind == "evidence" {
+            continue;
+        }
+
+        // Find evidence linked to this artifact
+        let outgoing = store.get_relations(&record.id).await.unwrap_or_default();
+        let outgoing_targets: Vec<String> = outgoing
+            .iter()
+            .filter(|(_, rel)| rel == "informs" || rel == "based_on" || rel == "refines")
+            .map(|(t, _)| t.clone())
+            .collect();
+
+        let mut items: Vec<EvidenceItem> = Vec::new();
+        let mut expired_list: Vec<ExpiredEvidence> = Vec::new();
+
+        for ev in &evidence_records {
+            let is_linked = outgoing_targets
+                .iter()
+                .any(|eid| eid.eq_ignore_ascii_case(&ev.id));
+
+            if !is_linked {
+                let ev_rels = store.get_relations(&ev.id).await.unwrap_or_default();
+                if !ev_rels
+                    .iter()
+                    .any(|(t, _)| t.eq_ignore_ascii_case(&record.id))
+                {
+                    continue;
+                }
+            }
+
+            let item = parse_evidence(ev);
+            let is_expired = item
+                .valid_until
+                .map(|dt| now > dt)
+                .unwrap_or(false);
+
+            if is_expired {
+                let valid_until_str = ev.valid_until.as_deref().unwrap_or("unknown");
+                let days = item
+                    .valid_until
+                    .map(|dt| (now - dt).num_days())
+                    .unwrap_or(0);
+
+                expired_list.push(ExpiredEvidence {
+                    id: ev.id.clone(),
+                    valid_until: valid_until_str.to_string(),
+                    days_expired: days,
+                    individual_score: reff::r_eff(&[item.clone()]),
+                });
+            }
+
+            items.push(item);
+        }
+
+        if items.is_empty() || expired_list.is_empty() {
+            continue;
+        }
+
+        // Current R_eff (with decay)
+        let current = reff::r_eff(&items);
+
+        // Fresh R_eff (pretend all evidence is valid)
+        let fresh_items: Vec<EvidenceItem> = items
+            .iter()
+            .map(|e| EvidenceItem {
+                valid_until: None, // remove expiry
+                ..e.clone()
+            })
+            .collect();
+        let fresh = reff::r_eff(&fresh_items);
+
+        entries.push(DecayEntry {
+            artifact_id: record.id.clone(),
+            artifact_title: record.title.clone(),
+            current_r_eff: current,
+            fresh_r_eff: fresh,
+            expired_evidence: expired_list,
+        });
+    }
+
+    // Sort by impact (biggest drop first)
+    entries.sort_by(|a, b| {
+        let drop_a = a.fresh_r_eff - a.current_r_eff;
+        let drop_b = b.fresh_r_eff - b.current_r_eff;
+        drop_b
+            .partial_cmp(&drop_a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    Ok(entries)
+}
+
+fn parse_evidence(record: &ArtifactRecord) -> EvidenceItem {
+    let verdict = extract_field(&record.body, "verdict")
+        .map(|s| match s.to_lowercase().as_str() {
+            "supports" => Verdict::Supports,
+            "weakens" => Verdict::Weakens,
+            "refutes" => Verdict::Refutes,
+            _ => Verdict::Supports,
+        })
+        .unwrap_or(Verdict::Supports);
+
+    let cl = extract_field(&record.body, "congruence_level")
+        .and_then(|s| s.parse::<u8>().ok())
+        .map(|v| v.min(3))
+        .unwrap_or(0);
+
+    let valid_until = record.valid_until.as_deref().and_then(|s| {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+            .ok()
+            .or_else(|| {
+                chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+                    .ok()
+                    .and_then(|d| d.and_hms_opt(23, 59, 59))
+            })
+    });
+
+    EvidenceItem {
+        id: record.id.clone(),
+        evidence_type: EvidenceType::Measurement,
+        verdict,
+        congruence_level: cl,
+        valid_until,
+    }
+}
+
+fn extract_field(body: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}:");
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix(&prefix) {
+            let val = rest.trim();
+            if !val.is_empty() {
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_field_basic() {
+        let body = "verdict: supports\ncongruence_level: 2\n";
+        assert_eq!(extract_field(body, "verdict"), Some("supports".into()));
+        assert_eq!(extract_field(body, "congruence_level"), Some("2".into()));
+        assert_eq!(extract_field(body, "missing"), None);
+    }
+
+    #[test]
+    fn extract_field_with_whitespace() {
+        let body = "  verdict:   Weakens  \n";
+        assert_eq!(extract_field(body, "verdict"), Some("Weakens".into()));
+    }
+}

--- a/crates/forgeplan-core/src/scoring/mod.rs
+++ b/crates/forgeplan-core/src/scoring/mod.rs
@@ -1,1 +1,2 @@
+pub mod decay;
 pub mod reff;

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -727,6 +727,111 @@ impl ForgeplanServer {
             total_completed,
         }))
     }
+
+    #[tool(description = "Show evidence decay impact on R_eff scores. Lists artifacts where expired evidence has degraded quality scores, with current vs fresh R_eff comparison.")]
+    async fn forgeplan_decay(&self) -> Result<CallToolResult, McpError> {
+        let guard = match self.require_store().await {
+            Ok(g) => g,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let store = guard.as_ref().unwrap();
+
+        let entries = forgeplan_core::scoring::decay::decay_report(store)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let total = entries.len();
+        let dtos: Vec<DecayEntryDto> = entries
+            .into_iter()
+            .map(|e| DecayEntryDto {
+                r_eff_drop: e.fresh_r_eff - e.current_r_eff,
+                artifact_id: e.artifact_id,
+                artifact_title: e.artifact_title,
+                current_r_eff: e.current_r_eff,
+                fresh_r_eff: e.fresh_r_eff,
+                expired_evidence: e
+                    .expired_evidence
+                    .into_iter()
+                    .map(|ev| ExpiredEvidenceDto {
+                        id: ev.id,
+                        valid_until: ev.valid_until,
+                        days_expired: ev.days_expired,
+                        score: ev.individual_score,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        Ok(json_result(&DecayResponse {
+            entries: dtos,
+            total_affected: total,
+        }))
+    }
+
+    #[tool(description = "Suggest depth level (Tactical/Standard/Deep/Critical) for artifacts based on content analysis. Detects security sections, breaking changes, link count, body complexity.")]
+    async fn forgeplan_calibrate(
+        &self,
+        Parameters(p): Parameters<CalibrateRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let guard = match self.require_store().await {
+            Ok(g) => g,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let store = guard.as_ref().unwrap();
+
+        let records = store
+            .list_records(None)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let to_check: Vec<&ArtifactRecord> = if let Some(ref target_id) = p.id {
+            let upper = target_id.to_uppercase();
+            let filtered: Vec<_> = records
+                .iter()
+                .filter(|r| r.id.to_uppercase() == upper)
+                .collect();
+            if filtered.is_empty() {
+                return Ok(err_result(&format!("Artifact '{target_id}' not found")));
+            }
+            filtered
+        } else {
+            records.iter().collect()
+        };
+
+        let mut results = Vec::new();
+        let mut total_escalations = 0;
+
+        for record in &to_check {
+            let link_count = store.get_relations(&record.id).await.unwrap_or_default().len();
+            let cal = forgeplan_core::depth::suggest_depth(record, link_count);
+
+            if cal.escalation_needed {
+                total_escalations += 1;
+            }
+
+            results.push(CalibrationDto {
+                artifact_id: cal.artifact_id,
+                artifact_title: cal.artifact_title,
+                current_depth: cal.current_depth,
+                suggested_depth: format!("{:?}", cal.suggested_depth),
+                escalation_needed: cal.escalation_needed,
+                signals: cal
+                    .signals
+                    .into_iter()
+                    .map(|s| SignalDto {
+                        name: s.name,
+                        value: s.value,
+                        minimum_depth: format!("{:?}", s.minimum_depth),
+                    })
+                    .collect(),
+            });
+        }
+
+        Ok(json_result(&CalibrateResponse {
+            results,
+            total_escalations,
+        }))
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -1,4 +1,4 @@
-use schemars::JsonSchema;
+use rmcp::schemars::{self, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 // ── Shared DTOs ──────────────────────────────────────────────
@@ -239,4 +239,62 @@ pub struct ProgressResponse {
     pub artifacts: Vec<ProgressDto>,
     pub total_checkboxes: usize,
     pub total_completed: usize,
+}
+
+// ── Decay types ──────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DecayResponse {
+    pub entries: Vec<DecayEntryDto>,
+    pub total_affected: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DecayEntryDto {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub current_r_eff: f64,
+    pub fresh_r_eff: f64,
+    pub r_eff_drop: f64,
+    pub expired_evidence: Vec<ExpiredEvidenceDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ExpiredEvidenceDto {
+    pub id: String,
+    pub valid_until: String,
+    pub days_expired: i64,
+    pub score: f64,
+}
+
+// ── Calibrate types ──────────────────────────────────────────
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CalibrateRequest {
+    /// Artifact ID (checks all if omitted)
+    #[serde(default)]
+    pub id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CalibrateResponse {
+    pub results: Vec<CalibrationDto>,
+    pub total_escalations: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct CalibrationDto {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub current_depth: String,
+    pub suggested_depth: String,
+    pub escalation_needed: bool,
+    pub signals: Vec<SignalDto>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SignalDto {
+    pub name: String,
+    pub value: String,
+    pub minimum_depth: String,
 }

--- a/docs/rfcs/RFC-003-lancedb-integration.md
+++ b/docs/rfcs/RFC-003-lancedb-integration.md
@@ -1,7 +1,7 @@
 ---
 id: RFC-003
 title: "LanceDB Integration — async storage, schema, migration"
-status: Draft
+status: Accepted
 author: explosovebit
 created: 2026-03-21
 updated: 2026-03-21
@@ -14,9 +14,9 @@ depth: deep
 ## Progress
 
 ```
-Phase D  ░░░░░░░░░░░░░░░░░░░░░░░░  0/5   (  0%)  LanceDB Integration
+Phase D  ████████████████████████  5/5   (100%)  LanceDB Integration  ✅ DONE
 ─────────────────────────────────────────────────
-TOTAL                               0/5   (  0%)
+TOTAL                               5/5   (100%)
 ```
 
 ---
@@ -311,11 +311,11 @@ forgeplan init --migrate (existing workspace):
 ## Implementation Phases
 
 ### Phase D: LanceDB Integration
-- [ ] **D.1** Async migration — tokio runtime, async core functions, async tests
-- [ ] **D.2** LanceDB db module — schema, connect, create tables
-- [ ] **D.3** ArtifactStore trait + LanceStore implementation (CRUD)
-- [ ] **D.4** Markdown projection — write LanceDB → render markdown
-- [ ] **D.5** Command migration — all 10 CLI commands use LanceStore
+- [x] **D.1** Async migration — tokio runtime, async core functions, async tests
+- [x] **D.2** LanceDB db module — schema, connect, create tables
+- [x] **D.3** ArtifactStore trait + LanceStore implementation (CRUD)
+- [x] **D.4** Markdown projection — write LanceDB → render markdown
+- [x] **D.5** Command migration — all 11 CLI commands use LanceStore
 
 ## Related Artifacts
 


### PR DESCRIPTION
## Summary

- **Evidence Decay** (4.5): `forgeplan decay` — shows R_eff impact of expired evidence. Compares current vs fresh scores per artifact.
- **Depth Calibration** (4.6): `forgeplan calibrate [id]` — heuristic depth suggestion based on artifact content analysis (FR count, security sections, breaking changes, link count, complexity).
- Both exposed as MCP tools: `forgeplan_decay`, `forgeplan_calibrate`
- RFC-003 progress updated to 100% (Accepted)

## New Modules

| Module | Location | Tests |
|--------|----------|-------|
| `scoring::decay` | `forgeplan-core/src/scoring/decay.rs` | 2 |
| `depth` | `forgeplan-core/src/depth/mod.rs` | 5 |

## Depth Calibration Signals

| Signal | Escalates to |
|--------|-------------|
| FR count > 10 | Deep |
| Security/compliance section | Deep |
| Breaking changes | Deep |
| >5 dependency links | Deep |
| Parent epic present | Standard |
| >8 sections | Deep |
| >200 lines | Deep |

## Test Plan

- [x] `cargo check --workspace` — 0 errors
- [x] `cargo test --workspace` — 165 tests pass
- [x] 5 new depth calibration tests (tactical, security escalation, links, parent epic, already-deep)
- [x] 2 new decay extract_field tests

Refs: Phase 4.5, 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)