### PR TITLE
[PRD-004] Decision Journal — timeline with R_eff scores

### DIFF
--- a/crates/forgeplan-cli/src/commands/journal.rs
+++ b/crates/forgeplan-cli/src/commands/journal.rs
@@ -1,0 +1,66 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::journal;
+use forgeplan_core::workspace;
+
+pub async fn run(kind: Option<&str>, risk: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let entries = journal::build_journal(&store, kind, risk).await?;
+
+    if entries.is_empty() {
+        println!("No decision artifacts found.");
+        if kind.is_some() {
+            println!("Try without --kind filter.");
+        }
+        return Ok(());
+    }
+
+    println!();
+    println!("Decision Journal{}", if risk { " (at-risk only)" } else { "" });
+    println!("{}", "═".repeat(50));
+    println!();
+
+    for entry in &entries {
+        let date = entry.created_at.split('T').next().unwrap_or(&entry.created_at);
+        let risk_indicator = if entry.evidence_count == 0 {
+            " ⚠ NO EVIDENCE"
+        } else if entry.has_stale_evidence {
+            " ⏰ STALE"
+        } else if entry.r_eff < 0.3 {
+            " ⚠ AT RISK"
+        } else {
+            ""
+        };
+
+        println!(
+            "  {}  {} [{}] \"{}\"",
+            date, entry.id, entry.kind, entry.title
+        );
+        if entry.evidence_count > 0 {
+            println!(
+                "         R_eff: {:.2} | {} evidence{}",
+                entry.r_eff, entry.evidence_count, risk_indicator
+            );
+        } else {
+            println!("         {}", risk_indicator.trim());
+        }
+    }
+
+    // Summary
+    let no_evidence = entries.iter().filter(|e| e.evidence_count == 0).count();
+    if no_evidence > 0 {
+        println!();
+        println!(
+            "  ⚠ {} decision(s) without any evidence",
+            no_evidence
+        );
+    }
+
+    println!();
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod get;
 pub mod graph;
 pub mod health;
 pub mod init;
+pub mod journal;
 pub mod link;
 pub mod list;
 pub mod new;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -137,6 +137,15 @@ enum Commands {
     },
     /// Show blind spots — decisions without evidence, orphan artifacts
     Blindspots,
+    /// Show decision journal — chronological timeline with R_eff scores
+    Journal {
+        /// Filter by kind (adr, note, problem, solution)
+        #[arg(long, short = 't')]
+        r#type: Option<String>,
+        /// Show only at-risk decisions (no evidence, stale, low R_eff)
+        #[arg(long)]
+        risk: bool,
+    },
     /// Show project health dashboard — gaps, risks, blind spots, next actions
     Health {
         /// Compact one-line output for hooks/scripts
@@ -209,6 +218,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
         Commands::Blindspots => commands::blindspots::run().await,
+        Commands::Journal { r#type, risk } => {
+            commands::journal::run(r#type.as_deref(), risk).await
+        }
         Commands::Health { compact } => commands::health::run(compact).await,
         Commands::Route { description } => commands::route::run(&description).await,
         Commands::Capture { decision, context } => {

--- a/crates/forgeplan-core/src/journal/mod.rs
+++ b/crates/forgeplan-core/src/journal/mod.rs
@@ -1,0 +1,115 @@
+use crate::db::store::{ArtifactFilter, ArtifactRecord, LanceStore};
+use crate::scoring::evidence::parse_evidence_from_record;
+use crate::scoring::reff;
+
+/// A single entry in the decision journal.
+#[derive(Debug, Clone)]
+pub struct JournalEntry {
+    pub id: String,
+    pub title: String,
+    pub kind: String,
+    pub status: String,
+    pub created_at: String,
+    pub r_eff: f64,
+    pub evidence_count: usize,
+    pub has_stale_evidence: bool,
+}
+
+/// Build decision journal — chronological timeline of ADR, Note, and capture artifacts.
+pub async fn build_journal(
+    store: &LanceStore,
+    kind_filter: Option<&str>,
+    risk_only: bool,
+) -> anyhow::Result<Vec<JournalEntry>> {
+    // Decision-type artifacts: adr, note, problem, solution
+    let decision_kinds = ["adr", "note", "problem", "solution"];
+
+    let records = if let Some(kind) = kind_filter {
+        let filter = ArtifactFilter {
+            kind: Some(kind.to_string()),
+            status: None,
+        };
+        store.list_records(Some(&filter)).await?
+    } else {
+        let all = store.list_records(None).await?;
+        all.into_iter()
+            .filter(|r| decision_kinds.contains(&r.kind.as_str()))
+            .collect()
+    };
+
+    let evidence_filter = ArtifactFilter {
+        kind: Some("evidence".to_string()),
+        status: None,
+    };
+    let evidence_records = store.list_records(Some(&evidence_filter)).await?;
+    let all_relations = store.get_all_relations().await?;
+
+    let now = chrono::Utc::now().naive_utc();
+
+    let mut entries: Vec<JournalEntry> = Vec::new();
+
+    for record in &records {
+        // Find linked evidence
+        let mut items = Vec::new();
+        let mut has_stale = false;
+
+        for ev in &evidence_records {
+            let linked = all_relations.iter().any(|(from, to, _)| {
+                (from.eq_ignore_ascii_case(&ev.id) && to.eq_ignore_ascii_case(&record.id))
+                    || (from.eq_ignore_ascii_case(&record.id) && to.eq_ignore_ascii_case(&ev.id))
+            });
+
+            if linked {
+                let item = parse_evidence_from_record(ev);
+                if item.valid_until.map(|dt| now > dt).unwrap_or(false) {
+                    has_stale = true;
+                }
+                items.push(item);
+            }
+        }
+
+        let r_eff = reff::r_eff(&items);
+        let evidence_count = items.len();
+
+        entries.push(JournalEntry {
+            id: record.id.clone(),
+            title: record.title.clone(),
+            kind: record.kind.clone(),
+            status: record.status.clone(),
+            created_at: record.created_at.clone(),
+            r_eff,
+            evidence_count,
+            has_stale_evidence: has_stale,
+        });
+    }
+
+    // Sort by created_at descending (newest first)
+    entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    if risk_only {
+        entries.retain(|e| e.evidence_count == 0 || e.r_eff < 0.3 || e.has_stale_evidence);
+    }
+
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn journal_entry_construction() {
+        let entry = JournalEntry {
+            id: "ADR-001".into(),
+            title: "Use Rust".into(),
+            kind: "adr".into(),
+            status: "active".into(),
+            created_at: "2026-03-22T00:00:00".into(),
+            r_eff: 0.8,
+            evidence_count: 2,
+            has_stale_evidence: false,
+        };
+        assert_eq!(entry.r_eff, 0.8);
+        assert!(!entry.has_stale_evidence);
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod depth;
 pub mod embed;
 pub mod health;
+pub mod journal;
 pub mod llm;
 pub mod error;
 pub mod graph;

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -173,6 +173,16 @@ struct RouteParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct JournalParams {
+    /// Filter by kind (adr, note, problem, solution)
+    #[serde(default)]
+    kind: Option<String>,
+    /// Show only at-risk decisions
+    #[serde(default)]
+    risk: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct CaptureParams {
     /// The decision statement to capture
     decision: String,
@@ -774,6 +784,37 @@ impl ForgeplanServer {
             "stale_count": report.stale_count,
             "orphans": report.orphans,
             "next_actions": report.next_actions,
+        })))
+    }
+
+    #[tool(description = "Show decision journal — chronological timeline of ADR, Note, Problem, Solution artifacts with R_eff scores and evidence status.")]
+    async fn forgeplan_journal(
+        &self,
+        Parameters(p): Parameters<JournalParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let entries = forgeplan_core::journal::build_journal(
+            &store, p.kind.as_deref(), p.risk.unwrap_or(false),
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let dtos: Vec<serde_json::Value> = entries
+            .iter()
+            .map(|e| serde_json::json!({
+                "id": e.id, "title": e.title, "kind": e.kind,
+                "created_at": e.created_at, "r_eff": e.r_eff,
+                "evidence_count": e.evidence_count,
+                "has_stale_evidence": e.has_stale_evidence,
+            }))
+            .collect();
+
+        Ok(json_result(&serde_json::json!({
+            "entries": dtos, "total": entries.len(),
         })))
     }
 


### PR DESCRIPTION
## Summary

`forgeplan journal` — chronological timeline of decisions with quality scores.

```
Decision Journal
══════════════════════════════════════════════════
  2026-03-22  ADR-001 [adr] "Use Rust"
         R_eff: 0.80 | 3 evidence
  2026-03-22  PROB-001 [problem] "Custom prompts"
         ⚠ NO EVIDENCE
  ⚠ 1 decision(s) without any evidence
```

- `--type adr` filter by kind
- `--risk` show only at-risk decisions
- MCP: `forgeplan_journal`
- 25 CLI commands, 25 MCP tools, 183 tests

Refs: PRD-004, EPIC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)