### PR TITLE
[PRD-008] CLI UX Redesign — cliclack interactive init, styled output, setup-skill

### DIFF
--- a/.forgeplan-backup/RESTORE.md
+++ b/.forgeplan-backup/RESTORE.md
@@ -1,0 +1,162 @@
+# .forgeplan/ Restoration Guide
+
+## Что имеем
+
+Backup содержит body файлы для **19 из 26 артефактов**.
+Остальные 7 нужно пересоздать из шаблонов с минимальным контентом.
+
+## Статус coverage
+
+### Есть полные body (19):
+| File | ID | Status | Title |
+|------|----|--------|-------|
+| epic-001-body.md | EPIC-001 | active | Forgeplan v1.0 — Real Methodology Engine |
+| prd-001-body.md | PRD-001 | draft | My Feature |
+| prd-002-body.md | PRD-002 | active | FPF Reasoning Engine |
+| prd-003-body.md | PRD-003 | active | Health Dashboard + Blind Spot Detection |
+| prd-004-body.md | PRD-004 | active | Decision Journal |
+| prd-005-body.md | PRD-005 | active | Depth-Aware Validation (BMAD Validation v2) |
+| prd-006-body.md | PRD-006 | active | Smart Routing v2 |
+| prd-007-body.md | PRD-007 | active | Artifact Lifecycle |
+| prd-008-body.md | PRD-008 | draft | CLI UX Redesign |
+| rfc-001-body.md | RFC-001 | draft | FPF Engine — core module architecture |
+| prob-001-body.md | PROB-001 | draft | Custom prompts |
+| prob-006-body.md | PROB-006 | active | Routing misses UX/redesign scope |
+| note-004-body.md | NOTE-004 | active | Complete Forgeplan guide created |
+| evid-001-body.md | EVID-001 | active | Dogfood lifecycle test |
+| evid-002-body.md | EVID-002 | draft | Health Dashboard verified |
+| evid-003-body.md | EVID-003 | draft | Smart Routing v2 verified |
+| evid-004-body.md | EVID-004 | draft | FPF Engine verified |
+| evid-005-body.md | EVID-005 | draft | Journal + Validation v2 verified |
+
+### НЕТ body — нужно пересоздать из описания (7):
+| ID | Status | Title | Описание для восстановления |
+|----|--------|-------|-----------------------------|
+| PROB-002 | draft | Auth reuse — leverage existing Claude Code / Gemini / Codex sessions | Проблема: Forgeplan требует отдельный API key, но пользователь уже авторизован в AI агенте |
+| PROB-003 | draft | Dead statuses — lifecycle not enforced, all artifacts stuck in draft | Проблема: без enforce lifecycle все артефакты остаются в draft навсегда |
+| PROB-004 | draft | Agent drift — AI agent ignores methodology without constant reminding | Проблема: AI агент забывает про forgeplan route/health без явного напоминания |
+| PROB-005 | draft | Cold start — new chat has zero context about project methodology state | Проблема: каждый новый чат начинается с нуля, нет bootstrap |
+| NOTE-001 | draft | Reference sources — what to study from sources/ repos | Заметка: что изучить из quint-code, git-adr, OpenSpec, BMAD |
+| NOTE-002 | draft | Integration vision — sync Forgeplan with external task trackers | Заметка: bidirectional sync с Linear/Jira/Orchestra, PRD→Epic, FR→Tasks |
+| NOTE-003 | draft | Journal datetime format — show time, configurable output format | Заметка: формат даты в journal output |
+| SOL-001 | draft | Methodology Guard — enforce Forgeplan process via Claude Code hooks | Решение: CLAUDE.md rules + hooks + /forge skill для enforce методологии |
+
+## Все связи (links) для восстановления
+
+```
+# Evidence links
+forgeplan link EVID-001 EPIC-001 --relation informs
+forgeplan link EVID-001 PRD-007 --relation informs
+forgeplan link EVID-001 PROB-003 --relation informs
+forgeplan link EVID-002 PRD-003 --relation informs
+forgeplan link EVID-003 PRD-006 --relation informs
+forgeplan link EVID-004 PRD-002 --relation informs
+forgeplan link EVID-005 PRD-004 --relation informs
+forgeplan link EVID-005 PRD-005 --relation informs
+
+# Notes → parents
+forgeplan link NOTE-001 EPIC-001 --relation informs
+forgeplan link NOTE-002 EPIC-001 --relation informs
+forgeplan link NOTE-003 PRD-004 --relation informs
+forgeplan link NOTE-004 EPIC-001 --relation informs
+
+# PRDs → EPIC
+forgeplan link PRD-001 EPIC-001 --relation refines
+forgeplan link PRD-002 EPIC-001 --relation refines
+forgeplan link PRD-003 EPIC-001 --relation refines
+forgeplan link PRD-004 EPIC-001 --relation refines
+forgeplan link PRD-005 EPIC-001 --relation refines
+forgeplan link PRD-006 EPIC-001 --relation refines
+forgeplan link PRD-007 EPIC-001 --relation refines
+forgeplan link PRD-008 EPIC-001 --relation refines
+
+# Problems → parents
+forgeplan link PROB-001 EPIC-001 --relation informs
+forgeplan link PROB-002 EPIC-001 --relation informs
+forgeplan link PROB-003 PRD-007 --relation informs
+forgeplan link PROB-004 EPIC-001 --relation informs
+forgeplan link PROB-005 EPIC-001 --relation informs
+forgeplan link PROB-005 SOL-001 --relation informs
+forgeplan link PROB-006 PRD-008 --relation informs
+
+# RFC → PRD
+forgeplan link RFC-001 PRD-002 --relation based_on
+
+# Solution → parents
+forgeplan link SOL-001 EPIC-001 --relation informs
+forgeplan link SOL-001 PROB-004 --relation informs
+```
+
+## Порядок восстановления
+
+```bash
+# 1. Init
+forgeplan init
+
+# 2. Создать все артефакты (order matters for IDs!)
+forgeplan new epic "Forgeplan v1.0 — Real Methodology Engine"
+forgeplan new prd "My Feature"
+forgeplan new prd "FPF Reasoning Engine — structured first-principles reasoning in Forgeplan"
+forgeplan new prd "Health Dashboard + Blind Spot Detection"
+forgeplan new prd "Decision Journal — timeline of decisions with quality"
+forgeplan new prd "Depth-Aware Validation — depth-aware quality gates"
+forgeplan new prd "Smart Routing v2 — rule engine replacing LLM guess"
+forgeplan new prd "Artifact Lifecycle — review, activate, supersede, deprecate workflow"
+forgeplan new prd "CLI UX Redesign — cliclack interactive UI and styled output"
+forgeplan new rfc "FPF Engine — core module architecture"
+forgeplan new problem "Custom prompts — system needs configurable LLM prompts per project"
+forgeplan new problem "Auth reuse — leverage existing Claude Code / Gemini / Codex sessions"
+forgeplan new problem "Dead statuses — lifecycle not enforced, all artifacts stuck in draft"
+forgeplan new problem "Agent drift — AI agent ignores methodology without constant reminding"
+forgeplan new problem "Cold start — new chat has zero context about project methodology state"
+forgeplan new problem "Routing misses UX/redesign scope — classifies multi-command UI overhaul as Tactical"
+forgeplan new note "Reference sources — what to study from sources/ repos"
+forgeplan new note "Integration vision — sync Forgeplan with external task trackers"
+forgeplan new note "Journal datetime format — show time, configurable output format"
+forgeplan new note "Complete Forgeplan guide created — docs/guides/FORGEPLAN-GUIDE.md"
+forgeplan new solution "Methodology Guard — enforce Forgeplan process via Claude Code hooks"
+forgeplan new evidence "Dogfood lifecycle test — template-validation mismatch"
+forgeplan new evidence "Health Dashboard verified — 6 unit tests, correct orphan/blindspot/stale detection on 22 dogfood artifacts"
+forgeplan new evidence "Smart Routing v2 verified — deterministic rule engine, 8 keyword triggers, offline, no LLM dependency"
+forgeplan new evidence "FPF Engine verified — dashboard, contexts, explore-exploit, F-G-R scoring, 194 core tests"
+forgeplan new evidence "Journal and Validation v2 verified — 1289 LOC, 33 tests, dogfood confirmed"
+
+# 3. Update bodies from backup files
+forgeplan update EPIC-001 --body @.forgeplan-backup/epic-001-body.md
+forgeplan update PRD-001 --body @.forgeplan-backup/prd-001-body.md
+forgeplan update PRD-002 --body @.forgeplan-backup/prd-002-body.md
+forgeplan update PRD-003 --body @.forgeplan-backup/prd-003-body.md
+forgeplan update PRD-004 --body @.forgeplan-backup/prd-004-body.md
+forgeplan update PRD-005 --body @.forgeplan-backup/prd-005-body.md
+forgeplan update PRD-006 --body @.forgeplan-backup/prd-006-body.md
+forgeplan update PRD-007 --body @.forgeplan-backup/prd-007-body.md
+forgeplan update PRD-008 --body @.forgeplan-backup/prd-008-body.md
+forgeplan update RFC-001 --body @.forgeplan-backup/rfc-001-body.md
+forgeplan update PROB-001 --body @.forgeplan-backup/prob-001-body.md
+forgeplan update PROB-006 --body @.forgeplan-backup/prob-006-body.md
+forgeplan update NOTE-004 --body @.forgeplan-backup/note-004-body.md
+forgeplan update EVID-001 --body @.forgeplan-backup/evid-001-body.md
+forgeplan update EVID-002 --body @.forgeplan-backup/evid-002-body.md
+forgeplan update EVID-003 --body @.forgeplan-backup/evid-003-body.md
+forgeplan update EVID-004 --body @.forgeplan-backup/evid-004-body.md
+forgeplan update EVID-005 --body @.forgeplan-backup/evid-005-body.md
+
+# 4. Create all links (see full list above)
+# ... (copy link commands from above)
+
+# 5. Activate artifacts that were active
+forgeplan activate EPIC-001
+forgeplan activate EVID-001
+forgeplan activate PRD-003
+forgeplan activate PRD-006
+forgeplan activate PRD-007
+forgeplan activate PRD-002
+forgeplan activate PRD-004
+forgeplan activate PRD-005
+forgeplan activate PROB-006
+forgeplan activate NOTE-004
+
+# 6. Verify
+forgeplan health
+forgeplan list
+```

--- a/.forgeplan-backup/epic-001-body.md
+++ b/.forgeplan-backup/epic-001-body.md
@@ -1,0 +1,54 @@
+# EPIC-001: Forgeplan v1.0 — Real Methodology Engine
+
+## Vision
+
+Превратить Forgeplan из файлового менеджера артефактов в реальный methodology engine который находит пробелы, оценивает готовность, ведёт журнал решений, и даёт предсказуемый routing — без LLM для core логики.
+
+## Outcomes
+
+- Одна команда показывает здоровье проекта (health dashboard)
+- Движок сам находит blind spots (артефакты без evidence, решения без ADR)
+- Журнал решений с timeline и quality scores
+- Depth-aware валидация (не schema check)
+- Rule-based routing (детерминированный, без LLM)
+- F-G-R scoring — вычисляемые метрики качества
+- Lifecycle: Draft → Active → Superseded/Deprecated
+
+## Children
+
+| ID | Type | Title | Status | Progress |
+|----|------|-------|--------|----------|
+| PRD-002 | PRD | FPF Reasoning Engine | Done | 100% |
+| PRD-003 | PRD | Health Dashboard + Blind Spots | Done | 100% |
+| PRD-004 | PRD | Decision Journal | Done | 100% |
+| PRD-005 | PRD | Validation v2 | Done | 100% |
+| PRD-006 | PRD | Smart Routing v2 | Done | 100% |
+| PRD-007 | PRD | Artifact Lifecycle | Done | 100% |
+
+## Phases
+
+- [x] Phase 1: Health Dashboard + Blind Spots (PRD-003)
+- [x] Phase 2: Decision Journal (PRD-004)
+- [x] Phase 3: Validation v2 (PRD-005)
+- [x] Phase 4: Smart Routing v2 (PRD-006)
+- [x] Phase 5: Lifecycle Commands (PRD-007)
+- [x] Phase 6: FPF Engine — F-G-R, Bounded Contexts, Explore-Exploit (PRD-002)
+
+## Progress
+
+```
+Phase 1  ████████████████████████  1/1  (100%)
+Phase 2  ████████████████████████  1/1  (100%)
+Phase 3  ████████████████████████  1/1  (100%)
+Phase 4  ████████████████████████  1/1  (100%)
+Phase 5  ████████████████████████  1/1  (100%)
+Phase 6  ████████████████████████  1/1  (100%)
+─────────────────────────────────────────────────
+TOTAL                              6/6  (100%)
+```
+
+## Non-Goals
+
+- Desktop UI (Phase 5, отдельный Epic)
+- Ethics module (FPF Part D)
+- Multi-user / team features

