### PR TITLE
Release v0.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,31 @@ Validator принимает синонимы для секций:
 
 Формула: **работа не закончена, пока прогресс не отражён в артефактах.**
 
+### Forge Mode (permission model)
+
+**Три зоны доверия** (FPF B.3 Trust Calculus applied to CLI permissions):
+
+| Зона | Что | Режим | Примеры |
+|------|-----|-------|---------|
+| **Green** | Read-only + build + test + forgeplan | Авто-разрешено | `cargo test`, `forgeplan health`, `git status` |
+| **Yellow** | Файлы + git add/commit | Авто-разрешено (acceptEdits) | Write, Edit, `git add`, `git commit` |
+| **Red** | Необратимые действия | **BLOCKED hook** | `git push --force`, `rm -rf /`, `cargo publish` |
+
+**Настройка:**
+- `settings.local.json` — whitelist permissions (wildcard patterns: `Bash(cargo:*)`, `Bash(git:*)`)
+- `.claude/hooks/forge-safety-hook.sh` — PreToolUse blacklist (blocked patterns)
+- Режим Claude Code: `acceptEdits` (файлы авто, bash через whitelist)
+
+**Blacklisted commands** (blocked даже в yolo mode):
+- `git push --force` / `git push -f`
+- `git reset --hard`
+- `git clean -fd`
+- `rm -rf /` / `rm -rf ~`
+- `cargo publish` (explicit manual action)
+- `DROP TABLE`
+
+**Команда `/forge-cycle`** — полный FPF-aligned цикл: Observe → Route → Shape → Sprint → Build → Audit → Fix → Evidence → Commit → PR → Activate.
+
 ### Git-конвенции
 
 #### Формат коммита (Conventional Commits + Forgeplan):
@@ -243,28 +268,53 @@ Refs: RFC-001, FR-001..004
 - Код: `cli`, `core`, `store`, `template`, `scoring`, `workspace`, `config`
 - Артефакты: `rfc`, `prd`, `adr`, `epic`
 
-#### Branching Strategy (Trunk-based):
+#### Branching Strategy (dev-based):
 ```
-main                              ← primary branch (tagged releases: v0.7.0)
-  ├── feat/epic-001-completion    ← feature branch
-  ├── fix/dogfood-findings        ← bugfix branch
-  └── docs/rfc-002-lancedb       ← docs-only branch
+main                              ← production (tagged releases: v0.8.0, v0.9.0)
+  │
+dev                               ← integration branch (all features merge here)
+  ├── feat/prd-018-openspec-dag   ← feature branch (from dev)
+  ├── fix/search-ranking          ← bugfix branch (from dev)
+  └── docs/rfc-002-lancedb       ← docs-only branch (from dev)
+  │
+release/v0.9.0                    ← release candidate (from dev → main)
 ```
 
-| Ветка | Мерджится в | Стратегия |
-|-------|-------------|-----------|
-| `feat/*`, `fix/*`, `docs/*` | `main` | Squash merge via PR |
+| Ветка | Создаётся из | Мерджится в | Стратегия |
+|-------|-------------|-------------|-----------|
+| `feat/*`, `fix/*`, `docs/*` | **dev** | **dev** | Squash merge via PR |
+| `release/v0.x.0` | **dev** | **main** + **dev** | Merge commit (сохраняет историю) |
+| `hotfix/*` | **main** | **main** + **dev** | Cherry-pick |
 
-Формат имени: `{type}/{slug}` — `feat/epic-001-completion`, `fix/dogfood-findings`
+Формат имени: `{type}/{slug}` — `feat/prd-018-openspec-dag`, `fix/search-ranking`
+
+#### ОБЯЗАТЕЛЬНО перед созданием ветки:
+```bash
+git checkout dev && git pull origin dev   # ВСЕГДА вытягивать перед новой веткой
+git checkout -b feat/my-feature
+```
+**НЕ создавать ветки из stale dev.** Всегда `git pull` первым.
 
 #### Lifecycle ветки:
 ```
-1. git checkout main && git checkout -b feat/my-feature
-2. ... работа, коммиты ...
-3. git push origin feat/my-feature
-4. gh pr create → squash merge в main (НЕ удалять ветку)
+1. git checkout dev && git pull origin dev        # обязательно pull!
+2. git checkout -b feat/my-feature
+3. ... работа, коммиты ...
+4. git push origin feat/my-feature
+5. gh pr create --base dev → squash merge в dev (НЕ удалять ветку)
+6. git checkout dev && git pull
+```
+
+#### Lifecycle релиза:
+```
+1. git checkout dev && git pull
+2. git checkout -b release/v0.x.0
+3. cargo test, финальные фиксы на ветке
+4. gh pr create --base main → merge commit в main
 5. git checkout main && git pull
-6. При release: git tag -a v0.x.0 && git push origin v0.x.0
+6. git tag -a v0.x.0 -m "Release v0.x.0" && git push origin v0.x.0
+7. git checkout dev && git merge main          # sync tag back to dev
+8. git push origin dev
 ```
 
 #### Правила коммитов:
@@ -274,19 +324,28 @@ main                              ← primary branch (tagged releases: v0.7.0)
 - **Не коммить напрямую в main или dev** — всегда через feature branch + PR
 
 #### PR и merge:
-- **PR title** = `[ARTIFACT-ID] description` — `[RFC-001] Implement Phase 3A core CLI`
+- **PR title** = `[ARTIFACT-ID] description` — `[PRD-018] OpenSpec DAG integration`
 - **PR body** = Summary (bullets) + Refs (артефакты) + Test plan
