### PR TITLE
[PRD-019] Codebase Awareness — module scanner + decision coverage

### DIFF
--- a/crates/forgeplan-cli/src/commands/coverage.rs
+++ b/crates/forgeplan-cli/src/commands/coverage.rs
@@ -1,0 +1,92 @@
+use std::env;
+
+use forgeplan_core::coverage;
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::workspace;
+
+/// `forgeplan scan [--path <dir>]` — scan codebase for modules
+pub async fn run_scan(path: Option<&str>) -> anyhow::Result<()> {
+    let project_root = match path {
+        Some(p) => std::path::PathBuf::from(p),
+        None => env::current_dir()?,
+    };
+
+    println!("  Scanning {}...", project_root.display());
+    let modules = coverage::scan_modules(&project_root).await?;
+
+    if modules.is_empty() {
+        println!("  No source modules found.");
+        return Ok(());
+    }
+
+    println!();
+    println!("  {:40} {:>5} {:>7}", "Module", "Files", "Lines");
+    println!("  {}", "-".repeat(55));
+    for m in &modules {
+        println!("  {:40} {:>5} {:>7}", m.path, m.file_count, m.line_count);
+    }
+    println!();
+    let total_files: usize = modules.iter().map(|m| m.file_count).sum();
+    let total_lines: usize = modules.iter().map(|m| m.line_count).sum();
+    println!(
+        "  {} modules, {} files, {} lines",
+        modules.len(),
+        total_files,
+        total_lines
+    );
+
+    Ok(())
+}
+
+/// `forgeplan coverage` — show decision coverage per module
+pub async fn run_coverage() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let project_root = ws.parent().unwrap_or(&ws);
+    let store = LanceStore::open(&ws).await?;
+
+    println!("  Scanning codebase...");
+    let mut modules = coverage::scan_modules(project_root).await?;
+    let report = coverage::build_coverage(&mut modules, &store).await?;
+
+    println!();
+    println!(
+        "  Decision Coverage: {:.0}% ({}/{} modules)",
+        report.coverage_percent, report.covered_modules, report.total_modules
+    );
+    println!();
+
+    // Show uncovered modules first (blind spots)
+    let uncovered: Vec<_> = report
+        .modules
+        .iter()
+        .filter(|m| m.decisions.is_empty())
+        .collect();
+    if !uncovered.is_empty() {
+        println!("  \u{26a0} Uncovered modules (architectural blind spots):");
+        for m in &uncovered {
+            println!(
+                "    {} ({} files, {} lines)",
+                m.path, m.file_count, m.line_count
+            );
+        }
+        println!();
+    }
+
+    // Show covered modules
+    let covered: Vec<_> = report
+        .modules
+        .iter()
+        .filter(|m| !m.decisions.is_empty())
+        .collect();
+    if !covered.is_empty() {
+        println!("  \u{2713} Covered modules:");
+        for m in &covered {
+            println!("    {} \u{2190} {}", m.path, m.decisions.join(", "));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod blindspots;
 pub mod blocked;
 pub mod calibrate;
 pub mod capture;
+pub mod coverage;
 pub mod decay;
 pub mod decompose;
 pub mod delete;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -196,6 +196,14 @@ enum Commands {
         /// Artifact ID (scores all if omitted)
         id: Option<String>,
     },
+    /// Scan codebase for source modules
+    Scan {
+        /// Path to project root (default: current dir)
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Show decision coverage per code module
+    Coverage,
     /// Check for drifted decisions (affected files changed after decision)
     Drift,
     /// Show blocked artifacts and their dependencies
@@ -345,6 +353,8 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Scan { path } => commands::coverage::run_scan(path.as_deref()).await,
+        Commands::Coverage => commands::coverage::run_coverage().await,
         Commands::Drift => commands::drift::run().await,
         Commands::Blocked { id } => commands::blocked::run(id.as_deref()).await,
         Commands::Blindspots => commands::blindspots::run().await,

--- a/crates/forgeplan-core/src/coverage/mod.rs
+++ b/crates/forgeplan-core/src/coverage/mod.rs
@@ -1,0 +1,234 @@
+//! Codebase Awareness — module scanning and decision coverage.
+//!
+//! Scans codebase to find modules, maps them to architectural decisions
+//! (ADR/RFC with affected_files), and reports coverage gaps.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::db::store::LanceStore;
+use crate::validation::checks;
+
+/// A detected code module.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CodeModule {
+    pub path: String,
+    pub file_count: usize,
+    pub line_count: usize,
+    pub decisions: Vec<String>,
+}
+
+/// Coverage report for the entire codebase.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CoverageReport {
+    pub total_modules: usize,
+    pub covered_modules: usize,
+    pub uncovered_modules: usize,
+    pub coverage_percent: f64,
+    pub modules: Vec<CodeModule>,
+}
+
+/// Scan a directory for code modules.
+/// Detects Rust (crates/*/src/**), TypeScript (src/**), Python (**/*.py).
+pub async fn scan_modules(project_root: &Path) -> anyhow::Result<Vec<CodeModule>> {
+    let mut modules = Vec::new();
+
+    let source_dirs = find_source_directories(project_root).await?;
+
+    for dir in source_dirs {
+        let rel_path = dir
+            .strip_prefix(project_root)
+            .unwrap_or(&dir)
+            .to_string_lossy()
+            .to_string();
+
+        let (file_count, line_count) = count_files_and_lines(&dir).await?;
+
+        if file_count > 0 {
+            modules.push(CodeModule {
+                path: rel_path,
+                file_count,
+                line_count,
+                decisions: vec![],
+            });
+        }
+    }
+
+    modules.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(modules)
+}
+
+/// Find directories containing source code files.
+async fn find_source_directories(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let dir_name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if dir_name.starts_with('.')
+            || dir_name == "target"
+            || dir_name == "node_modules"
+            || dir_name == "vendor"
+        {
+            continue;
+        }
+
+        let mut has_source = false;
+        let mut read_dir = match tokio::fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if is_source_file(&path) {
+                has_source = true;
+            }
+        }
+
+        if has_source {
+            dirs.push(dir);
+        }
+    }
+
+    Ok(dirs)
+}
+
+/// Check if file is a source code file.
+fn is_source_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|ext| matches!(ext, "rs" | "ts" | "tsx" | "js" | "jsx" | "py" | "go" | "java" | "kt" | "swift" | "c" | "cpp" | "h"))
+        .unwrap_or(false)
+}
+
+/// Count source files and total lines in a directory.
+async fn count_files_and_lines(dir: &Path) -> anyhow::Result<(usize, usize)> {
+    let mut file_count = 0;
+    let mut line_count = 0;
+
+    let mut read_dir = tokio::fs::read_dir(dir).await?;
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
+        let path = entry.path();
+        if path.is_file() && is_source_file(&path) {
+            file_count += 1;
+            if let Ok(content) = tokio::fs::read_to_string(&path).await {
+                line_count += content.lines().count();
+            }
+        }
+    }
+
+    Ok((file_count, line_count))
+}
+
+/// Build coverage report: map modules to decisions via affected_files.
+pub async fn build_coverage(
+    modules: &mut [CodeModule],
+    store: &LanceStore,
+) -> anyhow::Result<CoverageReport> {
+    let records = store.list_records(None).await?;
+
+    let mut file_to_decisions: HashMap<String, Vec<String>> = HashMap::new();
+
+    for record in &records {
+        if record.status != "active" {
+            continue;
+        }
+        if record.kind != "adr" && record.kind != "rfc" && record.kind != "prd" {
+            continue;
+        }
+
+        let affected = checks::extract_affected_files(&record.body);
+        for pattern in &affected {
+            file_to_decisions
+                .entry(pattern.clone())
+                .or_default()
+                .push(record.id.clone());
+        }
+    }
+
+    for module in modules.iter_mut() {
+        for (pattern, decision_ids) in &file_to_decisions {
+            if module_matches_pattern(&module.path, pattern) {
+                for id in decision_ids {
+                    if !module.decisions.contains(id) {
+                        module.decisions.push(id.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let total = modules.len();
+    let covered = modules.iter().filter(|m| !m.decisions.is_empty()).count();
+    let uncovered = total - covered;
+    let percent = if total > 0 {
+        (covered as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    Ok(CoverageReport {
+        total_modules: total,
+        covered_modules: covered,
+        uncovered_modules: uncovered,
+        coverage_percent: percent,
+        modules: modules.to_vec(),
+    })
+}
+
+/// Check if a module path matches an affected_files pattern.
+fn module_matches_pattern(module_path: &str, pattern: &str) -> bool {
+    let pattern_clean = pattern
+        .trim_end_matches("/*")
+        .trim_end_matches("/**")
+        .trim_end_matches("/*.rs");
+
+    module_path.contains(pattern_clean) || pattern_clean.contains(module_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_source_file_detects_rust() {
+        assert!(is_source_file(Path::new("foo.rs")));
+        assert!(is_source_file(Path::new("bar.ts")));
+        assert!(!is_source_file(Path::new("readme.md")));
+        assert!(!is_source_file(Path::new("Cargo.toml")));
+    }
+
+    #[test]
+    fn module_matches_exact_path() {
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "crates/core/src/scoring"
+        ));
+    }
+
+    #[test]
+    fn module_matches_glob_pattern() {
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/scoring/*.rs"
+        ));
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/scoring/**"
+        ));
+    }
+
+    #[test]
+    fn module_no_match() {
+        assert!(!module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/validation"
+        ));
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod artifact;
 pub mod config;
+pub mod coverage;
 pub mod db;
 pub mod depth;
 pub mod drift;

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1783,6 +1783,35 @@ impl ForgeplanServer {
             "reports": reports,
         })))
     }
+
+    #[tool(description = "Show decision coverage per code module — which modules have architectural decisions and which are blind spots.")]
+    async fn forgeplan_coverage(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let ws = match self.require_workspace().await {
+            Ok(p) => p,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let project_root = ws.parent().unwrap_or(&ws).to_path_buf();
+
+        let mut modules = forgeplan_core::coverage::scan_modules(&project_root)
+            .await
+            .unwrap_or_default();
+        let report = forgeplan_core::coverage::build_coverage(&mut modules, &store)
+            .await
+            .unwrap_or_else(|_| forgeplan_core::coverage::CoverageReport {
+                total_modules: 0,
+                covered_modules: 0,
+                uncovered_modules: 0,
+                coverage_percent: 0.0,
+                modules: vec![],
+            });
+
+        Ok(json_result(&report))
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Module scanner** — `forgeplan scan` detects 546 source modules across the codebase
- **Decision coverage** — `forgeplan coverage` maps modules to ADR/RFC/PRD with affected_files
- **Blind spots** — uncovered modules = architectural blind spots
- **MCP tool** — `forgeplan_coverage` returns JSON CoverageReport

## Test plan

- [x] 296/296 tests PASS (+4 coverage unit tests)
- [x] `forgeplan scan` — detects modules with file/line counts
- [x] `forgeplan coverage` — shows 0% coverage (expected, no affected_files in workspace)

Refs: PRD-019, PROB-010, EPIC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)