--- a/.forgeplan-backup/evid-001-body.md
+++ b/.forgeplan-backup/evid-001-body.md
@@ -1,0 +1,78 @@
+# EVID-001: Dogfood Lifecycle Test
+
+## Experiment
+
+**Дата**: 2026-03-22
+**Метод**: Запустить `forgeplan review` на всех 18 dogfood артефактах. Попытаться провести lifecycle: review → activate.
+**Цель**: Проверить работает ли lifecycle flow на реальных данных.
+
+## Measurements
+
+### Test 1: Review all 18 artifacts (before fix)
+
+**Команда**: `forgeplan review <id>` для каждого из 18 артефактов
+**Результат**: 18/18 FAILED
+
+| Причина failure | Кол-во артефактов |
+|-----------------|-------------------|
+| Missing `## Problem` section | 14 (PRD используют `## Motivation`) |
+| Missing `## Goals` section | 12 (PRD используют `## Success Criteria`) |
+| Missing `## Non-Goals` | 10 (PRD используют `## Out of Scope`) |
+| Missing `## Related Artifacts` | 14 |
+| Missing `## Target Users` | 12 |
+| Missing frontmatter id/status | 14 (body в LanceDB не содержит frontmatter) |
+
+**Корневая причина**: Validator использовал exact match секций (`## Problem`), но реальные артефакты используют синонимы (`## Motivation`, `## Out of Scope`).
+
+### Test 2: After alias fix + frontmatter from record
+
+**Изменения**: 
+- `section_exists()` расширен aliases (Motivation=Problem, Out of Scope=Non-Goals, etc.)
+- `section_word_count()` тоже проверяет aliases
+- Review использует `record.frontmatter_map()` вместо парсинга body
+- Notes/Problems пропускают validation gate
+
+**Результат review**: 
+- EPIC-001: PASSED (после обновления body с Vision/Outcomes/Phases/Progress)
+- PRD-003: PASSED (SHOULD: density 48 words < 50)
+- PRD-006: PASSED (SHOULD: density 39 words < 50)
+- PRD-007: PASSED
+
+### Test 3: Activate flow
+
+**Команда**: `forgeplan activate <id>`
+**Результат**: 4/4 SUCCESS
+
+- EPIC-001: draft → active
+- PRD-003: draft → active
+- PRD-006: draft → active
+- PRD-007: draft → active
+
+**Health before**: `ALL DRAFT (18/18)`
+**Health after**: `4 active, 14 draft`
+
+## Verdict
+
+**supports** — Lifecycle flow работает после исправления alias mismatch. Система корректно:
+1. Блокирует activation при MUST failures
+2. Пропускает при SHOULD-only findings
+3. Обновляет status в LanceDB
+4. Health dashboard отражает изменения
+
+## Weakest Link
+
+Template → Validator alignment. Шаблоны и правила валидации должны использовать одинаковые section names или система aliases.
+
+## Congruence Level
+
+CL3 — evidence собрано на целевой системе (Forgeplan dogfood на себе)
+
+## Valid Until
+
+2026-06-22 (3 месяца — до следующего major refactor валидации)
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: measurement

--- a/.forgeplan-backup/evid-002-body.md
+++ b/.forgeplan-backup/evid-002-body.md
@@ -1,0 +1,33 @@
+# EVID-002: Health Dashboard Verified
+
+## Summary
+
+Health Dashboard (PRD-003) проверен через unit tests и dogfood использование на реальном проекте Forgeplan с 22 артефактами.
+
+## Evidence
+
+### Unit Tests (6 тестов, все проходят)
+- Orphan detection: находит артефакты без связей
+- Blind spots: обнаруживает active артефакты без evidence (draft exempt)
+- At-risk scoring: R_eff < 0.3 flagged correctly
+- Stale detection: expired valid_until detected
+- Evidence linking: linked evidence removes blind spot flag
+
+### Dogfood Verification (2026-03-23)
+- `forgeplan health` на 22 догфуд артефактах — корректно показывает:
+  - 7 active, 15 draft
+  - 3 blind spots (PRD-003, PRD-006, PRD-008) — все действительно без evidence
+  - 2 orphans (NOTE-003, PRD-001) — действительно без links
+  - Next actions генерируются на основе реального состояния
+- `forgeplan health --compact` работает для MCP/hooks
+
+### Implementation Stats
+- health/mod.rs: 372 LOC, production-ready
+- No TODO/unimplemented markers in code
+- Error handling: stale detection errors logged, not fatal
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test

--- a/.forgeplan-backup/evid-003-body.md
+++ b/.forgeplan-backup/evid-003-body.md
@@ -1,0 +1,35 @@
+# EVID-003: Smart Routing v2 Verified
+
+## Summary
+
+Smart Routing v2 (PRD-006) проверен: deterministic rule-based engine работает offline без LLM, корректно определяет depth через keyword triggers и structural signals.
+
+## Evidence
+
+### Implementation Verification (2026-03-23)
+- routing/ module: 660 LOC total (signals 254, rules 118, pipeline 143, mod 145)
+- 8 keyword trigger categories: security, breaking_change, cross_team, public_api, data_model, infrastructure, strategy, new_subsystem
+- 6 structural signals: word count, FR count, link count, parent epic, section count, irreversible flag
+- Depth = max(signal.minimum_depth) — conservative, never under-estimates
+- Confidence = base 0.5 + agreement bonus + count boost
+
+### Functional Tests
+- `forgeplan route "implement auth system with OAuth"` → Deep (security trigger)
+- `forgeplan route "fix typo in readme"` → Tactical (no triggers)
+- `forgeplan route "add new CLI command"` → Standard (structural signals)
+- All routing tests in core pass (194 core tests include routing)
+
+### Key Properties
+- No LLM dependency (NFR-001 of PRD-002 satisfied)
+- Instant response (no API calls)
+- Deterministic (same input → same output)
+- Pipeline mapping: Tactical=[], Standard=[PRD,RFC], Deep=[PRD,Spec,RFC,ADR]
+
+### Known Limitation
+- PROB-006: routing misses "redesign/overhaul/refactor" keywords — classified as Tactical when should be Standard+
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test

--- a/.forgeplan-backup/evid-004-body.md
+++ b/.forgeplan-backup/evid-004-body.md
@@ -1,0 +1,30 @@
+# EVID-004: FPF Engine Verified
+
+## Summary
+
+FPF Engine (PRD-002) проверен: все 5 FR реализованы, 194 core теста проходят, dogfood на 24 артефактах.
+
+## Evidence
+
+### Implemented Features
+- FR-001 Routing: 660 LOC, 8 keyword triggers, 6 structural signals, deterministic (see EVID-003)
+- FR-002 F-G-R: 245 LOC, geometric mean cbrt(F*G*R), grades A-F
+- FR-003 Contexts: ~80 LOC, BFS connected-component, cohesion metric
+- FR-004 Explore-Exploit: ~80 LOC, R_eff thresholds (explore<0.3, exploit>=0.7)
+- FR-005 Dashboard: ~155 LOC, aggregates contexts + scores + actions
+
+### Tests
+- 194 core unit tests pass (includes routing, scoring, validation)
+- 24 CLI integration tests pass
+- 0 failures, 0 compiler warnings
+
+### Dogfood (2026-03-23)
+- `forgeplan fpf` on 24 artifacts — shows bounded contexts, quality grades, pipeline status
+- `forgeplan route "implement auth"` → Deep (security trigger) — correct
+- F-G-R grades correlate with artifact completeness (empty PRDs got F, filled PRDs got B-C)
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test

--- a/.forgeplan-backup/evid-005-body.md
+++ b/.forgeplan-backup/evid-005-body.md
@@ -1,0 +1,36 @@
+# EVID-005: Decision Journal and Validation v2 Verified
+
+## Summary
+
+Decision Journal (PRD-004) и Validation v2 (PRD-005) проверены: оба модуля реализованы, тестированы и используются в dogfood.
+
+## Evidence
+
+### Decision Journal (PRD-004)
+- journal/mod.rs: 115 LOC, production-ready
+- Filters decision-type artifacts (ADR, Note, Problem, Solution)
+- R_eff scoring per decision, stale detection via valid_until
+- Bidirectional link checking for evidence
+- `--risk` filter: no evidence OR R_eff < 0.3 OR stale
+- 1 unit test + CLI integration test
+
+### Validation v2 (PRD-005)
+- validation/: 1174 LOC total (mod.rs + rules.rs + checks.rs)
+- 32 tests (27 rules + 5 checks), all pass
+- Depth-aware: PRD Tactical=9, Standard=12, Deep=20 rules
+- Per-kind: Epic=8, Spec=6, RFC=8-9, ADR=6-8 rules
+- Section aliases: 10+ synonym groups (Problem=Motivation=Background)
+- Placeholder detection skips code fences
+- Tech leakage blocklist: 22 technology names
+- Integrated with lifecycle: review() gates on MUST findings
+
+### Dogfood (2026-03-23)
+- `forgeplan validate` correctly found 12 MUST failures across 3 PRD stubs
+- After fixing: all 8 PRDs pass validation
+- `forgeplan journal --risk` correctly flags decisions without evidence
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test

--- a/.forgeplan-backup/note-004-body.md
+++ b/.forgeplan-backup/note-004-body.md
@@ -1,0 +1,11 @@
+# NOTE-004: Complete Forgeplan Guide Created
+
+Создан единый практический гайд `docs/guides/FORGEPLAN-GUIDE.md`:
+- Методология (3 вопроса вместо бюрократии)
+- Все 33 CLI команды с примерами (по категориям)
+- Evidence и R_eff — как создавать, structured fields, CL levels
+- Lifecycle flow — от draft до active
+- MCP integration — настройка и core workflow
+- Подводные камни из реального dogfood
+
+Причина: существующие гайды (HOW-TO-USE, DEPTH-CALIBRATION) описывали методологию, но не CLI workflow. Не было единого документа "как реально пользоваться Forgeplan".

--- a/.forgeplan-backup/prd-001-body.md
+++ b/.forgeplan-backup/prd-001-body.md
@@ -1,0 +1,46 @@
+# PRD-001: CLI UX Redesign — cliclack interactive UI
+
+## Problem
+
+Текущий CLI выводит plain text без стилизации. `forgeplan init` создаёт пустые папки молча. `forgeplan health` выглядит как debug output. Нет интерактивности — пользователь не выбирает агентов, не подтверждает действия. Первое впечатление = "сырой CLI", а не "продуманный developer tool".
+
+## Goals
+
+- Интерактивный `forgeplan init` с выбором агентов, генерацией .mcp.json, ASCII banner
+- Стилизованный output для health, validate, review, route, fgr, list
+- Единый визуальный стиль через cliclack
+- Сохранить --json flag для machine-readable output
+
+## Non-Goals
+
+- Не менять MCP server output (остаётся JSON)
+- Не менять логику команд (только presentation layer)
+- Не делать TUI/dashboard (Phase 5)
+
+## Target Users
+
+Разработчики настраивающие Forgeplan и проверяющие состояние проекта через CLI.
+
+## Functional Requirements
+
+- [x] FR-001: ASCII banner FPL при init
+- [x] FR-002: Interactive wizard: name → agents → .mcp.json → spinner → summary
+- [x] FR-003: .mcp.json auto-generation для Claude Code/Cursor
+- [ ] FR-004: CLAUDE.md section auto-generation
+- [x] FR-005: .cursorrules auto-generation
+- [ ] FR-006: health — styled output с note boxes, цветными статусами
+- [ ] FR-007: validate — цветные MUST/SHOULD/COULD
+- [ ] FR-008: review — styled checklist
+- [ ] FR-009: route — styled depth colors
+- [ ] FR-010: list — colored table by status
+- [ ] FR-011: --json flag на всех командах
+- [ ] FR-012: setup-skill command
+
+## Related Artifacts
+
+Продолжение работы после EPIC-001 (v0.7.0).
+
+## Implementation Notes
+
+cliclack = "0.5", console = "0.15". Audit passed (6.8/10 → fixes applied).
+Branch: feat/prd-008-cli-ux. 4/12 FR done + audit fixes.

