### PR TITLE
[PRD-003] Health Dashboard + Blind Spot Detection

### DIFF
--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -1,0 +1,104 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::health;
+use forgeplan_core::workspace;
+
+pub async fn run(compact: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let config = workspace::load_config(&ws)?;
+    let store = LanceStore::open(&ws).await?;
+    let report = health::health_report(&store).await?;
+
+    if compact {
+        // Compact mode for hooks/scripts
+        println!("Project: {} | Artifacts: {} | Blind spots: {} | Stale: {} | At risk: {}",
+            config.project_name,
+            report.total,
+            report.blind_spots.len(),
+            report.stale_count,
+            report.at_risk.len(),
+        );
+        if let Some(action) = report.next_actions.first() {
+            println!("Next: {}", action);
+        }
+        return Ok(());
+    }
+
+    // Full dashboard
+    println!();
+    println!("Forgeplan Health — {}", config.project_name);
+    println!("{}", "═".repeat(50));
+
+    println!();
+    println!("  Artifacts:  {} total", report.total);
+
+    if !report.by_kind.is_empty() {
+        println!();
+        println!("  By kind:");
+        for (kind, count) in &report.by_kind {
+            println!("    {:<16} {}", kind, count);
+        }
+    }
+
+    if !report.by_status.is_empty() {
+        println!();
+        println!("  By status:");
+        for (status, count) in &report.by_status {
+            let warning = if status == "draft" && *count == report.total && report.total > 0 {
+                " ⚠ ALL DRAFT"
+            } else {
+                ""
+            };
+            println!("    {:<16} {}{}", status, count, warning);
+        }
+    }
+
+    // At Risk
+    if !report.at_risk.is_empty() {
+        println!();
+        println!("  ⚠ At Risk ({}):", report.at_risk.len());
+        for item in &report.at_risk {
+            println!("    {} \"{}\" — {}", item.id, item.title, item.reason);
+        }
+    }
+
+    // Blind Spots
+    if !report.blind_spots.is_empty() {
+        println!();
+        println!("  ● Blind Spots ({}):", report.blind_spots.len());
+        for spot in &report.blind_spots {
+            println!("    {} \"{}\" — {}", spot.id, spot.title, spot.issue);
+        }
+    }
+
+    // Stale
+    if report.stale_count > 0 {
+        println!();
+        println!("  ⏰ Stale: {} evidence expired", report.stale_count);
+    }
+
+    // Orphans
+    if !report.orphans.is_empty() {
+        println!();
+        println!("  ○ Orphans ({}):", report.orphans.len());
+        for id in &report.orphans {
+            println!("    {} — no links", id);
+        }
+    }
+
+    // Next Actions
+    if !report.next_actions.is_empty() {
+        println!();
+        println!("  → Next actions:");
+        for (i, action) in report.next_actions.iter().enumerate() {
+            println!("    {}. {}", i + 1, action);
+        }
+    }
+
+    println!();
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod delete;
 pub mod generate;
 pub mod get;
 pub mod graph;
+pub mod health;
 pub mod init;
 pub mod link;
 pub mod list;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -135,6 +135,12 @@ enum Commands {
         /// Task description in natural language
         description: String,
     },
+    /// Show project health dashboard — gaps, risks, blind spots, next actions
+    Health {
+        /// Compact one-line output for hooks/scripts
+        #[arg(long)]
+        compact: bool,
+    },
     /// Capture a decision from conversation into a Note or ADR artifact
     Capture {
         /// The decision statement
@@ -200,6 +206,7 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Health { compact } => commands::health::run(compact).await,
         Commands::Route { description } => commands::route::run(&description).await,
         Commands::Capture { decision, context } => {
             commands::capture::run(&decision, context.as_deref()).await

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -1,0 +1,239 @@
+use std::collections::BTreeMap;
+
+use crate::db::store::{ArtifactFilter, LanceStore};
+use crate::scoring::reff;
+use crate::scoring::evidence::parse_evidence_from_record;
+
+/// Full health report for a Forgeplan workspace.
+#[derive(Debug, Clone)]
+pub struct HealthReport {
+    pub total: usize,
+    pub by_kind: Vec<(String, usize)>,
+    pub by_status: Vec<(String, usize)>,
+    pub at_risk: Vec<AtRiskArtifact>,
+    pub blind_spots: Vec<BlindSpot>,
+    pub stale_count: usize,
+    pub orphans: Vec<String>,
+    pub next_actions: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AtRiskArtifact {
+    pub id: String,
+    pub title: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlindSpot {
+    pub id: String,
+    pub title: String,
+    pub issue: String,
+}
+
+/// Generate a full health report for the workspace.
+pub async fn health_report(store: &LanceStore) -> anyhow::Result<HealthReport> {
+    let all = store.list_records(None).await?;
+    let all_relations = store.get_all_relations().await?;
+
+    // Counts
+    let total = all.len();
+    let mut by_kind: BTreeMap<String, usize> = BTreeMap::new();
+    let mut by_status: BTreeMap<String, usize> = BTreeMap::new();
+    for r in &all {
+        *by_kind.entry(r.kind.clone()).or_default() += 1;
+        *by_status.entry(r.status.clone()).or_default() += 1;
+    }
+
+    // Evidence records
+    let evidence_filter = ArtifactFilter {
+        kind: Some("evidence".to_string()),
+        status: None,
+    };
+    let evidence_records = store.list_records(Some(&evidence_filter)).await?;
+
+    // Build relation index: artifact_id → [(target, relation)]
+    let mut outgoing: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    let mut incoming: BTreeMap<String, Vec<(String, String)>> = BTreeMap::new();
+    for (from, to, rel) in &all_relations {
+        outgoing.entry(from.clone()).or_default().push((to.clone(), rel.clone()));
+        incoming.entry(to.clone()).or_default().push((from.clone(), rel.clone()));
+    }
+
+    // At-risk: artifacts with R_eff < 0.3 that have evidence
+    let mut at_risk = Vec::new();
+
+    // Blind spots
+    let mut blind_spots = Vec::new();
+
+    // Orphans (no links at all)
+    let mut orphans = Vec::new();
+
+    // Stale
+    let stale = store.find_stale().await.unwrap_or_default();
+    let stale_count = stale.len();
+
+    for record in &all {
+        // Skip evidence artifacts themselves
+        if record.kind == "evidence" {
+            continue;
+        }
+
+        let has_outgoing = outgoing.contains_key(&record.id);
+        let has_incoming = incoming.contains_key(&record.id);
+
+        // Orphan check
+        if !has_outgoing && !has_incoming {
+            orphans.push(record.id.clone());
+        }
+
+        // Blind spot: decision-type artifacts without evidence
+        let is_decision_type = matches!(
+            record.kind.as_str(),
+            "prd" | "rfc" | "adr" | "epic"
+        );
+
+        if is_decision_type {
+            // Check if any evidence links to this artifact
+            let has_evidence = evidence_records.iter().any(|ev| {
+                // Evidence links TO this artifact
+                outgoing
+                    .get(&ev.id)
+                    .map(|links| links.iter().any(|(t, _)| t.eq_ignore_ascii_case(&record.id)))
+                    .unwrap_or(false)
+                ||
+                // This artifact links TO evidence
+                outgoing
+                    .get(&record.id)
+                    .map(|links| links.iter().any(|(t, _)| {
+                        evidence_records.iter().any(|e| e.id.eq_ignore_ascii_case(t))
+                    }))
+                    .unwrap_or(false)
+            });
+
+            if !has_evidence {
+                blind_spots.push(BlindSpot {
+                    id: record.id.clone(),
+                    title: record.title.clone(),
+                    issue: "No linked evidence — decision without proof".into(),
+                });
+            }
+        }
+
+        // Missing links checks
+        if record.kind == "rfc" {
+            let has_adr = outgoing
+                .get(&record.id)
+                .map(|links| links.iter().any(|(_, r)| r == "informs" || r == "based_on"))
+                .unwrap_or(false)
+                || incoming.get(&record.id).is_some();
+
+            if !has_adr && !has_outgoing {
+                blind_spots.push(BlindSpot {
+                    id: record.id.clone(),
+                    title: record.title.clone(),
+                    issue: "RFC without any links — isolated decision".into(),
+                });
+            }
+        }
+    }
+
+    // R_eff for artifacts with evidence
+    for record in &all {
+        if record.kind == "evidence" {
+            continue;
+        }
+
+        let mut items = Vec::new();
+        for ev in &evidence_records {
+            let ev_links_here = outgoing
+                .get(&ev.id)
+                .map(|links| links.iter().any(|(t, _)| t.eq_ignore_ascii_case(&record.id)))
+                .unwrap_or(false);
+            let here_links_ev = outgoing
+                .get(&record.id)
+                .map(|links| links.iter().any(|(t, _)| t.eq_ignore_ascii_case(&ev.id)))
+                .unwrap_or(false);
+
+            if ev_links_here || here_links_ev {
+                items.push(parse_evidence_from_record(ev));
+            }
+        }
+
+        if !items.is_empty() {
+            let score = reff::r_eff(&items);
+            if score < 0.3 {
+                at_risk.push(AtRiskArtifact {
+                    id: record.id.clone(),
+                    title: record.title.clone(),
+                    reason: format!("R_eff = {:.2} (below 0.3 threshold)", score),
+                });
+            }
+        }
+    }
+
+    // Next actions
+    let mut next_actions = Vec::new();
+
+    if by_status.get("draft").copied().unwrap_or(0) == total && total > 0 {
+        next_actions.push("All artifacts in Draft — review and activate ready ones".into());
+    }
+
+    if !blind_spots.is_empty() {
+        next_actions.push(format!(
+            "Create evidence for {} artifact(s) without proof",
+            blind_spots.len()
+        ));
+    }
+
+    if stale_count > 0 {
+        next_actions.push(format!(
+            "Refresh {} stale evidence (expired valid_until)",
+            stale_count
+        ));
+    }
+
+    if !orphans.is_empty() {
+        next_actions.push(format!(
+            "Link {} orphan artifact(s) — isolated, no connections",
+            orphans.len()
+        ));
+    }
+
+    if next_actions.is_empty() && total > 0 {
+        next_actions.push("Project looks healthy. Continue implementation.".into());
+    }
+
+    Ok(HealthReport {
+        total,
+        by_kind: by_kind.into_iter().collect(),
+        by_status: by_status.into_iter().collect(),
+        at_risk,
+        blind_spots,
+        stale_count,
+        orphans,
+        next_actions,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_health_report_fields() {
+        // Test struct construction
+        let report = HealthReport {
+            total: 0,
+            by_kind: vec![],
+            by_status: vec![],
+            at_risk: vec![],
+            blind_spots: vec![],
+            stale_count: 0,
+            orphans: vec![],
+            next_actions: vec![],
+        };
+        assert_eq!(report.total, 0);
+        assert!(report.blind_spots.is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod db;
 pub mod depth;
 pub mod embed;
+pub mod health;
 pub mod llm;
 pub mod error;
 pub mod graph;

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -750,6 +750,33 @@ impl ForgeplanServer {
         })))
     }
 
+    #[tool(description = "Show project health dashboard — gaps, risks, blind spots, orphans, stale evidence, and recommended next actions. No LLM needed.")]
+    async fn forgeplan_health(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let report = forgeplan_core::health::health_report(&store)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        Ok(json_result(&serde_json::json!({
+            "total": report.total,
+            "by_kind": report.by_kind,
+            "by_status": report.by_status,
+            "at_risk": report.at_risk.iter().map(|a| serde_json::json!({
+                "id": a.id, "title": a.title, "reason": a.reason
+            })).collect::<Vec<_>>(),
+            "blind_spots": report.blind_spots.iter().map(|b| serde_json::json!({
+                "id": b.id, "title": b.title, "issue": b.issue
+            })).collect::<Vec<_>>(),
+            "stale_count": report.stale_count,
+            "orphans": report.orphans,
+            "next_actions": report.next_actions,
+        })))
+    }
+
     #[tool(description = "Capture a decision from conversation into a Note or ADR artifact. Auto-detects type: simple decisions become Notes, architectural decisions become ADRs. Requires LLM provider.")]
     async fn forgeplan_capture(
         &self,


### PR DESCRIPTION
## Summary

`forgeplan health` — one command shows everything wrong with your project:

```
Forgeplan Health — ForgePlan
══════════════════════════════════════════════════
  Artifacts:  17 total
  By status:  draft 17 ⚠ ALL DRAFT
  ● Blind Spots (9): PRDs/RFCs without evidence
  ○ Orphans (1): PRD-001 — no links
  → Next actions:
    1. Review and activate ready artifacts
    2. Create evidence for 9 artifact(s)
    3. Link 1 orphan artifact(s)
```

- `forgeplan health --compact` — one-line for hooks
- MCP tool: `forgeplan_health`
- Pure Rust, no LLM needed
- 23 CLI commands, 22 MCP tools, 177 tests

Refs: PRD-003, EPIC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)