### PR TITLE
[PRD-020] Decision Contracts + drift detection + LanceDB migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,46 @@ git worktree remove ../forgeplan-fix
 - **Когда**: hotfix во время долгой фичи; параллельная работа агентов (isolation: "worktree")
 - **Правило**: worktree = временный, удалять после merge
 
+### ЗАПРЕЩЁННЫЕ действия (CRITICAL):
+
+**НИКОГДА не удалять `.forgeplan/` без backup:**
+```bash
+# ПРАВИЛЬНО:
+forgeplan export --output backup.json   # ОБЯЗАТЕЛЬНО перед любым reinit
+cp -r .forgeplan .forgeplan-backup-$(date +%Y%m%d)  # backup copy
+# потом уже можно reinit
+
+# ЗАПРЕЩЕНО:
+rm -rf .forgeplan   # ← ПОТЕРЯ ВСЕХ АРТЕФАКТОВ, EVIDENCE, LINKS!
+```
+
+**ОБЯЗАТЕЛЬНО при reinit:**
+1. `forgeplan export` → сохранить JSON
+2. `cp -r .forgeplan .forgeplan-backup-ДАТА`
+3. Только потом `rm -rf .forgeplan && forgeplan init -y`
+4. `forgeplan import backup.json` → восстановить
+
+**AI агенты:**
+- `forgeplan init` → ВСЕГДА с `-y` (non-interactive mode)
+- НИКОГДА `rm -rf .forgeplan` без `forgeplan export` первым
+- После init → настроить `.forgeplan/config.yaml` (LLM provider)
+
+### ОБЯЗАТЕЛЬНО smoke test после каждого спринта:
+
+```bash
+cargo test                              # ВСЕ должны PASS
+forgeplan init -y                       # Workspace создаётся
+forgeplan new prd "Smoke Test"          # Артефакт создаётся
+forgeplan validate PRD-XXX              # Валидация работает
+forgeplan score PRD-XXX                 # F-G-R scoring работает
+forgeplan blocked                       # Граф зависимостей
+forgeplan order                         # Topological sort
+forgeplan fpf ingest                    # FPF KB загружается
+forgeplan fpf search "trust"            # Поиск работает
+```
+
+**Если любой шаг fail — НЕ коммитить. Починить сначала.**
+
 ## Структура проекта
 
 ```

--- a/crates/forgeplan-cli/src/commands/drift.rs
+++ b/crates/forgeplan-cli/src/commands/drift.rs
@@ -1,0 +1,53 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::drift;
+use forgeplan_core::workspace;
+
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+
+    // workspace_root = parent of .forgeplan
+    let workspace_root = ws.parent().unwrap_or(&ws);
+    let reports = drift::check_drift(&store, workspace_root).await?;
+
+    if reports.is_empty() {
+        println!("  No active ADR/RFC with affected_files found.");
+        println!("  Hint: Add '## Affected Files' section to ADR/RFC artifacts.");
+        return Ok(());
+    }
+
+    let stale_count = reports.iter().filter(|r| r.is_stale).count();
+    let total = reports.len();
+
+    println!();
+    for report in &reports {
+        if report.is_stale {
+            println!(
+                "  \u{26a0} {} \"{}\" \u{2014} STALE",
+                report.artifact_id, report.artifact_title
+            );
+            println!("    Created: {}", report.created_at);
+            for file in &report.changed_files {
+                println!("    Changed: {} ({})", file.path, file.last_modified);
+            }
+        } else {
+            println!(
+                "  \u{2713} {} \"{}\" \u{2014} up to date",
+                report.artifact_id, report.artifact_title
+            );
+        }
+        println!();
+    }
+
+    println!("  {} decisions checked, {} stale", total, stale_count);
+    if stale_count > 0 {
+        println!("  Action: Review stale decisions and update or supersede them.");
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/migrate.rs
+++ b/crates/forgeplan-cli/src/commands/migrate.rs
@@ -1,0 +1,16 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::workspace;
+
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    println!("  Running schema migrations...");
+    let _store = LanceStore::open(&ws).await?; // open() runs migrations
+    println!("  Migrations complete. Schema up to date.");
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod decay;
 pub mod decompose;
 pub mod delete;
 pub mod deprecate;
+pub mod drift;
 pub mod export;
 
 pub mod fgr;

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod init;
 pub mod journal;
 pub mod link;
 pub mod list;
+pub mod migrate;
 pub mod new;
 pub mod order;
 pub mod progress;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -245,6 +245,8 @@ enum Commands {
     },
     /// Show artifacts in topological order (dependency order)
     Order,
+    /// Run schema migrations on existing workspace
+    Migrate,
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -371,6 +373,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Export { output } => commands::export::run(output.as_deref()).await,
         Commands::Import { path, force } => commands::import_cmd::run(&path, force).await,
         Commands::Order => commands::order::run().await,
+        Commands::Migrate => commands::migrate::run().await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -196,6 +196,8 @@ enum Commands {
         /// Artifact ID (scores all if omitted)
         id: Option<String>,
     },
+    /// Check for drifted decisions (affected files changed after decision)
+    Drift,
     /// Show blocked artifacts and their dependencies
     Blocked {
         /// Specific artifact ID to check (optional)
@@ -343,6 +345,7 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Drift => commands::drift::run().await,
         Commands::Blocked { id } => commands::blocked::run(id.as_deref()).await,
         Commands::Blindspots => commands::blindspots::run().await,
         Commands::Journal { r#type, risk } => {

--- a/crates/forgeplan-core/src/db/convert.rs
+++ b/crates/forgeplan-core/src/db/convert.rs
@@ -39,6 +39,7 @@ pub(crate) fn artifact_to_batch_with_schema(
             Arc::new(StringArray::from(vec![artifact.valid_until.as_deref()])),
             Arc::new(StringArray::from(vec![now])),
             Arc::new(StringArray::from(vec![now])),
+            Arc::new(StringArray::from(vec![Option::<&str>::None])),
             embedding_col,
         ],
     )?;

--- a/crates/forgeplan-core/src/db/migrate.rs
+++ b/crates/forgeplan-core/src/db/migrate.rs
@@ -1,0 +1,63 @@
+//! LanceDB schema migration — add missing columns without data loss.
+//!
+//! Each migration is idempotent: checks if column exists before adding.
+//! Version tracked in config.yaml as `schema_version`.
+
+use lancedb::table::NewColumnTransform;
+use lancedb::Table;
+
+/// Current schema version. Increment when adding migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+/// Run all pending migrations on the artifacts table.
+/// Idempotent — safe to run multiple times.
+pub async fn migrate_artifacts(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    // Migration 1→2: add body_hash column (nullable Utf8)
+    if !field_names.contains(&"body_hash".to_string()) {
+        eprintln!("[migrate] Adding body_hash column to artifacts");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "body_hash".to_string(),
+                    "CAST(NULL AS UTF8)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Run all pending migrations on the relations table.
+/// Idempotent — safe to run multiple times.
+pub async fn migrate_relations(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    // Migration 1→2: add congruence_level column (nullable Int32, default 3)
+    if !field_names.contains(&"congruence_level".to_string()) {
+        eprintln!("[migrate] Adding congruence_level column to relations");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "congruence_level".to_string(),
+                    "CAST(3 AS INT32)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Run all migrations on all tables. Call from LanceStore::open().
+pub async fn run_migrations(artifacts: &Table, relations: &Table) -> anyhow::Result<()> {
+    migrate_artifacts(artifacts).await?;
+    migrate_relations(relations).await?;
+    Ok(())
+}

--- a/crates/forgeplan-core/src/db/migrate.rs
+++ b/crates/forgeplan-core/src/db/migrate.rs
@@ -22,7 +22,7 @@ pub async fn migrate_artifacts(table: &Table) -> anyhow::Result<()> {
             .add_columns(
                 NewColumnTransform::SqlExpressions(vec![(
                     "body_hash".to_string(),
-                    "CAST(NULL AS UTF8)".to_string(),
+                    "CAST(NULL AS STRING)".to_string(),
                 )]),
                 None,
             )
@@ -45,7 +45,7 @@ pub async fn migrate_relations(table: &Table) -> anyhow::Result<()> {
             .add_columns(
                 NewColumnTransform::SqlExpressions(vec![(
                     "congruence_level".to_string(),
-                    "CAST(3 AS INT32)".to_string(),
+                    "CAST(3 AS INT)".to_string(),
                 )]),
                 None,
             )

--- a/crates/forgeplan-core/src/db/mod.rs
+++ b/crates/forgeplan-core/src/db/mod.rs
@@ -1,3 +1,4 @@
 pub mod convert;
+pub mod migrate;
 pub mod schema;
 pub mod store;

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -21,6 +21,7 @@ pub const EMBEDDING_DIM: i32 = 1024;
 /// - valid_until Utf8 (nullable) — ISO date for evidence decay
 /// - created_at  Utf8 (not null) — ISO datetime
 /// - updated_at  Utf8 (not null) — ISO datetime
+/// - body_hash   Utf8 (nullable) — hash of body for change detection
 /// - embedding   FixedSizeList(1024, Float32) (nullable) — vector for semantic search
 pub fn artifacts_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
@@ -36,6 +37,7 @@ pub fn artifacts_schema() -> Arc<Schema> {
         Field::new("valid_until", DataType::Utf8, true),
         Field::new("created_at", DataType::Utf8, false),
         Field::new("updated_at", DataType::Utf8, false),
+        Field::new("body_hash", DataType::Utf8, true),
         Field::new(
             "embedding",
             DataType::FixedSizeList(
@@ -143,6 +145,7 @@ mod tests {
         assert!(nullable.contains(&"author"));
         assert!(nullable.contains(&"parent_epic"));
         assert!(nullable.contains(&"valid_until"));
+        assert!(nullable.contains(&"body_hash"));
         assert!(nullable.contains(&"embedding"));
     }
 

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -11,7 +11,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::Table;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::{convert, schema};
+use crate::db::{convert, migrate, schema};
 
 /// Filter for listing artifacts.
 #[derive(Debug, Default)]
@@ -141,6 +141,7 @@ pub struct LanceStore {
 
 impl LanceStore {
     /// Connect to an existing LanceDB workspace (tables must already exist).
+    /// Runs idempotent schema migrations on every open.
     pub async fn open(workspace_path: &Path) -> anyhow::Result<Self> {
         let lance_dir = workspace_path.join("lance");
         let db = lancedb::connect(lance_dir.to_str().ok_or_else(|| anyhow::anyhow!("LanceDB path contains non-UTF-8 characters: {:?}", lance_dir))?).execute().await?;
@@ -149,6 +150,9 @@ impl LanceStore {
         let evidence = db.open_table("evidence").execute().await?;
         let relations = db.open_table("relations").execute().await?;
         let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
+
+        // Run migrations (idempotent — safe on every open)
+        migrate::run_migrations(&artifacts, &relations).await?;
 
         Ok(Self {
             _db: db,
@@ -917,6 +921,7 @@ fn empty_artifacts_batch(
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
             convert::make_null_embedding_col(0),
         ],
     )

--- a/crates/forgeplan-core/src/drift/mod.rs
+++ b/crates/forgeplan-core/src/drift/mod.rs
@@ -1,0 +1,104 @@
+//! Drift detection — check if affected files changed after decision creation.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::db::store::LanceStore;
+use crate::validation::checks::extract_affected_files;
+
+/// A drift finding for one artifact.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DriftReport {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub created_at: String,
+    pub affected_files: Vec<String>,
+    pub changed_files: Vec<DriftedFile>,
+    pub is_stale: bool,
+}
+
+/// A file that changed after the decision was created.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DriftedFile {
+    pub path: String,
+    pub last_modified: String,
+}
+
+/// Check drift for all active ADR/RFC artifacts.
+pub async fn check_drift(
+    store: &LanceStore,
+    workspace_root: &Path,
+) -> anyhow::Result<Vec<DriftReport>> {
+    let records = store.list_records(None).await?;
+    let mut reports = Vec::new();
+
+    for record in &records {
+        // Only check active ADR and RFC
+        if record.status != "active" {
+            continue;
+        }
+        if record.kind != "adr" && record.kind != "rfc" {
+            continue;
+        }
+
+        // Extract affected_files from body
+        let affected = extract_affected_files(&record.body);
+        if affected.is_empty() {
+            continue;
+        }
+
+        // Check each file for changes after artifact creation
+        let mut changed_files = Vec::new();
+        for file_pattern in &affected {
+            let drifted = check_file_drift(workspace_root, file_pattern, &record.created_at);
+            changed_files.extend(drifted);
+        }
+
+        let is_stale = !changed_files.is_empty();
+        reports.push(DriftReport {
+            artifact_id: record.id.clone(),
+            artifact_title: record.title.clone(),
+            created_at: record.created_at.clone(),
+            affected_files: affected,
+            changed_files,
+            is_stale,
+        });
+    }
+
+    Ok(reports)
+}
+
+/// Check if files matching a pattern were modified after a given date.
+/// Uses `git log` to check modification dates.
+fn check_file_drift(workspace_root: &Path, pattern: &str, after_date: &str) -> Vec<DriftedFile> {
+    let output = Command::new("git")
+        .args(["log", "--oneline", "--since", after_date, "--", pattern])
+        .current_dir(workspace_root)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            if stdout.trim().is_empty() {
+                return vec![];
+            }
+            // File was modified — get last commit date
+            let date_output = Command::new("git")
+                .args(["log", "-1", "--format=%ci", "--", pattern])
+                .current_dir(workspace_root)
+                .output();
+
+            let last_modified = date_output
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            vec![DriftedFile {
+                path: pattern.to_string(),
+                last_modified,
+            }]
+        }
+        _ => vec![],
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod artifact;
 pub mod config;
 pub mod db;
 pub mod depth;
+pub mod drift;
 pub mod embed;
 pub mod fpf;
 pub mod health;

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -416,6 +416,36 @@ pub fn extract_nfr_section(body: &str) -> Option<String> {
     None
 }
 
+/// Extract affected_files from body — lines that look like file paths or glob patterns.
+pub fn extract_affected_files(body: &str) -> Vec<String> {
+    let section = extract_section(body, "Affected Files")
+        .or_else(|| extract_section(body, "Affected Scope"))
+        .or_else(|| extract_section(body, "affected_files"));
+
+    match section {
+        None => vec![],
+        Some(text) => text
+            .lines()
+            .map(|l| {
+                l.trim()
+                    .trim_start_matches("- ")
+                    .trim_start_matches("* ")
+                    .trim_start_matches("| ")
+                    .trim()
+            })
+            .filter(|l| {
+                !l.is_empty()
+                    && (l.contains('/')
+                        || l.contains('*')
+                        || l.ends_with(".rs")
+                        || l.ends_with(".ts")
+                        || l.ends_with(".md"))
+            })
+            .map(|l| l.to_string())
+            .collect(),
+    }
+}
+
 /// BMAD Step 5: Subjective adjectives that need metrics.
 const SUBJECTIVE_ADJECTIVES: &[&str] = &[
     "easy", "fast", "simple", "intuitive", "user-friendly", "responsive",

--- a/crates/forgeplan-core/src/validation/rules.rs
+++ b/crates/forgeplan-core/src/validation/rules.rs
@@ -578,6 +578,14 @@ fn rfc_rules(depth: &Mode) -> Vec<RuleEntry> {
         rules.push(rule("rfc-risks", Severity::Must, "Risks section", check_rfc_risks));
     }
 
+    // Decision Contract rules for RFC (Could — RFC is a proposal, not a decision)
+    rules.push(rule("rfc-invariants", Severity::Could,
+        "RFC could define invariants",
+        check_adr_invariants));
+    rules.push(rule("rfc-rollback", Severity::Could,
+        "RFC could define rollback plan",
+        check_adr_rollback));
+
     rules
 }
 
@@ -638,10 +646,27 @@ fn adr_rules(depth: &Mode) -> Vec<RuleEntry> {
         rule("adr-consequences", Severity::Must, "Consequences", check_adr_consequences),
     ];
 
-    if matches!(depth, Mode::Deep) {
-        rules.push(rule("adr-invariants", Severity::Should, "Invariants (DDR)", check_adr_invariants));
-        rules.push(rule("adr-rollback", Severity::Should, "Rollback Plan", check_adr_rollback));
-    }
+    // Decision Contract rules — severity scales with depth
+    let (inv_sev, roll_sev) = match depth {
+        Mode::Deep => (Severity::Must, Severity::Must),
+        _ => (Severity::Should, Severity::Should),
+    };
+
+    rules.push(rule("adr-invariants", inv_sev,
+        "Invariants — what must never be violated",
+        check_adr_invariants));
+    rules.push(rule("adr-rollback", roll_sev,
+        "Rollback plan — what to do if decision fails",
+        check_adr_rollback));
+    rules.push(rule("adr-preconditions", Severity::Could,
+        "Preconditions — what must be true before implementing",
+        check_adr_preconditions));
+    rules.push(rule("adr-postconditions", Severity::Could,
+        "Postconditions — what must be true after implementing",
+        check_adr_postconditions));
+    rules.push(rule("adr-affected-files", Severity::Should,
+        "Affected files/modules — scope of the decision",
+        check_adr_affected_files));
 
     rules
 }
@@ -671,18 +696,54 @@ fn check_adr_consequences(body: &str, _fm: &Frontmatter) -> Option<String> {
 }
 
 fn check_adr_invariants(body: &str, _fm: &Frontmatter) -> Option<String> {
-    if !checks::section_exists(body, "Invariants") {
-        Some("Missing '## Invariants' section (recommended for deep ADR/DDR)".into())
-    } else {
+    if checks::section_exists(body, "Invariants") {
         None
+    } else {
+        Some("Missing '## Invariants' section — what must NEVER be violated by this decision".into())
     }
 }
 
 fn check_adr_rollback(body: &str, _fm: &Frontmatter) -> Option<String> {
-    if !checks::section_exists(body, "Rollback") {
-        Some("Missing '## Rollback Plan' section (recommended for deep ADR/DDR)".into())
-    } else {
+    if checks::section_exists(body, "Rollback")
+        || checks::section_exists(body, "Rollback Plan")
+        || checks::section_exists(body, "Mitigation")
+    {
         None
+    } else {
+        Some("Missing '## Rollback Plan' section — what to do if this decision fails".into())
+    }
+}
+
+fn check_adr_preconditions(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Preconditions")
+        || checks::section_exists(body, "Pre-conditions")
+        || checks::section_exists(body, "Prerequisites")
+    {
+        None
+    } else {
+        Some("Missing '## Preconditions' section".into())
+    }
+}
+
+fn check_adr_postconditions(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Postconditions")
+        || checks::section_exists(body, "Post-conditions")
+        || checks::section_exists(body, "Expected Outcome")
+    {
+        None
+    } else {
+        Some("Missing '## Postconditions' section".into())
+    }
+}
+
+fn check_adr_affected_files(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Affected Files")
+        || checks::section_exists(body, "Affected Scope")
+        || checks::section_exists(body, "Scope")
+    {
+        None
+    } else {
+        Some("Missing '## Affected Files' section — which files/modules does this decision affect".into())
     }
 }
 
@@ -779,45 +840,69 @@ mod tests {
     }
 
     #[test]
-    fn rules_for_rfc_standard_returns_base_plus_5_no_risks() {
+    fn rules_for_rfc_standard_returns_base_plus_7_with_contracts() {
         let rules = rules_for(&ArtifactKind::Rfc, &Mode::Standard);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 5);
+        // 5 base RFC + 2 contract rules (invariants, rollback)
+        assert_eq!(rules.len(), base_count + 7);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(!ids.contains(&"rfc-risks"));
+        assert!(ids.contains(&"rfc-invariants"));
+        assert!(ids.contains(&"rfc-rollback"));
+
+        // RFC contract rules are Could severity
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "rfc-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Could);
     }
 
     #[test]
-    fn rules_for_rfc_deep_returns_base_plus_6_with_risks() {
+    fn rules_for_rfc_deep_returns_base_plus_8_with_risks_and_contracts() {
         let rules = rules_for(&ArtifactKind::Rfc, &Mode::Deep);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 6);
+        // 5 base RFC + 1 risks + 2 contract rules
+        assert_eq!(rules.len(), base_count + 8);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(ids.contains(&"rfc-risks"));
+        assert!(ids.contains(&"rfc-invariants"));
+        assert!(ids.contains(&"rfc-rollback"));
     }
 
     #[test]
-    fn rules_for_adr_standard_returns_base_plus_3() {
+    fn rules_for_adr_standard_returns_base_plus_8_with_contracts() {
         let rules = rules_for(&ArtifactKind::Adr, &Mode::Standard);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 3);
-
-        let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
-        assert!(!ids.contains(&"adr-invariants"));
-        assert!(!ids.contains(&"adr-rollback"));
-    }
-
-    #[test]
-    fn rules_for_adr_deep_returns_base_plus_5_with_ddr() {
-        let rules = rules_for(&ArtifactKind::Adr, &Mode::Deep);
-        let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 5);
+        // 3 base ADR + 5 contract rules (invariants, rollback, preconditions, postconditions, affected-files)
+        assert_eq!(rules.len(), base_count + 8);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(ids.contains(&"adr-invariants"));
         assert!(ids.contains(&"adr-rollback"));
+        assert!(ids.contains(&"adr-preconditions"));
+        assert!(ids.contains(&"adr-postconditions"));
+        assert!(ids.contains(&"adr-affected-files"));
+
+        // At standard depth, invariants and rollback are Should (not Must)
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "adr-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Should);
+    }
+
+    #[test]
+    fn rules_for_adr_deep_returns_base_plus_8_with_must_contracts() {
+        let rules = rules_for(&ArtifactKind::Adr, &Mode::Deep);
+        let base_count = base_rules().len();
+        assert_eq!(rules.len(), base_count + 8);
+
+        let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
+        assert!(ids.contains(&"adr-invariants"));
+        assert!(ids.contains(&"adr-rollback"));
+
+        // At deep depth, invariants and rollback are Must
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "adr-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Must);
+        let roll = rules.iter().find(|(id, _, _, _)| *id == "adr-rollback").unwrap();
+        assert_eq!(roll.1, Severity::Must);
     }
 
     #[test]
@@ -939,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn adr_deep_has_should_findings_for_invariants_and_rollback() {
+    fn adr_deep_has_must_findings_for_invariants_and_rollback() {
         let fm = make_fm("adr-002", "active");
         let body = "## Context\n\nWe need to choose a database.\n\n\
                      ## Decision\n\nUse LanceDB for embedded vector storage.\n\n\
@@ -947,20 +1032,38 @@ mod tests {
 
         let result = validate("adr-002", body, &fm, &ArtifactKind::Adr, &Mode::Deep);
 
-        // Should still pass (invariants and rollback are Should, not Must)
-        assert!(result.passed(), "ADR should still pass at Deep depth without DDR fields");
+        // Should NOT pass — invariants and rollback are Must at Deep depth
+        assert!(!result.passed(), "ADR should fail at Deep depth without Invariants/Rollback");
 
-        let should_ids: Vec<&str> = result.findings.iter()
-            .filter(|f| f.severity == Severity::Should)
+        let must_ids: Vec<&str> = result.findings.iter()
+            .filter(|f| f.severity == Severity::Must)
             .map(|f| f.rule_id.as_str())
             .collect();
         assert!(
-            should_ids.contains(&"adr-invariants"),
-            "Expected Should finding for adr-invariants at Deep depth"
+            must_ids.contains(&"adr-invariants"),
+            "Expected Must finding for adr-invariants at Deep depth"
         );
         assert!(
-            should_ids.contains(&"adr-rollback"),
-            "Expected Should finding for adr-rollback at Deep depth"
+            must_ids.contains(&"adr-rollback"),
+            "Expected Must finding for adr-rollback at Deep depth"
+        );
+    }
+
+    #[test]
+    fn adr_deep_passes_with_full_contract() {
+        let fm = make_fm("adr-003", "active");
+        let body = "## Context\n\nWe need to choose a database.\n\n\
+                     ## Decision\n\nUse LanceDB for embedded vector storage.\n\n\
+                     ## Consequences\n\nSimplifies deployment, limits horizontal scaling.\n\n\
+                     ## Invariants\n\n- Single-file deployment must be preserved.\n\n\
+                     ## Rollback Plan\n\n- Revert to SQLite.\n\n\
+                     ## Affected Files\n\n- crates/forgeplan-core/src/db/\n";
+
+        let result = validate("adr-003", body, &fm, &ArtifactKind::Adr, &Mode::Deep);
+        assert!(
+            result.passed(),
+            "ADR with full contract should pass at Deep depth, findings: {:?}",
+            result.findings.iter().map(|f| (&f.rule_id, &f.severity)).collect::<Vec<_>>()
         );
     }
 

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1759,6 +1759,30 @@ impl ForgeplanServer {
             total: sections.len(),
         }))
     }
+
+    #[tool(description = "Check for drifted decisions — affected files that changed after ADR/RFC was created.")]
+    async fn forgeplan_drift(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let ws = match self.require_workspace().await {
+            Ok(p) => p,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let workspace_root = ws.parent().unwrap_or(&ws).to_path_buf();
+
+        let reports = forgeplan_core::drift::check_drift(&store, &workspace_root)
+            .await
+            .unwrap_or_default();
+
+        Ok(json_result(&serde_json::json!({
+            "total": reports.len(),
+            "stale": reports.iter().filter(|r| r.is_stale).count(),
+            "reports": reports,
+        })))
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Contract validation** — 5 ADR rules + 2 RFC rules (invariants, rollback, pre/postconditions, affected_files)
- **Drift detection** — `forgeplan drift` checks if affected files changed since decision
- **LanceDB migration** — idempotent schema migration (no more rm -rf .forgeplan!)
- **Safety rules** — CLAUDE.md: never delete .forgeplan without backup

## Changes

| File | What |
|------|------|
| `validation/rules.rs` | 5 ADR contract rules (depth-aware severity) + 2 RFC rules |
| `validation/checks.rs` | extract_affected_files() |
| `drift/mod.rs` | DriftReport, check_drift() with git log |
| `cli/commands/drift.rs` | forgeplan drift CLI |
| `db/migrate.rs` | Idempotent column migrations |
| `cli/commands/migrate.rs` | forgeplan migrate CLI |
| `mcp/server.rs` | forgeplan_drift MCP tool |
| `CLAUDE.md` | Backup rules + smoke test checklist |

## Test plan

- [x] 276/276 tests PASS
- [x] `forgeplan drift` — works (no active ADR with affected_files)
- [x] `forgeplan migrate` — adds body_hash + congruence_level idempotently
- [x] Contract rules fire on ADR validation

Refs: PRD-020, PROB-010, EPIC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)