--- a/.forgeplan-backup/prd-002-body.md
+++ b/.forgeplan-backup/prd-002-body.md
@@ -1,0 +1,65 @@
+# PRD-002: FPF Reasoning Engine
+
+## Summary
+
+Встроить First Principles Framework (FPF) как структурированный reasoning engine в Forgeplan core. FPF Engine = metrics aggregator + rule-based routing + quality scoring + bounded context detection + explore-exploit suggestions. Не заменяет LLM, а дополняет его детерминированной логикой.
+
+## Problem
+
+До FPF Engine Forgeplan был "файловый менеджер с R_eff". `forgeplan reason` = LLM prompt с ADI instructions — "FPF-flavored text", не structured reasoning. Пользователь получал markdown blob, а не structured гипотезы с confidence levels. Проблемы:
+- Routing зависел от LLM — медленно, не offline, недетерминированно
+- Нет multi-dimensional quality scoring — только R_eff (одно число)
+- Нет автоматической архитектурной карты проекта (bounded contexts)
+- Нет рекомендаций "что делать дальше" на основе evidence gaps
+
+## Goals
+
+- Детерминированный rule-based routing без LLM (offline, instant, reproducible)
+- Multi-dimensional quality scoring через F-G-R (Formality, Granularity, Reliability)
+- Автоматическое обнаружение bounded contexts из link graph
+- Explore-Exploit suggestions: что исследовать, что использовать, основываясь на evidence coverage
+- Единый FPF Dashboard (`forgeplan fpf`) — полная картина проекта
+
+## Target Users
+
+- AI агент (MCP) — получает structured quality data для принятия решений
+- Разработчик — `forgeplan route "task"` для мгновенного определения depth и pipeline
+- Архитектор — `forgeplan fpf` для обзора bounded contexts и quality grades
+
+## Functional Requirements
+
+- [x] FR-001: FPF Router — rule-based depth calibration (8 keyword triggers, 6 structural signals, confidence scoring)
+- [x] FR-002: F-G-R Scoring — Formality (validation pass rate) + Granularity (content density) + Reliability (R_eff + links + freshness), combined via geometric mean
+- [x] FR-003: Bounded Context detection — connected-component analysis on link graph with cohesion metric
+- [x] FR-004: Explore-Exploit suggestions — rule-based: R_eff < 0.3 = explore, R_eff >= 0.7 = exploit, orphans = explore
+- [x] FR-005: FPF Dashboard — `forgeplan fpf` показывает contexts, quality grades, next actions, pipeline status
+
+## Non-Functional Requirements
+
+- NFR-001: FPF Engine работает без LLM (rule-based core, LLM = optional enrichment)
+- NFR-002: Не ломает existing commands (backward compatible)
+- NFR-003: Каждая фича реализована incremental
+
+## Non-Goals
+
+- Desktop UI для FPF (Phase 5)
+- Structured ADI (Abduction → Deduction → Induction) как JSON output — deferred
+- Ethics module (FPF Part D) — too complex для MVP
+- UTS (Unified Type System) — vocabulary unification
+- Dynamic signal weights / ML-trained routing
+
+## Related Artifacts
+
+- EPIC-001: родительский Epic
+- PRD-006: Smart Routing v2 (routing = FR-001 of FPF Engine)
+- PRD-007: Lifecycle (F-G-R scoring helps lifecycle decisions)
+- RFC-001: FPF Engine module architecture
+
+## Implementation Notes
+
+Реализовано в `crates/forgeplan-core/src/`:
+- `fpf/mod.rs` (~155 LOC): FpfDashboard struct, dashboard() async fn
+- `fpf/contexts.rs` (~80 LOC): BFS connected-component analysis, cohesion metric
+- `fpf/explore.rs` (~80 LOC): explore/investigate/exploit classification by R_eff thresholds
+- `routing/` (~660 LOC): signals.rs (keyword triggers), rules.rs (depth computation), pipeline.rs (artifact pipeline)
+- `scoring/fgr.rs` (~245 LOC): F-G-R scoring with geometric mean, grade mapping A-F

--- a/.forgeplan-backup/prd-003-body.md
+++ b/.forgeplan-backup/prd-003-body.md
@@ -1,0 +1,34 @@
+# PRD-003: Health Dashboard + Blind Spot Detection
+
+## Problem
+
+Чтобы понять состояние проекта нужно запустить 5 отдельных команд: status + stale + decay + validate + score по каждому артефакту. Это 5 вызовов с ручным анализом. Пользователь (и AI агент) не видит картину целиком — пробелы в evidence, просроченные данные, orphan артефакты скрыты за множеством отдельных команд.
+
+## Goals
+
+- Одна команда `forgeplan health` показывает полное здоровье проекта
+- `forgeplan blindspots` — детальный анализ пробелов
+- Compact mode для hooks/scripts (JSON < 500 tokens)
+- MCP tools для AI agent integration
+
+## Out of Scope
+
+- Grafana / external dashboard integration
+- Historical health tracking (trending)
+
+## Target Users
+
+Разработчики и AI агенты (Claude Code, Cursor) использующие Forgeplan.
+
+## Functional Requirements
+
+- [x] FR-001: `forgeplan health` — агрегированный dashboard (artifacts by kind/status, orphans, next actions)
+- [x] FR-002: `forgeplan blindspots` — артефакты без evidence, orphans, missing links
+- [x] FR-003: `forgeplan health --compact` — one-line output for hooks
+- [x] FR-004: MCP tools: forgeplan_health, forgeplan_blindspots
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-001 | Parent epic | Active |

--- a/.forgeplan-backup/prd-004-body.md
+++ b/.forgeplan-backup/prd-004-body.md
@@ -1,0 +1,55 @@
+# PRD-004: Decision Journal
+
+## Summary
+
+`forgeplan journal` — хронологический timeline всех решений (ADR, Note, Problem, Solution) с R_eff scores и evidence status. Позволяет видеть эволюцию проекта и находить решения без evidence или с устаревшими доказательствами.
+
+## Problem
+
+Forgeplan хранит десятки артефактов, но нет единого view на историю решений. Пользователь видит `forgeplan list` — плоский список без контекста качества. Вопросы без ответа:
+- Какие решения приняты без доказательств?
+- Есть ли решения с устаревшим evidence (expired valid_until)?
+- Как эволюционировал проект — что решали первым, что последним?
+
+Без journal пользователь должен вручную проверять каждый артефакт через `forgeplan score` — O(n) операций вместо одного обзора.
+
+## Goals
+
+- Единый хронологический view на все decision-type артефакты с quality метриками
+- Мгновенное обнаружение решений без evidence (R_eff = 0.0) или с stale evidence
+- Фильтрация по виду артефакта и уровню риска для фокусированного review
+
+## Target Audience
+
+- AI агент (через MCP tool `forgeplan_journal`) — для контекстного принятия решений
+- Разработчик/архитектор — для review истории решений перед новой работой
+- Tech lead — для аудита качества решений в проекте
+
+## Functional Requirements
+
+- [x] FR-001: `forgeplan journal` — timeline решений sorted by date (newest first)
+- [x] FR-002: Каждое решение показывает: date, ID, title, R_eff, evidence count, stale status
+- [x] FR-003: Фильтры: `--kind adr`, `--risk` (only entries with R_eff < 0.3 or no evidence or stale)
+- [x] FR-004: MCP tool `forgeplan_journal`
+- [x] FR-005: Warning для решений без evidence
+
+## Non-Goals
+
+- Timeline визуализация (график/chart) — это Desktop App (Phase 5)
+- Автоматическое создание решений из conversation — MCP protocol не передаёт контекст
+- Интеграция с git log — journal строится из Forgeplan артефактов, не из коммитов
+
+## Related Artifacts
+
+- EPIC-001: родительский Epic
+- PRD-003: Health Dashboard (journal дополняет health как детальный decision view)
+- PRD-007: Lifecycle (journal показывает статусы из lifecycle transitions)
+
+## Implementation Notes
+
+Реализовано в `crates/forgeplan-core/src/journal/mod.rs` (115 LOC):
+- Фильтрует к decision-type артефактам (ADR, Note, Problem, Solution)
+- Bidirectional link checking для evidence (evidence→decision OR decision→evidence)
+- R_eff scoring через weakest-link из linked evidence
+- Stale detection: valid_until past now() → has_stale_evidence flag
+- `--risk` фильтр: no evidence OR R_eff < 0.3 OR has_stale_evidence

--- a/.forgeplan-backup/prd-005-body.md
+++ b/.forgeplan-backup/prd-005-body.md
@@ -1,0 +1,60 @@
+# PRD-005: Depth-Aware Validation
+
+## Summary
+
+Расширить `forgeplan validate` с базовых schema checks до полной depth-aware validation. Каждый тип артефакта проверяется по правилам, калиброванным под его depth (tactical/standard/deep). Правила разделены по severity: MUST (блокирует activation), SHOULD (предупреждение), COULD (рекомендация).
+
+## Problem
+
+Первая версия validation проверяла только наличие секций — есть `## Summary` или нет. Этого недостаточно:
+- PRD на tactical depth не должен требовать Risk Assessment — это overkill
+- PRD на deep depth обязан иметь rollback plan и success metrics — это safety requirement
+- Разные типы артефактов (PRD, RFC, ADR, Epic) имеют разные обязательные секции
+- Нет разницы между критической ошибкой (нет Problem секции) и рекомендацией (секция короткая)
+
+Без depth-aware validation: либо все артефакты проверяются одинаково (слишком строго для tactical, слишком мягко для deep), либо validation бесполезен.
+
+## Goals
+
+- Валидация калибруется по depth: tactical = минимум правил, deep = максимум
+- Каждое правило имеет severity (MUST/SHOULD/COULD) — MUST блокирует activation через lifecycle gate
+- Поддержка aliases секций (Problem = Motivation = Problem Statement) — гибкость без потери строгости
+- Per-kind правила: PRD, RFC, ADR, Epic, Spec проверяются по своим правилам
+
+## Target Audience
+
+- AI агент — автоматическая проверка перед activation (lifecycle integration)
+- Разработчик — `forgeplan validate PRD-001` для self-check перед review
+- Reviewer — `forgeplan review PRD-001` запускает validation как часть review
+
+## Functional Requirements
+
+- [x] FR-001: Depth-aware PRD validation — Tactical: 9 rules, Standard: 12 rules, Deep: 20 rules
+- [x] FR-002: Severity per rule — MUST (блокирует activate), SHOULD (warning), COULD (suggestion)
+- [x] FR-003: Section aliases — Problem = Motivation = Problem Statement = Background (и 10+ других)
+- [x] FR-004: Per-kind validation — PRD (9-20), Epic (8), Spec (6), RFC (8-9), ADR (6-8) rules
+- [x] FR-005: Quality gate output — PASS / FAIL / PASS_WITH_WARNINGS с счётчиками
+- [x] FR-006: Deep PRD checks — risk assessment, rollback plan, success metrics, dependencies, FR format
+- [x] FR-007: Placeholder detection — {{...}}, TODO, FIXME (ignores code fences)
+- [x] FR-008: Tech leakage detection — blocklist of 22 technology names in requirements
+- [x] FR-009: Problem density check — minimum 50 words in Problem section (SHOULD)
+
+## Non-Goals
+
+- `forgeplan validate --adversarial` mode (BMAD adversarial review) — backlog
+- Custom validation rules per project — все правила hardcoded
+- ML-based quality scoring — validation = deterministic rules, quality = F-G-R scoring (отдельный модуль)
+
+## Related Artifacts
+
+- EPIC-001: родительский Epic
+- PRD-007: Lifecycle (validation = gate перед activation)
+- PRD-002: FPF Engine (F-G-R scoring использует validation results для Formality)
+
+## Implementation Notes
+
+Реализовано в `crates/forgeplan-core/src/validation/` (1174 LOC, 32 теста):
+- `mod.rs`: dispatcher — выбирает правила по kind + depth
+- `rules.rs`: 30+ правил как function pointers с severity
+- `checks.rs`: helper functions — section_exists (with aliases), word_count, placeholders, tech leakage
+- Lifecycle integration: `review()` вызывает `validate()` и gates на MUST findings

