### PR TITLE
[PRD-009/010/011] Export/import, adversarial validation, agent hooks

### DIFF
--- a/crates/forgeplan-cli/src/commands/export.rs
+++ b/crates/forgeplan-cli/src/commands/export.rs
@@ -1,0 +1,75 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::workspace;
+
+pub async fn run(output: Option<&str>) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+
+    let records = store.list_records(None).await?;
+    let artifacts: Vec<serde_json::Value> = records
+        .iter()
+        .map(|r| {
+            serde_json::json!({
+                "id": r.id,
+                "kind": r.kind,
+                "status": r.status,
+                "title": r.title,
+                "body": r.body,
+                "depth": r.depth,
+                "author": r.author,
+                "parent_epic": r.parent_epic,
+                "r_eff_score": r.r_eff_score,
+                "valid_until": r.valid_until,
+                "created_at": r.created_at,
+                "updated_at": r.updated_at,
+            })
+        })
+        .collect();
+
+    let all_relations = store.get_all_relations().await?;
+    let relations: Vec<serde_json::Value> = all_relations
+        .into_iter()
+        .map(|(source, target, relation)| {
+            serde_json::json!({
+                "source": source,
+                "target": target,
+                "relation": relation,
+            })
+        })
+        .collect();
+
+    let artifact_count = artifacts.len();
+    let relation_count = relations.len();
+
+    let data = serde_json::json!({
+        "version": 1,
+        "artifacts": artifacts,
+        "relations": relations,
+    });
+
+    let json = serde_json::to_string_pretty(&data)?;
+
+    let path = output.unwrap_or(".forgeplan/export.json");
+    let full_path = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        cwd.join(path)
+    };
+
+    if let Some(parent) = full_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&full_path, &json)?;
+
+    println!(
+        "Exported {} artifacts, {} relations to {}",
+        artifact_count, relation_count, full_path.display()
+    );
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/import_cmd.rs
+++ b/crates/forgeplan-cli/src/commands/import_cmd.rs
@@ -1,0 +1,83 @@
+use std::env;
+
+use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::workspace;
+
+pub async fn run(path: &str, force: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let full_path = if std::path::Path::new(path).is_absolute() {
+        std::path::PathBuf::from(path)
+    } else {
+        cwd.join(path)
+    };
+
+    let json = std::fs::read_to_string(&full_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read '{}': {}", full_path.display(), e))?;
+    let data: serde_json::Value = serde_json::from_str(&json)
+        .map_err(|e| anyhow::anyhow!("Invalid export JSON: {}", e))?;
+
+    let artifacts = data["artifacts"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Missing 'artifacts' array in export file"))?;
+
+    let store = LanceStore::open(&ws).await?;
+
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+
+    for art in artifacts {
+        let id = art["id"].as_str().unwrap_or_default();
+        if id.is_empty() {
+            continue;
+        }
+
+        let existing = store.get_record(id).await?;
+        if existing.is_some() && !force {
+            skipped += 1;
+            continue;
+        }
+
+        if existing.is_some() {
+            store.delete_artifact(id).await?;
+        }
+
+        let new_artifact = NewArtifact {
+            id: id.to_string(),
+            kind: art["kind"].as_str().unwrap_or("note").to_string(),
+            status: art["status"].as_str().unwrap_or("draft").to_string(),
+            title: art["title"].as_str().unwrap_or("").to_string(),
+            body: art["body"].as_str().unwrap_or("").to_string(),
+            depth: art["depth"].as_str().unwrap_or("standard").to_string(),
+            author: art["author"].as_str().map(String::from),
+            parent_epic: art["parent_epic"].as_str().map(String::from),
+            valid_until: art["valid_until"].as_str().map(String::from),
+        };
+
+        store.create_artifact(&new_artifact).await?;
+        imported += 1;
+    }
+
+    let mut relations_imported = 0usize;
+    if let Some(relations) = data["relations"].as_array() {
+        for rel in relations {
+            let source = rel["source"].as_str().unwrap_or_default();
+            let target = rel["target"].as_str().unwrap_or_default();
+            let relation = rel["relation"].as_str().unwrap_or("informs");
+            if !source.is_empty() && !target.is_empty() {
+                if store.add_relation(source, target, relation).await.is_ok() {
+                    relations_imported += 1;
+                }
+            }
+        }
+    }
+
+    println!(
+        "Imported {} artifacts ({} skipped), {} relations",
+        imported, skipped, relations_imported
+    );
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -6,12 +6,15 @@ pub mod decay;
 pub mod decompose;
 pub mod delete;
 pub mod deprecate;
+pub mod export;
+
 pub mod fgr;
 pub mod fpf;
 pub mod generate;
 pub mod get;
 pub mod graph;
 pub mod health;
+pub mod import_cmd;
 pub mod init;
 pub mod journal;
 pub mod link;

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -3,12 +3,12 @@ use std::env;
 use console::style;
 use forgeplan_core::artifact::types::{ArtifactKind, Mode};
 use forgeplan_core::db::store::LanceStore;
-use forgeplan_core::validation::{self, Severity, ValidationResult};
+use forgeplan_core::validation::{self, adversarial, Severity, ValidationResult};
 use forgeplan_core::workspace;
 
 use crate::ui;
 
-pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
+pub async fn run(id: Option<&str>, json: bool, adversarial: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -56,7 +56,14 @@ pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
         });
         let depth = record.depth.parse::<Mode>().unwrap_or(Mode::Standard);
 
-        let result = validation::validate(&record.id, &record.body, &fm, &kind, &depth);
+        let mut result = validation::validate(&record.id, &record.body, &fm, &kind, &depth);
+
+        if adversarial {
+            let adv_findings = adversarial::adversarial_checks(&record.body, &record.kind);
+            let adv_count = adv_findings.len();
+            result.findings.extend(adv_findings);
+            result.total_rules_checked += adv_count;
+        }
 
         if json {
             json_results.push(serde_json::json!({

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -50,6 +50,9 @@ enum Commands {
         /// Output as JSON for machine consumption
         #[arg(long)]
         json: bool,
+        /// Run adversarial (devil's advocate) review
+        #[arg(long)]
+        adversarial: bool,
     },
     /// Compute R_eff quality score for decisions with evidence
     Score {
@@ -214,6 +217,20 @@ enum Commands {
         #[arg(long)]
         context: Option<String>,
     },
+    /// Export all artifacts to JSON file
+    Export {
+        /// Output file path (default: .forgeplan/export.json)
+        #[arg(long, short)]
+        output: Option<String>,
+    },
+    /// Import artifacts from JSON file
+    Import {
+        /// Path to JSON export file
+        path: String,
+        /// Overwrite existing artifacts
+        #[arg(long)]
+        force: bool,
+    },
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -229,7 +246,9 @@ async fn main() -> anyhow::Result<()> {
             commands::list::run(r#type.as_deref(), status.as_deref(), json).await
         }
         Commands::Status => commands::status::run().await,
-        Commands::Validate { id, json } => commands::validate::run(id.as_deref(), json).await,
+        Commands::Validate { id, json, adversarial } => {
+            commands::validate::run(id.as_deref(), json, adversarial).await
+        }
         Commands::Score { id } => commands::score::run(id.as_deref()).await,
         Commands::Link {
             source,
@@ -290,6 +309,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Capture { decision, context } => {
             commands::capture::run(&decision, context.as_deref()).await
         }
+        Commands::Export { output } => commands::export::run(output.as_deref()).await,
+        Commands::Import { path, force } => commands::import_cmd::run(&path, force).await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -35,7 +35,7 @@ pub struct NewArtifact {
 }
 
 /// Full artifact record from LanceDB — includes body and all metadata.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ArtifactRecord {
     pub id: String,
     pub kind: String,

--- a/crates/forgeplan-core/src/export/mod.rs
+++ b/crates/forgeplan-core/src/export/mod.rs
@@ -1,0 +1,220 @@
+use serde::{Deserialize, Serialize};
+
+use crate::db::store::{ArtifactRecord, LanceStore, NewArtifact};
+
+/// Full export of all artifacts + relations.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExportData {
+    pub version: String,
+    pub exported_at: String,
+    pub artifacts: Vec<ArtifactRecord>,
+    pub relations: Vec<(String, String, String)>,
+}
+
+/// Result of an import operation.
+#[derive(Debug)]
+pub struct ImportResult {
+    pub created: usize,
+    pub skipped: usize,
+    pub relations_created: usize,
+}
+
+/// Export all data from LanceStore to ExportData.
+pub async fn export_all(store: &LanceStore) -> anyhow::Result<ExportData> {
+    let artifacts = store.list_records(None).await?;
+    let relations = store.get_all_relations().await?;
+
+    Ok(ExportData {
+        version: "1.0".to_string(),
+        exported_at: chrono::Utc::now().to_rfc3339(),
+        artifacts,
+        relations,
+    })
+}
+
+/// Import data into LanceStore. Skip existing artifacts unless force=true.
+pub async fn import_all(
+    store: &LanceStore,
+    data: &ExportData,
+    force: bool,
+) -> anyhow::Result<ImportResult> {
+    let mut created = 0usize;
+    let mut skipped = 0usize;
+
+    for record in &data.artifacts {
+        let exists = store.get_record(&record.id).await?.is_some();
+
+        if exists && !force {
+            skipped += 1;
+            continue;
+        }
+
+        if exists {
+            // force: delete existing, then re-create
+            store.delete_artifact(&record.id).await?;
+        }
+
+        let new = NewArtifact {
+            id: record.id.clone(),
+            kind: record.kind.clone(),
+            status: record.status.clone(),
+            title: record.title.clone(),
+            body: record.body.clone(),
+            depth: record.depth.clone(),
+            author: record.author.clone(),
+            parent_epic: record.parent_epic.clone(),
+            valid_until: record.valid_until.clone(),
+        };
+        store.create_artifact(&new).await?;
+        created += 1;
+    }
+
+    let mut relations_created = 0usize;
+    for (source, target, relation) in &data.relations {
+        store.add_relation(source, target, relation).await?;
+        relations_created += 1;
+    }
+
+    Ok(ImportResult {
+        created,
+        skipped,
+        relations_created,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::store::LanceStore;
+    use tempfile::TempDir;
+
+    async fn make_store() -> (LanceStore, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let store = LanceStore::init(&ws).await.unwrap();
+        (store, tmp)
+    }
+
+    #[tokio::test]
+    async fn export_empty_store() {
+        let (store, _tmp) = make_store().await;
+        let data = export_all(&store).await.unwrap();
+        assert_eq!(data.version, "1.0");
+        assert!(data.artifacts.is_empty());
+        assert!(data.relations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_with_data() {
+        let (store, _tmp) = make_store().await;
+
+        let artifact = NewArtifact {
+            id: "prd-001".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Test PRD".to_string(),
+            body: "# Test\n\nBody".to_string(),
+            depth: "standard".to_string(),
+            author: Some("test".to_string()),
+            parent_epic: None,
+            valid_until: None,
+        };
+        store.create_artifact(&artifact).await.unwrap();
+
+        let data = export_all(&store).await.unwrap();
+        assert_eq!(data.artifacts.len(), 1);
+        assert_eq!(data.artifacts[0].id, "prd-001");
+        assert_eq!(data.artifacts[0].title, "Test PRD");
+    }
+
+    #[tokio::test]
+    async fn import_skip_existing() {
+        let (store, _tmp) = make_store().await;
+
+        let artifact = NewArtifact {
+            id: "prd-001".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Original".to_string(),
+            body: "body".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+        };
+        store.create_artifact(&artifact).await.unwrap();
+
+        let data = ExportData {
+            version: "1.0".to_string(),
+            exported_at: "2026-01-01T00:00:00Z".to_string(),
+            artifacts: vec![ArtifactRecord {
+                id: "prd-001".to_string(),
+                kind: "prd".to_string(),
+                status: "draft".to_string(),
+                title: "Imported".to_string(),
+                body: "new body".to_string(),
+                depth: "standard".to_string(),
+                author: None,
+                parent_epic: None,
+                r_eff_score: 0.0,
+                valid_until: None,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-01T00:00:00Z".to_string(),
+            }],
+            relations: vec![],
+        };
+
+        let result = import_all(&store, &data, false).await.unwrap();
+        assert_eq!(result.created, 0);
+        assert_eq!(result.skipped, 1);
+
+        // Title unchanged
+        let rec = store.get_record("prd-001").await.unwrap().unwrap();
+        assert_eq!(rec.title, "Original");
+    }
+
+    #[tokio::test]
+    async fn import_force_overwrites() {
+        let (store, _tmp) = make_store().await;
+
+        let artifact = NewArtifact {
+            id: "prd-002".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Original".to_string(),
+            body: "body".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+        };
+        store.create_artifact(&artifact).await.unwrap();
+
+        let data = ExportData {
+            version: "1.0".to_string(),
+            exported_at: "2026-01-01T00:00:00Z".to_string(),
+            artifacts: vec![ArtifactRecord {
+                id: "prd-002".to_string(),
+                kind: "prd".to_string(),
+                status: "active".to_string(),
+                title: "Overwritten".to_string(),
+                body: "new body".to_string(),
+                depth: "deep".to_string(),
+                author: Some("importer".to_string()),
+                parent_epic: None,
+                r_eff_score: 0.5,
+                valid_until: None,
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+                updated_at: "2026-01-01T00:00:00Z".to_string(),
+            }],
+            relations: vec![],
+        };
+
+        let result = import_all(&store, &data, true).await.unwrap();
+        assert_eq!(result.created, 1);
+        assert_eq!(result.skipped, 0);
+
+        let rec = store.get_record("prd-002").await.unwrap().unwrap();
+        assert_eq!(rec.title, "Overwritten");
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -19,4 +19,5 @@ pub mod search;
 pub mod stale;
 pub mod template;
 pub mod validation;
+pub mod export;
 pub mod workspace;

--- a/crates/forgeplan-core/src/validation/adversarial.rs
+++ b/crates/forgeplan-core/src/validation/adversarial.rs
@@ -1,0 +1,155 @@
+use crate::validation::{Finding, Severity};
+
+/// Additional adversarial checks — content quality, not just structure.
+/// Implements devil's advocate review: MUST find at least 1 issue.
+pub fn adversarial_checks(body: &str, kind: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let lower = body.to_lowercase();
+
+    // Check 1: Vague words without measurable metrics
+    let vague = [
+        "улучшить",
+        "ускорить",
+        "повысить",
+        "оптимизировать",
+        "improve",
+        "enhance",
+        "optimize",
+        "better",
+        "faster",
+    ];
+    for word in &vague {
+        if let Some(pos) = lower.find(word) {
+            // Check if there's a number nearby (within 80 chars)
+            let start = pos.saturating_sub(40);
+            let end = (pos + word.len() + 40).min(lower.len());
+            let nearby = &lower[start..end];
+            let has_metric = nearby.chars().any(|c| c.is_ascii_digit());
+            if !has_metric {
+                findings.push(Finding {
+                    rule_id: "adversarial-vague".into(),
+                    severity: Severity::Should,
+                    message: format!(
+                        "Vague word '{}' without measurable metric nearby",
+                        word
+                    ),
+                    section: None,
+                });
+                break; // one finding per vague category
+            }
+        }
+    }
+
+    // Check 2: RFC without alternatives/options considered
+    if kind == "rfc"
+        && !lower.contains("option")
+        && !lower.contains("alternative")
+        && !lower.contains("variant")
+        && !lower.contains("вариант")
+    {
+        findings.push(Finding {
+            rule_id: "adversarial-no-alternatives".into(),
+            severity: Severity::Should,
+            message: "RFC has no alternatives/options section — single-option proposals lack rigor"
+                .into(),
+            section: Some("Options".into()),
+        });
+    }
+
+    // Check 3: PRD without risk assessment
+    if kind == "prd" && !lower.contains("risk") && !lower.contains("риск") {
+        findings.push(Finding {
+            rule_id: "adversarial-no-risks".into(),
+            severity: Severity::Should,
+            message: "PRD has no risk assessment — what could go wrong?".into(),
+            section: Some("Risks".into()),
+        });
+    }
+
+    // Check 4: ADR without trade-offs or downsides
+    if kind == "adr"
+        && !lower.contains("trade")
+        && !lower.contains("downside")
+        && !lower.contains("disadvantage")
+        && !lower.contains("недостат")
+        && !lower.contains("компромисс")
+    {
+        findings.push(Finding {
+            rule_id: "adversarial-no-tradeoffs".into(),
+            severity: Severity::Should,
+            message: "ADR has no trade-offs or downsides — every decision has costs".into(),
+            section: Some("Trade-offs".into()),
+        });
+    }
+
+    // Check 5: Adversarial MUST find >= 1 issue (BMAD rule)
+    if findings.is_empty() {
+        findings.push(Finding {
+            rule_id: "adversarial-too-clean".into(),
+            severity: Severity::Could,
+            message:
+                "Adversarial found 0 issues — either perfect or review was insufficient".into(),
+            section: None,
+        });
+    }
+
+    findings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn always_finds_at_least_one_issue() {
+        let findings = adversarial_checks("Perfect document with no issues.", "note");
+        assert!(!findings.is_empty());
+        assert_eq!(findings[0].rule_id, "adversarial-too-clean");
+    }
+
+    #[test]
+    fn detects_vague_words() {
+        let findings = adversarial_checks("We need to improve the system.", "prd");
+        assert!(findings.iter().any(|f| f.rule_id == "adversarial-vague"));
+    }
+
+    #[test]
+    fn vague_word_with_metric_ok() {
+        let findings =
+            adversarial_checks("We need to improve latency by 50ms to meet SLA.", "note");
+        assert!(!findings.iter().any(|f| f.rule_id == "adversarial-vague"));
+    }
+
+    #[test]
+    fn rfc_without_alternatives() {
+        let findings = adversarial_checks("## Proposal\nUse Redis for caching.", "rfc");
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == "adversarial-no-alternatives"));
+    }
+
+    #[test]
+    fn rfc_with_alternatives_ok() {
+        let body = "## Proposal\nUse Redis.\n## Alternative\nUse Memcached.";
+        let findings = adversarial_checks(body, "rfc");
+        assert!(!findings
+            .iter()
+            .any(|f| f.rule_id == "adversarial-no-alternatives"));
+    }
+
+    #[test]
+    fn prd_without_risks() {
+        let findings = adversarial_checks("## Goals\nBuild auth system.", "prd");
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == "adversarial-no-risks"));
+    }
+
+    #[test]
+    fn adr_without_tradeoffs() {
+        let findings = adversarial_checks("## Decision\nUse Rust.", "adr");
+        assert!(findings
+            .iter()
+            .any(|f| f.rule_id == "adversarial-no-tradeoffs"));
+    }
+}

--- a/crates/forgeplan-core/src/validation/mod.rs
+++ b/crates/forgeplan-core/src/validation/mod.rs
@@ -1,3 +1,4 @@
+pub mod adversarial;
 pub mod checks;
 pub mod rules;
 

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -266,6 +266,22 @@ struct ProgressParams {
     id: Option<String>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ExportParams {
+    /// Optional output file path. If omitted, returns JSON directly.
+    #[serde(default)]
+    output: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ImportParams {
+    /// JSON export data as a string
+    data: String,
+    /// Overwrite existing artifacts (default: false)
+    #[serde(default)]
+    force: Option<bool>,
+}
+
 // ── Tool implementations ─────────────────────────────────────
 
 #[tool_router]
@@ -1450,6 +1466,160 @@ impl ForgeplanServer {
             provider: llm_config.provider,
             model: llm_config.model,
         }))
+    }
+
+    #[tool(description = "Export all artifacts and relations to a JSON bundle. Returns the exported data directly for programmatic use, or writes to a file path.")]
+    async fn forgeplan_export(
+        &self,
+        Parameters(p): Parameters<ExportParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let records = store
+            .list_records(None)
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let artifacts: Vec<serde_json::Value> = records
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "kind": r.kind,
+                    "status": r.status,
+                    "title": r.title,
+                    "body": r.body,
+                    "depth": r.depth,
+                    "author": r.author,
+                    "parent_epic": r.parent_epic,
+                    "r_eff_score": r.r_eff_score,
+                    "valid_until": r.valid_until,
+                    "created_at": r.created_at,
+                    "updated_at": r.updated_at,
+                })
+            })
+            .collect();
+
+        let all_relations = store
+            .get_all_relations()
+            .await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let relations: Vec<serde_json::Value> = all_relations
+            .into_iter()
+            .map(|(s, t, r)| serde_json::json!({"source": s, "target": t, "relation": r}))
+            .collect();
+
+        let data = serde_json::json!({
+            "version": 1,
+            "artifacts": artifacts,
+            "relations": relations,
+        });
+
+        if let Some(ref output_path) = p.output {
+            let ws = match self.require_workspace().await {
+                Ok(ws) => ws,
+                Err(e) => return Ok(err_result(&e)),
+            };
+            let full_path = if std::path::Path::new(output_path).is_absolute() {
+                std::path::PathBuf::from(output_path)
+            } else {
+                ws.parent().unwrap_or(&ws).join(output_path)
+            };
+            let json_str = serde_json::to_string_pretty(&data)
+                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+            tokio::fs::write(&full_path, &json_str)
+                .await
+                .map_err(|e| McpError::internal_error(format!("Write failed: {e}"), None))?;
+            return Ok(text_result(&format!(
+                "Exported {} artifacts, {} relations to {}",
+                artifacts.len(),
+                relations.len(),
+                full_path.display()
+            )));
+        }
+
+        Ok(json_result(&data))
+    }
+
+    #[tool(description = "Import artifacts and relations from a JSON export bundle. Set force=true to overwrite existing artifacts.")]
+    async fn forgeplan_import(
+        &self,
+        Parameters(p): Parameters<ImportParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let data: serde_json::Value = serde_json::from_str(&p.data).map_err(|e| {
+            McpError::internal_error(format!("Invalid JSON: {e}"), None)
+        })?;
+
+        let artifacts = data["artifacts"]
+            .as_array()
+            .ok_or_else(|| McpError::internal_error("Missing 'artifacts' array", None))?;
+
+        let force = p.force.unwrap_or(false);
+        let mut imported = 0usize;
+        let mut skipped = 0usize;
+
+        for art in artifacts {
+            let id = art["id"].as_str().unwrap_or_default();
+            if id.is_empty() {
+                continue;
+            }
+
+            let existing = store.get_record(id).await.unwrap_or(None);
+            if existing.is_some() && !force {
+                skipped += 1;
+                continue;
+            }
+
+            if existing.is_some() {
+                let _ = store.delete_artifact(id).await;
+            }
+
+            let new_art = NewArtifact {
+                id: id.to_string(),
+                kind: art["kind"].as_str().unwrap_or("note").to_string(),
+                status: art["status"].as_str().unwrap_or("draft").to_string(),
+                title: art["title"].as_str().unwrap_or("").to_string(),
+                body: art["body"].as_str().unwrap_or("").to_string(),
+                depth: art["depth"].as_str().unwrap_or("standard").to_string(),
+                author: art["author"].as_str().map(String::from),
+                parent_epic: art["parent_epic"].as_str().map(String::from),
+                valid_until: art["valid_until"].as_str().map(String::from),
+            };
+
+            if let Err(e) = store.create_artifact(&new_art).await {
+                return Ok(err_result(&format!("Failed to import {}: {}", id, e)));
+            }
+            imported += 1;
+        }
+
+        let mut relations_imported = 0usize;
+        if let Some(relations) = data["relations"].as_array() {
+            for rel in relations {
+                let source = rel["source"].as_str().unwrap_or_default();
+                let target = rel["target"].as_str().unwrap_or_default();
+                let relation = rel["relation"].as_str().unwrap_or("informs");
+                if !source.is_empty() && !target.is_empty() {
+                    if store.add_relation(source, target, relation).await.is_ok() {
+                        relations_imported += 1;
+                    }
+                }
+            }
+        }
+
+        Ok(json_result(&serde_json::json!({
+            "imported": imported,
+            "skipped": skipped,
+            "relations_imported": relations_imported,
+        })))
     }
 }
 

--- a/docs/guides/AGENT-HOOKS.md
+++ b/docs/guides/AGENT-HOOKS.md
@@ -1,0 +1,123 @@
+# Agent Hooks — Auto-integrate Forgeplan with AI Agents
+
+Forgeplan can automatically provide project context to AI agents through hooks.
+This guide covers integration with Claude Code, but the same principles apply to any agent framework.
+
+## SessionStart Hook (Claude Code)
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "command": "forgeplan health --compact --json 2>/dev/null || true"
+      }
+    ]
+  }
+}
+```
+
+This runs `forgeplan health` at the start of every prompt, giving the agent project context automatically.
+
+### What the agent sees
+
+`forgeplan health --compact --json` returns a compact JSON payload (< 500 tokens):
+
+```json
+{
+  "total": 27,
+  "active": 11,
+  "draft": 16,
+  "blind_spots": 0,
+  "at_risk": 2,
+  "stale": 1,
+  "next_action": "Review EVID-003 — evidence expires in 3 days"
+}
+```
+
+This tells the agent:
+- How many artifacts exist and their status breakdown
+- Whether there are blind spots (decisions without evidence)
+- What the most urgent next action is
+
+## PostToolUse Hook
+
+Remind the agent to capture decisions after significant file changes:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "command": "echo '[Forgeplan] Consider: does this change represent a decision worth capturing? Use forgeplan capture if so.'"
+      }
+    ]
+  }
+}
+```
+
+This is intentionally lightweight — a text reminder, not an automated action.
+
+## Route-Before-Work Hook
+
+Auto-determine depth before starting work on a task:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "implement|build|create|add feature",
+        "command": "forgeplan route \"$PROMPT\" --json 2>/dev/null || true"
+      }
+    ]
+  }
+}
+```
+
+The agent receives routing guidance:
+```json
+{
+  "depth": "Standard",
+  "pipeline": ["PRD", "RFC"],
+  "confidence": 85
+}
+```
+
+## MCP Server (Recommended)
+
+For deeper integration, run Forgeplan as an MCP server:
+
+```bash
+forgeplan serve
+```
+
+This exposes all 26+ tools via MCP stdio transport, giving the agent full CRUD access to artifacts, validation, scoring, and search without needing CLI hooks.
+
+### Claude Code MCP config
+
+Add to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "forgeplan": {
+      "command": "forgeplan",
+      "args": ["serve"],
+      "cwd": "/path/to/your/project"
+    }
+  }
+}
+```
+
+## Best Practices
+
+1. **Start with health** — the SessionStart hook gives the agent situational awareness
+2. **MCP > hooks** — MCP provides structured tool access; hooks are text-only
+3. **Keep hooks lightweight** — `2>/dev/null || true` prevents hook failures from blocking the agent
+4. **Don't over-automate** — the PostToolUse hook should suggest, not force artifact creation
+5. **Route before work** — helps the agent decide whether to create artifacts or just code


### PR DESCRIPTION
## Summary
- **Export/Import** (PRD-009): `forgeplan export/import` for data safety backup
- **Adversarial Validation** (PRD-011): `forgeplan validate --adversarial` devil's advocate mode
- **Agent Hooks** (PRD-010): docs/guides/AGENT-HOOKS.md for SessionStart/PostToolUse
- 242 tests pass, +864 LOC

## Test plan
- [x] `forgeplan export` → creates JSON dump
- [x] `forgeplan import export.json` → restores artifacts
- [x] `forgeplan validate --adversarial PRD-001` → finds content issues
- [x] 242 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)