### PR TITLE
[PRD-021] Embedded FPF Knowledge Base — ingest, search, ADI integration

### DIFF
--- a/crates/forgeplan-cli/src/commands/fpf.rs
+++ b/crates/forgeplan-cli/src/commands/fpf.rs
@@ -1,10 +1,13 @@
 use std::env;
+use std::path::PathBuf;
 
-use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::db::store::{FpfChunk, LanceStore};
 use forgeplan_core::fpf;
+use forgeplan_core::fpf::knowledge;
 use forgeplan_core::workspace;
 
-pub async fn run() -> anyhow::Result<()> {
+/// FPF Dashboard (original command, now `forgeplan fpf dashboard`)
+pub async fn run_dashboard() -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -13,5 +16,140 @@ pub async fn run() -> anyhow::Result<()> {
     let dashboard = fpf::dashboard(&store).await?;
     print!("{dashboard}");
 
+    Ok(())
+}
+
+/// `forgeplan fpf ingest [--path <dir>]`
+pub async fn run_ingest(path: Option<&str>) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let fpf_path = match path {
+        Some(p) => PathBuf::from(p),
+        None => knowledge::default_fpf_path().ok_or_else(|| {
+            anyhow::anyhow!("FPF spec not found. Use --path to specify location")
+        })?,
+    };
+
+    println!("  Ingesting FPF spec from {}...", fpf_path.display());
+
+    let chunks = knowledge::ingest_fpf_directory(&fpf_path).await?;
+    println!("  Parsed {} sections", chunks.len());
+
+    // Use init() to ensure fpf_spec table exists
+    let store = LanceStore::init(&ws).await?;
+
+    // Clear existing FPF data and re-ingest
+    if store.has_fpf() {
+        store.clear_fpf().await?;
+    }
+
+    // Convert IngestChunk to FpfChunk
+    let now = chrono::Utc::now().to_rfc3339();
+    let fpf_chunks: Vec<FpfChunk> = chunks
+        .iter()
+        .map(|c| FpfChunk {
+            id: c.id.clone(),
+            section_id: c.section_id.clone(),
+            parent_section: c.parent_section.clone(),
+            title: c.title.clone(),
+            body: c.body.clone(),
+            line_count: c.line_count,
+            file_path: c.file_path.clone(),
+            created_at: now.clone(),
+        })
+        .collect();
+
+    let count = store.insert_fpf_chunks(&fpf_chunks).await?;
+    println!("  Ingested {} FPF sections into LanceDB", count);
+    Ok(())
+}
+
+/// `forgeplan fpf search <query> [--limit N]`
+pub async fn run_search(query: &str, limit: usize) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let results = store.search_fpf(query, limit).await?;
+
+    if results.is_empty() {
+        println!("  No FPF sections match '{}'", query);
+        println!("  Hint: Run `forgeplan fpf ingest` first");
+        return Ok(());
+    }
+
+    println!();
+    for (i, chunk) in results.iter().enumerate() {
+        let snippet: String = chunk
+            .body
+            .lines()
+            .take(3)
+            .collect::<Vec<_>>()
+            .join(" ")
+            .chars()
+            .take(200)
+            .collect();
+        println!("  {}. [{}] {}", i + 1, chunk.section_id, chunk.title);
+        println!("     {} ({} lines)", snippet, chunk.line_count);
+        println!();
+    }
+    Ok(())
+}
+
+/// `forgeplan fpf section <id> [--summary]`
+pub async fn run_section(id: &str, summary: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let chunk = store
+        .get_fpf_section(id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("FPF section '{}' not found", id))?;
+
+    println!();
+    println!("## {} — {}", chunk.section_id, chunk.title);
+    println!();
+    if summary {
+        let preview: String = chunk.body.chars().take(500).collect();
+        println!("{}", preview);
+        if chunk.body.len() > 500 {
+            println!(
+                "\n  ... ({} more chars. Use without --summary for full text)",
+                chunk.body.len() - 500
+            );
+        }
+    } else {
+        println!("{}", chunk.body);
+    }
+    Ok(())
+}
+
+/// `forgeplan fpf list`
+pub async fn run_list() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let sections = store.list_fpf_sections().await?;
+
+    if sections.is_empty() {
+        println!("  No FPF sections loaded. Run `forgeplan fpf ingest` first.");
+        return Ok(());
+    }
+
+    println!();
+    println!("  {:10}  {:5}  {}", "Section", "Lines", "Title");
+    println!("  {}", "-".repeat(60));
+    for s in &sections {
+        println!("  {:10}  {:5}  {}", s.section_id, s.line_count, s.title);
+    }
+    println!();
+    println!("  {} sections total", sections.len());
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/fpf.rs
+++ b/crates/forgeplan-cli/src/commands/fpf.rs
@@ -129,6 +129,82 @@ pub async fn run_section(id: &str, summary: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `forgeplan fpf status`
+pub async fn run_status() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    println!();
+    println!("FPF Knowledge Base Status");
+    println!("{}", "=".repeat(40));
+
+    // Check source
+    let source_path = knowledge::default_fpf_path();
+    let source_count = match &source_path {
+        Some(p) => {
+            println!("  Source:    {} (exists)", p.display());
+            count_md_files(p).await
+        }
+        None => {
+            println!("  Source:    not found (set fpf.path in config or install fpf-simple skill)");
+            0
+        }
+    };
+    if source_count > 0 {
+        println!("  Files:     {} markdown files", source_count);
+    }
+
+    // Check ingested
+    let store = LanceStore::open(&ws).await?;
+    if store.has_fpf() {
+        let sections = store.list_fpf_sections().await?;
+        if sections.is_empty() {
+            println!("  Ingested:  empty (run `forgeplan fpf ingest`)");
+        } else {
+            let total_lines: i32 = sections.iter().map(|s| s.line_count).sum();
+            println!("  Ingested:  {} sections, {} total lines", sections.len(), total_lines);
+
+            // Staleness check
+            if source_count > 0 && source_count != sections.len() {
+                println!("  Status:    STALE — source has {} files, ingested has {} sections",
+                    source_count, sections.len());
+                println!("  Action:    Run `forgeplan fpf ingest` to re-sync");
+            } else if source_count > 0 {
+                println!("  Status:    UP TO DATE");
+            }
+        }
+    } else {
+        println!("  Ingested:  not initialized");
+        println!("  Action:    Run `forgeplan fpf ingest` to load FPF spec");
+    }
+
+    println!();
+    Ok(())
+}
+
+async fn count_md_files(dir: &std::path::Path) -> usize {
+    let mut count = 0;
+    if let Ok(mut rd) = tokio::fs::read_dir(dir).await {
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let p = entry.path();
+            if p.is_dir() {
+                if let Ok(mut sub) = tokio::fs::read_dir(&p).await {
+                    while let Ok(Some(sub_entry)) = sub.next_entry().await {
+                        let sp = sub_entry.path();
+                        if sp.extension().map_or(false, |e| e == "md")
+                            && sp.file_name().map_or(false, |n| n != "_index.md")
+                        {
+                            count += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    count
+}
+
 /// `forgeplan fpf list`
 pub async fn run_list() -> anyhow::Result<()> {
     let cwd = env::current_dir()?;

--- a/crates/forgeplan-cli/src/commands/reason.rs
+++ b/crates/forgeplan-cli/src/commands/reason.rs
@@ -4,7 +4,7 @@ use forgeplan_core::db::store::{LanceStore, NewArtifact};
 use forgeplan_core::llm::reason;
 use forgeplan_core::workspace::{self, load_config};
 
-pub async fn run(id: &str, json: bool, save: bool) -> anyhow::Result<()> {
+pub async fn run(id: &str, json: bool, save: bool, fpf: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -18,6 +18,26 @@ pub async fn run(id: &str, json: bool, save: bool) -> anyhow::Result<()> {
         .await?
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' not found", id))?;
 
+    // Build FPF context if requested
+    let fpf_context = if fpf {
+        match reason::build_fpf_context(&store, &record.title, &record.body).await {
+            Ok(ctx) => {
+                if ctx.is_some() {
+                    println!("  FPF context injected into ADI prompt");
+                } else {
+                    println!("  No FPF sections found (run `forgeplan fpf ingest` first)");
+                }
+                ctx
+            }
+            Err(e) => {
+                eprintln!("  Warning: FPF context lookup failed: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     println!(
         "  Analyzing {} with ADI cycle ({}/{})...\n",
         record.id, llm_config.provider, llm_config.model
@@ -29,6 +49,7 @@ pub async fn run(id: &str, json: bool, save: bool) -> anyhow::Result<()> {
         &record.title,
         &record.kind,
         &record.body,
+        fpf_context.as_deref(),
     )
     .await?;
 

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -270,6 +270,8 @@ enum FpfCommands {
     },
     /// List all FPF sections
     List,
+    /// Show FPF knowledge base status — source, ingested count, staleness
+    Status,
 }
 
 #[tokio::main]
@@ -352,6 +354,7 @@ async fn main() -> anyhow::Result<()> {
             FpfCommands::Search { query, limit } => commands::fpf::run_search(&query, limit).await,
             FpfCommands::Section { id, summary } => commands::fpf::run_section(&id, summary).await,
             FpfCommands::List => commands::fpf::run_list().await,
+            FpfCommands::Status => commands::fpf::run_status().await,
         },
         Commands::Fgr { id } => commands::fgr::run(id.as_deref()).await,
         Commands::Capture { decision, context } => {

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -113,6 +113,9 @@ enum Commands {
         /// Save ADI analysis as a Note artifact linked to the source
         #[arg(long)]
         save: bool,
+        /// Inject relevant FPF patterns into the ADI prompt
+        #[arg(long)]
+        fpf: bool,
     },
     /// Decompose a PRD into RFC tasks using AI
     Decompose {
@@ -185,8 +188,9 @@ enum Commands {
     },
     /// Install /forge skill for Claude Code
     SetupSkill,
-    /// FPF Dashboard — bounded contexts, quality scores, explore-exploit actions
-    Fpf,
+    /// FPF Knowledge Base — dashboard, ingest, search, sections
+    #[command(subcommand)]
+    Fpf(FpfCommands),
     /// Show F-G-R quality scores (Formality, Granularity, Reliability)
     Fgr {
         /// Artifact ID (scores all if omitted)
@@ -238,6 +242,36 @@ enum Commands {
     Serve,
 }
 
+#[derive(Subcommand)]
+enum FpfCommands {
+    /// Show FPF dashboard — bounded contexts, quality scores, explore-exploit actions
+    Dashboard,
+    /// Ingest FPF spec into knowledge base
+    Ingest {
+        /// Path to FPF sections directory
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Search FPF knowledge base
+    Search {
+        /// Search query
+        query: String,
+        /// Max results
+        #[arg(long, default_value = "5")]
+        limit: usize,
+    },
+    /// Show a specific FPF section
+    Section {
+        /// Section ID (e.g. "B.3", "C.2.2")
+        id: String,
+        /// Show summary only (first 500 chars)
+        #[arg(long)]
+        summary: bool,
+    },
+    /// List all FPF sections
+    List,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -273,7 +307,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::Generate { kind, description } => {
             commands::generate::run(&kind, &description).await
         }
-        Commands::Reason { id, json, save } => commands::reason::run(&id, json, save).await,
+        Commands::Reason {
+            id,
+            json,
+            save,
+            fpf,
+        } => commands::reason::run(&id, json, save, fpf).await,
         Commands::Decompose { id } => commands::decompose::run(&id).await,
         Commands::Get { id } => commands::get::run(&id).await,
         Commands::Update {
@@ -307,7 +346,13 @@ async fn main() -> anyhow::Result<()> {
         Commands::Supersede { id, by } => commands::supersede::run(&id, &by).await,
         Commands::Deprecate { id, reason } => commands::deprecate::run(&id, &reason).await,
         Commands::SetupSkill => commands::setup_skill::run().await,
-        Commands::Fpf => commands::fpf::run().await,
+        Commands::Fpf(sub) => match sub {
+            FpfCommands::Dashboard => commands::fpf::run_dashboard().await,
+            FpfCommands::Ingest { path } => commands::fpf::run_ingest(path.as_deref()).await,
+            FpfCommands::Search { query, limit } => commands::fpf::run_search(&query, limit).await,
+            FpfCommands::Section { id, summary } => commands::fpf::run_section(&id, summary).await,
+            FpfCommands::List => commands::fpf::run_list().await,
+        },
         Commands::Fgr { id } => commands::fgr::run(id.as_deref()).await,
         Commands::Capture { decision, context } => {
             commands::capture::run(&decision, context.as_deref()).await

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -87,6 +87,30 @@ pub fn relations_schema() -> Arc<Schema> {
     ]))
 }
 
+/// Arrow schema for the `fpf_spec` table — FPF knowledge base chunks.
+///
+/// Columns:
+/// - id            Utf8 (not null) — unique chunk ID: "fpf-B.3-001"
+/// - section_id    Utf8 (not null) — FPF section ID: "B.3", "C.2.2", "A.1"
+/// - parent_section Utf8 (nullable) — parent section: "07-part-b"
+/// - title         Utf8 (not null) — section title
+/// - body          LargeUtf8 (not null) — full markdown content
+/// - line_count    Int32 (not null) — number of lines
+/// - file_path     Utf8 (not null) — original file path
+/// - created_at    Utf8 (not null) — ISO datetime of ingestion
+pub fn fpf_spec_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("section_id", DataType::Utf8, false),
+        Field::new("parent_section", DataType::Utf8, true),
+        Field::new("title", DataType::Utf8, false),
+        Field::new("body", DataType::LargeUtf8, false),
+        Field::new("line_count", DataType::Int32, false),
+        Field::new("file_path", DataType::Utf8, false),
+        Field::new("created_at", DataType::Utf8, false),
+    ]))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +177,31 @@ mod tests {
         assert!(names.contains(&"target_id"));
         assert!(names.contains(&"relation_type"));
         assert!(names.contains(&"created_at"));
+    }
+
+    #[test]
+    fn fpf_spec_schema_has_required_columns() {
+        let schema = fpf_spec_schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"id"));
+        assert!(names.contains(&"section_id"));
+        assert!(names.contains(&"parent_section"));
+        assert!(names.contains(&"title"));
+        assert!(names.contains(&"body"));
+        assert!(names.contains(&"line_count"));
+        assert!(names.contains(&"file_path"));
+        assert!(names.contains(&"created_at"));
+    }
+
+    #[test]
+    fn fpf_spec_schema_nullable_fields() {
+        let schema = fpf_spec_schema();
+        let nullable: Vec<&str> = schema
+            .fields()
+            .iter()
+            .filter(|f| f.is_nullable())
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(nullable, vec!["parent_section"]);
     }
 }

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -642,25 +642,43 @@ impl LanceStore {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
 
-        let escaped = query.to_lowercase().replace('\'', "''");
+        let query_lower = query.to_lowercase();
+        let escaped = query_lower.replace('\'', "''");
         let filter = format!(
             "LOWER(title) LIKE '%{}%' OR LOWER(body) LIKE '%{}%'",
             escaped, escaped
         );
 
+        // Fetch more candidates than needed, then rank by relevance
+        let fetch_limit = (limit * 10).min(200);
         let batches = collect_batches(
-            table.query().only_if(filter).limit(limit).execute().await?,
+            table.query().only_if(filter).limit(fetch_limit).execute().await?,
         )
         .await?;
 
-        let mut results = Vec::new();
+        let mut scored: Vec<(FpfChunk, usize)> = Vec::new();
         for batch in &batches {
             for i in 0..batch.num_rows() {
                 if let Some(chunk) = extract_fpf_chunk(batch, i) {
-                    results.push(chunk);
+                    // Simple relevance: title match = 10 points, body occurrence = 1 point each
+                    let mut score = 0usize;
+                    let title_lower = chunk.title.to_lowercase();
+                    let body_lower = chunk.body.to_lowercase();
+
+                    if title_lower.contains(&query_lower) {
+                        score += 10;
+                    }
+                    // Count occurrences in body
+                    score += body_lower.matches(&query_lower).count();
+
+                    scored.push((chunk, score));
                 }
             }
         }
+
+        // Sort by score descending, then truncate
+        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        let results: Vec<FpfChunk> = scored.into_iter().take(limit).map(|(c, _)| c).collect();
         Ok(results)
     }
 

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -91,6 +91,27 @@ impl ArtifactRecord {
     }
 }
 
+/// FPF knowledge base chunk.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FpfChunk {
+    pub id: String,
+    pub section_id: String,
+    pub parent_section: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub line_count: i32,
+    pub file_path: String,
+    pub created_at: String,
+}
+
+/// FPF chunk summary (without body for listing).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FpfChunkSummary {
+    pub section_id: String,
+    pub title: String,
+    pub line_count: i32,
+}
+
 /// LanceDB-backed artifact store.
 pub struct LanceStore {
     _db: Connection,
@@ -98,6 +119,7 @@ pub struct LanceStore {
     #[allow(dead_code)]
     evidence: Table,
     relations: Table,
+    fpf_spec: Option<Table>,
 }
 
 impl LanceStore {
@@ -109,12 +131,14 @@ impl LanceStore {
         let artifacts = db.open_table("artifacts").execute().await?;
         let evidence = db.open_table("evidence").execute().await?;
         let relations = db.open_table("relations").execute().await?;
+        let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
 
         Ok(Self {
             _db: db,
             artifacts,
             evidence,
             relations,
+            fpf_spec,
         })
     }
 
@@ -147,15 +171,24 @@ impl LanceStore {
             db.create_table("relations", vec![batch]).execute().await?;
         }
 
+        // Create fpf_spec table if not present
+        if !existing_tables.contains(&"fpf_spec".to_string()) {
+            let schema = schema::fpf_spec_schema();
+            let batch = empty_fpf_batch(schema.clone())?;
+            db.create_table("fpf_spec", vec![batch]).execute().await?;
+        }
+
         let artifacts = db.open_table("artifacts").execute().await?;
         let evidence = db.open_table("evidence").execute().await?;
         let relations = db.open_table("relations").execute().await?;
+        let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
 
         Ok(Self {
             _db: db,
             artifacts,
             evidence,
             relations,
+            fpf_spec,
         })
     }
 
@@ -559,6 +592,144 @@ impl LanceStore {
         }
         Ok(results)
     }
+
+    // ── FPF Knowledge Base ───────────────────────────────────────────
+
+    /// Check if FPF knowledge base is loaded.
+    pub fn has_fpf(&self) -> bool {
+        self.fpf_spec.is_some()
+    }
+
+    /// Insert FPF chunks in batch.
+    pub async fn insert_fpf_chunks(&self, chunks: &[FpfChunk]) -> anyhow::Result<usize> {
+        let table = self
+            .fpf_spec
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized. Run `forgeplan fpf ingest`"))?;
+
+        let ids: Vec<&str> = chunks.iter().map(|c| c.id.as_str()).collect();
+        let section_ids: Vec<&str> = chunks.iter().map(|c| c.section_id.as_str()).collect();
+        let parent_sections: Vec<Option<&str>> =
+            chunks.iter().map(|c| c.parent_section.as_deref()).collect();
+        let titles: Vec<&str> = chunks.iter().map(|c| c.title.as_str()).collect();
+        let bodies: Vec<&str> = chunks.iter().map(|c| c.body.as_str()).collect();
+        let line_counts: Vec<i32> = chunks.iter().map(|c| c.line_count).collect();
+        let file_paths: Vec<&str> = chunks.iter().map(|c| c.file_path.as_str()).collect();
+        let created_ats: Vec<&str> = chunks.iter().map(|c| c.created_at.as_str()).collect();
+
+        let batch = RecordBatch::try_new(
+            schema::fpf_spec_schema(),
+            vec![
+                Arc::new(StringArray::from(ids)),
+                Arc::new(StringArray::from(section_ids)),
+                Arc::new(StringArray::from(parent_sections)),
+                Arc::new(StringArray::from(titles)),
+                Arc::new(arrow_array::LargeStringArray::from(bodies)),
+                Arc::new(Int32Array::from(line_counts)),
+                Arc::new(StringArray::from(file_paths)),
+                Arc::new(StringArray::from(created_ats)),
+            ],
+        )?;
+
+        table.add(vec![batch]).execute().await?;
+        Ok(chunks.len())
+    }
+
+    /// Search FPF spec by keyword (case-insensitive substring match on title + body).
+    pub async fn search_fpf(&self, query: &str, limit: usize) -> anyhow::Result<Vec<FpfChunk>> {
+        let table = self
+            .fpf_spec
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
+
+        let escaped = query.to_lowercase().replace('\'', "''");
+        let filter = format!(
+            "LOWER(title) LIKE '%{}%' OR LOWER(body) LIKE '%{}%'",
+            escaped, escaped
+        );
+
+        let batches = collect_batches(
+            table.query().only_if(filter).limit(limit).execute().await?,
+        )
+        .await?;
+
+        let mut results = Vec::new();
+        for batch in &batches {
+            for i in 0..batch.num_rows() {
+                if let Some(chunk) = extract_fpf_chunk(batch, i) {
+                    results.push(chunk);
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Get a specific FPF section by section_id.
+    pub async fn get_fpf_section(&self, section_id: &str) -> anyhow::Result<Option<FpfChunk>> {
+        let table = self
+            .fpf_spec
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
+
+        let filter = format!("section_id = '{}'", section_id.replace('\'', "''"));
+        let batches = collect_batches(
+            table.query().only_if(filter).limit(1).execute().await?,
+        )
+        .await?;
+
+        for batch in &batches {
+            if batch.num_rows() > 0 {
+                return Ok(extract_fpf_chunk(batch, 0));
+            }
+        }
+        Ok(None)
+    }
+
+    /// List all FPF sections (without body content for performance).
+    pub async fn list_fpf_sections(&self) -> anyhow::Result<Vec<FpfChunkSummary>> {
+        let table = self
+            .fpf_spec
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
+
+        let batches = collect_batches(table.query().execute().await?).await?;
+
+        let mut results = Vec::new();
+        for batch in &batches {
+            let id_col = batch
+                .column_by_name("section_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let title_col = batch
+                .column_by_name("title")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let lines_col = batch
+                .column_by_name("line_count")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+
+            if let (Some(ids), Some(titles), Some(lines)) = (id_col, title_col, lines_col) {
+                for i in 0..batch.num_rows() {
+                    if !ids.is_null(i) {
+                        results.push(FpfChunkSummary {
+                            section_id: ids.value(i).to_string(),
+                            title: titles.value(i).to_string(),
+                            line_count: lines.value(i),
+                        });
+                    }
+                }
+            }
+        }
+        Ok(results)
+    }
+
+    /// Delete all FPF chunks (for re-ingestion).
+    pub async fn clear_fpf(&self) -> anyhow::Result<()> {
+        let table = self
+            .fpf_spec
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
+        table.delete("id IS NOT NULL").await?;
+        Ok(())
+    }
 }
 
 /// Collect a stream of RecordBatches into a Vec.
@@ -662,6 +833,36 @@ fn get_f64(batch: &RecordBatch, col: &str, row: usize) -> Option<f64> {
     }
 }
 
+/// Extract an FpfChunk from a RecordBatch row.
+fn extract_fpf_chunk(batch: &RecordBatch, row: usize) -> Option<FpfChunk> {
+    let id = get_string(batch, "id", row)?;
+    let section_id = get_string(batch, "section_id", row)?;
+    let parent_section = get_string(batch, "parent_section", row);
+    let title = get_string(batch, "title", row)?;
+    let body = get_large_string(batch, "body", row)?;
+    let line_count = {
+        let array = batch.column_by_name("line_count")?;
+        let arr = array.as_any().downcast_ref::<Int32Array>()?;
+        if arr.is_null(row) {
+            return None;
+        }
+        arr.value(row)
+    };
+    let file_path = get_string(batch, "file_path", row)?;
+    let created_at = get_string(batch, "created_at", row)?;
+
+    Some(FpfChunk {
+        id,
+        section_id,
+        parent_section,
+        title,
+        body,
+        line_count,
+        file_path,
+        created_at,
+    })
+}
+
 /// Create an empty RecordBatch for artifacts (used when initializing tables).
 fn empty_artifacts_batch(
     schema: Arc<arrow_schema::Schema>,
@@ -716,6 +917,24 @@ fn empty_relations_batch(
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
+        ],
+    )
+}
+
+fn empty_fpf_batch(
+    schema: Arc<arrow_schema::Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(StringArray::from(Vec::<&str>::new())),       // id
+            Arc::new(StringArray::from(Vec::<&str>::new())),       // section_id
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // parent_section (nullable)
+            Arc::new(StringArray::from(Vec::<&str>::new())),       // title
+            Arc::new(arrow_array::LargeStringArray::from(Vec::<&str>::new())), // body
+            Arc::new(Int32Array::from(Vec::<i32>::new())),         // line_count
+            Arc::new(StringArray::from(Vec::<&str>::new())),       // file_path
+            Arc::new(StringArray::from(Vec::<&str>::new())),       // created_at
         ],
     )
 }

--- a/crates/forgeplan-core/src/fpf/knowledge.rs
+++ b/crates/forgeplan-core/src/fpf/knowledge.rs
@@ -1,6 +1,7 @@
 //! FPF Knowledge Base — ingest and search over FPF specification.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use regex::Regex;
 
@@ -67,7 +68,9 @@ pub async fn ingest_fpf_directory(sections_dir: &Path) -> anyhow::Result<Vec<Ing
         md_files.sort();
 
         for file_path in &md_files {
-            let content = tokio::fs::read_to_string(file_path).await?;
+            let content = tokio::fs::read_to_string(file_path)
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to read {}: {e}", file_path.display()))?;
             if content.trim().is_empty() {
                 continue;
             }
@@ -98,16 +101,18 @@ pub async fn ingest_fpf_directory(sections_dir: &Path) -> anyhow::Result<Vec<Ing
 /// Tries to extract from first `##` heading: `## B.3 - Trust & Assurance Calculus`
 /// Falls back to extracting from filename: `13-b-3---trust-assurance-calculus.md`
 fn parse_section_header(content: &str, file_path: &Path) -> (String, String) {
-    // Try to find ## heading
-    // Pattern: ## X.Y.Z - Title or ## X.Y.Z — Title
-    let heading_re =
-        Regex::new(r"^##\s+([A-Z]\.\d+(?:\.\d+)*(?:\.[A-Z])?)\s*[-—:]\s*(.+)$").unwrap();
+    // Compile regex once (OnceLock) — avoids re-compilation on every call
+    static HEADING_RE: OnceLock<Regex> = OnceLock::new();
+    let heading_re = HEADING_RE.get_or_init(|| {
+        Regex::new(r"^##\s+([A-Z]\.\d+(?:\.\d+)*(?:\.[A-Z])?)\s*[-—:]\s*(.+)$")
+            .expect("FPF heading regex is valid")
+    });
 
     for line in content.lines().take(5) {
         let trimmed = line.trim();
         if let Some(caps) = heading_re.captures(trimmed) {
-            let section_id = caps.get(1).unwrap().as_str().to_string();
-            let title = caps.get(2).unwrap().as_str().trim().to_string();
+            let section_id = caps.get(1).expect("group 1 present after match").as_str().to_string();
+            let title = caps.get(2).expect("group 2 present after match").as_str().trim().to_string();
             return (section_id, title);
         }
     }

--- a/crates/forgeplan-core/src/fpf/knowledge.rs
+++ b/crates/forgeplan-core/src/fpf/knowledge.rs
@@ -1,0 +1,174 @@
+//! FPF Knowledge Base — ingest and search over FPF specification.
+
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+/// FPF chunk for ingestion (mirrors store::FpfChunk).
+#[derive(Debug, Clone)]
+pub struct IngestChunk {
+    pub id: String,
+    pub section_id: String,
+    pub parent_section: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub line_count: i32,
+    pub file_path: String,
+}
+
+/// Scan FPF sections directory and produce chunks for ingestion.
+///
+/// Expected structure:
+/// ```text
+/// sections/
+///   07-part-b.../
+///     _index.md
+///     01-b-1---title.md
+///     13-b-3---trust-assurance-calculus.md
+/// ```
+pub async fn ingest_fpf_directory(sections_dir: &Path) -> anyhow::Result<Vec<IngestChunk>> {
+    let mut chunks = Vec::new();
+    let mut counter = 0u32;
+
+    let mut section_dirs = tokio::fs::read_dir(sections_dir).await?;
+
+    // Collect and sort section directories
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    while let Some(entry) = section_dirs.next_entry().await? {
+        let path = entry.path();
+        if path.is_dir() {
+            dirs.push(path);
+        }
+    }
+    dirs.sort();
+
+    for dir in &dirs {
+        let parent_name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut files = tokio::fs::read_dir(dir).await?;
+        let mut md_files: Vec<PathBuf> = Vec::new();
+        while let Some(entry) = files.next_entry().await? {
+            let path = entry.path();
+            if path.extension().map_or(false, |e| e == "md") {
+                let name = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                if name != "_index.md" {
+                    md_files.push(path);
+                }
+            }
+        }
+        md_files.sort();
+
+        for file_path in &md_files {
+            let content = tokio::fs::read_to_string(file_path).await?;
+            if content.trim().is_empty() {
+                continue;
+            }
+
+            let (section_id, title) = parse_section_header(&content, file_path);
+            let line_count = content.lines().count() as i32;
+
+            counter += 1;
+            let chunk_id = format!("fpf-{counter:04}");
+
+            chunks.push(IngestChunk {
+                id: chunk_id,
+                section_id,
+                parent_section: Some(parent_name.clone()),
+                title,
+                body: content,
+                line_count,
+                file_path: file_path.to_string_lossy().to_string(),
+            });
+        }
+    }
+
+    Ok(chunks)
+}
+
+/// Parse section ID and title from file content or filename.
+///
+/// Tries to extract from first `##` heading: `## B.3 - Trust & Assurance Calculus`
+/// Falls back to extracting from filename: `13-b-3---trust-assurance-calculus.md`
+fn parse_section_header(content: &str, file_path: &Path) -> (String, String) {
+    // Try to find ## heading
+    // Pattern: ## X.Y.Z - Title or ## X.Y.Z — Title
+    let heading_re =
+        Regex::new(r"^##\s+([A-Z]\.\d+(?:\.\d+)*(?:\.[A-Z])?)\s*[-—:]\s*(.+)$").unwrap();
+
+    for line in content.lines().take(5) {
+        let trimmed = line.trim();
+        if let Some(caps) = heading_re.captures(trimmed) {
+            let section_id = caps.get(1).unwrap().as_str().to_string();
+            let title = caps.get(2).unwrap().as_str().trim().to_string();
+            return (section_id, title);
+        }
+    }
+
+    // Fallback: extract from filename
+    // e.g. "13-b-3---trust-assurance-calculus.md" → section_id="B.3", title="Trust assurance calculus"
+    let filename = file_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+
+    // Remove leading NN- prefix
+    let without_prefix = filename
+        .split_once('-')
+        .map(|(_, rest)| rest)
+        .unwrap_or(filename);
+
+    // Extract section ID part (before ---)
+    let (section_part, title_part) = if let Some((sec, title)) = without_prefix.split_once("---") {
+        (sec.trim_end_matches('-'), title)
+    } else {
+        (without_prefix, "")
+    };
+
+    // Convert section part to proper ID: "b-3-4" → "B.3.4"
+    let section_id = section_part
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .enumerate()
+        .map(|(i, part)| {
+            if i == 0 {
+                part.to_uppercase()
+            } else {
+                part.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(".");
+
+    // Convert title part: "trust-assurance-calculus" → "Trust assurance calculus"
+    let title = if title_part.is_empty() {
+        section_id.clone()
+    } else {
+        let t = title_part.replace('-', " ");
+        let mut chars = t.chars();
+        match chars.next() {
+            None => String::new(),
+            Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        }
+    };
+
+    (section_id, title)
+}
+
+/// Default path to FPF sections (Claude Code skill directory).
+pub fn default_fpf_path() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    let path = PathBuf::from(home).join(".claude/skills/fpf-simple/sections");
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod contexts;
 pub mod explore;
+pub mod knowledge;
 
 use std::collections::BTreeMap;
 

--- a/crates/forgeplan-core/src/llm/reason.rs
+++ b/crates/forgeplan-core/src/llm/reason.rs
@@ -128,6 +128,59 @@ pub fn parse_adi_output(response: &str) -> AdiOutput {
     }
 }
 
+/// Search FPF knowledge base for patterns relevant to the artifact, and build
+/// a context string for injection into the ADI system prompt.
+pub async fn build_fpf_context(
+    store: &crate::db::store::LanceStore,
+    artifact_title: &str,
+    _artifact_body: &str,
+) -> anyhow::Result<Option<String>> {
+    if !store.has_fpf() {
+        return Ok(None);
+    }
+
+    // Search by significant title keywords (skip short/common words, try each)
+    let keywords: Vec<&str> = artifact_title
+        .split_whitespace()
+        .filter(|w| w.len() > 3 && w.chars().all(|c| c.is_alphanumeric()))
+        .filter(|w| !matches!(w.to_lowercase().as_str(), "the" | "and" | "for" | "with" | "from" | "that" | "this"))
+        .take(5)
+        .collect();
+
+    // Try each keyword, collect unique results
+    let mut results = Vec::new();
+    let mut seen_ids = std::collections::HashSet::new();
+    for keyword in &keywords {
+        if let Ok(hits) = store.search_fpf(keyword, 3).await {
+            for hit in hits {
+                if seen_ids.insert(hit.section_id.clone()) {
+                    results.push(hit);
+                }
+            }
+        }
+        if results.len() >= 3 {
+            break;
+        }
+    }
+    results.truncate(3);
+
+    if results.is_empty() {
+        return Ok(None);
+    }
+
+    let mut context = String::from("\n\n## Relevant FPF Patterns (from knowledge base)\n\n");
+    for chunk in &results {
+        // Include first 300 chars of each section
+        let preview: String = chunk.body.chars().take(300).collect();
+        context.push_str(&format!(
+            "### {} — {}\n{}\n\n",
+            chunk.section_id, chunk.title, preview
+        ));
+    }
+
+    Ok(Some(context))
+}
+
 /// Run ADI reasoning cycle on an artifact.
 /// Returns both the raw response string and the parsed AdiOutput.
 pub async fn reason(
@@ -136,10 +189,11 @@ pub async fn reason(
     artifact_title: &str,
     artifact_kind: &str,
     artifact_body: &str,
+    fpf_context: Option<&str>,
 ) -> anyhow::Result<(String, AdiOutput)> {
     let client = LlmClient::new(config.clone());
 
-    let prompt = format!(
+    let mut prompt = format!(
         "Analyze this {kind} artifact using the ADI cycle:\n\n\
          **ID**: {id}\n\
          **Title**: {title}\n\n\
@@ -150,6 +204,10 @@ pub async fn reason(
         title = artifact_title,
         body = artifact_body,
     );
+
+    if let Some(ctx) = fpf_context {
+        prompt.push_str(ctx);
+    }
 
     let system = crate::llm::load_prompt("reason", ADI_SYSTEM_PROMPT);
     let response = client.generate(&prompt, Some(&system)).await?;

--- a/crates/forgeplan-core/src/llm/reason.rs
+++ b/crates/forgeplan-core/src/llm/reason.rs
@@ -98,16 +98,19 @@ fn default_effort() -> String {
 
 /// Try to parse LLM response as structured ADI JSON, with fallback to raw markdown.
 pub fn parse_adi_output(response: &str) -> AdiOutput {
-    // Try JSON parse first (may be wrapped in ```json ... ```)
-    let cleaned = response
-        .trim()
-        .strip_prefix("```json")
-        .unwrap_or(response.trim())
-        .strip_prefix("```")
-        .unwrap_or(response.trim())
-        .strip_suffix("```")
-        .unwrap_or(response.trim())
-        .trim();
+    // Strip code fences sequentially — each step feeds the next
+    let s = response.trim();
+    let s = s.strip_prefix("```json").map(|r| r.trim_start()).unwrap_or(s);
+    let s = s.strip_prefix("```").map(|r| r.trim_start()).unwrap_or(s);
+    let s = s.strip_suffix("```").map(|r| r.trim_end()).unwrap_or(s);
+    // Find first '{' for cases where LLM adds text before JSON
+    let cleaned = if s.starts_with('{') {
+        s
+    } else if let Some(pos) = s.find('{') {
+        &s[pos..]
+    } else {
+        s
+    };
 
     match serde_json::from_str::<AdiOutput>(cleaned) {
         Ok(mut output) => {

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -284,6 +284,21 @@ struct ImportParams {
     force: Option<bool>,
 }
 
+#[derive(Debug, Deserialize, JsonSchema)]
+struct FpfSearchParams {
+    /// Search query for FPF knowledge base
+    query: String,
+    /// Max results (default 5)
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct FpfSectionParams {
+    /// FPF section ID (e.g. "B.3", "C.2.2")
+    id: String,
+}
+
 // ── Tool implementations ─────────────────────────────────────
 
 #[tool_router]
@@ -1378,7 +1393,7 @@ impl ForgeplanServer {
         let llm_config = config.llm.unwrap_or_default().with_env_overrides();
 
         let (analysis, _adi_output) = forgeplan_core::llm::reason::reason(
-            &llm_config, &record.id, &record.title, &record.kind, &record.body,
+            &llm_config, &record.id, &record.title, &record.kind, &record.body, None,
         )
         .await
         .map_err(|e| McpError::internal_error(format!("ADI reasoning failed: {e}"), None))?;
@@ -1666,6 +1681,83 @@ impl ForgeplanServer {
             "skipped": skipped,
             "relations_imported": relations_imported,
         })))
+    }
+
+    // ── FPF Knowledge Base tools ────────────────────────────────
+
+    #[tool(description = "Search FPF (First Principles Framework) knowledge base for relevant patterns and concepts. Returns matching sections with titles and snippets.")]
+    async fn forgeplan_fpf_search(
+        &self,
+        Parameters(p): Parameters<FpfSearchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        if !store.has_fpf() {
+            return Ok(err_result("FPF knowledge base not loaded. Run `forgeplan fpf ingest` first."));
+        }
+
+        let limit = p.limit.unwrap_or(5);
+        let results = store.search_fpf(&p.query, limit).await.unwrap_or_else(|e| {
+            tracing::warn!("FPF search failed: {e}");
+            Vec::new()
+        });
+
+        Ok(json_result(&FpfSearchResponse {
+            query: p.query,
+            results: results.iter().map(|c| FpfSearchHit {
+                section_id: c.section_id.clone(),
+                title: c.title.clone(),
+                snippet: c.body.lines().take(3).collect::<Vec<_>>().join(" ").chars().take(200).collect(),
+                line_count: c.line_count,
+            }).collect(),
+        }))
+    }
+
+    #[tool(description = "Get full content of a specific FPF section by ID (e.g. 'B.3', 'C.2.2', 'A.1').")]
+    async fn forgeplan_fpf_section(
+        &self,
+        Parameters(p): Parameters<FpfSectionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        match store.get_fpf_section(&p.id).await {
+            Ok(Some(chunk)) => Ok(json_result(&FpfSectionResponse {
+                section_id: chunk.section_id,
+                title: chunk.title,
+                body: chunk.body,
+                line_count: chunk.line_count,
+            })),
+            Ok(None) => Ok(err_result(&format!("FPF section '{}' not found", p.id))),
+            Err(e) => Ok(err_result(&format!("Failed to get section: {e}"))),
+        }
+    }
+
+    #[tool(description = "List all available FPF (First Principles Framework) sections in the knowledge base.")]
+    async fn forgeplan_fpf_list(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let sections = store.list_fpf_sections().await.unwrap_or_else(|e| {
+            tracing::warn!("FPF list failed: {e}");
+            Vec::new()
+        });
+
+        Ok(json_result(&FpfListResponse {
+            sections: sections.iter().map(|s| FpfListItem {
+                section_id: s.section_id.clone(),
+                title: s.title.clone(),
+                line_count: s.line_count,
+            }).collect(),
+            total: sections.len(),
+        }))
     }
 }
 

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -263,3 +263,40 @@ pub struct SignalDto {
     pub value: String,
     pub minimum_depth: String,
 }
+
+// ── FPF Knowledge Base types ────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FpfSearchResponse {
+    pub query: String,
+    pub results: Vec<FpfSearchHit>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FpfSearchHit {
+    pub section_id: String,
+    pub title: String,
+    pub snippet: String,
+    pub line_count: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FpfSectionResponse {
+    pub section_id: String,
+    pub title: String,
+    pub body: String,
+    pub line_count: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FpfListResponse {
+    pub sections: Vec<FpfListItem>,
+    pub total: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FpfListItem {
+    pub section_id: String,
+    pub title: String,
+    pub line_count: i32,
+}


### PR DESCRIPTION
## Summary

- **FPF Ingest**: `forgeplan fpf ingest` loads 204 FPF spec sections from `~/.claude/skills/fpf-simple/sections/` into LanceDB
- **FPF Search**: `forgeplan fpf search "trust"` — keyword search across FPF knowledge base
- **FPF Section**: `forgeplan fpf section "B.3"` — show full section content
- **ADI + FPF**: `forgeplan reason PRD-016 --fpf` — injects relevant FPF patterns into LLM prompt for grounded reasoning
- **3 MCP tools**: `forgeplan_fpf_search`, `forgeplan_fpf_section`, `forgeplan_fpf_list`

## Changes

| File | LOC | What |
|------|-----|------|
| `fpf/knowledge.rs` | +174 | Ingest pipeline: scan dirs, parse headings, chunk |
| `db/schema.rs` | +50 | fpf_spec LanceDB schema |
| `db/store.rs` | +219 | FpfChunk structs + 6 store methods |
| `llm/reason.rs` | +60 | build_fpf_context + per-keyword search |
| `cli/commands/fpf.rs` | +142 | 5 subcommands: ingest/search/section/list/dashboard |
| `cli/main.rs` | +53 | FpfCommands enum + dispatch |
| `cli/commands/reason.rs` | +23 | --fpf flag |
| `mcp/server.rs` | +94 | 3 FPF tools |
| `mcp/types.rs` | +37 | Response structs |

## Test plan

- [x] 262/262 tests PASS
- [x] `forgeplan fpf ingest` — 204 sections loaded
- [x] `forgeplan fpf list` — all sections displayed
- [x] `forgeplan fpf search "trust"` — results returned
- [x] `forgeplan fpf section "B.3"` — full content shown
- [x] `forgeplan reason PRD-016 --fpf` — FPF context injected, Gemini 2.5 Pro returns grounded analysis

Refs: PRD-021, PROB-010, EPIC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)