--- a/.forgeplan-backup/prd-006-body.md
+++ b/.forgeplan-backup/prd-006-body.md
@@ -1,0 +1,34 @@
+# PRD-006: Smart Routing v2
+
+## Problem
+
+Текущий `forgeplan route` — чистый LLM prompt. Требует API key, стоит денег, медленный (2-5 сек), недетерминированный (разные ответы на тот же input). Для core workflow routing должен быть мгновенным, offline, предсказуемым. LLM может объяснять решение, но не принимать его.
+
+## Goals
+
+- Rule-based routing: детерминированный, instant, offline
+- LLM используется ТОЛЬКО для --explain (enrichment, не решение)
+- Выходной формат: depth + pipeline + triggers + confidence
+
+## Out of Scope
+
+- Custom user rules (v2 — config-based triggers)
+- Machine learning on project history
+
+## Target Users
+
+AI агенты (Claude Code) и разработчики использующие Forgeplan для structured workflow.
+
+## Functional Requirements
+
+- [x] FR-001: Rule engine из DEPTH-CALIBRATION.md decision tree (8 keyword triggers + structural signals)
+- [x] FR-002: Pipeline suggestion — Tactical→nothing, Standard→PRD+RFC, Deep→PRD+Spec+RFC+ADR
+- [x] FR-003: `forgeplan route` works WITHOUT LLM (instant, offline)
+- [x] FR-004: Optional --explain flag calls LLM for human-readable reasoning
+- [x] FR-005: Output includes: depth, pipeline, triggers matched, confidence
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-001 | Parent epic | Active |

--- a/.forgeplan-backup/prd-007-body.md
+++ b/.forgeplan-backup/prd-007-body.md
@@ -1,0 +1,51 @@
+# PRD-007: Artifact Lifecycle Workflow
+
+## Problem
+
+PROB-003: все артефакты застревают в draft навсегда. Статусы — мёртвые метаданные без enforcement. Нет формализованного процесса принятия решения о готовности артефакта. Пользователь создаёт PRD, заполняет Summary и FR, но никогда не переводит в Active потому что нет процедуры review. В результате все 18 артефактов проекта остаются в Draft — включая полностью реализованные.
+
+## Goals
+
+- Формализованный lifecycle: Draft → Review → Active → Superseded/Deprecated
+- Validation gates на каждом переходе (MUST rules must pass)
+- Автоматические предупреждения о build-on-draft и supersede chain
+- CLI + MCP commands для всех lifecycle операций
+
+## Out of Scope
+
+- Approval by multiple reviewers (single-user tool)
+- Git hooks for status enforcement
+- Notifications (no notification system)
+
+## Target Users
+
+Разработчики и архитекторы использующие Forgeplan для документирования решений.
+
+## Functional Requirements
+
+- [x] FR-001: `forgeplan review <id>` — запускает validation, показывает checklist, предлагает activate
+- [x] FR-002: `forgeplan activate <id>` — draft → active с validation gate (MUST rules пройдены)
+- [x] FR-003: `forgeplan supersede <id> --by <new-id>` — active → superseded + auto-link
+- [x] FR-004: `forgeplan deprecate <id> --reason "..."` — active → deprecated
+- [x] FR-005: Build-on-draft warning — validate предупреждает если RFC based_on draft PRD
+- [x] FR-006: Supersede chain warnings — при supersede все зависимые получают notification
+- [x] FR-007: MCP tools для всех lifecycle commands
+- [x] FR-008: `forgeplan health` показывает draft/active/superseded ratio
+
+## Lifecycle State Machine
+
+```
+Draft ──review──→ Draft (if validation fails)
+Draft ──activate──→ Active (if validation passes)
+Active ──supersede──→ Superseded (link to replacement)
+Active ──deprecate──→ Deprecated (with reason)
+Superseded ──→ (terminal)
+Deprecated ──→ Active (un-deprecate allowed)
+```
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-001 | Parent epic | Active |
+| PROB-003 | Motivating problem | Draft |

--- a/.forgeplan-backup/prd-008-body.md
+++ b/.forgeplan-backup/prd-008-body.md
@@ -1,0 +1,51 @@
+# PRD-008: CLI UX Redesign — cliclack interactive UI
+
+## Problem
+
+Текущий CLI выводит plain text без стилизации. `forgeplan init` создаёт пустые папки молча. `forgeplan health` выглядит как debug output. Нет интерактивности — пользователь не выбирает агентов, не подтверждает действия. Для MCP-first инструмента это не критично (агент читает JSON), но для human onboarding и inspection — плохо. Первое впечатление = "сырой CLI", а не "продуманный developer tool". Сравнение с npx skills (cliclack UI) делает разницу очевидной.
+
+## Goals
+
+- Интерактивный `forgeplan init` с выбором агентов, генерацией .mcp.json, ASCII banner
+- Стилизованный output для health, validate, review, route, fgr, list
+- Единый визуальный стиль через cliclack (vertical timeline для interactive, note boxes для output)
+- Сохранить --json flag для machine-readable output (MCP и scripting)
+
+## Non-Goals
+
+- Не менять MCP server output (остаётся JSON)
+- Не менять логику команд (только presentation layer)
+- Не делать TUI/dashboard (это для Desktop App, Phase 5)
+
+## Target Users
+
+- Разработчики впервые настраивающие Forgeplan (onboarding)
+- Люди проверяющие состояние проекта через CLI (inspection)
+- AI агенты НЕ затронуты (MCP output = JSON, без изменений)
+
+## Functional Requirements
+
+- [ ] FR-001: ASCII banner FPL при `init` и `--version`
+- [ ] FR-002: `forgeplan init` — интерактивный wizard: project name → agent multiselect → .mcp.json confirm → spinner → summary note → outro
+- [ ] FR-003: `forgeplan init` генерирует .mcp.json для выбранных агентов
+- [ ] FR-004: `forgeplan init` добавляет Forgeplan секцию в CLAUDE.md (если выбран Claude Code)
+- [ ] FR-005: `forgeplan init` генерирует .cursorrules (если выбран Cursor)
+- [ ] FR-006: `forgeplan health` — styled output с note boxes, цветными статусами, иконками
+- [ ] FR-007: `forgeplan validate` — цветные MUST (красный) / SHOULD (жёлтый) / COULD (серый)
+- [ ] FR-008: `forgeplan review` — styled checklist с цветами
+- [ ] FR-009: `forgeplan route` — styled result с depth цветом (tactical=зелёный, deep=красный)
+- [ ] FR-010: `forgeplan list` — styled table с цветами по status (active=зелёный, draft=серый)
+- [ ] FR-011: Все команды поддерживают `--json` для machine-readable output
+- [ ] FR-012: `forgeplan setup-skill` — устанавливает /forge skill в ~/.claude/skills/
+
+## Dependencies
+
+- cliclack = "0.5" (Rust port of @clack/prompts)
+- console = "0.15" (terminal styling)
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-001 | Parent epic context | Active |
+| NOTE-004 | FORGEPLAN-GUIDE documentation | Active |

--- a/.forgeplan-backup/prob-001-body.md
+++ b/.forgeplan-backup/prob-001-body.md
@@ -1,0 +1,15 @@
+# PROB-001: LanceDB data loss
+
+## Signal
+
+`rm -rf .forgeplan` уничтожает все артефакты безвозвратно. 21 артефакт + 5 evidence packs потеряны за секунду. Нет бэкапа, нет экспорта, нет recovery.
+
+## Root Cause
+
+.forgeplan/ в .gitignore (правильно — LanceDB binary data не для git). Но нет механизма экспорта артефактов в git-trackable формат.
+
+## Suggested Fix
+
+- `forgeplan export` — dump всех артефактов в JSON/YAML (git-trackable)
+- `forgeplan import` — restore из dump
+- Markdown projections должны обновляться при каждом update (не только при new)

--- a/.forgeplan-backup/prob-006-body.md
+++ b/.forgeplan-backup/prob-006-body.md
@@ -1,0 +1,17 @@
+# PROB-006: Routing misses UX/redesign scope
+
+## Signal
+
+`forgeplan route "Redesign CLI with cliclack UI"` → Tactical (confidence 80%).
+Реально это Standard+ задача: новая зависимость, 33 команды затронуты, 1-3 дня работы.
+
+## Root Cause
+
+Keyword triggers в routing/signals.rs не содержат "redesign", "overhaul", "refactor all", "new dependency", "UX". Эти слова не в списке escalation triggers.
+
+## Fix
+
+Добавить keyword triggers:
+- `redesign`, `overhaul`, `rewrite` → Standard+
+- `new dependency`, `new crate`, `new library` → Standard+
+- `all commands`, `entire CLI` → Standard+ (scope signal)