-- **feat/* → dev**: Squash merge (чистая история)
-- **release/* → main**: Merge commit (сохраняет историю RC)
+- **feat/* → dev**: Squash merge (чистая история) — `gh pr create --base dev`
+- **release/* → main**: Merge commit (сохраняет историю RC) — `gh pr create --base main`
 - **НЕ удалять ветки после merge** — feature и release branches сохраняются как история
-- **После merge в main**: tag + sync dev from main
+- **После merge в main**: tag + sync dev from main (`git checkout dev && git merge main`)
+- **НЕ коммить напрямую в main** — только через release branch
+- **НЕ коммить напрямую в dev** — только через feature branch + PR
 
-#### Релизы:
-- **Формат тега**: `v{major}.{minor}.{patch}` — `v0.1.0`, `v0.2.0`
-- **Когда**: после завершения Phase (3A → v0.1.0, 3B → v0.2.0, 3C → v1.0.0)
-- **Процесс**: `dev` → `release/v0.x.0` (RC) → тесты → фиксы → `main` + tag
-- **Release notes**: автогенерация из conventional commits
-- **Binary**: `cargo build --release` (152MB с LanceDB+Arrow+tokio)
+#### Релизы и тегирование:
+- **Формат тега**: `v{major}.{minor}.{patch}` — `v0.8.0`, `v0.9.0`, `v1.0.0`
+- **Когда тегировать**: после merge release/* в main
+- **ОБЯЗАТЕЛЬНО тегировать каждый релиз** — без тега релиз не считается выпущенным
+- **Процесс**:
+  1. `dev` → `release/v0.x.0` (RC branch)
+  2. Тесты + финальные фиксы на release branch
+  3. PR в main → merge commit
+  4. `git tag -a v0.x.0 -m "Release v0.x.0: описание"` на main
+  5. `git push origin v0.x.0`
+  6. Sync: `git checkout dev && git merge main && git push origin dev`
+- **Release notes**: автогенерация из conventional commits (`gh release create`)
+- **Binary**: `cargo build --release`
 
 #### Worktrees (параллельная работа):
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,40 @@ forgeplan route "описание задачи"   # определи depth и pi
 
 **Работа не закончена, пока: PRD заполнен + validate PASS + evidence создан + R_eff > 0 + activated.**
 
+### ОБЯЗАТЕЛЬНО smoke test после каждого спринта:
+
+```bash
+# 1. Unit tests
+cargo test                              # ВСЕ должны PASS
+
+# 2. Workspace init (AI всегда использует -y!)
+forgeplan init -y                       # НИКОГДА без -y в AI контексте
+
+# 3. Core operations
+forgeplan new prd "Smoke Test"          # Создание артефакта
+forgeplan validate PRD-XXX              # Валидация работает
+forgeplan score PRD-XXX                 # F-G-R scoring работает
+
+# 4. Новые фичи (PRD-016+)
+forgeplan blocked                       # Граф зависимостей
+forgeplan order                         # Topological sort
+
+# 5. FPF Knowledge Base (PRD-021)
+forgeplan fpf ingest                    # 204 секции загружены
+forgeplan fpf search "trust"            # Поиск находит B.3
+
+# 6. LLM integration
+GEMINI_API_KEY=<key> forgeplan reason PRD-XXX --fpf  # ADI + FPF context
+```
+
+**Если любой шаг fail — НЕ коммитить. Починить сначала.**
+
+### ВАЖНО для AI агентов:
+- **`forgeplan init`** — ВСЕГДА с `-y` флагом (без interactive prompt)
+- **Config после init** — проверить `.forgeplan/config.yaml`, настроить LLM provider
+- **`.forgeplan/` в gitignore** — workspace данные НЕ трекаются, config теряется при reinit
+- **LanceDB migration** — новые columns требуют reinit workspace (`rm -rf .forgeplan && forgeplan init -y`)
+
 ### ОБЯЗАТЕЛЬНО при написании Rust кода:
 
 1. **Перед сложными паттернами** — активируй Rust skills:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,6 +392,46 @@ git worktree remove ../forgeplan-fix
 - **Когда**: hotfix во время долгой фичи; параллельная работа агентов (isolation: "worktree")
 - **Правило**: worktree = временный, удалять после merge
 
+### ЗАПРЕЩЁННЫЕ действия (CRITICAL):
+
+**НИКОГДА не удалять `.forgeplan/` без backup:**
+```bash
+# ПРАВИЛЬНО:
+forgeplan export --output backup.json   # ОБЯЗАТЕЛЬНО перед любым reinit
+cp -r .forgeplan .forgeplan-backup-$(date +%Y%m%d)  # backup copy
+# потом уже можно reinit
+
+# ЗАПРЕЩЕНО:
+rm -rf .forgeplan   # ← ПОТЕРЯ ВСЕХ АРТЕФАКТОВ, EVIDENCE, LINKS!
+```
+
+**ОБЯЗАТЕЛЬНО при reinit:**
+1. `forgeplan export` → сохранить JSON
+2. `cp -r .forgeplan .forgeplan-backup-ДАТА`
+3. Только потом `rm -rf .forgeplan && forgeplan init -y`
+4. `forgeplan import backup.json` → восстановить
+
+**AI агенты:**
+- `forgeplan init` → ВСЕГДА с `-y` (non-interactive mode)
+- НИКОГДА `rm -rf .forgeplan` без `forgeplan export` первым
+- После init → настроить `.forgeplan/config.yaml` (LLM provider)
+
+### ОБЯЗАТЕЛЬНО smoke test после каждого спринта:
+
+```bash
+cargo test                              # ВСЕ должны PASS
+forgeplan init -y                       # Workspace создаётся
+forgeplan new prd "Smoke Test"          # Артефакт создаётся
+forgeplan validate PRD-XXX              # Валидация работает
+forgeplan score PRD-XXX                 # F-G-R scoring работает
+forgeplan blocked                       # Граф зависимостей
+forgeplan order                         # Topological sort
+forgeplan fpf ingest                    # FPF KB загружается
+forgeplan fpf search "trust"            # Поиск работает
+```
+
+**Если любой шаг fail — НЕ коммитить. Починить сначала.**
+
 ## Структура проекта
 
 ```

--- a/crates/forgeplan-cli/src/commands/blocked.rs
+++ b/crates/forgeplan-cli/src/commands/blocked.rs
@@ -1,0 +1,68 @@
+use std::collections::HashSet;
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::graph::topological;
+use forgeplan_core::workspace;
+
+/// `forgeplan blocked [id]` — show blocked artifacts and their dependencies.
+pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let all_relations = store.get_all_relations().await?;
+
+    // Get active artifact IDs
+    let all_records = store.list_records(None).await?;
+    let active_ids: HashSet<String> = all_records
+        .iter()
+        .filter(|r| r.status == "active")
+        .map(|r| r.id.clone())
+        .collect();
+
+    if let Some(artifact_id) = id {
+        // Show blocked status for specific artifact
+        let blocked_by = topological::get_blocked_by(artifact_id, &all_relations, &active_ids);
+        if blocked_by.is_empty() {
+            println!("  {} is NOT blocked (all dependencies met)", artifact_id);
+        } else {
+            println!("  {} is BLOCKED by:", artifact_id);
+            for dep in &blocked_by {
+                let status = if active_ids.contains(dep) {
+                    "active"
+                } else {
+                    "draft"
+                };
+                println!("    -> {} ({})", dep, status);
+            }
+        }
+    } else {
+        // Show all blocked artifacts
+        let result = topological::kahn_sort(&all_relations, &active_ids);
+
+        if !result.cycles.is_empty() {
+            println!("  Warning: Cycles detected:");
+            for cycle in &result.cycles {
+                println!("    {}", cycle.join(" -> "));
+            }
+            println!();
+        }
+
+        if result.blocked.is_empty() {
+            println!("  No blocked artifacts. All dependencies met.");
+        } else {
+            println!("  Blocked artifacts:");
+            for (id, blockers) in &result.blocked {
+                println!("    {} <- blocked by: {}", id, blockers.join(", "));
+            }
+        }
+
+        println!();
+        println!("  Ready to work: {}", result.ready.len());
+        println!("  Blocked: {}", result.blocked.len());
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/coverage.rs
+++ b/crates/forgeplan-cli/src/commands/coverage.rs
@@ -1,0 +1,92 @@
+use std::env;
+
+use forgeplan_core::coverage;
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::workspace;
+
+/// `forgeplan scan [--path <dir>]` — scan codebase for modules
+pub async fn run_scan(path: Option<&str>) -> anyhow::Result<()> {
+    let project_root = match path {
+        Some(p) => std::path::PathBuf::from(p),
+        None => env::current_dir()?,
+    };
+
+    println!("  Scanning {}...", project_root.display());
+    let modules = coverage::scan_modules(&project_root).await?;
+
+    if modules.is_empty() {
+        println!("  No source modules found.");
+        return Ok(());
+    }
+
+    println!();
+    println!("  {:40} {:>5} {:>7}", "Module", "Files", "Lines");
+    println!("  {}", "-".repeat(55));
+    for m in &modules {
+        println!("  {:40} {:>5} {:>7}", m.path, m.file_count, m.line_count);
+    }
+    println!();
+    let total_files: usize = modules.iter().map(|m| m.file_count).sum();
+    let total_lines: usize = modules.iter().map(|m| m.line_count).sum();
+    println!(
+        "  {} modules, {} files, {} lines",
+        modules.len(),
+        total_files,
+        total_lines
+    );
+
+    Ok(())
+}
+
+/// `forgeplan coverage` — show decision coverage per module
+pub async fn run_coverage() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let project_root = ws.parent().unwrap_or(&ws);
+    let store = LanceStore::open(&ws).await?;
+
+    println!("  Scanning codebase...");
+    let mut modules = coverage::scan_modules(project_root).await?;
+    let report = coverage::build_coverage(&mut modules, &store).await?;
+
+    println!();
+    println!(
+        "  Decision Coverage: {:.0}% ({}/{} modules)",
+        report.coverage_percent, report.covered_modules, report.total_modules
+    );
+    println!();
+
+    // Show uncovered modules first (blind spots)
+    let uncovered: Vec<_> = report
+        .modules
+        .iter()
+        .filter(|m| m.decisions.is_empty())
+        .collect();
+    if !uncovered.is_empty() {
+        println!("  \u{26a0} Uncovered modules (architectural blind spots):");
+        for m in &uncovered {
+            println!(
+                "    {} ({} files, {} lines)",
+                m.path, m.file_count, m.line_count
+            );
+        }
+        println!();
+    }
+
+    // Show covered modules
+    let covered: Vec<_> = report
+        .modules
+        .iter()
+        .filter(|m| !m.decisions.is_empty())
+        .collect();
+    if !covered.is_empty() {
+        println!("  \u{2713} Covered modules:");
+        for m in &covered {
+            println!("    {} \u{2190} {}", m.path, m.decisions.join(", "));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/drift.rs
+++ b/crates/forgeplan-cli/src/commands/drift.rs
@@ -1,0 +1,53 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::drift;
+use forgeplan_core::workspace;
+
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+
+    // workspace_root = parent of .forgeplan
+    let workspace_root = ws.parent().unwrap_or(&ws);
+    let reports = drift::check_drift(&store, workspace_root).await?;
+
+    if reports.is_empty() {
+        println!("  No active ADR/RFC with affected_files found.");
+        println!("  Hint: Add '## Affected Files' section to ADR/RFC artifacts.");
+        return Ok(());
+    }
+
+    let stale_count = reports.iter().filter(|r| r.is_stale).count();
+    let total = reports.len();
+
+    println!();
+    for report in &reports {
+        if report.is_stale {
+            println!(
+                "  \u{26a0} {} \"{}\" \u{2014} STALE",
+                report.artifact_id, report.artifact_title
+            );
+            println!("    Created: {}", report.created_at);
+            for file in &report.changed_files {
+                println!("    Changed: {} ({})", file.path, file.last_modified);
+            }
+        } else {
+            println!(
+                "  \u{2713} {} \"{}\" \u{2014} up to date",
+                report.artifact_id, report.artifact_title
+            );
+        }
+        println!();
+    }
+
+    println!("  {} decisions checked, {} stale", total, stale_count);
+    if stale_count > 0 {
+        println!("  Action: Review stale decisions and update or supersede them.");
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/migrate.rs
+++ b/crates/forgeplan-cli/src/commands/migrate.rs
@@ -1,0 +1,16 @@
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::workspace;
+
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    println!("  Running schema migrations...");
+    let _store = LanceStore::open(&ws).await?; // open() runs migrations
+    println!("  Migrations complete. Schema up to date.");
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod activate;
 pub mod blindspots;
+pub mod blocked;
 pub mod calibrate;
 pub mod capture;
 pub mod decay;
@@ -20,6 +21,7 @@ pub mod journal;
 pub mod link;
 pub mod list;
 pub mod new;
+pub mod order;
 pub mod progress;
 pub mod reason;
 pub mod review;

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod decay;
 pub mod decompose;
 pub mod delete;
 pub mod deprecate;
+pub mod drift;
 pub mod export;
 
 pub mod fgr;
@@ -20,6 +21,7 @@ pub mod init;
 pub mod journal;
 pub mod link;
 pub mod list;
+pub mod migrate;
 pub mod new;
 pub mod order;
 pub mod progress;

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod blindspots;
 pub mod blocked;
 pub mod calibrate;
 pub mod capture;
+pub mod coverage;
 pub mod decay;
 pub mod decompose;
 pub mod delete;

--- a/crates/forgeplan-cli/src/commands/order.rs
+++ b/crates/forgeplan-cli/src/commands/order.rs
@@ -1,0 +1,85 @@
+use std::collections::HashSet;
+use std::env;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::graph::topological;
+use forgeplan_core::workspace;
+
+/// `forgeplan order` — show artifacts in topological order (dependency order).
+pub async fn run() -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::open(&ws).await?;
+    let all_relations = store.get_all_relations().await?;
+
+    let all_records = store.list_records(None).await?;
+    let active_ids: HashSet<String> = all_records
+        .iter()
+        .filter(|r| r.status == "active")
+        .map(|r| r.id.clone())
+        .collect();
+
+    let result = topological::kahn_sort(&all_relations, &active_ids);
+
+    if !result.cycles.is_empty() {
+        println!("  Warning: Cycles detected:");
+        for cycle in &result.cycles {
+            println!("    {}", cycle.join(" -> "));
+        }
+        println!();
+    }
+
+    if result.order.is_empty() {
+        println!("  No linked artifacts found. Use `forgeplan link` to create dependencies.");
+        return Ok(());
+    }
+
+    // Build lookup sets for display
+    let blocked_ids: HashSet<&str> = result
+        .blocked
+        .iter()
+        .map(|(id, _)| id.as_str())
+        .collect();
+
+    println!("  Artifacts in dependency order:");
+    println!();
+    for id in &result.order {
+        let marker = if active_ids.contains(id) {
+            "v"
+        } else if blocked_ids.contains(id.as_str()) {
+            "x"
+        } else {
+            "o"
+        };
+
+        let status: String = if active_ids.contains(id) {
+            "active".to_string()
+        } else if blocked_ids.contains(id.as_str()) {
+            let blockers: Vec<&str> = result
+                .blocked
+                .iter()
+                .find(|(bid, _)| bid == id)
+                .map(|(_, deps)| deps.iter().map(|s| s.as_str()).collect())
+                .unwrap_or_default();
+            format!("draft, blocked by {}", blockers.join(", "))
+        } else {
+            "draft, ready".to_string()
+        };
+
+        println!("    {} {} ({})", marker, id, status);
+    }
+
+    println!();
+    let total = result.order.len();
+    let active_count = result.order.iter().filter(|id| active_ids.contains(*id)).count();
+    let ready_count = result.ready.len().saturating_sub(active_count);
+    let blocked_count = result.blocked.len();
+    println!(
+        "  Total: {}  Active: {}  Ready: {}  Blocked: {}",
+        total, active_count, ready_count, blocked_count
+    );
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -196,6 +196,8 @@ enum Commands {
         /// Artifact ID (scores all if omitted)
         id: Option<String>,
     },
+    /// Check for drifted decisions (affected files changed after decision)
+    Drift,
     /// Show blocked artifacts and their dependencies
     Blocked {
         /// Specific artifact ID to check (optional)
@@ -245,6 +247,8 @@ enum Commands {
     },
     /// Show artifacts in topological order (dependency order)
     Order,
+    /// Run schema migrations on existing workspace
+    Migrate,
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -341,6 +345,7 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Drift => commands::drift::run().await,
         Commands::Blocked { id } => commands::blocked::run(id.as_deref()).await,
         Commands::Blindspots => commands::blindspots::run().await,
         Commands::Journal { r#type, risk } => {
@@ -371,6 +376,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Export { output } => commands::export::run(output.as_deref()).await,
         Commands::Import { path, force } => commands::import_cmd::run(&path, force).await,
         Commands::Order => commands::order::run().await,
+        Commands::Migrate => commands::migrate::run().await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -196,6 +196,14 @@ enum Commands {
         /// Artifact ID (scores all if omitted)
         id: Option<String>,
     },
+    /// Scan codebase for source modules
+    Scan {
+        /// Path to project root (default: current dir)
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Show decision coverage per code module
+    Coverage,
     /// Check for drifted decisions (affected files changed after decision)
     Drift,
     /// Show blocked artifacts and their dependencies
@@ -345,6 +353,8 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Scan { path } => commands::coverage::run_scan(path.as_deref()).await,
+        Commands::Coverage => commands::coverage::run_coverage().await,
         Commands::Drift => commands::drift::run().await,
         Commands::Blocked { id } => commands::blocked::run(id.as_deref()).await,
         Commands::Blindspots => commands::blindspots::run().await,

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -196,6 +196,11 @@ enum Commands {
         /// Artifact ID (scores all if omitted)
         id: Option<String>,
     },
+    /// Show blocked artifacts and their dependencies
+    Blocked {
+        /// Specific artifact ID to check (optional)
+        id: Option<String>,
+    },
     /// Show blind spots — decisions without evidence, orphan artifacts
     Blindspots,
     /// Show decision journal — chronological timeline with R_eff scores
@@ -238,6 +243,8 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Show artifacts in topological order (dependency order)
+    Order,
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -334,6 +341,7 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Commands::Delete { id, yes } => commands::delete::run(&id, yes).await,
+        Commands::Blocked { id } => commands::blocked::run(id.as_deref()).await,
         Commands::Blindspots => commands::blindspots::run().await,
         Commands::Journal { r#type, risk } => {
             commands::journal::run(r#type.as_deref(), risk).await
@@ -362,6 +370,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Export { output } => commands::export::run(output.as_deref()).await,
         Commands::Import { path, force } => commands::import_cmd::run(&path, force).await,
+        Commands::Order => commands::order::run().await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -671,3 +671,541 @@ fn full_workflow_dogfood() {
         .stdout(predicate::str::contains("PRD-001"))
         .stdout(predicate::str::contains("1 artifact"));
 }
+
+// ── E2E: Dependency Graph + Topological Sort ─────────────
+
+#[test]
+fn e2e_blocked_shows_dependencies() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create PRD and RFC
+    forgeplan().args(["new", "prd", "Design Doc"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "Implementation Plan"]).current_dir(tmp.path()).assert().success();
+
+    // Link RFC depends on PRD
+    forgeplan()
+        .args(["link", "RFC-001", "PRD-001", "--relation", "based_on"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Blocked should show RFC blocked by PRD
+    forgeplan()
+        .args(["blocked"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RFC-001"))
+        .stdout(predicate::str::contains("PRD-001"));
+}
+
+#[test]
+fn e2e_order_shows_topological_sequence() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create chain: Epic → PRD → RFC
+    forgeplan().args(["new", "epic", "Platform"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Feature A"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "How to build A"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan().args(["link", "PRD-001", "EPIC-001", "--relation", "refines"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["link", "RFC-001", "PRD-001", "--relation", "based_on"]).current_dir(tmp.path()).assert().success();
+
+    // Order should list all 3
+    forgeplan()
+        .args(["order"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EPIC-001"))
+        .stdout(predicate::str::contains("PRD-001"))
+        .stdout(predicate::str::contains("RFC-001"));
+}
+
+#[test]
+fn e2e_activate_unblocks_dependent() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan().args(["new", "prd", "Base Feature"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "How to build"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["link", "RFC-001", "PRD-001", "--relation", "based_on"]).current_dir(tmp.path()).assert().success();
+
+    // Before activate: RFC blocked
+    let output = forgeplan()
+        .args(["blocked"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let before = String::from_utf8_lossy(&output.stdout);
+    assert!(before.contains("Blocked") || before.contains("blocked"), "RFC should be blocked before activate");
+
+    // Activate PRD
+    forgeplan().args(["activate", "PRD-001"]).current_dir(tmp.path()).assert().success();
+
+    // After activate: RFC should be ready
+    let output2 = forgeplan()
+        .args(["blocked"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let after = String::from_utf8_lossy(&output2.stdout);
+    // RFC-001 should no longer appear as blocked (PRD-001 is now active)
+    assert!(
+        !after.contains("RFC-001 <- blocked") || after.contains("Ready"),
+        "RFC should be unblocked after PRD activation, got: {}", after
+    );
+}
+
+#[test]
+fn e2e_graph_shows_mermaid_with_links() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan().args(["new", "prd", "Feature"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "Plan"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["link", "RFC-001", "PRD-001", "--relation", "based_on"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan()
+        .args(["graph"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("graph LR"))
+        .stdout(predicate::str::contains("RFC-001"))
+        .stdout(predicate::str::contains("PRD-001"))
+        .stdout(predicate::str::contains("based_on"));
+}
+
+#[test]
+fn e2e_drift_runs_on_empty_workspace() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Drift should run even with no ADR/RFC
+    forgeplan()
+        .args(["drift"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No active ADR/RFC").or(predicate::str::contains("affected_files")));
+}
+
+#[test]
+fn e2e_migrate_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // First migrate
+    forgeplan()
+        .args(["migrate"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("up to date").or(predicate::str::contains("complete")));
+
+    // Second migrate — should also succeed (idempotent)
+    forgeplan()
+        .args(["migrate"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+// ── E2E: Full Methodology Cycle + Validation Quality ─────
+
+#[test]
+fn e2e_full_methodology_cycle() {
+    let tmp = TempDir::new().unwrap();
+
+    // 1. Init
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // 2. Create PRD with full content
+    forgeplan().args(["new", "prd", "Auth System"]).current_dir(tmp.path()).assert().success();
+
+    // 3. Fill PRD body with proper content (Problem, Goals, FR, etc.)
+    let body = r#"# PRD-001: Auth System
+
+## Problem
+
+Users cannot authenticate. The system has no login mechanism, no session management, and no access control. This blocks all features that require user identity.
+
+## Goals
+
+- [ ] Users can log in with email and password
+- [ ] Sessions persist across browser refreshes
+- [ ] Admin users have elevated permissions
+
+## Non-Goals
+
+- Social login (OAuth) — deferred to Phase 2
+- Two-factor authentication — future enhancement
+
+## Target Users
+
+- End users who need to access the application
+- Administrators who manage user accounts
+
+## Functional Requirements
+
+- [ ] FR-001: User can create an account with email and password
+- [ ] FR-002: User can log in with valid credentials
+- [ ] FR-003: System can maintain session state across requests
+- [ ] FR-004: Admin can view and manage user list
+
+## Related
+
+- EPIC-001: Application Platform"#;
+
+    forgeplan()
+        .args(["update", "PRD-001", "--body", body])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // 4. Validate — should PASS
+    forgeplan()
+        .args(["validate", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PASS"));
+
+    // 5. Create evidence
+    forgeplan()
+        .args(["new", "evidence", "Auth system tests pass"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Fill evidence with structured fields
+    let evid_body = "## Structured Fields\n\nverdict: supports\ncongruence_level: 3\nevidence_type: test\n\n## Results\n- 10 tests pass\n- Login flow verified";
+    forgeplan()
+        .args(["update", "EVID-001", "--body", evid_body])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // 6. Link evidence → PRD
+    forgeplan()
+        .args(["link", "EVID-001", "PRD-001", "--relation", "informs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // 7. Score — should show evidence and R_eff
+    forgeplan()
+        .args(["score", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EVID-001"))
+        .stdout(predicate::str::contains("R_eff"));
+
+    // 8. Activate PRD (runs review internally, should pass)
+    forgeplan()
+        .args(["activate", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("active"));
+
+    // 9. Health — should show 1 active artifact
+    forgeplan()
+        .args(["health"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("active"));
+}
+
+#[test]
+fn e2e_validation_catches_quality_issues() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Bad PRD"]).current_dir(tmp.path()).assert().success();
+
+    // PRD with subjective adjectives, tech leakage, filler phrases
+    let bad_body = r#"# PRD-001: Bad PRD
+
+## Problem
+
+This is a simple problem statement that needs to be fixed quickly.
+
+## Goals
+
+- [ ] Make the system easy to use and fast
+- [ ] Build an intuitive interface with multiple features
+
+## Non-Goals
+
+- None
+
+## Target Users
+
+- Users
+
+## Functional Requirements
+
+- [ ] FR-001: System will allow users to easily navigate using React components with PostgreSQL database
+- [ ] FR-002: In order to provide a seamless experience, the system should support multiple authentication methods via JWT and OAuth
+
+## Related
+
+- None"#;
+
+    forgeplan()
+        .args(["update", "PRD-001", "--body", bad_body])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Validate should catch issues
+    let output = forgeplan()
+        .args(["validate", "PRD-001"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should detect measurability issues (subjective adjectives)
+    assert!(
+        stdout.contains("Subjective adjective") || stdout.contains("adjective") || stdout.contains("easy"),
+        "Should detect subjective adjectives like 'easy', got: {}", stdout
+    );
+
+    // Should detect implementation leakage
+    assert!(
+        stdout.contains("Tech names") || stdout.contains("React") || stdout.contains("PostgreSQL"),
+        "Should detect tech leakage (React, PostgreSQL), got: {}", stdout
+    );
+
+    // Should detect filler phrases
+    assert!(
+        stdout.contains("filler") || stdout.contains("in order to"),
+        "Should detect filler phrases like 'in order to', got: {}", stdout
+    );
+}
+
+#[test]
+fn e2e_score_shows_fgr_breakdown() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Test Feature"]).current_dir(tmp.path()).assert().success();
+
+    // Score should show F-G-R breakdown
+    forgeplan()
+        .args(["score", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Formality"))
+        .stdout(predicate::str::contains("Granularity"))
+        .stdout(predicate::str::contains("Reliability"));
+}
+
+#[test]
+fn e2e_route_determines_depth() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Simple task → Tactical
+    forgeplan()
+        .args(["route", "fix typo in readme"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Tactical"));
+
+    // Complex task with security keyword → Deep or Standard
+    forgeplan()
+        .args(["route", "implement OAuth2 authentication with security audit and compliance review"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Deep").or(predicate::str::contains("Standard")));
+}
+
+// ── E2E: Export/Import + FPF Knowledge Base ──────────────
+
+#[test]
+fn e2e_export_import_preserves_data() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create 3 artifacts with links
+    forgeplan().args(["new", "prd", "Feature A"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "Plan for A"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "evidence", "Tests pass"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["link", "RFC-001", "PRD-001", "--relation", "based_on"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["link", "EVID-001", "PRD-001", "--relation", "informs"]).current_dir(tmp.path()).assert().success();
+
+    // Export
+    let export_path = tmp.path().join("backup.json");
+    forgeplan()
+        .args(["export", "--output", export_path.to_str().unwrap()])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3 artifacts"));
+
+    assert!(export_path.exists());
+
+    // Verify export file is valid JSON
+    let content = std::fs::read_to_string(&export_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(json["artifacts"].is_array());
+    assert_eq!(json["artifacts"].as_array().unwrap().len(), 3);
+
+    // Destroy workspace
+    std::fs::remove_dir_all(tmp.path().join(".forgeplan")).unwrap();
+
+    // Re-init
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Import
+    forgeplan()
+        .args(["import", export_path.to_str().unwrap()])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Verify data restored
+    forgeplan()
+        .args(["health"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3 total").or(predicate::str::contains("prd")));
+
+    // Verify specific artifact
+    forgeplan()
+        .args(["get", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Feature A"));
+}
+
+#[test]
+fn e2e_health_comprehensive() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create varied artifacts
+    forgeplan().args(["new", "prd", "Feature"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "problem", "Bug Report"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "note", "Quick Note"]).current_dir(tmp.path()).assert().success();
+
+    // Health should show all kinds
+    forgeplan()
+        .args(["health"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("prd"))
+        .stdout(predicate::str::contains("problem"))
+        .stdout(predicate::str::contains("note"))
+        .stdout(predicate::str::contains("3 total"));
+}
+
+#[test]
+fn e2e_list_shows_all_artifact_types() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan().args(["new", "prd", "My PRD"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "rfc", "My RFC"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "adr", "My ADR"]).current_dir(tmp.path()).assert().success();
+
+    forgeplan()
+        .args(["list"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PRD-001"))
+        .stdout(predicate::str::contains("RFC-001"))
+        .stdout(predicate::str::contains("ADR-001"))
+        .stdout(predicate::str::contains("My PRD"))
+        .stdout(predicate::str::contains("My RFC"))
+        .stdout(predicate::str::contains("My ADR"));
+}
+
+#[test]
+fn e2e_supersede_workflow() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create and activate old PRD
+    forgeplan().args(["new", "prd", "Old Feature"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["activate", "PRD-001"]).current_dir(tmp.path()).assert().success();
+
+    // Create new PRD
+    forgeplan().args(["new", "prd", "New Feature"]).current_dir(tmp.path()).assert().success();
+
+    // Supersede old with new
+    forgeplan()
+        .args(["supersede", "PRD-001", "--by", "PRD-002"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Superseded"));
+
+    // Old PRD should be superseded
+    forgeplan()
+        .args(["get", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("superseded").or(predicate::str::contains("Superseded")));
+}
+
+#[test]
+fn e2e_fpf_commands_available() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // FPF status before ingest
+    forgeplan()
+        .args(["fpf", "status"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("not initialized").or(predicate::str::contains("Status")));
+
+    // FPF list before ingest
+    forgeplan()
+        .args(["fpf", "list"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // FPF search before ingest (should not crash)
+    forgeplan()
+        .args(["fpf", "search", "test"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn e2e_adr_contract_validation() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create ADR without contract sections
+    forgeplan().args(["new", "adr", "Use PostgreSQL"]).current_dir(tmp.path()).assert().success();
+
+    // Validate runs and produces result (PASS or warnings depending on depth)
+    forgeplan()
+        .args(["validate", "ADR-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ADR-001"))
+        .stdout(predicate::str::contains("PASS").or(predicate::str::contains("error").or(predicate::str::contains("warning"))));
+}

--- a/crates/forgeplan-core/src/artifact/delta.rs
+++ b/crates/forgeplan-core/src/artifact/delta.rs
@@ -1,0 +1,250 @@
+//! Delta-spec parser for ADDED/MODIFIED/REMOVED requirement changes.
+
+/// A single requirement in a delta spec.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeltaRequirement {
+    pub name: String,
+    pub body: String,
+}
+
+/// Parsed delta spec — changes between versions.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DeltaSpec {
+    pub added: Vec<DeltaRequirement>,
+    pub modified: Vec<DeltaRequirement>,
+    pub removed: Vec<String>, // just names
+}
+
+/// Parse a markdown delta spec.
+///
+/// Expected format:
+/// ```markdown
+/// ## ADDED Requirements
+/// ### Requirement: Two-Factor Auth
+/// Description here...
+///
+/// ## MODIFIED Requirements
+/// ### Requirement: Session Timeout
+/// Changed from 30 to 60 minutes...
+///
+/// ## REMOVED Requirements
+/// ### Requirement: Legacy Login
+/// ```
+pub fn parse_delta(markdown: &str) -> DeltaSpec {
+    let mut added = Vec::new();
+    let mut modified = Vec::new();
+    let mut removed = Vec::new();
+
+    let mut current_section = ""; // "added", "modified", "removed"
+    let mut current_req_name = String::new();
+    let mut current_req_body = String::new();
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+
+        // Detect section headers
+        if trimmed.eq_ignore_ascii_case("## added requirements")
+            || trimmed.eq_ignore_ascii_case("## added")
+        {
+            flush_requirement(
+                &mut current_req_name,
+                &mut current_req_body,
+                current_section,
+                &mut added,
+                &mut modified,
+                &mut removed,
+            );
+            current_section = "added";
+            continue;
+        }
+        if trimmed.eq_ignore_ascii_case("## modified requirements")
+            || trimmed.eq_ignore_ascii_case("## modified")
+        {
+            flush_requirement(
+                &mut current_req_name,
+                &mut current_req_body,
+                current_section,
+                &mut added,
+                &mut modified,
+                &mut removed,
+            );
+            current_section = "modified";
+            continue;
+        }
+        if trimmed.eq_ignore_ascii_case("## removed requirements")
+            || trimmed.eq_ignore_ascii_case("## removed")
+        {
+            flush_requirement(
+                &mut current_req_name,
+                &mut current_req_body,
+                current_section,
+                &mut added,
+                &mut modified,
+                &mut removed,
+            );
+            current_section = "removed";
+            continue;
+        }
+
+        // Detect requirement headers: ### Requirement: Name
+        if let Some(rest) = trimmed
+            .strip_prefix("### Requirement:")
+            .or_else(|| trimmed.strip_prefix("### requirement:"))
+        {
+            flush_requirement(
+                &mut current_req_name,
+                &mut current_req_body,
+                current_section,
+                &mut added,
+                &mut modified,
+                &mut removed,
+            );
+            current_req_name = rest.trim().to_string();
+            continue;
+        }
+
+        // Accumulate body
+        if !current_req_name.is_empty() {
+            current_req_body.push_str(line);
+            current_req_body.push('\n');
+        }
+    }
+
+    // Flush last requirement
+    flush_requirement(
+        &mut current_req_name,
+        &mut current_req_body,
+        current_section,
+        &mut added,
+        &mut modified,
+        &mut removed,
+    );
+
+    DeltaSpec {
+        added,
+        modified,
+        removed,
+    }
+}
+
+fn flush_requirement(
+    name: &mut String,
+    body: &mut String,
+    section: &str,
+    added: &mut Vec<DeltaRequirement>,
+    modified: &mut Vec<DeltaRequirement>,
+    removed: &mut Vec<String>,
+) {
+    if name.is_empty() {
+        return;
+    }
+    let trimmed_body = body.trim().to_string();
+    match section {
+        "added" => added.push(DeltaRequirement {
+            name: name.clone(),
+            body: trimmed_body,
+        }),
+        "modified" => modified.push(DeltaRequirement {
+            name: name.clone(),
+            body: trimmed_body,
+        }),
+        "removed" => removed.push(name.clone()),
+        _ => {}
+    }
+    name.clear();
+    body.clear();
+}
+
+/// Generate a simple delta summary string.
+pub fn delta_summary(delta: &DeltaSpec) -> String {
+    let mut parts = Vec::new();
+    if !delta.added.is_empty() {
+        parts.push(format!("+{} added", delta.added.len()));
+    }
+    if !delta.modified.is_empty() {
+        parts.push(format!("~{} modified", delta.modified.len()));
+    }
+    if !delta.removed.is_empty() {
+        parts.push(format!("-{} removed", delta.removed.len()));
+    }
+    if parts.is_empty() {
+        "No changes".to_string()
+    } else {
+        parts.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_full_delta() {
+        let md = r#"
+## ADDED Requirements
+### Requirement: Two-Factor Auth
+Users must authenticate via TOTP or SMS.
+
+### Requirement: Audit Log
+All login attempts are recorded.
+
+## MODIFIED Requirements
+### Requirement: Session Timeout
+Changed from 30 to 60 minutes.
+
+## REMOVED Requirements
+### Requirement: Legacy Login
+"#;
+        let delta = parse_delta(md);
+        assert_eq!(delta.added.len(), 2);
+        assert_eq!(delta.added[0].name, "Two-Factor Auth");
+        assert!(delta.added[0].body.contains("TOTP"));
+        assert_eq!(delta.added[1].name, "Audit Log");
+        assert_eq!(delta.modified.len(), 1);
+        assert_eq!(delta.modified[0].name, "Session Timeout");
+        assert!(delta.modified[0].body.contains("60 minutes"));
+        assert_eq!(delta.removed.len(), 1);
+        assert_eq!(delta.removed[0], "Legacy Login");
+    }
+
+    #[test]
+    fn parse_empty_delta() {
+        let delta = parse_delta("");
+        assert!(delta.added.is_empty());
+        assert!(delta.modified.is_empty());
+        assert!(delta.removed.is_empty());
+    }
+
+    #[test]
+    fn parse_added_only() {
+        let md = "## Added\n### Requirement: Feature X\nDescription.";
+        let delta = parse_delta(md);
+        assert_eq!(delta.added.len(), 1);
+        assert_eq!(delta.added[0].name, "Feature X");
+        assert!(delta.modified.is_empty());
+        assert!(delta.removed.is_empty());
+    }
+
+    #[test]
+    fn delta_summary_all_types() {
+        let delta = DeltaSpec {
+            added: vec![DeltaRequirement { name: "A".into(), body: "".into() }],
+            modified: vec![
+                DeltaRequirement { name: "B".into(), body: "".into() },
+                DeltaRequirement { name: "C".into(), body: "".into() },
+            ],
+            removed: vec!["D".into()],
+        };
+        assert_eq!(delta_summary(&delta), "+1 added, ~2 modified, -1 removed");
+    }
+
+    #[test]
+    fn delta_summary_empty() {
+        let delta = DeltaSpec {
+            added: vec![],
+            modified: vec![],
+            removed: vec![],
+        };
+        assert_eq!(delta_summary(&delta), "No changes");
+    }
+}

--- a/crates/forgeplan-core/src/artifact/mod.rs
+++ b/crates/forgeplan-core/src/artifact/mod.rs
@@ -1,3 +1,4 @@
+pub mod delta;
 pub mod frontmatter;
 pub mod store;
 pub mod types;

--- a/crates/forgeplan-core/src/coverage/mod.rs
+++ b/crates/forgeplan-core/src/coverage/mod.rs
@@ -72,6 +72,10 @@ async fn find_source_directories(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
             || dir_name == "target"
             || dir_name == "node_modules"
             || dir_name == "vendor"
+            || dir_name == "sources"
+            || dir_name == "research"
+            || dir_name == "docs"
+            || dir_name == "templates"
         {
             continue;
         }

--- a/crates/forgeplan-core/src/coverage/mod.rs
+++ b/crates/forgeplan-core/src/coverage/mod.rs
@@ -1,0 +1,234 @@
+//! Codebase Awareness — module scanning and decision coverage.
+//!
+//! Scans codebase to find modules, maps them to architectural decisions
+//! (ADR/RFC with affected_files), and reports coverage gaps.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::db::store::LanceStore;
+use crate::validation::checks;
+
+/// A detected code module.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CodeModule {
+    pub path: String,
+    pub file_count: usize,
+    pub line_count: usize,
+    pub decisions: Vec<String>,
+}
+
+/// Coverage report for the entire codebase.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CoverageReport {
+    pub total_modules: usize,
+    pub covered_modules: usize,
+    pub uncovered_modules: usize,
+    pub coverage_percent: f64,
+    pub modules: Vec<CodeModule>,
+}
+
+/// Scan a directory for code modules.
+/// Detects Rust (crates/*/src/**), TypeScript (src/**), Python (**/*.py).
+pub async fn scan_modules(project_root: &Path) -> anyhow::Result<Vec<CodeModule>> {
+    let mut modules = Vec::new();
+
+    let source_dirs = find_source_directories(project_root).await?;
+
+    for dir in source_dirs {
+        let rel_path = dir
+            .strip_prefix(project_root)
+            .unwrap_or(&dir)
+            .to_string_lossy()
+            .to_string();
+
+        let (file_count, line_count) = count_files_and_lines(&dir).await?;
+
+        if file_count > 0 {
+            modules.push(CodeModule {
+                path: rel_path,
+                file_count,
+                line_count,
+                decisions: vec![],
+            });
+        }
+    }
+
+    modules.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(modules)
+}
+
+/// Find directories containing source code files.
+async fn find_source_directories(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let dir_name = dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+        if dir_name.starts_with('.')
+            || dir_name == "target"
+            || dir_name == "node_modules"
+            || dir_name == "vendor"
+        {
+            continue;
+        }
+
+        let mut has_source = false;
+        let mut read_dir = match tokio::fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            Err(_) => continue,
+        };
+
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if is_source_file(&path) {
+                has_source = true;
+            }
+        }
+
+        if has_source {
+            dirs.push(dir);
+        }
+    }
+
+    Ok(dirs)
+}
+
+/// Check if file is a source code file.
+fn is_source_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|ext| matches!(ext, "rs" | "ts" | "tsx" | "js" | "jsx" | "py" | "go" | "java" | "kt" | "swift" | "c" | "cpp" | "h"))
+        .unwrap_or(false)
+}
+
+/// Count source files and total lines in a directory.
+async fn count_files_and_lines(dir: &Path) -> anyhow::Result<(usize, usize)> {
+    let mut file_count = 0;
+    let mut line_count = 0;
+
+    let mut read_dir = tokio::fs::read_dir(dir).await?;
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
+        let path = entry.path();
+        if path.is_file() && is_source_file(&path) {
+            file_count += 1;
+            if let Ok(content) = tokio::fs::read_to_string(&path).await {
+                line_count += content.lines().count();
+            }
+        }
+    }
+
+    Ok((file_count, line_count))
+}
+
+/// Build coverage report: map modules to decisions via affected_files.
+pub async fn build_coverage(
+    modules: &mut [CodeModule],
+    store: &LanceStore,
+) -> anyhow::Result<CoverageReport> {
+    let records = store.list_records(None).await?;
+
+    let mut file_to_decisions: HashMap<String, Vec<String>> = HashMap::new();
+
+    for record in &records {
+        if record.status != "active" {
+            continue;
+        }
+        if record.kind != "adr" && record.kind != "rfc" && record.kind != "prd" {
+            continue;
+        }
+
+        let affected = checks::extract_affected_files(&record.body);
+        for pattern in &affected {
+            file_to_decisions
+                .entry(pattern.clone())
+                .or_default()
+                .push(record.id.clone());
+        }
+    }
+
+    for module in modules.iter_mut() {
+        for (pattern, decision_ids) in &file_to_decisions {
+            if module_matches_pattern(&module.path, pattern) {
+                for id in decision_ids {
+                    if !module.decisions.contains(id) {
+                        module.decisions.push(id.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let total = modules.len();
+    let covered = modules.iter().filter(|m| !m.decisions.is_empty()).count();
+    let uncovered = total - covered;
+    let percent = if total > 0 {
+        (covered as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    Ok(CoverageReport {
+        total_modules: total,
+        covered_modules: covered,
+        uncovered_modules: uncovered,
+        coverage_percent: percent,
+        modules: modules.to_vec(),
+    })
+}
+
+/// Check if a module path matches an affected_files pattern.
+fn module_matches_pattern(module_path: &str, pattern: &str) -> bool {
+    let pattern_clean = pattern
+        .trim_end_matches("/*")
+        .trim_end_matches("/**")
+        .trim_end_matches("/*.rs");
+
+    module_path.contains(pattern_clean) || pattern_clean.contains(module_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_source_file_detects_rust() {
+        assert!(is_source_file(Path::new("foo.rs")));
+        assert!(is_source_file(Path::new("bar.ts")));
+        assert!(!is_source_file(Path::new("readme.md")));
+        assert!(!is_source_file(Path::new("Cargo.toml")));
+    }
+
+    #[test]
+    fn module_matches_exact_path() {
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "crates/core/src/scoring"
+        ));
+    }
+
+    #[test]
+    fn module_matches_glob_pattern() {
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/scoring/*.rs"
+        ));
+        assert!(module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/scoring/**"
+        ));
+    }
+
+    #[test]
+    fn module_no_match() {
+        assert!(!module_matches_pattern(
+            "crates/core/src/scoring",
+            "src/validation"
+        ));
+    }
+}

--- a/crates/forgeplan-core/src/db/convert.rs
+++ b/crates/forgeplan-core/src/db/convert.rs
@@ -39,6 +39,7 @@ pub(crate) fn artifact_to_batch_with_schema(
             Arc::new(StringArray::from(vec![artifact.valid_until.as_deref()])),
             Arc::new(StringArray::from(vec![now])),
             Arc::new(StringArray::from(vec![now])),
+            Arc::new(StringArray::from(vec![Option::<&str>::None])),
             embedding_col,
         ],
     )?;

--- a/crates/forgeplan-core/src/db/convert.rs
+++ b/crates/forgeplan-core/src/db/convert.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow_array::{Array, Float64Array, RecordBatch, StringArray};
+use arrow_array::{Array, Float64Array, Int32Array, RecordBatch, StringArray};
 use arrow_schema::Schema;
 
 use crate::artifact::store::ArtifactSummary;
@@ -63,6 +63,17 @@ pub fn relation_to_batch(
     relation: &str,
     now: &str,
 ) -> anyhow::Result<RecordBatch> {
+    relation_to_batch_with_cl(source, target, relation, now, None)
+}
+
+/// Build a one-row RecordBatch for a relation record with explicit CL.
+pub fn relation_to_batch_with_cl(
+    source: &str,
+    target: &str,
+    relation: &str,
+    now: &str,
+    cl: Option<i32>,
+) -> anyhow::Result<RecordBatch> {
     let schema = schema::relations_schema();
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -71,6 +82,7 @@ pub fn relation_to_batch(
             Arc::new(StringArray::from(vec![target])),
             Arc::new(StringArray::from(vec![relation])),
             Arc::new(StringArray::from(vec![now])),
+            Arc::new(Int32Array::from(vec![cl])),
         ],
     )?;
     Ok(batch)

--- a/crates/forgeplan-core/src/db/migrate.rs
+++ b/crates/forgeplan-core/src/db/migrate.rs
@@ -1,0 +1,63 @@
+//! LanceDB schema migration — add missing columns without data loss.
+//!
+//! Each migration is idempotent: checks if column exists before adding.
+//! Version tracked in config.yaml as `schema_version`.
+
+use lancedb::table::NewColumnTransform;
+use lancedb::Table;
+
+/// Current schema version. Increment when adding migrations.
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+
+/// Run all pending migrations on the artifacts table.
+/// Idempotent — safe to run multiple times.
+pub async fn migrate_artifacts(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    // Migration 1→2: add body_hash column (nullable Utf8)
+    if !field_names.contains(&"body_hash".to_string()) {
+        eprintln!("[migrate] Adding body_hash column to artifacts");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "body_hash".to_string(),
+                    "CAST(NULL AS STRING)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Run all pending migrations on the relations table.
+/// Idempotent — safe to run multiple times.
+pub async fn migrate_relations(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    // Migration 1→2: add congruence_level column (nullable Int32, default 3)
+    if !field_names.contains(&"congruence_level".to_string()) {
+        eprintln!("[migrate] Adding congruence_level column to relations");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "congruence_level".to_string(),
+                    "CAST(3 AS INT)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// Run all migrations on all tables. Call from LanceStore::open().
+pub async fn run_migrations(artifacts: &Table, relations: &Table) -> anyhow::Result<()> {
+    migrate_artifacts(artifacts).await?;
+    migrate_relations(relations).await?;
+    Ok(())
+}

--- a/crates/forgeplan-core/src/db/mod.rs
+++ b/crates/forgeplan-core/src/db/mod.rs
@@ -1,3 +1,4 @@
 pub mod convert;
+pub mod migrate;
 pub mod schema;
 pub mod store;

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -84,6 +84,7 @@ pub fn relations_schema() -> Arc<Schema> {
         Field::new("target_id", DataType::Utf8, false),
         Field::new("relation_type", DataType::Utf8, false),
         Field::new("created_at", DataType::Utf8, false),
+        Field::new("congruence_level", DataType::Int32, true),
     ]))
 }
 

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -21,6 +21,7 @@ pub const EMBEDDING_DIM: i32 = 1024;
 /// - valid_until Utf8 (nullable) — ISO date for evidence decay
 /// - created_at  Utf8 (not null) — ISO datetime
 /// - updated_at  Utf8 (not null) — ISO datetime
+/// - body_hash   Utf8 (nullable) — hash of body for change detection
 /// - embedding   FixedSizeList(1024, Float32) (nullable) — vector for semantic search
 pub fn artifacts_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
@@ -36,6 +37,7 @@ pub fn artifacts_schema() -> Arc<Schema> {
         Field::new("valid_until", DataType::Utf8, true),
         Field::new("created_at", DataType::Utf8, false),
         Field::new("updated_at", DataType::Utf8, false),
+        Field::new("body_hash", DataType::Utf8, true),
         Field::new(
             "embedding",
             DataType::FixedSizeList(
@@ -143,6 +145,7 @@ mod tests {
         assert!(nullable.contains(&"author"));
         assert!(nullable.contains(&"parent_epic"));
         assert!(nullable.contains(&"valid_until"));
+        assert!(nullable.contains(&"body_hash"));
         assert!(nullable.contains(&"embedding"));
     }
 

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -658,22 +658,37 @@ impl LanceStore {
 
     /// Search FPF spec by keyword (case-insensitive substring match on title + body).
     pub async fn search_fpf(&self, query: &str, limit: usize) -> anyhow::Result<Vec<FpfChunk>> {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("Search query cannot be empty");
+        }
+
         let table = self
             .fpf_spec
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("FPF knowledge base not initialized"))?;
 
-        let query_lower = query.to_lowercase();
-        let escaped = query_lower.replace('\'', "''");
-        let filter = format!(
-            "LOWER(title) LIKE '%{}%' OR LOWER(body) LIKE '%{}%'",
-            escaped, escaped
-        );
+        let query_lower = trimmed.to_lowercase();
+        // Split query into words for per-word OR matching
+        let words: Vec<String> = query_lower
+            .split_whitespace()
+            .filter(|w| w.len() > 2)
+            .map(|w| w.replace('\'', "''"))
+            .collect();
 
-        // Fetch more candidates than needed, then rank by relevance
-        let fetch_limit = (limit * 10).min(200);
+        let filter = if words.is_empty() {
+            let escaped = query_lower.replace('\'', "''");
+            format!("LOWER(title) LIKE '%{}%' OR LOWER(body) LIKE '%{}%'", escaped, escaped)
+        } else {
+            words.iter()
+                .map(|w| format!("(LOWER(title) LIKE '%{}%' OR LOWER(body) LIKE '%{}%')", w, w))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        };
+
+        // Fetch ALL matching then rank (small dataset ~204 sections)
         let batches = collect_batches(
-            table.query().only_if(filter).limit(fetch_limit).execute().await?,
+            table.query().only_if(filter).execute().await?,
         )
         .await?;
 
@@ -681,23 +696,29 @@ impl LanceStore {
         for batch in &batches {
             for i in 0..batch.num_rows() {
                 if let Some(chunk) = extract_fpf_chunk(batch, i) {
-                    // Simple relevance: title match = 10 points, body occurrence = 1 point each
                     let mut score = 0usize;
                     let title_lower = chunk.title.to_lowercase();
                     let body_lower = chunk.body.to_lowercase();
 
-                    if title_lower.contains(&query_lower) {
-                        score += 10;
+                    for word in &words {
+                        if title_lower.contains(word.as_str()) {
+                            score += 50;
+                        }
+                        score += body_lower.matches(word.as_str()).count().min(20);
                     }
-                    // Count occurrences in body
-                    score += body_lower.matches(&query_lower).count();
+                    let all_in_title = words.len() > 1 && words.iter().all(|w| title_lower.contains(w.as_str()));
+                    if all_in_title {
+                        score += 100;
+                    }
+                    if title_lower.contains(&query_lower) {
+                        score += 200;
+                    }
 
                     scored.push((chunk, score));
                 }
             }
         }
 
-        // Sort by score descending, then truncate
         scored.sort_by(|a, b| b.1.cmp(&a.1));
         let results: Vec<FpfChunk> = scored.into_iter().take(limit).map(|(c, _)| c).collect();
         Ok(results)

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -91,6 +91,23 @@ impl ArtifactRecord {
     }
 }
 
+/// Compute a simple fingerprint hash for artifact body content.
+///
+/// Uses a lightweight approach (length + byte sum) to avoid adding sha2 dependency.
+/// Sufficient for change detection across artifact versions.
+pub fn compute_body_hash(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let len = bytes.len();
+    // Simple hash: sum of bytes with position weighting
+    let hash: u64 = bytes
+        .iter()
+        .enumerate()
+        .fold(0u64, |acc, (i, &b)| {
+            acc.wrapping_add((b as u64).wrapping_mul(i as u64 + 1))
+        });
+    format!("{:016x}-{:08x}", hash, len)
+}
+
 /// FPF knowledge base chunk.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FpfChunk {
@@ -935,6 +952,7 @@ fn empty_relations_batch(
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(Int32Array::from(Vec::<Option<i32>>::new())), // congruence_level
         ],
     )
 }

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -11,7 +11,7 @@ use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::Table;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::{convert, schema};
+use crate::db::{convert, migrate, schema};
 
 /// Filter for listing artifacts.
 #[derive(Debug, Default)]
@@ -141,6 +141,7 @@ pub struct LanceStore {
 
 impl LanceStore {
     /// Connect to an existing LanceDB workspace (tables must already exist).
+    /// Runs idempotent schema migrations on every open.
     pub async fn open(workspace_path: &Path) -> anyhow::Result<Self> {
         let lance_dir = workspace_path.join("lance");
         let db = lancedb::connect(lance_dir.to_str().ok_or_else(|| anyhow::anyhow!("LanceDB path contains non-UTF-8 characters: {:?}", lance_dir))?).execute().await?;
@@ -149,6 +150,9 @@ impl LanceStore {
         let evidence = db.open_table("evidence").execute().await?;
         let relations = db.open_table("relations").execute().await?;
         let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
+
+        // Run migrations (idempotent — safe on every open)
+        migrate::run_migrations(&artifacts, &relations).await?;
 
         Ok(Self {
             _db: db,
@@ -917,6 +921,7 @@ fn empty_artifacts_batch(
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
             Arc::new(StringArray::from(Vec::<&str>::new())),
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
             convert::make_null_embedding_col(0),
         ],
     )

--- a/crates/forgeplan-core/src/drift/mod.rs
+++ b/crates/forgeplan-core/src/drift/mod.rs
@@ -1,0 +1,104 @@
+//! Drift detection — check if affected files changed after decision creation.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::db::store::LanceStore;
+use crate::validation::checks::extract_affected_files;
+
+/// A drift finding for one artifact.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DriftReport {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub created_at: String,
+    pub affected_files: Vec<String>,
+    pub changed_files: Vec<DriftedFile>,
+    pub is_stale: bool,
+}
+
+/// A file that changed after the decision was created.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DriftedFile {
+    pub path: String,
+    pub last_modified: String,
+}
+
+/// Check drift for all active ADR/RFC artifacts.
+pub async fn check_drift(
+    store: &LanceStore,
+    workspace_root: &Path,
+) -> anyhow::Result<Vec<DriftReport>> {
+    let records = store.list_records(None).await?;
+    let mut reports = Vec::new();
+
+    for record in &records {
+        // Only check active ADR and RFC
+        if record.status != "active" {
+            continue;
+        }
+        if record.kind != "adr" && record.kind != "rfc" {
+            continue;
+        }
+
+        // Extract affected_files from body
+        let affected = extract_affected_files(&record.body);
+        if affected.is_empty() {
+            continue;
+        }
+
+        // Check each file for changes after artifact creation
+        let mut changed_files = Vec::new();
+        for file_pattern in &affected {
+            let drifted = check_file_drift(workspace_root, file_pattern, &record.created_at);
+            changed_files.extend(drifted);
+        }
+
+        let is_stale = !changed_files.is_empty();
+        reports.push(DriftReport {
+            artifact_id: record.id.clone(),
+            artifact_title: record.title.clone(),
+            created_at: record.created_at.clone(),
+            affected_files: affected,
+            changed_files,
+            is_stale,
+        });
+    }
+
+    Ok(reports)
+}
+
+/// Check if files matching a pattern were modified after a given date.
+/// Uses `git log` to check modification dates.
+fn check_file_drift(workspace_root: &Path, pattern: &str, after_date: &str) -> Vec<DriftedFile> {
+    let output = Command::new("git")
+        .args(["log", "--oneline", "--since", after_date, "--", pattern])
+        .current_dir(workspace_root)
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            if stdout.trim().is_empty() {
+                return vec![];
+            }
+            // File was modified — get last commit date
+            let date_output = Command::new("git")
+                .args(["log", "-1", "--format=%ci", "--", pattern])
+                .current_dir(workspace_root)
+                .output();
+
+            let last_modified = date_output
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+
+            vec![DriftedFile {
+                path: pattern.to_string(),
+                last_modified,
+            }]
+        }
+        _ => vec![],
+    }
+}

--- a/crates/forgeplan-core/src/graph/mod.rs
+++ b/crates/forgeplan-core/src/graph/mod.rs
@@ -1,3 +1,5 @@
+pub mod topological;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 

--- a/crates/forgeplan-core/src/graph/topological.rs
+++ b/crates/forgeplan-core/src/graph/topological.rs
@@ -1,0 +1,279 @@
+//! Topological sort (Kahn's algorithm) and cycle detection for artifact DAG.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// Result of topological sort.
+#[derive(Debug, Clone)]
+pub struct TopologicalResult {
+    /// Artifacts in dependency order (do first -> do last).
+    pub order: Vec<String>,
+    /// Cycle paths if any (e.g., ["A", "B", "C", "A"]).
+    pub cycles: Vec<Vec<String>>,
+    /// Artifacts with no dependencies (ready to work on).
+    pub ready: Vec<String>,
+    /// Artifacts that are blocked (have unmet dependencies).
+    pub blocked: Vec<(String, Vec<String>)>,
+}
+
+/// Run Kahn's algorithm on artifact relations.
+///
+/// `edges`: (from, to, relation_type) — "from" depends on "to"
+/// `active_ids`: set of artifact IDs that are considered "done" (active status)
+///
+/// Returns topological order + cycle detection + ready/blocked classification.
+pub fn kahn_sort(
+    edges: &[(String, String, String)],
+    active_ids: &HashSet<String>,
+) -> TopologicalResult {
+    let mut adj: HashMap<String, Vec<String>> = HashMap::new();
+    let mut in_degree: HashMap<String, usize> = HashMap::new();
+    let mut all_nodes: HashSet<String> = HashSet::new();
+
+    for (from, to, _rel) in edges {
+        all_nodes.insert(from.clone());
+        all_nodes.insert(to.clone());
+        adj.entry(from.clone()).or_default().push(to.clone());
+        *in_degree.entry(to.clone()).or_default() += 1;
+        in_degree.entry(from.clone()).or_default();
+    }
+
+    // Kahn's: start with nodes that have in_degree 0
+    let mut queue: VecDeque<String> = all_nodes
+        .iter()
+        .filter(|n| *in_degree.get(*n).unwrap_or(&0) == 0)
+        .cloned()
+        .collect();
+
+    // Sort queue for deterministic output
+    let mut initial: Vec<String> = queue.drain(..).collect();
+    initial.sort();
+    queue.extend(initial);
+
+    let mut order = Vec::new();
+    let mut visited = HashSet::new();
+
+    while let Some(node) = queue.pop_front() {
+        order.push(node.clone());
+        visited.insert(node.clone());
+
+        if let Some(neighbors) = adj.get(&node) {
+            let mut sorted_neighbors: Vec<&String> = neighbors.iter().collect();
+            sorted_neighbors.sort();
+            for neighbor in sorted_neighbors {
+                if let Some(deg) = in_degree.get_mut(neighbor) {
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push_back(neighbor.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    // Detect cycles: nodes not in order are part of cycles
+    let cycle_nodes: HashSet<String> = all_nodes.difference(&visited).cloned().collect();
+    let cycles = if cycle_nodes.is_empty() {
+        vec![]
+    } else {
+        detect_cycle_paths(&adj, &cycle_nodes)
+    };
+
+    // Classify: ready (no unmet deps) vs blocked
+    let mut ready = Vec::new();
+    let mut blocked = Vec::new();
+
+    for node in &order {
+        let unmet: Vec<String> = edges
+            .iter()
+            .filter(|(from, _, _)| from == node)
+            .map(|(_, to, _)| to.clone())
+            .filter(|dep| !active_ids.contains(dep))
+            .collect();
+
+        if unmet.is_empty() {
+            ready.push(node.clone());
+        } else {
+            blocked.push((node.clone(), unmet));
+        }
+    }
+
+    TopologicalResult {
+        order,
+        cycles,
+        ready,
+        blocked,
+    }
+}
+
+/// Find cycle paths using DFS.
+fn detect_cycle_paths(
+    adj: &HashMap<String, Vec<String>>,
+    cycle_nodes: &HashSet<String>,
+) -> Vec<Vec<String>> {
+    let mut cycles = Vec::new();
+    let mut visited = HashSet::new();
+
+    let mut sorted_starts: Vec<&String> = cycle_nodes.iter().collect();
+    sorted_starts.sort();
+
+    for start in sorted_starts {
+        if visited.contains(start) {
+            continue;
+        }
+        let mut path = vec![start.clone()];
+        let mut current = start.clone();
+
+        loop {
+            visited.insert(current.clone());
+            let next = adj
+                .get(&current)
+                .and_then(|neighbors| neighbors.iter().find(|n| cycle_nodes.contains(*n)));
+
+            match next {
+                Some(n) if path.contains(n) => {
+                    if let Some(pos) = path.iter().position(|x| x == n) {
+                        let mut cycle: Vec<String> = path[pos..].to_vec();
+                        cycle.push(n.clone());
+                        cycles.push(cycle);
+                    }
+                    break;
+                }
+                Some(n) => {
+                    path.push(n.clone());
+                    current = n.clone();
+                }
+                None => break,
+            }
+        }
+    }
+
+    cycles
+}
+
+/// Get blocked status for a specific artifact.
+pub fn get_blocked_by(
+    artifact_id: &str,
+    edges: &[(String, String, String)],
+    active_ids: &HashSet<String>,
+) -> Vec<String> {
+    edges
+        .iter()
+        .filter(|(from, _, _)| from == artifact_id)
+        .map(|(_, to, _)| to.clone())
+        .filter(|dep| !active_ids.contains(dep))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_chain_sorted_correctly() {
+        let edges = vec![
+            ("A".into(), "B".into(), "depends_on".into()),
+            ("B".into(), "C".into(), "depends_on".into()),
+        ];
+        let result = kahn_sort(&edges, &HashSet::new());
+        // A depends on B, B depends on C → order: A, B, C (roots first in Kahn's)
+        // But "from depends on to" means to has lower in-degree from from's perspective
+        // In our adjacency: A->B, B->C. in_degree: A=0, B=1, C=1
+        // Wait — Kahn's processes in_degree=0 first. A has in_degree 0.
+        // After removing A: B in_degree drops to 0. After B: C.
+        // So order = [A, B, C]
+        assert_eq!(result.order, vec!["A", "B", "C"]);
+        assert!(result.cycles.is_empty());
+    }
+
+    #[test]
+    fn diamond_dependency() {
+        let edges = vec![
+            ("D".into(), "B".into(), "depends_on".into()),
+            ("D".into(), "C".into(), "depends_on".into()),
+            ("B".into(), "A".into(), "depends_on".into()),
+            ("C".into(), "A".into(), "depends_on".into()),
+        ];
+        let result = kahn_sort(&edges, &HashSet::new());
+        // in_degree: D=0, B=1, C=1, A=2
+        // D first, then B and C (both in_degree 0), then A
+        assert_eq!(*result.order.first().unwrap(), "D");
+        assert_eq!(*result.order.last().unwrap(), "A");
+        assert!(result.cycles.is_empty());
+    }
+
+    #[test]
+    fn cycle_detected() {
+        let edges = vec![
+            ("A".into(), "B".into(), "depends_on".into()),
+            ("B".into(), "A".into(), "depends_on".into()),
+        ];
+        let result = kahn_sort(&edges, &HashSet::new());
+        assert!(!result.cycles.is_empty());
+        assert!(result.order.is_empty());
+    }
+
+    #[test]
+    fn ready_vs_blocked() {
+        let edges = vec![(
+            "RFC-001".into(),
+            "PRD-001".into(),
+            "based_on".into(),
+        )];
+        let mut active = HashSet::new();
+        active.insert("PRD-001".to_string());
+
+        let result = kahn_sort(&edges, &active);
+        assert!(result.ready.contains(&"RFC-001".to_string()));
+        assert!(result.ready.contains(&"PRD-001".to_string()));
+        assert!(result.blocked.is_empty());
+    }
+
+    #[test]
+    fn blocked_when_dep_not_active() {
+        let edges = vec![(
+            "RFC-001".into(),
+            "PRD-001".into(),
+            "based_on".into(),
+        )];
+        let result = kahn_sort(&edges, &HashSet::new());
+        assert!(result.blocked.iter().any(|(id, _)| id == "RFC-001"));
+    }
+
+    #[test]
+    fn no_edges_all_ready() {
+        let result = kahn_sort(&[], &HashSet::new());
+        assert!(result.order.is_empty());
+        assert!(result.cycles.is_empty());
+        assert!(result.ready.is_empty());
+    }
+
+    #[test]
+    fn get_blocked_by_returns_unmet_deps() {
+        let edges = vec![
+            ("RFC-001".into(), "PRD-001".into(), "based_on".into()),
+            ("RFC-001".into(), "PRD-002".into(), "based_on".into()),
+        ];
+        let mut active = HashSet::new();
+        active.insert("PRD-001".to_string());
+
+        let blocked = get_blocked_by("RFC-001", &edges, &active);
+        assert_eq!(blocked, vec!["PRD-002".to_string()]);
+    }
+
+    #[test]
+    fn three_node_cycle() {
+        let edges = vec![
+            ("A".into(), "B".into(), "depends_on".into()),
+            ("B".into(), "C".into(), "depends_on".into()),
+            ("C".into(), "A".into(), "depends_on".into()),
+        ];
+        let result = kahn_sort(&edges, &HashSet::new());
+        assert!(result.order.is_empty());
+        assert!(!result.cycles.is_empty());
+        // The cycle should contain all three nodes
+        let cycle = &result.cycles[0];
+        assert!(cycle.contains(&"A".to_string()));
+        assert!(cycle.contains(&"B".to_string()));
+        assert!(cycle.contains(&"C".to_string()));
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod artifact;
 pub mod config;
 pub mod db;
 pub mod depth;
+pub mod drift;
 pub mod embed;
 pub mod fpf;
 pub mod health;

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod artifact;
 pub mod config;
+pub mod coverage;
 pub mod db;
 pub mod depth;
 pub mod drift;

--- a/crates/forgeplan-core/src/routing/mod.rs
+++ b/crates/forgeplan-core/src/routing/mod.rs
@@ -90,7 +90,17 @@ impl std::fmt::Display for RoutingResult {
 
 /// Route a task description to depth + pipeline using rule engine.
 pub fn route(description: &str) -> RoutingResult {
-    let signals = signals::extract(description);
+    let trimmed = description.trim();
+    if trimmed.is_empty() {
+        return RoutingResult {
+            depth: crate::artifact::types::Mode::Tactical,
+            pipeline: vec![],
+            triggers: vec![],
+            confidence: 0.0,
+        };
+    }
+
+    let signals = signals::extract(trimmed);
     let depth = rules::compute_depth(&signals);
     let pipeline = pipeline::for_depth(&depth);
     let confidence = rules::compute_confidence(&signals, &depth);

--- a/crates/forgeplan-core/src/scoring/evidence.rs
+++ b/crates/forgeplan-core/src/scoring/evidence.rs
@@ -12,10 +12,11 @@ pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
         })
         .unwrap_or(Verdict::Supports);
 
+    // Default CL=3 (same context) — evidence created locally is same-context by default.
     let cl = extract_field(&record.body, "congruence_level")
         .and_then(|s| s.parse::<u8>().ok())
         .map(|v| v.min(3))
-        .unwrap_or(0);
+        .unwrap_or(3);
 
     let valid_until = record.valid_until.as_deref().and_then(|s| {
         chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -416,6 +416,36 @@ pub fn extract_nfr_section(body: &str) -> Option<String> {
     None
 }
 
+/// Extract affected_files from body — lines that look like file paths or glob patterns.
+pub fn extract_affected_files(body: &str) -> Vec<String> {
+    let section = extract_section(body, "Affected Files")
+        .or_else(|| extract_section(body, "Affected Scope"))
+        .or_else(|| extract_section(body, "affected_files"));
+
+    match section {
+        None => vec![],
+        Some(text) => text
+            .lines()
+            .map(|l| {
+                l.trim()
+                    .trim_start_matches("- ")
+                    .trim_start_matches("* ")
+                    .trim_start_matches("| ")
+                    .trim()
+            })
+            .filter(|l| {
+                !l.is_empty()
+                    && (l.contains('/')
+                        || l.contains('*')
+                        || l.ends_with(".rs")
+                        || l.ends_with(".ts")
+                        || l.ends_with(".md"))
+            })
+            .map(|l| l.to_string())
+            .collect(),
+    }
+}
+
 /// BMAD Step 5: Subjective adjectives that need metrics.
 const SUBJECTIVE_ADJECTIVES: &[&str] = &[
     "easy", "fast", "simple", "intuitive", "user-friendly", "responsive",

--- a/crates/forgeplan-core/src/validation/rules.rs
+++ b/crates/forgeplan-core/src/validation/rules.rs
@@ -578,6 +578,14 @@ fn rfc_rules(depth: &Mode) -> Vec<RuleEntry> {
         rules.push(rule("rfc-risks", Severity::Must, "Risks section", check_rfc_risks));
     }
 
+    // Decision Contract rules for RFC (Could — RFC is a proposal, not a decision)
+    rules.push(rule("rfc-invariants", Severity::Could,
+        "RFC could define invariants",
+        check_adr_invariants));
+    rules.push(rule("rfc-rollback", Severity::Could,
+        "RFC could define rollback plan",
+        check_adr_rollback));
+
     rules
 }
 
@@ -638,10 +646,27 @@ fn adr_rules(depth: &Mode) -> Vec<RuleEntry> {
         rule("adr-consequences", Severity::Must, "Consequences", check_adr_consequences),
     ];
 
-    if matches!(depth, Mode::Deep) {
-        rules.push(rule("adr-invariants", Severity::Should, "Invariants (DDR)", check_adr_invariants));
-        rules.push(rule("adr-rollback", Severity::Should, "Rollback Plan", check_adr_rollback));
-    }
+    // Decision Contract rules — severity scales with depth
+    let (inv_sev, roll_sev) = match depth {
+        Mode::Deep => (Severity::Must, Severity::Must),
+        _ => (Severity::Should, Severity::Should),
+    };
+
+    rules.push(rule("adr-invariants", inv_sev,
+        "Invariants — what must never be violated",
+        check_adr_invariants));
+    rules.push(rule("adr-rollback", roll_sev,
+        "Rollback plan — what to do if decision fails",
+        check_adr_rollback));
+    rules.push(rule("adr-preconditions", Severity::Could,
+        "Preconditions — what must be true before implementing",
+        check_adr_preconditions));
+    rules.push(rule("adr-postconditions", Severity::Could,
+        "Postconditions — what must be true after implementing",
+        check_adr_postconditions));
+    rules.push(rule("adr-affected-files", Severity::Should,
+        "Affected files/modules — scope of the decision",
+        check_adr_affected_files));
 
     rules
 }
@@ -671,18 +696,54 @@ fn check_adr_consequences(body: &str, _fm: &Frontmatter) -> Option<String> {
 }
 
 fn check_adr_invariants(body: &str, _fm: &Frontmatter) -> Option<String> {
-    if !checks::section_exists(body, "Invariants") {
-        Some("Missing '## Invariants' section (recommended for deep ADR/DDR)".into())
-    } else {
+    if checks::section_exists(body, "Invariants") {
         None
+    } else {
+        Some("Missing '## Invariants' section — what must NEVER be violated by this decision".into())
     }
 }
 
 fn check_adr_rollback(body: &str, _fm: &Frontmatter) -> Option<String> {
-    if !checks::section_exists(body, "Rollback") {
-        Some("Missing '## Rollback Plan' section (recommended for deep ADR/DDR)".into())
-    } else {
+    if checks::section_exists(body, "Rollback")
+        || checks::section_exists(body, "Rollback Plan")
+        || checks::section_exists(body, "Mitigation")
+    {
         None
+    } else {
+        Some("Missing '## Rollback Plan' section — what to do if this decision fails".into())
+    }
+}
+
+fn check_adr_preconditions(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Preconditions")
+        || checks::section_exists(body, "Pre-conditions")
+        || checks::section_exists(body, "Prerequisites")
+    {
+        None
+    } else {
+        Some("Missing '## Preconditions' section".into())
+    }
+}
+
+fn check_adr_postconditions(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Postconditions")
+        || checks::section_exists(body, "Post-conditions")
+        || checks::section_exists(body, "Expected Outcome")
+    {
+        None
+    } else {
+        Some("Missing '## Postconditions' section".into())
+    }
+}
+
+fn check_adr_affected_files(body: &str, _fm: &Frontmatter) -> Option<String> {
+    if checks::section_exists(body, "Affected Files")
+        || checks::section_exists(body, "Affected Scope")
+        || checks::section_exists(body, "Scope")
+    {
+        None
+    } else {
+        Some("Missing '## Affected Files' section — which files/modules does this decision affect".into())
     }
 }
 
@@ -779,45 +840,69 @@ mod tests {
     }
 
     #[test]
-    fn rules_for_rfc_standard_returns_base_plus_5_no_risks() {
+    fn rules_for_rfc_standard_returns_base_plus_7_with_contracts() {
         let rules = rules_for(&ArtifactKind::Rfc, &Mode::Standard);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 5);
+        // 5 base RFC + 2 contract rules (invariants, rollback)
+        assert_eq!(rules.len(), base_count + 7);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(!ids.contains(&"rfc-risks"));
+        assert!(ids.contains(&"rfc-invariants"));
+        assert!(ids.contains(&"rfc-rollback"));
+
+        // RFC contract rules are Could severity
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "rfc-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Could);
     }
 
     #[test]
-    fn rules_for_rfc_deep_returns_base_plus_6_with_risks() {
+    fn rules_for_rfc_deep_returns_base_plus_8_with_risks_and_contracts() {
         let rules = rules_for(&ArtifactKind::Rfc, &Mode::Deep);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 6);
+        // 5 base RFC + 1 risks + 2 contract rules
+        assert_eq!(rules.len(), base_count + 8);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(ids.contains(&"rfc-risks"));
+        assert!(ids.contains(&"rfc-invariants"));
+        assert!(ids.contains(&"rfc-rollback"));
     }
 
     #[test]
-    fn rules_for_adr_standard_returns_base_plus_3() {
+    fn rules_for_adr_standard_returns_base_plus_8_with_contracts() {
         let rules = rules_for(&ArtifactKind::Adr, &Mode::Standard);
         let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 3);
-
-        let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
-        assert!(!ids.contains(&"adr-invariants"));
-        assert!(!ids.contains(&"adr-rollback"));
-    }
-
-    #[test]
-    fn rules_for_adr_deep_returns_base_plus_5_with_ddr() {
-        let rules = rules_for(&ArtifactKind::Adr, &Mode::Deep);
-        let base_count = base_rules().len();
-        assert_eq!(rules.len(), base_count + 5);
+        // 3 base ADR + 5 contract rules (invariants, rollback, preconditions, postconditions, affected-files)
+        assert_eq!(rules.len(), base_count + 8);
 
         let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
         assert!(ids.contains(&"adr-invariants"));
         assert!(ids.contains(&"adr-rollback"));
+        assert!(ids.contains(&"adr-preconditions"));
+        assert!(ids.contains(&"adr-postconditions"));
+        assert!(ids.contains(&"adr-affected-files"));
+
+        // At standard depth, invariants and rollback are Should (not Must)
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "adr-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Should);
+    }
+
+    #[test]
+    fn rules_for_adr_deep_returns_base_plus_8_with_must_contracts() {
+        let rules = rules_for(&ArtifactKind::Adr, &Mode::Deep);
+        let base_count = base_rules().len();
+        assert_eq!(rules.len(), base_count + 8);
+
+        let ids: Vec<&str> = rules.iter().map(|(id, _, _, _)| *id).collect();
+        assert!(ids.contains(&"adr-invariants"));
+        assert!(ids.contains(&"adr-rollback"));
+
+        // At deep depth, invariants and rollback are Must
+        let inv = rules.iter().find(|(id, _, _, _)| *id == "adr-invariants").unwrap();
+        assert_eq!(inv.1, Severity::Must);
+        let roll = rules.iter().find(|(id, _, _, _)| *id == "adr-rollback").unwrap();
+        assert_eq!(roll.1, Severity::Must);
     }
 
     #[test]
@@ -939,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn adr_deep_has_should_findings_for_invariants_and_rollback() {
+    fn adr_deep_has_must_findings_for_invariants_and_rollback() {
         let fm = make_fm("adr-002", "active");
         let body = "## Context\n\nWe need to choose a database.\n\n\
                      ## Decision\n\nUse LanceDB for embedded vector storage.\n\n\
@@ -947,20 +1032,38 @@ mod tests {
 
         let result = validate("adr-002", body, &fm, &ArtifactKind::Adr, &Mode::Deep);
 
-        // Should still pass (invariants and rollback are Should, not Must)
-        assert!(result.passed(), "ADR should still pass at Deep depth without DDR fields");
+        // Should NOT pass — invariants and rollback are Must at Deep depth
+        assert!(!result.passed(), "ADR should fail at Deep depth without Invariants/Rollback");
 
-        let should_ids: Vec<&str> = result.findings.iter()
-            .filter(|f| f.severity == Severity::Should)
+        let must_ids: Vec<&str> = result.findings.iter()
+            .filter(|f| f.severity == Severity::Must)
             .map(|f| f.rule_id.as_str())
             .collect();
         assert!(
-            should_ids.contains(&"adr-invariants"),
-            "Expected Should finding for adr-invariants at Deep depth"
+            must_ids.contains(&"adr-invariants"),
+            "Expected Must finding for adr-invariants at Deep depth"
         );
         assert!(
-            should_ids.contains(&"adr-rollback"),
-            "Expected Should finding for adr-rollback at Deep depth"
+            must_ids.contains(&"adr-rollback"),
+            "Expected Must finding for adr-rollback at Deep depth"
+        );
+    }
+
+    #[test]
+    fn adr_deep_passes_with_full_contract() {
+        let fm = make_fm("adr-003", "active");
+        let body = "## Context\n\nWe need to choose a database.\n\n\
+                     ## Decision\n\nUse LanceDB for embedded vector storage.\n\n\
+                     ## Consequences\n\nSimplifies deployment, limits horizontal scaling.\n\n\
+                     ## Invariants\n\n- Single-file deployment must be preserved.\n\n\
+                     ## Rollback Plan\n\n- Revert to SQLite.\n\n\
+                     ## Affected Files\n\n- crates/forgeplan-core/src/db/\n";
+
+        let result = validate("adr-003", body, &fm, &ArtifactKind::Adr, &Mode::Deep);
+        assert!(
+            result.passed(),
+            "ADR with full contract should pass at Deep depth, findings: {:?}",
+            result.findings.iter().map(|f| (&f.rule_id, &f.severity)).collect::<Vec<_>>()
         );
     }
 

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1759,6 +1759,30 @@ impl ForgeplanServer {
             total: sections.len(),
         }))
     }
+
+    #[tool(description = "Check for drifted decisions — affected files that changed after ADR/RFC was created.")]
+    async fn forgeplan_drift(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let ws = match self.require_workspace().await {
+            Ok(p) => p,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let workspace_root = ws.parent().unwrap_or(&ws).to_path_buf();
+
+        let reports = forgeplan_core::drift::check_drift(&store, &workspace_root)
+            .await
+            .unwrap_or_default();
+
+        Ok(json_result(&serde_json::json!({
+            "total": reports.len(),
+            "stale": reports.iter().filter(|r| r.is_stale).count(),
+            "reports": reports,
+        })))
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1783,6 +1783,35 @@ impl ForgeplanServer {
             "reports": reports,
         })))
     }
+
+    #[tool(description = "Show decision coverage per code module — which modules have architectural decisions and which are blind spots.")]
+    async fn forgeplan_coverage(&self) -> Result<CallToolResult, McpError> {
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let ws = match self.require_workspace().await {
+            Ok(p) => p,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let project_root = ws.parent().unwrap_or(&ws).to_path_buf();
+
+        let mut modules = forgeplan_core::coverage::scan_modules(&project_root)
+            .await
+            .unwrap_or_default();
+        let report = forgeplan_core::coverage::build_coverage(&mut modules, &store)
+            .await
+            .unwrap_or_else(|_| forgeplan_core::coverage::CoverageReport {
+                total_modules: 0,
+                covered_modules: 0,
+                uncovered_modules: 0,
+                coverage_percent: 0.0,
+                modules: vec![],
+            });
+
+        Ok(json_result(&report))
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────


### PR DESCRIPTION
## Release v0.9.0

### New Features (6 PRDs)
- **PRD-016**: Recursive R_eff engine + F-G-R breakdown + ADI structured JSON output
- **PRD-017**: BMAD Validation v2 — 13-step quality gates (measurability, leakage, density, traceability, domain/project-type classification)
- **PRD-018**: OpenSpec DAG — topological sort (Kahn's), cycle detection, delta-spec parser
- **PRD-019**: Codebase Awareness — module scanner, decision coverage report
- **PRD-020**: Decision Contracts — invariants, rollback plan, preconditions, affected_files on ADR/RFC
- **PRD-021**: FPF Knowledge Base — 204 sections ingested, semantic keyword search, ADI --fpf context injection

### Infrastructure
- **LanceDB Schema Migration** — idempotent column additions, auto-migrate on open, `forgeplan migrate` CLI
- **24 E2E Tests** — full workflow coverage (methodology cycle, dependency graph, export/import, drift, contracts)
- **Quality Fixes** — FPF search ranking (per-word OR + title-heavy), scan filter, evidence CL default, empty input handling

### New Commands
`forgeplan score` (F-G-R breakdown), `forgeplan blocked`, `forgeplan order`, `forgeplan drift`, `forgeplan scan`, `forgeplan coverage`, `forgeplan migrate`, `forgeplan fpf ingest/search/section/list/status`, `forgeplan reason --fpf --save`

### New MCP Tools
`forgeplan_fpf_search`, `forgeplan_fpf_section`, `forgeplan_fpf_list`, `forgeplan_coverage`, `forgeplan_drift`

### Stats
- 296 tests (244 unit + 40 integration + 12 other)
- ~5500 LOC added
- 9 PRs merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)