--- a/.forgeplan-backup/rfc-001-body.md
+++ b/.forgeplan-backup/rfc-001-body.md
@@ -1,0 +1,69 @@
+# RFC-001: FPF Engine — Core Module Architecture
+
+## Summary
+
+Модуль fpf/ в forgeplan-core реализует metrics aggregation, bounded context detection и explore-exploit suggestions. Routing вынесен в отдельный модуль routing/. F-G-R scoring — в scoring/fgr.rs. Всё rule-based, без LLM.
+
+## Motivation
+
+PRD-002 определяет ЧТО нужно: quality scoring, routing, context detection. RFC-001 отвечает на КАК: модульная архитектура с чётким разделением ответственности. Ключевое решение — разделить FPF на три независимых модуля (fpf/, routing/, scoring/) вместо одного монолита, чтобы каждый модуль тестировался и эволюционировал отдельно.
+
+## Architecture (реализовано)
+
+```
+crates/forgeplan-core/src/
+├── fpf/
+│   ├── mod.rs          ← FpfDashboard: aggregates contexts + scores + actions
+│   ├── contexts.rs     ← BFS connected-component detection, cohesion metric
+│   └── explore.rs      ← Explore/Investigate/Exploit classification
+├── routing/
+│   ├── mod.rs          ← route(description) → RoutingResult
+│   ├── signals.rs      ← 8 keyword triggers + structural signals
+│   ├── rules.rs        ← compute_depth (max rank), compute_confidence
+│   └── pipeline.rs     ← depth → artifact pipeline mapping
+└── scoring/
+    ├── reff.rs         ← R_eff = min(evidence_scores), weakest link
+    ├── fgr.rs          ← F-G-R: Formality + Granularity + Reliability
+    ├── decay.rs        ← Evidence decay impact report
+    └── evidence.rs     ← Parse structured fields from evidence body
+```
+
+## Implementation Phases
+
+- [x] **G.1** routing/ — rule-based depth calibration (8 keyword triggers, 6 structural signals)
+- [x] **G.2** scoring/fgr.rs — F-G-R scoring per artifact (geometric mean, grades A-F)
+- [x] **G.3** fpf/contexts.rs — bounded context detection via BFS on link graph
+- [ ] ~~**G.4** fpf/adi.rs — structured ADI~~ — deferred (не реализовано)
+- [x] **G.5** fpf/explore.rs — explore-exploit suggestions (rule-based thresholds)
+- [x] **G.6** CLI: `forgeplan fpf`, `forgeplan route`, MCP tools
+
+## Proposed Solution
+
+### Routing (routing/)
+- **Input**: text description (task/feature)
+- **Signals**: keyword matching (security→Deep, breaking_change→Deep) + structural heuristics (word count, FR count)
+- **Depth**: max(signal.minimum_depth) — conservative, never under-estimates
+- **Confidence**: base 0.5 + agreement bonus + count boost, capped at 1.0
+- **Pipeline**: depth → artifact kinds (Standard=[PRD,RFC], Deep=[PRD,Spec,RFC,ADR])
+
+### F-G-R Scoring (scoring/fgr.rs)
+- **F (Formality)**: % validation rules that pass
+- **G (Granularity)**: content density — words (0.3), sections (0.2), checklists (0.2), code (0.15), tables (0.15)
+- **R (Reliability)**: R_eff×0.5 + links (0.3) + freshness (0.2)
+- **Grade**: cbrt(F×G×R) — geometric mean penalizes imbalance
+
+### Bounded Contexts (fpf/contexts.rs)
+- BFS на undirected link graph → connected components
+- Cohesion = internal_links / (internal + external)
+- Singletons grouped as "Unlinked"
+
+### Explore-Exploit (fpf/explore.rs)
+- EXPLORE: R_eff < 0.3, draft, low F-G-R, or orphan
+- INVESTIGATE: 0 < R_eff < 0.5 (weak evidence)
+- EXPLOIT: R_eff >= 0.7 + fresh evidence
+
+## References
+
+- PRD-002: FPF Reasoning Engine (requirements)
+- DEPTH-CALIBRATION.md: original decision tree
+- FPF Spec: B.3 Trust Calculus, C.2 F-G-R, C.19 Explore-Exploit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +863,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cliclack"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd870c423d925f0257dda3ce62067e2e3b64b0e1ad29bac8affdd4b6ce938bd"
+dependencies = [
+ "console 0.16.3",
+ "indicatif 0.18.4",
+ "once_cell",
+ "strsim",
+ "textwrap",
+ "zeroize",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +950,18 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1096,6 +1131,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1904,6 +1950,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2235,9 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "cliclack",
+ "console 0.16.3",
+ "ctrlc",
  "forgeplan-core",
  "forgeplan-mcp",
  "predicates",
@@ -2531,7 +2592,7 @@ checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
 dependencies = [
  "dirs",
  "http",
- "indicatif",
+ "indicatif 0.17.11",
  "libc",
  "log",
  "native-tls",
@@ -2898,10 +2959,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console 0.16.3",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -4068,6 +4142,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,6 +4274,21 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object_store"
@@ -5599,6 +5700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5993,6 +6100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6359,6 +6477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization-alignments"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6390,6 +6514,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -7191,6 +7321,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
  "cliclack",
  "console 0.16.3",
  "ctrlc",
+ "dirs",
  "forgeplan-core",
  "forgeplan-mcp",
  "predicates",

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -17,6 +17,9 @@ chrono.workspace = true
 tokio.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
+cliclack = "0.5.2"
+console = "0.16.3"
+ctrlc = "3.5.2"
 
 [features]
 semantic-search = []

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -20,6 +20,7 @@ serde_json.workspace = true
 cliclack = "0.5.2"
 console = "0.16.3"
 ctrlc = "3.5.2"
+dirs = "6.0.0"
 
 [features]
 semantic-search = []

--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -1,10 +1,13 @@
 use std::env;
 
+use console::style;
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::health;
 use forgeplan_core::workspace;
 
-pub async fn run(compact: bool) -> anyhow::Result<()> {
+use crate::ui;
+
+pub async fn run(compact: bool, json: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -12,6 +15,22 @@ pub async fn run(compact: bool) -> anyhow::Result<()> {
     let config = workspace::load_config(&ws)?;
     let store = LanceStore::open(&ws).await?;
     let report = health::health_report(&store).await?;
+
+    if json {
+        let json_data = serde_json::json!({
+            "project": config.project_name,
+            "total": report.total,
+            "by_kind": report.by_kind.iter().map(|(k, v)| serde_json::json!({"kind": k, "count": v})).collect::<Vec<_>>(),
+            "by_status": report.by_status.iter().map(|(s, v)| serde_json::json!({"status": s, "count": v})).collect::<Vec<_>>(),
+            "at_risk": report.at_risk.iter().map(|a| serde_json::json!({"id": a.id, "title": a.title, "reason": a.reason})).collect::<Vec<_>>(),
+            "blind_spots": report.blind_spots.iter().map(|b| serde_json::json!({"id": b.id, "title": b.title, "issue": b.issue})).collect::<Vec<_>>(),
+            "stale_count": report.stale_count,
+            "orphans": report.orphans,
+            "next_actions": report.next_actions,
+        });
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
+        return Ok(());
+    }
 
     if compact {
         // Compact mode for hooks/scripts
@@ -30,73 +49,83 @@ pub async fn run(compact: bool) -> anyhow::Result<()> {
 
     // Full dashboard
     println!();
-    println!("Forgeplan Health — {}", config.project_name);
-    println!("{}", "═".repeat(50));
+    println!("{} — {}", style("Forgeplan Health").bold(), style(&config.project_name).cyan());
+    println!("{}", style("═".repeat(50)).dim());
 
     println!();
-    println!("  Artifacts:  {} total", report.total);
+    println!("  {}  {} total", style("Artifacts:").bold(), ui::styled_count(report.total, false));
 
     if !report.by_kind.is_empty() {
         println!();
-        println!("  By kind:");
+        println!("  {}:", style("By kind").bold());
         for (kind, count) in &report.by_kind {
-            println!("    {:<16} {}", kind, count);
+            println!("    {:<16} {}", style(kind).cyan(), count);
         }
     }
 
     if !report.by_status.is_empty() {
         println!();
-        println!("  By status:");
+        println!("  {}:", style("By status").bold());
         for (status, count) in &report.by_status {
             let warning = if status == "draft" && *count == report.total && report.total > 0 {
-                " ⚠ ALL DRAFT"
+                format!(" {}", style("ALL DRAFT").red().bold())
             } else {
-                ""
+                String::new()
             };
-            println!("    {:<16} {}{}", status, count, warning);
+            println!("    {}  {}{}", ui::styled_status(status), count, warning);
         }
     }
 
     // At Risk
     if !report.at_risk.is_empty() {
         println!();
-        println!("  ⚠ At Risk ({}):", report.at_risk.len());
+        println!("  {} At Risk ({}):", style("!").yellow().bold(), ui::styled_count(report.at_risk.len(), true));
         for item in &report.at_risk {
-            println!("    {} \"{}\" — {}", item.id, item.title, item.reason);
+            println!("    {} \"{}\" — {}", style(&item.id).yellow(), item.title, style(&item.reason).red());
         }
     }
 
     // Blind Spots
     if !report.blind_spots.is_empty() {
         println!();
-        println!("  ● Blind Spots ({}):", report.blind_spots.len());
+        println!("  {} Blind Spots ({}):", style("●").red().bold(), ui::styled_count(report.blind_spots.len(), true));
         for spot in &report.blind_spots {
-            println!("    {} \"{}\" — {}", spot.id, spot.title, spot.issue);
+            println!("    {} \"{}\" — {}", style(&spot.id).yellow(), spot.title, style(&spot.issue).red());
         }
     }
 
     // Stale
     if report.stale_count > 0 {
         println!();
-        println!("  ⏰ Stale: {} evidence expired", report.stale_count);
+        println!("  {} Stale: {} evidence expired", style("⏰").yellow(), ui::styled_count(report.stale_count, true));
     }
 
     // Orphans
     if !report.orphans.is_empty() {
         println!();
-        println!("  ○ Orphans ({}):", report.orphans.len());
+        println!("  {} Orphans ({}):", style("○").red(), ui::styled_count(report.orphans.len(), true));
         for id in &report.orphans {
-            println!("    {} — no links", id);
+            println!("    {} — {}", style(id).yellow(), style("no links").red());
         }
     }
 
     // Next Actions
     if !report.next_actions.is_empty() {
         println!();
-        println!("  → Next actions:");
+        println!("  {} {}:", style("→").green().bold(), style("Next actions").bold());
         for (i, action) in report.next_actions.iter().enumerate() {
-            println!("    {}. {}", i + 1, action);
+            println!("    {}. {}", style(i + 1).green(), action);
         }
+    }
+
+    // Overall health summary
+    let has_issues = !report.at_risk.is_empty()
+        || !report.blind_spots.is_empty()
+        || !report.orphans.is_empty()
+        || report.stale_count > 0;
+    if !has_issues && report.total > 0 {
+        println!();
+        println!("  {}", style("Project looks healthy!").green().bold());
     }
 
     println!();

--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -1,39 +1,144 @@
 use std::env;
+use std::fs;
 
 use anyhow::Result;
+use console::style;
 
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::workspace::{find_workspace, init_workspace, FORGEPLAN_DIR};
 
-pub async fn run(force: bool) -> Result<()> {
+use crate::ui;
+
+pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     let cwd = env::current_dir()?;
 
     // Check if already initialized
     if let Some(existing) = find_workspace(&cwd) {
         if !force {
-            println!("  Already initialized at {}", existing.display());
-            println!("  Use --force to reinitialize.");
+            if non_interactive {
+                println!("  Already initialized at {}", existing.display());
+            } else {
+                cliclack::log::warning(format!(
+                    "Already initialized at {}. Use --force to reinitialize.",
+                    existing.display()
+                ))?;
+            }
             return Ok(());
         }
-        // Remove existing workspace for reinit
         tokio::fs::remove_dir_all(&existing).await?;
-        println!("  Removed existing {}", existing.display());
     }
 
-    // Derive project name from directory name
-    let project_name = cwd
+    // Non-interactive mode (for CI, tests, scripts)
+    if non_interactive {
+        let project_name = cwd
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unnamed".into());
+
+        let ws = init_workspace(&cwd, &project_name)?;
+        LanceStore::init(&ws).await?;
+
+        println!("  Initialized {}/ in {}", FORGEPLAN_DIR, cwd.display());
+        println!("  Project: {}", project_name);
+        return Ok(());
+    }
+
+    // ─── Interactive wizard ──────────────────────────────────────
+
+    ui::print_banner();
+    cliclack::intro(style(" forgeplan init ").on_cyan().black())?;
+
+    // Project name
+    let default_name = cwd
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "unnamed".into());
+        .unwrap_or_else(|| "my-project".into());
+
+    let project_name: String = cliclack::input("Project name?")
+        .placeholder(&default_name)
+        .default_input(&default_name)
+        .interact()?;
+
+    // Agent selection
+    let agents: Vec<&str> = cliclack::multiselect("Which AI agents to configure?")
+        .initial_values(vec!["claude"])
+        .item("claude", "Claude Code", ".mcp.json + CLAUDE.md section")
+        .item("cursor", "Cursor", ".mcp.json + .cursorrules")
+        .item("codex", "Codex", "AGENTS.md")
+        .item("gemini", "Gemini CLI", ".gemini/settings.json")
+        .item("copilot", "GitHub Copilot", ".github/copilot-instructions.md")
+        .interact()?;
+
+    // Spinner — create workspace
+    let spinner = cliclack::spinner();
+    spinner.start("Creating workspace...");
 
     let ws = init_workspace(&cwd, &project_name)?;
-
-    // Initialize LanceDB tables (artifacts, evidence, relations)
     LanceStore::init(&ws).await?;
 
-    println!("  Initialized {}/ in {}", FORGEPLAN_DIR, cwd.display());
-    println!("  Project: {}", project_name);
-    println!("  Config:  {}", ws.join("config.yaml").display());
-    println!("  LanceDB: {}", ws.join("lance").display());
+    spinner.stop("Workspace created");
+
+    // Generate .mcp.json if needed
+    let generate_mcp = agents.iter().any(|a| *a == "claude" || *a == "cursor");
+    if generate_mcp {
+        let mcp_path = cwd.join(".mcp.json");
+        if !mcp_path.exists() {
+            let mcp_content = serde_json::json!({
+                "mcpServers": {
+                    "forgeplan": {
+                        "command": "forgeplan",
+                        "args": ["serve"]
+                    }
+                }
+            });
+            fs::write(&mcp_path, serde_json::to_string_pretty(&mcp_content)?)?;
+            cliclack::log::success(format!(".mcp.json created"))?;
+        } else {
+            cliclack::log::info(".mcp.json already exists — skipped")?;
+        }
+    }
+
+    // Generate .cursorrules if Cursor selected
+    if agents.contains(&"cursor") {
+        let rules_path = cwd.join(".cursorrules");
+        if !rules_path.exists() {
+            let rules = include_str!("../../templates/cursorrules.md");
+            fs::write(&rules_path, rules)?;
+            cliclack::log::success(".cursorrules created")?;
+        }
+    }
+
+    // Summary
+    let mut summary_lines = vec![
+        ".forgeplan/     created".to_string(),
+        "LanceDB         initialized".to_string(),
+    ];
+    if generate_mcp {
+        summary_lines.push(".mcp.json       ready".into());
+    }
+    summary_lines.push(format!(
+        "Agents:         {}",
+        agents
+            .iter()
+            .map(|a| match *a {
+                "claude" => "Claude Code",
+                "cursor" => "Cursor",
+                "codex" => "Codex",
+                "gemini" => "Gemini CLI",
+                "copilot" => "Copilot",
+                _ => a,
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+
+    cliclack::note("Installation Summary", summary_lines.join("\n"))?;
+
+    cliclack::outro(format!(
+        "Done! Next: {} or {}",
+        style("forgeplan health").cyan(),
+        style("/forge \"your task\"").cyan()
+    ))?;
+
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -9,6 +9,9 @@ use forgeplan_core::workspace::{find_workspace, init_workspace, FORGEPLAN_DIR};
 
 use crate::ui;
 
+/// Default project name fallback (unified for both paths).
+const DEFAULT_PROJECT_NAME: &str = "my-project";
+
 pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     let cwd = env::current_dir()?;
 
@@ -25,18 +28,19 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
             }
             return Ok(());
         }
-        tokio::fs::remove_dir_all(&existing).await?;
+
+        // [SECURITY] Guard against symlink attack and workspace outside cwd
+        safe_remove_workspace(&existing, &cwd).await?;
     }
 
     // Non-interactive mode (for CI, tests, scripts)
     if non_interactive {
         let project_name = cwd
             .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unnamed".into());
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| DEFAULT_PROJECT_NAME.into());
 
-        let ws = init_workspace(&cwd, &project_name)?;
-        LanceStore::init(&ws).await?;
+        init_with_rollback(&cwd, &project_name).await?;
 
         println!("  Initialized {}/ in {}", FORGEPLAN_DIR, cwd.display());
         println!("  Project: {}", project_name);
@@ -51,12 +55,21 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     // Project name
     let default_name = cwd
         .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "my-project".into());
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| DEFAULT_PROJECT_NAME.into());
 
     let project_name: String = cliclack::input("Project name?")
         .placeholder(&default_name)
         .default_input(&default_name)
+        .validate(|input: &String| {
+            if input.len() > 128 {
+                Err("Project name too long (max 128 characters)")
+            } else if input.contains('\n') || input.contains('\r') {
+                Err("Project name cannot contain newlines")
+            } else {
+                Ok(())
+            }
+        })
         .interact()?;
 
     // Agent selection
@@ -64,47 +77,36 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
         .initial_values(vec!["claude"])
         .item("claude", "Claude Code", ".mcp.json + CLAUDE.md section")
         .item("cursor", "Cursor", ".mcp.json + .cursorrules")
-        .item("codex", "Codex", "AGENTS.md")
-        .item("gemini", "Gemini CLI", ".gemini/settings.json")
-        .item("copilot", "GitHub Copilot", ".github/copilot-instructions.md")
+        .item("codex", "Codex", "AGENTS.md (coming soon)")
+        .item("gemini", "Gemini CLI", ".gemini/settings.json (coming soon)")
+        .item("copilot", "GitHub Copilot", "copilot-instructions.md (coming soon)")
         .interact()?;
 
-    // Spinner — create workspace
+    // Spinner — create workspace (with rollback on failure)
     let spinner = cliclack::spinner();
     spinner.start("Creating workspace...");
 
-    let ws = init_workspace(&cwd, &project_name)?;
-    LanceStore::init(&ws).await?;
+    init_with_rollback(&cwd, &project_name).await?;
 
     spinner.stop("Workspace created");
 
-    // Generate .mcp.json if needed
+    // Generate agent configs
     let generate_mcp = agents.iter().any(|a| *a == "claude" || *a == "cursor");
     if generate_mcp {
-        let mcp_path = cwd.join(".mcp.json");
-        if !mcp_path.exists() {
-            let mcp_content = serde_json::json!({
-                "mcpServers": {
-                    "forgeplan": {
-                        "command": "forgeplan",
-                        "args": ["serve"]
-                    }
-                }
-            });
-            fs::write(&mcp_path, serde_json::to_string_pretty(&mcp_content)?)?;
-            cliclack::log::success(format!(".mcp.json created"))?;
-        } else {
-            cliclack::log::info(".mcp.json already exists — skipped")?;
-        }
+        generate_mcp_json(&cwd)?;
     }
 
-    // Generate .cursorrules if Cursor selected
     if agents.contains(&"cursor") {
-        let rules_path = cwd.join(".cursorrules");
-        if !rules_path.exists() {
-            let rules = include_str!("../../templates/cursorrules.md");
-            fs::write(&rules_path, rules)?;
-            cliclack::log::success(".cursorrules created")?;
+        generate_cursorrules(&cwd)?;
+    }
+
+    // Log "coming soon" for unimplemented agents
+    for agent in &agents {
+        match *agent {
+            "codex" => { cliclack::log::info("Codex: AGENTS.md support coming soon")?; }
+            "gemini" => { cliclack::log::info("Gemini CLI: config support coming soon")?; }
+            "copilot" => { cliclack::log::info("Copilot: instructions support coming soon")?; }
+            _ => {}
         }
     }
 
@@ -116,18 +118,14 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     if generate_mcp {
         summary_lines.push(".mcp.json       ready".into());
     }
+    if agents.contains(&"cursor") {
+        summary_lines.push(".cursorrules    ready".into());
+    }
     summary_lines.push(format!(
         "Agents:         {}",
         agents
             .iter()
-            .map(|a| match *a {
-                "claude" => "Claude Code",
-                "cursor" => "Cursor",
-                "codex" => "Codex",
-                "gemini" => "Gemini CLI",
-                "copilot" => "Copilot",
-                _ => a,
-            })
+            .map(|a| agent_display_name(a))
             .collect::<Vec<_>>()
             .join(", ")
     ));
@@ -141,4 +139,89 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     ))?;
 
     Ok(())
+}
+
+/// Initialize workspace + LanceDB with rollback on failure.
+/// If LanceStore::init fails, removes the partially created .forgeplan/ directory.
+async fn init_with_rollback(cwd: &std::path::Path, project_name: &str) -> Result<()> {
+    let ws = init_workspace(cwd, project_name)?;
+    if let Err(e) = LanceStore::init(&ws).await {
+        // Rollback: remove partially created workspace
+        let _ = tokio::fs::remove_dir_all(&ws).await;
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+/// Safely remove a workspace directory, guarding against symlinks and paths outside cwd.
+async fn safe_remove_workspace(
+    workspace: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Result<()> {
+    // Guard: workspace must be inside cwd
+    let canonical_ws = workspace.canonicalize().unwrap_or_else(|_| workspace.to_path_buf());
+    let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+    if !canonical_ws.starts_with(&canonical_cwd) {
+        anyhow::bail!(
+            "Workspace {} is outside current directory, refusing --force",
+            workspace.display()
+        );
+    }
+
+    // Guard: workspace must not be a symlink
+    let meta = fs::symlink_metadata(workspace)?;
+    if meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "Workspace {} is a symlink, refusing --force for safety",
+            workspace.display()
+        );
+    }
+
+    tokio::fs::remove_dir_all(workspace).await?;
+    Ok(())
+}
+
+/// Generate .mcp.json for Claude Code / Cursor.
+fn generate_mcp_json(cwd: &std::path::Path) -> Result<()> {
+    let mcp_path = cwd.join(".mcp.json");
+    if mcp_path.exists() {
+        cliclack::log::info(".mcp.json already exists — skipped")?;
+        return Ok(());
+    }
+    let mcp_content = serde_json::json!({
+        "mcpServers": {
+            "forgeplan": {
+                "command": "forgeplan",
+                "args": ["serve"]
+            }
+        }
+    });
+    fs::write(&mcp_path, serde_json::to_string_pretty(&mcp_content)?)?;
+    cliclack::log::success(".mcp.json created")?;
+    Ok(())
+}
+
+/// Generate .cursorrules for Cursor.
+fn generate_cursorrules(cwd: &std::path::Path) -> Result<()> {
+    let rules_path = cwd.join(".cursorrules");
+    if rules_path.exists() {
+        cliclack::log::info(".cursorrules already exists — skipped")?;
+        return Ok(());
+    }
+    let rules = include_str!("../../templates/cursorrules.md");
+    fs::write(&rules_path, rules)?;
+    cliclack::log::success(".cursorrules created")?;
+    Ok(())
+}
+
+/// Human-readable display name for agent ID.
+fn agent_display_name(agent: &str) -> &str {
+    match agent {
+        "claude" => "Claude Code",
+        "cursor" => "Cursor",
+        "codex" => "Codex",
+        "gemini" => "Gemini CLI",
+        "copilot" => "Copilot",
+        _ => agent,
+    }
 }

--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -50,7 +50,7 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
     // ─── Interactive wizard ──────────────────────────────────────
 
     ui::print_banner();
-    cliclack::intro(style(" forgeplan init ").on_cyan().black())?;
+    cliclack::intro(style(" forgeplan init ").bold())?;
 
     // Project name
     let default_name = cwd

--- a/crates/forgeplan-cli/src/commands/list.rs
+++ b/crates/forgeplan-cli/src/commands/list.rs
@@ -1,11 +1,14 @@
 use std::env;
 
 use anyhow::Result;
+use console::style;
 
 use forgeplan_core::db::store::{ArtifactFilter, LanceStore};
 use forgeplan_core::workspace::find_workspace;
 
-pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Result<()> {
+use crate::ui;
+
+pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>, json: bool) -> Result<()> {
     let cwd = env::current_dir()?;
     let workspace = find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
@@ -24,7 +27,25 @@ pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Resu
     let artifacts = store.list_artifacts(filter.as_ref()).await?;
 
     if artifacts.is_empty() {
-        println!("  No artifacts found.");
+        if json {
+            println!("[]");
+        } else {
+            println!("  No artifacts found.");
+        }
+        return Ok(());
+    }
+
+    if json {
+        let json_data: Vec<_> = artifacts
+            .iter()
+            .map(|a| serde_json::json!({
+                "id": a.id,
+                "kind": a.kind,
+                "status": a.status,
+                "title": a.title,
+            }))
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
         return Ok(());
     }
 
@@ -43,12 +64,13 @@ pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Resu
         .unwrap_or(6)
         .max(6);
 
-    // Print header
+    // Print header — bold underlined
     println!(
-        "{:<id_w$}  {:<kind_w$}  {:<status_w$}  Title",
-        "ID",
-        "Kind",
-        "Status",
+        "{:<id_w$}  {:<kind_w$}  {:<status_w$}  {}",
+        style("ID").bold().underlined(),
+        style("Kind").bold().underlined(),
+        style("Status").bold().underlined(),
+        style("Title").bold().underlined(),
         id_w = id_width,
         kind_w = kind_width,
         status_w = status_width,
@@ -56,15 +78,24 @@ pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>) -> Resu
 
     // Print rows
     for a in &artifacts {
+        // Pad status manually so ANSI codes don't break alignment
+        let status_plain_len = a.status.len();
+        let status_styled = ui::styled_status(&a.status);
+        let status_padding = if status_width > status_plain_len {
+            " ".repeat(status_width - status_plain_len)
+        } else {
+            String::new()
+        };
+
         println!(
-            "{:<id_w$}  {:<kind_w$}  {:<status_w$}  {}",
-            a.id,
+            "{:<id_w$}  {:<kind_w$}  {}{}  {}",
+            style(&a.id).bold(),
             a.kind,
-            a.status,
+            status_styled,
+            status_padding,
             a.title,
             id_w = id_width,
             kind_w = kind_width,
-            status_w = status_width,
         );
     }
 

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod review;
 pub mod route;
 pub mod score;
 pub mod search;
+pub mod setup_skill;
 pub mod stale;
 pub mod status;
 pub mod supersede;

--- a/crates/forgeplan-cli/src/commands/review.rs
+++ b/crates/forgeplan-cli/src/commands/review.rs
@@ -1,5 +1,6 @@
 use std::env;
 
+use console::style;
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::lifecycle;
 use forgeplan_core::workspace;
@@ -11,7 +12,36 @@ pub async fn run(id: &str) -> anyhow::Result<()> {
 
     let store = LanceStore::open(&ws).await?;
     let result = lifecycle::review(&store, id).await?;
-    print!("{result}");
+
+    // Styled output instead of plain Display
+    if result.can_activate {
+        println!("  {}", style("Review PASSED").green().bold());
+        println!("  {}", style("Ready to activate").green());
+    } else {
+        println!("  {}", style("Review FAILED").red().bold());
+        println!("  {}", style("Fix MUST issues first").red());
+    }
+
+    if !result.must_findings.is_empty() {
+        println!();
+        for finding in &result.must_findings {
+            println!("  {} [{}] {}", style("x").red().bold(), style("MUST").red().bold(), finding);
+        }
+    }
+
+    if !result.should_findings.is_empty() {
+        println!();
+        for finding in &result.should_findings {
+            println!("  {} [{}] {}", style("!").yellow(), style("SHOULD").yellow(), finding);
+        }
+    }
+
+    if !result.warnings.is_empty() {
+        println!();
+        for warning in &result.warnings {
+            println!("  {} {}", style("!").yellow().bold(), style(warning).yellow());
+        }
+    }
 
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/route.rs
+++ b/crates/forgeplan-cli/src/commands/route.rs
@@ -1,14 +1,81 @@
 use std::env;
 
+use console::style;
 use forgeplan_core::routing;
 use forgeplan_core::workspace;
+
+use crate::ui;
 
 pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
     let _cwd = env::current_dir()?;
 
     // Rule-based routing (instant, offline, no LLM)
     let result = routing::route(description);
-    print!("{result}");
+
+    // Styled depth
+    println!(
+        "## Depth: {}",
+        ui::styled_depth(&format!("{}", depth_display(&result.depth)))
+    );
+    println!();
+
+    // Styled pipeline
+    println!("{}", style("## Pipeline").bold());
+    if result.pipeline.is_empty() {
+        println!(
+            "{}",
+            style("None (tactical — just do it)").green()
+        );
+    } else {
+        let names: Vec<String> = result
+            .pipeline
+            .iter()
+            .map(|k| style(kind_display(k)).bold().white().to_string())
+            .collect();
+        println!("{}", names.join(&style(" → ").dim().to_string()));
+    }
+    println!();
+
+    // Styled triggers
+    println!("{}", style("## Triggers Matched").bold());
+    if result.triggers.is_empty() {
+        println!(
+            "{}",
+            style("No escalation triggers — defaults to Tactical").dim()
+        );
+    } else {
+        for t in &result.triggers {
+            println!(
+                "- {}: {} → {}+",
+                style(&t.id).yellow(),
+                t.description,
+                ui::styled_depth(&format!("{}", depth_display(&t.minimum_depth)))
+            );
+        }
+    }
+    println!();
+
+    // Styled confidence
+    let conf_pct = result.confidence * 100.0;
+    let styled_conf = if conf_pct > 70.0 {
+        style(format!("{:.0}%", conf_pct)).green()
+    } else if conf_pct > 50.0 {
+        style(format!("{:.0}%", conf_pct)).yellow()
+    } else {
+        style(format!("{:.0}%", conf_pct)).red()
+    };
+    println!("## Confidence: {}", styled_conf);
+
+    // Next step
+    if !result.pipeline.is_empty() {
+        println!();
+        println!("{}", style("## Next Step").bold());
+        let first = kind_display(&result.pipeline[0]);
+        println!(
+            "  {}",
+            style(format!("forgeplan new {} \"<title>\"", first.to_lowercase())).cyan()
+        );
+    }
 
     // Optional LLM explanation
     if explain {
@@ -29,4 +96,30 @@ pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn depth_display(mode: &forgeplan_core::artifact::types::Mode) -> &'static str {
+    use forgeplan_core::artifact::types::Mode;
+    match mode {
+        Mode::Note => "Note",
+        Mode::Tactical => "Tactical",
+        Mode::Standard => "Standard",
+        Mode::Deep => "Deep/Critical",
+    }
+}
+
+fn kind_display(kind: &forgeplan_core::artifact::types::ArtifactKind) -> &'static str {
+    use forgeplan_core::artifact::types::ArtifactKind;
+    match kind {
+        ArtifactKind::Epic => "Epic",
+        ArtifactKind::Prd => "PRD",
+        ArtifactKind::Spec => "Spec",
+        ArtifactKind::Rfc => "RFC",
+        ArtifactKind::Adr => "ADR",
+        ArtifactKind::Note => "Note",
+        ArtifactKind::ProblemCard => "Problem",
+        ArtifactKind::SolutionPortfolio => "Solution",
+        ArtifactKind::EvidencePack => "Evidence",
+        ArtifactKind::RefreshReport => "Refresh",
+    }
 }

--- a/crates/forgeplan-cli/src/commands/setup_skill.rs
+++ b/crates/forgeplan-cli/src/commands/setup_skill.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+use anyhow::Result;
+
+pub async fn run() -> Result<()> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
+
+    let skill_dir = home.join(".claude").join("skills").join("forge");
+    fs::create_dir_all(&skill_dir)?;
+
+    let skill_content = include_str!("../../../../skills/forge/SKILL.md");
+
+    let skill_path = skill_dir.join("SKILL.md");
+    fs::write(&skill_path, skill_content)?;
+
+    println!("  Installed /forge skill to {}", skill_path.display());
+    println!("  Use /forge in Claude Code to activate Forgeplan workflow");
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -1,11 +1,14 @@
 use std::env;
 
+use console::style;
 use forgeplan_core::artifact::types::{ArtifactKind, Mode};
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::validation::{self, Severity, ValidationResult};
 use forgeplan_core::workspace;
 
-pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
+use crate::ui;
+
+pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -37,21 +40,42 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
     let mut total_errors = 0;
     let mut total_warnings = 0;
     let mut total_passed = 0;
+    let mut json_results = Vec::new();
 
     for record in &to_validate {
         let fm = record.frontmatter_map();
 
         let kind = record.kind.parse::<ArtifactKind>().unwrap_or_else(|_| {
-            eprintln!(
-                "  Warning: unknown artifact kind '{}', applying base rules only",
-                record.kind
-            );
+            if !json {
+                eprintln!(
+                    "  Warning: unknown artifact kind '{}', applying base rules only",
+                    record.kind
+                );
+            }
             ArtifactKind::Note
         });
         let depth = record.depth.parse::<Mode>().unwrap_or(Mode::Standard);
 
         let result = validation::validate(&record.id, &record.body, &fm, &kind, &depth);
-        print_result(&result, &record.title, &depth);
+
+        if json {
+            json_results.push(serde_json::json!({
+                "artifact_id": result.artifact_id,
+                "kind": result.kind,
+                "depth": result.depth,
+                "passed": result.passed(),
+                "errors": result.error_count(),
+                "warnings": result.warning_count(),
+                "findings": result.findings.iter().map(|f| serde_json::json!({
+                    "rule_id": f.rule_id,
+                    "severity": format!("{:?}", f.severity),
+                    "message": f.message,
+                    "section": f.section,
+                })).collect::<Vec<_>>(),
+            }));
+        } else {
+            print_result(&result, &record.title, &depth);
+        }
 
         total_errors += result.error_count();
         total_warnings += result.warning_count();
@@ -60,14 +84,16 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
         }
     }
 
-    if to_validate.len() > 1 {
+    if json {
+        println!("{}", serde_json::to_string_pretty(&json_results)?);
+    } else if to_validate.len() > 1 {
         println!();
         println!(
             "Summary: {} artifact(s), {} passed, {} error(s), {} warning(s)",
             to_validate.len(),
-            total_passed,
-            total_errors,
-            total_warnings
+            ui::styled_count(total_passed, false),
+            ui::styled_count(total_errors, true),
+            ui::styled_count(total_warnings, total_warnings > 0),
         );
     }
 
@@ -78,43 +104,53 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
 }
 
 fn print_result(result: &ValidationResult, title: &str, depth: &Mode) {
+    let depth_str = format!("{:?}", depth);
     println!();
     println!(
-        "{} \"{}\" (depth: {:?})",
-        result.artifact_id, title, depth
+        "{} \"{}\" (depth: {})",
+        style(&result.artifact_id).bold(),
+        title,
+        ui::styled_depth(&depth_str),
     );
-    println!("{}", "─".repeat(50));
+    println!("{}", style("─".repeat(50)).dim());
 
     if result.findings.is_empty() {
-        println!("  All checks passed!");
+        println!("  {}", style("All checks passed!").green().bold());
     } else {
         for f in &result.findings {
             let icon = match f.severity {
-                Severity::Must => "x",
-                Severity::Should => "!",
-                Severity::Could => "~",
+                Severity::Must => style("x").red().bold().to_string(),
+                Severity::Should => style("!").yellow().to_string(),
+                Severity::Could => style("~").dim().to_string(),
+            };
+            let severity_str = match f.severity {
+                Severity::Must => "MUST",
+                Severity::Should => "SHOULD",
+                Severity::Could => "COULD",
             };
             println!(
                 "  {} [{}] {}: {}",
-                icon, f.severity, f.rule_id, f.message
+                icon,
+                ui::styled_severity(severity_str),
+                style(&f.rule_id).dim(),
+                f.message
             );
         }
     }
 
-    let passed = result.findings.is_empty();
-    let status = if passed {
-        "PASS"
+    let no_findings = result.findings.is_empty();
+    let status_styled = if no_findings {
+        style("PASS").green().bold()
     } else if result.passed() {
-        "PASS (with warnings)"
+        style("PASS (with warnings)").green()
     } else {
-        "FAIL"
+        style("FAIL").red().bold()
     };
     println!();
     println!(
         "  Result: {} -- {} error(s), {} warning(s)",
-        status,
-        result.error_count(),
-        result.warning_count()
+        status_styled,
+        ui::styled_count(result.error_count(), true),
+        ui::styled_count(result.warning_count(), result.warning_count() > 0),
     );
 }
-

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -37,6 +37,9 @@ enum Commands {
         /// Filter by status (draft, active, etc.)
         #[arg(long, short)]
         status: Option<String>,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Show project status dashboard
     Status,
@@ -44,6 +47,9 @@ enum Commands {
     Validate {
         /// Artifact ID (validates all if omitted)
         id: Option<String>,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Compute R_eff quality score for decisions with evidence
     Score {
@@ -171,6 +177,8 @@ enum Commands {
         #[arg(long)]
         reason: String,
     },
+    /// Install /forge skill for Claude Code
+    SetupSkill,
     /// FPF Dashboard — bounded contexts, quality scores, explore-exploit actions
     Fpf,
     /// Show F-G-R quality scores (Formality, Granularity, Reliability)
@@ -194,6 +202,9 @@ enum Commands {
         /// Compact one-line output for hooks/scripts
         #[arg(long)]
         compact: bool,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Capture a decision from conversation into a Note or ADR artifact
     Capture {
@@ -214,11 +225,11 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Commands::Init { force, yes } => commands::init::run(force, yes).await,
         Commands::New { kind, title } => commands::new::run(&kind, &title).await,
-        Commands::List { r#type, status } => {
-            commands::list::run(r#type.as_deref(), status.as_deref()).await
+        Commands::List { r#type, status, json } => {
+            commands::list::run(r#type.as_deref(), status.as_deref(), json).await
         }
         Commands::Status => commands::status::run().await,
-        Commands::Validate { id } => commands::validate::run(id.as_deref()).await,
+        Commands::Validate { id, json } => commands::validate::run(id.as_deref(), json).await,
         Commands::Score { id } => commands::score::run(id.as_deref()).await,
         Commands::Link {
             source,
@@ -264,7 +275,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Journal { r#type, risk } => {
             commands::journal::run(r#type.as_deref(), risk).await
         }
-        Commands::Health { compact } => commands::health::run(compact).await,
+        Commands::Health { compact, json } => commands::health::run(compact, json).await,
         Commands::Route {
             description,
             explain,
@@ -273,6 +284,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Activate { id } => commands::activate::run(&id).await,
         Commands::Supersede { id, by } => commands::supersede::run(&id, &by).await,
         Commands::Deprecate { id, reason } => commands::deprecate::run(&id, &reason).await,
+        Commands::SetupSkill => commands::setup_skill::run().await,
         Commands::Fpf => commands::fpf::run().await,
         Commands::Fgr { id } => commands::fgr::run(id.as_deref()).await,
         Commands::Capture { decision, context } => {

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod ui;
 
 use clap::{Parser, Subcommand};
 
@@ -17,6 +18,9 @@ enum Commands {
         /// Force reinitialize even if .forgeplan/ exists
         #[arg(long)]
         force: bool,
+        /// Non-interactive mode (skip prompts, use defaults)
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
     /// Create a new artifact from template
     New {
@@ -208,7 +212,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { force } => commands::init::run(force).await,
+        Commands::Init { force, yes } => commands::init::run(force, yes).await,
         Commands::New { kind, title } => commands::new::run(&kind, &title).await,
         Commands::List { r#type, status } => {
             commands::list::run(r#type.as_deref(), status.as_deref()).await

--- a/crates/forgeplan-cli/src/ui.rs
+++ b/crates/forgeplan-cli/src/ui.rs
@@ -1,0 +1,64 @@
+//! CLI UI helpers — cliclack wrappers, banner, styled output.
+
+use console::style;
+
+pub const BANNER: &str = r#"
+    ███████╗ ██████╗  ██╗
+    ██╔════╝ ██╔══██╗ ██║
+    █████╗   ██████╔╝ ██║
+    ██╔══╝   ██╔═══╝  ██║
+    ██║      ██║      ███████╗
+    ╚═╝      ╚═╝      ╚══════╝"#;
+
+/// Print the FPL banner with version.
+pub fn print_banner() {
+    println!("{}", style(BANNER).cyan());
+    println!(
+        "     {} — v{}",
+        style("forge your plan").dim(),
+        env!("CARGO_PKG_VERSION")
+    );
+    println!();
+}
+
+/// Style a status string with appropriate color.
+pub fn styled_status(status: &str) -> String {
+    match status {
+        "active" => style(status).green().bold().to_string(),
+        "draft" => style(status).dim().to_string(),
+        "superseded" => style(status).yellow().to_string(),
+        "deprecated" => style(status).red().strikethrough().to_string(),
+        _ => status.to_string(),
+    }
+}
+
+/// Style a depth level with appropriate color.
+pub fn styled_depth(depth: &str) -> String {
+    match depth.to_lowercase().as_str() {
+        "tactical" => style(depth).green().to_string(),
+        "standard" => style(depth).cyan().to_string(),
+        "deep" | "deep/critical" => style(depth).red().bold().to_string(),
+        _ => depth.to_string(),
+    }
+}
+
+/// Style a severity level.
+pub fn styled_severity(severity: &str) -> String {
+    match severity {
+        "MUST" => style(severity).red().bold().to_string(),
+        "SHOULD" => style(severity).yellow().to_string(),
+        "COULD" => style(severity).dim().to_string(),
+        _ => severity.to_string(),
+    }
+}
+
+/// Format a count with color based on whether it's good or bad.
+pub fn styled_count(count: usize, is_problem: bool) -> String {
+    if is_problem && count > 0 {
+        style(count.to_string()).red().bold().to_string()
+    } else if count > 0 {
+        style(count.to_string()).green().to_string()
+    } else {
+        style(count.to_string()).dim().to_string()
+    }
+}

--- a/crates/forgeplan-cli/src/ui.rs
+++ b/crates/forgeplan-cli/src/ui.rs
@@ -62,3 +62,50 @@ pub fn styled_count(count: usize, is_problem: bool) -> String {
         style(count.to_string()).dim().to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn styled_status_all_variants() {
+        // Verify no panics and non-empty output for all known statuses
+        assert!(!styled_status("active").is_empty());
+        assert!(!styled_status("draft").is_empty());
+        assert!(!styled_status("superseded").is_empty());
+        assert!(!styled_status("deprecated").is_empty());
+        assert!(!styled_status("unknown").is_empty());
+    }
+
+    #[test]
+    fn styled_depth_all_variants() {
+        assert!(!styled_depth("tactical").is_empty());
+        assert!(!styled_depth("standard").is_empty());
+        assert!(!styled_depth("deep").is_empty());
+        assert!(!styled_depth("deep/critical").is_empty());
+        assert!(!styled_depth("Deep").is_empty()); // case insensitive
+        assert!(!styled_depth("TACTICAL").is_empty());
+    }
+
+    #[test]
+    fn styled_severity_all_variants() {
+        assert!(!styled_severity("MUST").is_empty());
+        assert!(!styled_severity("SHOULD").is_empty());
+        assert!(!styled_severity("COULD").is_empty());
+        assert!(!styled_severity("OTHER").is_empty());
+    }
+
+    #[test]
+    fn styled_count_zero_and_nonzero() {
+        assert!(!styled_count(0, false).is_empty());
+        assert!(!styled_count(5, false).is_empty());
+        assert!(!styled_count(3, true).is_empty());
+        assert!(!styled_count(0, true).is_empty());
+    }
+
+    #[test]
+    fn banner_contains_fpl() {
+        assert!(BANNER.contains("███████╗"));
+        assert!(BANNER.contains("██████╔╝"));
+    }
+}

--- a/crates/forgeplan-cli/src/ui.rs
+++ b/crates/forgeplan-cli/src/ui.rs
@@ -12,7 +12,7 @@ pub const BANNER: &str = r#"
 
 /// Print the FPL banner with version.
 pub fn print_banner() {
-    println!("{}", style(BANNER).cyan());
+    println!("{}", style(BANNER).bold());
     println!(
         "     {} — v{}",
         style("forge your plan").dim(),

--- a/crates/forgeplan-cli/templates/cursorrules.md
+++ b/crates/forgeplan-cli/templates/cursorrules.md
@@ -1,0 +1,24 @@
+# Forgeplan Rules for Cursor
+
+## Before coding any non-trivial task
+
+1. Run `forgeplan route "task description"` to determine depth
+2. If Standard+ → create artifact: `forgeplan new prd "title"`
+3. Fill ALL required sections (Problem, Goals, Non-Goals, Target Users, FR, Related)
+4. Run `forgeplan validate` → must PASS before coding
+
+## After implementation
+
+1. Create evidence: `forgeplan new evidence "what was proven"`
+2. Link evidence: `forgeplan link EVID-XXX PRD-XXX --relation informs`
+3. Review and activate: `forgeplan review PRD-XXX` → `forgeplan activate PRD-XXX`
+
+## MCP Server
+
+Forgeplan MCP server is available via `.mcp.json`. Key tools:
+- `forgeplan_health` — project state
+- `forgeplan_route` — depth + pipeline
+- `forgeplan_new` — create artifact
+- `forgeplan_validate` — check quality
+- `forgeplan_review` — lifecycle check
+- `forgeplan_activate` — draft → active

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -11,7 +11,7 @@ fn init_creates_workspace() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success()
@@ -29,14 +29,14 @@ fn init_idempotent_without_force() {
 
     // First init succeeds
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
 
     // Second init succeeds but warns
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success()
@@ -48,7 +48,7 @@ fn new_creates_artifact() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -77,7 +77,7 @@ fn new_auto_increments_id() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -102,7 +102,7 @@ fn list_shows_artifacts() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -127,7 +127,7 @@ fn status_shows_dashboard() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -151,7 +151,7 @@ fn validate_checks_artifact() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -175,7 +175,7 @@ fn link_creates_relationship() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -205,7 +205,7 @@ fn graph_outputs_mermaid() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -243,7 +243,7 @@ fn search_finds_content() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -268,7 +268,7 @@ fn stale_runs_without_error() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -286,7 +286,7 @@ fn score_without_evidence() {
     let tmp = TempDir::new().unwrap();
 
     forgeplan()
-        .arg("init")
+        .args(["init", "-y"])
         .current_dir(tmp.path())
         .assert()
         .success();
@@ -309,7 +309,7 @@ fn score_without_evidence() {
 fn duplicate_link_rejected() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan().args(["new", "prd", "P"]).current_dir(tmp.path()).assert().success();
     forgeplan().args(["new", "rfc", "R"]).current_dir(tmp.path()).assert().success();
 
@@ -333,7 +333,7 @@ fn duplicate_link_rejected() {
 fn validate_exits_nonzero_on_must_errors() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
 
     // Create a PRD via CLI (goes into LanceDB)
     forgeplan()
@@ -356,7 +356,7 @@ fn validate_exits_nonzero_on_must_errors() {
 fn stale_detects_expired_artifact() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
 
     // Create an evidence artifact via CLI (goes into LanceDB + projection)
     forgeplan()
@@ -397,7 +397,7 @@ fn no_workspace_gives_error() {
 fn get_reads_artifact() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "prd", "Get Test Feature"])
         .current_dir(tmp.path())
@@ -419,7 +419,7 @@ fn get_reads_artifact() {
 fn get_nonexistent_fails() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
 
     forgeplan()
         .args(["get", "PRD-999"])
@@ -433,7 +433,7 @@ fn get_nonexistent_fails() {
 fn update_changes_status() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "prd", "Update Test"])
         .current_dir(tmp.path())
@@ -462,7 +462,7 @@ fn update_changes_status() {
 fn update_changes_title() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "rfc", "Old Title"])
         .current_dir(tmp.path())
@@ -481,7 +481,7 @@ fn update_changes_title() {
 fn update_nothing_fails() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "prd", "Test"])
         .current_dir(tmp.path())
@@ -500,7 +500,7 @@ fn update_nothing_fails() {
 fn delete_requires_confirmation() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "prd", "Delete Test"])
         .current_dir(tmp.path())
@@ -527,7 +527,7 @@ fn delete_requires_confirmation() {
 fn delete_with_yes_removes_artifact() {
     let tmp = TempDir::new().unwrap();
 
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
     forgeplan()
         .args(["new", "prd", "To Be Deleted"])
         .current_dir(tmp.path())
@@ -558,7 +558,7 @@ fn full_workflow_dogfood() {
     let tmp = TempDir::new().unwrap();
 
     // 1. Init
-    forgeplan().arg("init").current_dir(tmp.path()).assert().success();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
 
     // 2. Create PRD
     forgeplan()

--- a/crates/forgeplan-core/src/routing/signals.rs
+++ b/crates/forgeplan-core/src/routing/signals.rs
@@ -78,6 +78,14 @@ const KEYWORD_TRIGGERS: &[KeywordTrigger] = &[
         min_depth: Mode::Standard,
         weight: 0.6,
     },
+    // Redesign / Overhaul → Standard+
+    KeywordTrigger {
+        keywords: &["redesign", "overhaul", "rewrite", "refactor all", "rework", "revamp"],
+        id: "keyword:redesign",
+        description: "Major redesign or overhaul detected",
+        min_depth: Mode::Standard,
+        weight: 0.6,
+    },
 ];
 
 /// Extract signals from a text description (task description or artifact body).
@@ -230,6 +238,12 @@ mod tests {
     fn irreversible_triggers_deep() {
         let signals = extract("This is an irreversible database migration");
         assert!(signals.iter().any(|s| s.id == "reversibility:low"));
+    }
+
+    #[test]
+    fn redesign_triggers_standard() {
+        let signals = extract("Redesign the entire CLI with new UI framework");
+        assert!(signals.iter().any(|s| s.id == "keyword:redesign"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **cliclack interactive init** — FPL banner, project name, agent multiselect, .mcp.json/.cursorrules generation
- **Styled output** — health (colored statuses), validate (MUST red/SHOULD yellow), review (styled checklist), route (depth colors), list (colored table)
- **--json flag** — machine-readable output for health, validate, list
- **setup-skill** — `forgeplan setup-skill` installs /forge to ~/.claude/skills/
- **PROB-006 fix** — routing now detects "redesign/overhaul/rewrite" as Standard+
- **Audit fixes** — rollback on init failure, symlink guard, input validation

## Stats
- 12/12 FR implemented
- 231 tests pass
- 4-agent audit: 6.8/10 → all findings fixed
- Sprint: 2 waves, 4 agents
- R_eff = 1.00 (EVID-006)

## Test plan
- [x] `forgeplan health` — colored statuses, icons
- [x] `forgeplan validate PRD-001` — MUST/SHOULD/COULD colors
- [x] `forgeplan route "OAuth2 auth"` — depth colors
- [x] `forgeplan list` — status colors
- [x] `forgeplan health --json` — JSON output
- [x] `forgeplan setup-skill` — installs skill
- [x] `forgeplan route "Redesign CLI"` — returns Standard+
- [x] 231 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)