### PR TITLE
[PRD-012] Project Onboarding — scan-import for existing docs

### DIFF
--- a/crates/forgeplan-cli/src/commands/init.rs
+++ b/crates/forgeplan-cli/src/commands/init.rs
@@ -1,10 +1,12 @@
 use std::env;
 use std::fs;
+use std::path::Path;
 
 use anyhow::Result;
 use console::style;
 
 use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::scan::import::{ImportStatus, ScanImportOptions, scan_and_import};
 use forgeplan_core::workspace::{find_workspace, init_workspace, FORGEPLAN_DIR};
 
 use crate::ui;
@@ -12,7 +14,7 @@ use crate::ui;
 /// Default project name fallback (unified for both paths).
 const DEFAULT_PROJECT_NAME: &str = "my-project";
 
-pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
+pub async fn run(force: bool, non_interactive: bool, scan: bool) -> Result<()> {
     let cwd = env::current_dir()?;
 
     // Check if already initialized
@@ -25,6 +27,10 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
                     "Already initialized at {}. Use --force to reinitialize.",
                     existing.display()
                 ))?;
+            }
+            // Even if already initialized, run scan if requested
+            if scan {
+                run_scan_import(&cwd, &existing).await?;
             }
             return Ok(());
         }
@@ -44,6 +50,12 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
 
         println!("  Initialized {}/ in {}", FORGEPLAN_DIR, cwd.display());
         println!("  Project: {}", project_name);
+
+        if scan {
+            let workspace = cwd.join(FORGEPLAN_DIR);
+            run_scan_import(&cwd, &workspace).await?;
+        }
+
         return Ok(());
     }
 
@@ -228,6 +240,11 @@ pub async fn run(force: bool, non_interactive: bool) -> Result<()> {
         style("/forge \"your task\"").cyan()
     ))?;
 
+    if scan {
+        let workspace = cwd.join(FORGEPLAN_DIR);
+        run_scan_import(&cwd, &workspace).await?;
+    }
+
     Ok(())
 }
 
@@ -314,4 +331,58 @@ fn agent_display_name(agent: &str) -> &str {
         "copilot" => "Copilot",
         _ => agent,
     }
+}
+
+/// Run scan-import after init to discover and import existing docs.
+async fn run_scan_import(project_root: &Path, workspace: &Path) -> Result<()> {
+    println!("\n  {} Scanning for existing documents...", style("◉").cyan());
+
+    let store = LanceStore::init(workspace).await?;
+    let options = ScanImportOptions::default();
+
+    let result = scan_and_import(project_root, &store, &options).await?;
+
+    if result.total_found == 0 {
+        println!("  No documents found to import.");
+        return Ok(());
+    }
+
+    let mut by_kind: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    for entry in &result.entries {
+        if entry.status == ImportStatus::Imported {
+            let kind = entry
+                .detected_kind
+                .as_ref()
+                .map(|k| k.template_key().to_uppercase())
+                .unwrap_or_else(|| "???".to_string());
+            *by_kind.entry(kind).or_insert(0) += 1;
+        }
+    }
+
+    let kind_summary: Vec<String> = by_kind
+        .iter()
+        .map(|(k, v)| format!("{} {}", v, k))
+        .collect();
+
+    println!(
+        "  Imported {} artifact(s): {}",
+        style(result.imported).green().bold(),
+        kind_summary.join(", ")
+    );
+
+    if result.skipped > 0 {
+        println!(
+            "  Skipped {} (already exist)",
+            style(result.skipped).yellow()
+        );
+    }
+    if result.unknown > 0 {
+        println!(
+            "  {} unknown file(s) — run {} for details",
+            style(result.unknown).dim(),
+            style("forgeplan scan-import --dry-run").cyan()
+        );
+    }
+
+    Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod progress;
 pub mod reason;
 pub mod review;
 pub mod route;
+pub mod scan_import;
 pub mod score;
 pub mod search;
 pub mod setup_skill;

--- a/crates/forgeplan-cli/src/commands/scan_import.rs
+++ b/crates/forgeplan-cli/src/commands/scan_import.rs
@@ -1,0 +1,111 @@
+use std::env;
+
+use anyhow::Result;
+use console::style;
+
+use forgeplan_core::db::store::LanceStore;
+use forgeplan_core::scan::import::{ImportStatus, ScanImportOptions, scan_and_import};
+use forgeplan_core::scan::detect::DetectionTier;
+use forgeplan_core::workspace::find_workspace;
+
+/// `forgeplan scan-import [--path <dir>] [--dry-run]`
+pub async fn run(path: Option<&str>, dry_run: bool) -> Result<()> {
+    let cwd = env::current_dir()?;
+    let workspace = find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+
+    let store = LanceStore::init(&workspace).await?;
+    let project_root = workspace
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine project root"))?;
+
+    let options = ScanImportOptions {
+        dry_run,
+        custom_path: path.map(|s| s.to_string()),
+    };
+
+    if dry_run {
+        println!("  {} Dry-run mode — no changes will be made\n", style("⊘").dim());
+    }
+
+    let result = scan_and_import(project_root, &store, &options).await?;
+
+    // Print results
+    if result.entries.is_empty() {
+        println!("  No markdown documents found.");
+        return Ok(());
+    }
+
+    println!(
+        "  Found {} document(s):\n",
+        style(result.total_found).bold()
+    );
+
+    for entry in &result.entries {
+        let status_icon = match &entry.status {
+            ImportStatus::Imported => style("+").green().to_string(),
+            ImportStatus::Skipped => style("~").yellow().to_string(),
+            ImportStatus::Unknown => style("?").dim().to_string(),
+            ImportStatus::Failed(_) => style("✗").red().to_string(),
+        };
+
+        let kind_str = entry
+            .detected_kind
+            .as_ref()
+            .map(|k| format!("{}", k.template_key().to_uppercase()))
+            .unwrap_or_else(|| "???".to_string());
+
+        let tier_str = entry
+            .detection_tier
+            .as_ref()
+            .map(|t| match t {
+                DetectionTier::Frontmatter => "fm",
+                DetectionTier::Filename => "fn",
+                DetectionTier::Content => "ct",
+            })
+            .unwrap_or("-");
+
+        let id_str = entry
+            .artifact_id
+            .as_deref()
+            .unwrap_or("-");
+
+        let status_note = match &entry.status {
+            ImportStatus::Skipped => " (exists)".to_string(),
+            ImportStatus::Failed(msg) => format!(" ({})", msg),
+            _ => String::new(),
+        };
+
+        println!(
+            "  {} {:5} [{:2}] {:10} {}{}",
+            status_icon,
+            kind_str,
+            tier_str,
+            id_str,
+            entry.relative_path,
+            style(status_note).dim()
+        );
+    }
+
+    println!();
+    println!(
+        "  Summary: {} imported, {} skipped, {} unknown, {} failed",
+        style(result.imported).green().bold(),
+        style(result.skipped).yellow(),
+        style(result.unknown).dim(),
+        if result.failed > 0 {
+            style(result.failed).red().bold().to_string()
+        } else {
+            style(result.failed).dim().to_string()
+        }
+    );
+
+    if dry_run && result.imported > 0 {
+        println!(
+            "\n  Run without {} to import.",
+            style("--dry-run").cyan()
+        );
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -21,6 +21,9 @@ enum Commands {
         /// Non-interactive mode (skip prompts, use defaults)
         #[arg(long, short = 'y')]
         yes: bool,
+        /// Scan for existing documents and import them
+        #[arg(long)]
+        scan: bool,
     },
     /// Create a new artifact from template
     New {
@@ -253,6 +256,16 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Scan for existing docs and import as artifacts
+    #[command(name = "scan-import")]
+    ScanImport {
+        /// Directory to scan (default: standard doc dirs)
+        #[arg(long)]
+        path: Option<String>,
+        /// Preview only, don't actually import
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Show artifacts in topological order (dependency order)
     Order,
     /// Run schema migrations on existing workspace
@@ -298,7 +311,7 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { force, yes } => commands::init::run(force, yes).await,
+        Commands::Init { force, yes, scan } => commands::init::run(force, yes, scan).await,
         Commands::New { kind, title } => commands::new::run(&kind, &title).await,
         Commands::List { r#type, status, json } => {
             commands::list::run(r#type.as_deref(), status.as_deref(), json).await
@@ -385,6 +398,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Export { output } => commands::export::run(output.as_deref()).await,
         Commands::Import { path, force } => commands::import_cmd::run(&path, force).await,
+        Commands::ScanImport { path, dry_run } => commands::scan_import::run(path.as_deref(), dry_run).await,
         Commands::Order => commands::order::run().await,
         Commands::Migrate => commands::migrate::run().await,
         Commands::Serve => {

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -1209,3 +1209,221 @@ fn e2e_adr_contract_validation() {
         .stdout(predicate::str::contains("ADR-001"))
         .stdout(predicate::str::contains("PASS").or(predicate::str::contains("error").or(predicate::str::contains("warning"))));
 }
+
+// ─── Scan-Import E2E Tests ───────────────────────────────────────
+
+#[test]
+fn scan_import_dry_run_shows_preview() {
+    let tmp = TempDir::new().unwrap();
+
+    // Init workspace
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Create docs/ with a PRD file
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("PRD-001-auth.md"),
+        "---\nkind: prd\nid: PRD-001\ntitle: Auth System\n---\n\n# PRD-001: Auth System\n\n## Problem\nUsers can't log in.\n\n## Goals\nSecure auth.",
+    ).unwrap();
+
+    // Dry-run
+    forgeplan()
+        .args(["scan-import", "--dry-run"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PRD"))
+        .stdout(predicate::str::contains("1 imported"));
+}
+
+#[test]
+fn scan_import_imports_frontmatter_prd() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("PRD-042-payments.md"),
+        "---\nkind: prd\nid: PRD-042\ntitle: Payment Integration\n---\n\n# Payments\n\n## Problem\nNo payments.\n\n## Goals\nAccept payments.",
+    ).unwrap();
+
+    // Import
+    forgeplan()
+        .args(["scan-import"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 imported"));
+
+    // Verify artifact exists
+    forgeplan()
+        .args(["get", "PRD-042"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Payment Integration"));
+}
+
+#[test]
+fn scan_import_detects_by_filename() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    // File with no frontmatter but a PRD filename pattern
+    std::fs::write(
+        docs.join("RFC-001-api-redesign.md"),
+        "# API Redesign\n\nWe should redesign the API.",
+    ).unwrap();
+
+    forgeplan()
+        .args(["scan-import"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("RFC"))
+        .stdout(predicate::str::contains("1 imported"));
+}
+
+#[test]
+fn scan_import_skips_existing_artifacts() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Create a PRD first
+    forgeplan()
+        .args(["new", "prd", "Existing PRD"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Now put a doc with the same ID
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("PRD-001-duplicate.md"),
+        "---\nkind: prd\nid: PRD-001\ntitle: Duplicate\n---\n# Duplicate",
+    ).unwrap();
+
+    // Import should skip
+    forgeplan()
+        .args(["scan-import"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 skipped"));
+}
+
+#[test]
+fn scan_import_handles_unknown_files() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("random-notes.md"),
+        "# Shopping List\n\n- Milk\n- Bread",
+    ).unwrap();
+
+    forgeplan()
+        .args(["scan-import", "--dry-run"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 unknown"));
+}
+
+#[test]
+fn init_with_scan_flag_imports_docs() {
+    let tmp = TempDir::new().unwrap();
+
+    // Pre-create docs before init
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("ADR-001-use-rust.md"),
+        "---\nkind: adr\nid: ADR-001\ntitle: Use Rust\n---\n\n## Decision\nUse Rust.\n\n## Status\nAccepted.",
+    ).unwrap();
+
+    // Init with --scan
+    forgeplan()
+        .args(["init", "-y", "--scan"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Imported"));
+
+    // Verify
+    forgeplan()
+        .args(["get", "ADR-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Use Rust"));
+}
+
+#[test]
+fn scan_import_multiple_types() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("PRD-001-feature.md"),
+        "---\nkind: prd\nid: PRD-001\ntitle: Feature\n---\n# Feature",
+    ).unwrap();
+    std::fs::write(
+        docs.join("RFC-001-design.md"),
+        "---\nkind: rfc\nid: RFC-001\ntitle: Design\n---\n# Design",
+    ).unwrap();
+    std::fs::write(
+        docs.join("ADR-001-choice.md"),
+        "---\nkind: adr\nid: ADR-001\ntitle: Choice\n---\n# Choice",
+    ).unwrap();
+
+    forgeplan()
+        .args(["scan-import"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("3 imported"));
+
+    // All three exist
+    forgeplan().args(["get", "PRD-001"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["get", "RFC-001"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["get", "ADR-001"]).current_dir(tmp.path()).assert().success();
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod link;
 pub mod progress;
 pub mod projection;
 pub mod routing;
+pub mod scan;
 pub mod scoring;
 pub mod search;
 pub mod stale;

--- a/crates/forgeplan-core/src/scan/detect.rs
+++ b/crates/forgeplan-core/src/scan/detect.rs
@@ -1,0 +1,275 @@
+use crate::artifact::frontmatter::parse_frontmatter;
+use crate::artifact::types::ArtifactKind;
+
+/// How the artifact kind was detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetectionTier {
+    /// Tier 1: `kind` field in YAML frontmatter — most reliable.
+    Frontmatter,
+    /// Tier 2: Filename pattern (PRD-001, RFC-*, ADR-*) — high reliability.
+    Filename,
+    /// Tier 3: Content heuristics (## Problem, ## Decision) — moderate reliability.
+    Content,
+}
+
+/// Result of artifact type detection.
+#[derive(Debug, Clone)]
+pub struct DetectionResult {
+    pub kind: ArtifactKind,
+    pub tier: DetectionTier,
+    /// Suggested ID extracted from the document (e.g., "PRD-001" from frontmatter `id` field).
+    pub suggested_id: Option<String>,
+    /// Title extracted from frontmatter or first heading.
+    pub suggested_title: Option<String>,
+}
+
+/// Detect artifact kind using 3-tier fallback chain:
+/// frontmatter → filename → content heuristics.
+///
+/// Returns `None` if no tier can determine the type.
+pub fn detect_kind(filename: &str, content: &str) -> Option<DetectionResult> {
+    // Tier 1: Frontmatter
+    if let Some(result) = detect_from_frontmatter(content) {
+        return Some(result);
+    }
+
+    // Tier 2: Filename pattern
+    if let Some(result) = detect_from_filename(filename) {
+        return Some(result);
+    }
+
+    // Tier 3: Content heuristics
+    detect_from_content(content)
+}
+
+/// Tier 1: Parse YAML frontmatter for `kind` field.
+fn detect_from_frontmatter(content: &str) -> Option<DetectionResult> {
+    let (fm, _body) = parse_frontmatter(content).ok()?;
+
+    let kind_str = fm.get("kind").and_then(|v| v.as_str())?;
+    let kind: ArtifactKind = kind_str.parse().ok()?;
+
+    let suggested_id = fm
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_uppercase());
+
+    let suggested_title = fm
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(|s| s.trim_matches('"').to_string());
+
+    Some(DetectionResult {
+        kind,
+        tier: DetectionTier::Frontmatter,
+        suggested_id,
+        suggested_title,
+    })
+}
+
+/// Tier 2: Detect from filename patterns like `PRD-001-title.md`, `RFC-002.md`.
+fn detect_from_filename(filename: &str) -> Option<DetectionResult> {
+    let name = filename.strip_suffix(".md")
+        .or_else(|| filename.strip_suffix(".markdown"))
+        .unwrap_or(filename);
+    let upper = name.to_uppercase();
+
+    let patterns: &[(&str, ArtifactKind)] = &[
+        ("PRD-", ArtifactKind::Prd),
+        ("RFC-", ArtifactKind::Rfc),
+        ("ADR-", ArtifactKind::Adr),
+        ("EPIC-", ArtifactKind::Epic),
+        ("SPEC-", ArtifactKind::Spec),
+        ("NOTE-", ArtifactKind::Note),
+        ("PROB-", ArtifactKind::ProblemCard),
+        ("SOL-", ArtifactKind::SolutionPortfolio),
+        ("EVID-", ArtifactKind::EvidencePack),
+        ("REF-", ArtifactKind::RefreshReport),
+    ];
+
+    for (prefix, kind) in patterns {
+        if upper.starts_with(prefix) {
+            // Extract ID: everything before first non-ID character
+            let id = extract_id_from_name(&upper, prefix);
+            let title = extract_title_from_name(name, prefix);
+            return Some(DetectionResult {
+                kind: kind.clone(),
+                tier: DetectionTier::Filename,
+                suggested_id: Some(id),
+                suggested_title: title,
+            });
+        }
+    }
+
+    None
+}
+
+/// Extract the ID portion (e.g., "PRD-001") from a filename like "PRD-001-my-title".
+fn extract_id_from_name(upper_name: &str, prefix: &str) -> String {
+    let after_prefix = &upper_name[prefix.len()..];
+    let num_end = after_prefix
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(after_prefix.len());
+
+    let kind_prefix = prefix.trim_end_matches('-');
+    if num_end > 0 {
+        let num_str = &after_prefix[..num_end];
+        format!("{}-{}", kind_prefix, num_str)
+    } else {
+        format!("{}-001", kind_prefix)
+    }
+}
+
+/// Extract a human-readable title from filename (e.g., "my-title" from "PRD-001-my-title").
+fn extract_title_from_name(name: &str, prefix: &str) -> Option<String> {
+    let after_prefix = &name[prefix.len()..];
+    // Skip digits
+    let after_num = after_prefix.trim_start_matches(|c: char| c.is_ascii_digit());
+    let title_part = after_num.trim_start_matches('-').trim_start_matches('_');
+    if title_part.is_empty() {
+        None
+    } else {
+        Some(title_part.replace('-', " ").replace('_', " "))
+    }
+}
+
+/// Tier 3: Content-based heuristics — look for section headings that indicate artifact type.
+fn detect_from_content(content: &str) -> Option<DetectionResult> {
+    let lower = content.to_lowercase();
+
+    // Extract title from first H1
+    let title = content
+        .lines()
+        .find(|l| l.starts_with("# "))
+        .map(|l| l.trim_start_matches('#').trim().to_string());
+
+    // ADR indicators
+    if (lower.contains("## decision") || lower.contains("## context"))
+        && (lower.contains("## status") || lower.contains("## consequences"))
+    {
+        return Some(DetectionResult {
+            kind: ArtifactKind::Adr,
+            tier: DetectionTier::Content,
+            suggested_id: None,
+            suggested_title: title,
+        });
+    }
+
+    // PRD indicators
+    if (lower.contains("## problem") || lower.contains("## motivation"))
+        && (lower.contains("## goals") || lower.contains("## success criteria")
+            || lower.contains("## requirements") || lower.contains("## functional requirements"))
+    {
+        return Some(DetectionResult {
+            kind: ArtifactKind::Prd,
+            tier: DetectionTier::Content,
+            suggested_id: None,
+            suggested_title: title,
+        });
+    }
+
+    // RFC indicators
+    if (lower.contains("## proposal") || lower.contains("## design") || lower.contains("## approach"))
+        && (lower.contains("## alternatives") || lower.contains("## implementation"))
+    {
+        return Some(DetectionResult {
+            kind: ArtifactKind::Rfc,
+            tier: DetectionTier::Content,
+            suggested_id: None,
+            suggested_title: title,
+        });
+    }
+
+    // Spec indicators
+    if (lower.contains("## api") || lower.contains("## endpoints") || lower.contains("## data model"))
+        && (lower.contains("## request") || lower.contains("## response")
+            || lower.contains("## schema"))
+    {
+        return Some(DetectionResult {
+            kind: ArtifactKind::Spec,
+            tier: DetectionTier::Content,
+            suggested_id: None,
+            suggested_title: title,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier1_frontmatter_detection() {
+        let content = "---\nkind: prd\nid: PRD-001\ntitle: \"My PRD\"\n---\n# PRD-001";
+        let result = detect_kind("anything.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Prd);
+        assert_eq!(result.tier, DetectionTier::Frontmatter);
+        assert_eq!(result.suggested_id, Some("PRD-001".to_string()));
+        assert_eq!(result.suggested_title, Some("My PRD".to_string()));
+    }
+
+    #[test]
+    fn tier1_frontmatter_rfc() {
+        let content = "---\nkind: rfc\nid: RFC-002\ntitle: Architecture\n---\n# RFC";
+        let result = detect_kind("some-file.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Rfc);
+        assert_eq!(result.tier, DetectionTier::Frontmatter);
+    }
+
+    #[test]
+    fn tier2_filename_prd() {
+        let content = "# Just a document\nNo frontmatter here.";
+        let result = detect_kind("PRD-003-auth-system.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Prd);
+        assert_eq!(result.tier, DetectionTier::Filename);
+        assert!(result.suggested_title.is_some());
+    }
+
+    #[test]
+    fn tier2_filename_adr() {
+        let content = "No frontmatter";
+        let result = detect_kind("ADR-001-use-rust.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Adr);
+        assert_eq!(result.tier, DetectionTier::Filename);
+    }
+
+    #[test]
+    fn tier3_content_adr() {
+        let content = "# Use PostgreSQL\n\n## Context\nWe need a database.\n\n## Decision\nUse PostgreSQL.\n\n## Status\nAccepted\n\n## Consequences\nGood.";
+        let result = detect_kind("random-name.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Adr);
+        assert_eq!(result.tier, DetectionTier::Content);
+    }
+
+    #[test]
+    fn tier3_content_prd() {
+        let content = "# Auth System\n\n## Problem\nUsers can't log in.\n\n## Goals\nSecure auth.\n\n## Requirements\nFR-001";
+        let result = detect_kind("auth.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Prd);
+        assert_eq!(result.tier, DetectionTier::Content);
+    }
+
+    #[test]
+    fn tier3_content_rfc() {
+        let content = "# API Redesign\n\n## Proposal\nNew REST API.\n\n## Alternatives\nGraphQL.\n\n## Implementation\nPhased.";
+        let result = detect_kind("api.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Rfc);
+        assert_eq!(result.tier, DetectionTier::Content);
+    }
+
+    #[test]
+    fn unknown_returns_none() {
+        let content = "# Shopping List\n\n- Milk\n- Bread";
+        assert!(detect_kind("shopping.md", content).is_none());
+    }
+
+    #[test]
+    fn frontmatter_takes_priority_over_filename() {
+        let content = "---\nkind: rfc\nid: RFC-001\n---\n# RFC";
+        let result = detect_kind("PRD-001-looks-like-prd.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Rfc); // frontmatter wins
+        assert_eq!(result.tier, DetectionTier::Frontmatter);
+    }
+}

--- a/crates/forgeplan-core/src/scan/discovery.rs
+++ b/crates/forgeplan-core/src/scan/discovery.rs
@@ -1,0 +1,176 @@
+use std::path::{Path, PathBuf};
+
+/// A markdown file discovered during scan.
+#[derive(Debug, Clone)]
+pub struct DiscoveredFile {
+    /// Absolute path to the file.
+    pub path: PathBuf,
+    /// Path relative to the scan root.
+    pub relative_path: PathBuf,
+    /// Raw file content.
+    pub content: String,
+}
+
+/// Standard directories to scan for documentation.
+const SCAN_DIRS: &[&str] = &[
+    "docs",
+    "doc",
+    "documentation",
+    "design",
+    "specs",
+    "rfcs",
+    "adrs",
+    "prds",
+    "decisions",
+    "architecture",
+];
+
+/// Discover markdown files in standard documentation directories.
+/// Scans `SCAN_DIRS` under `root`, plus any `.md` files directly in `root`.
+/// Skips files inside `.forgeplan/`, `node_modules/`, `.git/`, `target/`.
+pub fn discover_markdown_files(root: &Path) -> anyhow::Result<Vec<DiscoveredFile>> {
+    let mut results = Vec::new();
+    let skip_dirs = [".forgeplan", "node_modules", ".git", "target", "vendor", ".venv"];
+
+    // Scan standard doc directories
+    for dir_name in SCAN_DIRS {
+        let dir = root.join(dir_name);
+        if dir.is_dir() {
+            collect_markdown_recursive(&dir, root, &skip_dirs, &mut results)?;
+        }
+    }
+
+    // Also scan root-level .md files (README.md, ARCHITECTURE.md, etc.)
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && has_markdown_ext(&path) {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    // Skip common non-artifact files
+                    if matches!(
+                        name.to_lowercase().as_str(),
+                        "readme.md"
+                            | "changelog.md"
+                            | "contributing.md"
+                            | "license.md"
+                            | "code_of_conduct.md"
+                    ) {
+                        continue;
+                    }
+                    if let Ok(content) = std::fs::read_to_string(&path) {
+                        let relative = path
+                            .strip_prefix(root)
+                            .unwrap_or(&path)
+                            .to_path_buf();
+                        results.push(DiscoveredFile {
+                            path: path.clone(),
+                            relative_path: relative,
+                            content,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// Recursively collect markdown files from a directory.
+fn collect_markdown_recursive(
+    dir: &Path,
+    root: &Path,
+    skip_dirs: &[&str],
+    results: &mut Vec<DiscoveredFile>,
+) -> anyhow::Result<()> {
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let dir_name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            if !skip_dirs.contains(&dir_name) {
+                collect_markdown_recursive(&path, root, skip_dirs, results)?;
+            }
+        } else if path.is_file() && has_markdown_ext(&path) {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                let relative = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .to_path_buf();
+                results.push(DiscoveredFile {
+                    path: path.clone(),
+                    relative_path: relative,
+                    content,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn has_markdown_ext(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("markdown"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discovers_files_in_docs_dir() {
+        let tmp = TempDir::new().unwrap();
+        let docs = tmp.path().join("docs");
+        fs::create_dir_all(&docs).unwrap();
+        fs::write(docs.join("PRD-001.md"), "---\nkind: prd\n---\n# PRD").unwrap();
+        fs::write(docs.join("notes.txt"), "not markdown").unwrap();
+
+        let found = discover_markdown_files(tmp.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert!(found[0].relative_path.to_str().unwrap().contains("PRD-001"));
+    }
+
+    #[test]
+    fn skips_forgeplan_and_node_modules() {
+        let tmp = TempDir::new().unwrap();
+        let fp = tmp.path().join(".forgeplan/prds");
+        let nm = tmp.path().join("node_modules/pkg");
+        fs::create_dir_all(&fp).unwrap();
+        fs::create_dir_all(&nm).unwrap();
+        fs::write(fp.join("test.md"), "inside forgeplan").unwrap();
+        fs::write(nm.join("test.md"), "inside node_modules").unwrap();
+
+        let found = discover_markdown_files(tmp.path()).unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[test]
+    fn discovers_root_level_md_files() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("ARCHITECTURE.md"), "# Arch").unwrap();
+        fs::write(tmp.path().join("README.md"), "# Read").unwrap(); // should be skipped
+
+        let found = discover_markdown_files(tmp.path()).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].relative_path.to_str().unwrap(), "ARCHITECTURE.md");
+    }
+
+    #[test]
+    fn discovers_nested_docs() {
+        let tmp = TempDir::new().unwrap();
+        let nested = tmp.path().join("docs/prds");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("PRD-001.md"), "# PRD").unwrap();
+        fs::write(nested.join("PRD-002.md"), "# PRD 2").unwrap();
+
+        let found = discover_markdown_files(tmp.path()).unwrap();
+        assert_eq!(found.len(), 2);
+    }
+}

--- a/crates/forgeplan-core/src/scan/import.rs
+++ b/crates/forgeplan-core/src/scan/import.rs
@@ -1,0 +1,232 @@
+use std::path::Path;
+
+use crate::artifact::types::ArtifactKind;
+use crate::db::store::{LanceStore, NewArtifact};
+use crate::scan::detect::{detect_kind, DetectionResult, DetectionTier};
+use crate::scan::discovery::{discover_markdown_files, DiscoveredFile};
+
+/// Options for scan-import operation.
+#[derive(Debug, Clone)]
+pub struct ScanImportOptions {
+    /// If true, only show what would be imported without making changes.
+    pub dry_run: bool,
+    /// Custom path to scan (overrides default doc directories).
+    pub custom_path: Option<String>,
+}
+
+impl Default for ScanImportOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: false,
+            custom_path: None,
+        }
+    }
+}
+
+/// Status of a single file during import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportStatus {
+    /// Successfully imported into LanceDB.
+    Imported,
+    /// Skipped because artifact with same ID already exists.
+    Skipped,
+    /// Could not determine artifact type.
+    Unknown,
+    /// Failed to import (with error message).
+    Failed(String),
+}
+
+/// Entry in the scan-import result.
+#[derive(Debug, Clone)]
+pub struct ScanImportEntry {
+    /// Relative path of the source file.
+    pub relative_path: String,
+    /// Detected artifact kind (if any).
+    pub detected_kind: Option<ArtifactKind>,
+    /// Detection tier used.
+    pub detection_tier: Option<DetectionTier>,
+    /// Assigned artifact ID.
+    pub artifact_id: Option<String>,
+    /// Import status.
+    pub status: ImportStatus,
+}
+
+/// Aggregate result of scan-import operation.
+#[derive(Debug, Clone)]
+pub struct ScanImportResult {
+    pub entries: Vec<ScanImportEntry>,
+    pub total_found: usize,
+    pub imported: usize,
+    pub skipped: usize,
+    pub unknown: usize,
+    pub failed: usize,
+}
+
+/// Run scan-import: discover files, detect types, import into LanceDB.
+pub async fn scan_and_import(
+    project_root: &Path,
+    store: &LanceStore,
+    options: &ScanImportOptions,
+) -> anyhow::Result<ScanImportResult> {
+    // Discover files
+    let scan_root = if let Some(ref custom) = options.custom_path {
+        project_root.join(custom)
+    } else {
+        project_root.to_path_buf()
+    };
+
+    let files = discover_markdown_files(&scan_root)?;
+    let total_found = files.len();
+
+    let mut entries = Vec::with_capacity(total_found);
+    let mut imported = 0usize;
+    let mut skipped = 0usize;
+    let mut unknown = 0usize;
+    let mut failed = 0usize;
+
+    for file in &files {
+        let filename = file
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown");
+
+        let detection = detect_kind(filename, &file.content);
+
+        let entry = match detection {
+            Some(det) => {
+                process_detected_file(file, &det, store, options.dry_run).await
+            }
+            None => {
+                unknown += 1;
+                ScanImportEntry {
+                    relative_path: file.relative_path.display().to_string(),
+                    detected_kind: None,
+                    detection_tier: None,
+                    artifact_id: None,
+                    status: ImportStatus::Unknown,
+                }
+            }
+        };
+
+        match entry.status {
+            ImportStatus::Imported => imported += 1,
+            ImportStatus::Skipped => skipped += 1,
+            ImportStatus::Failed(_) => failed += 1,
+            ImportStatus::Unknown => {} // already counted
+        }
+
+        entries.push(entry);
+    }
+
+    Ok(ScanImportResult {
+        entries,
+        total_found,
+        imported,
+        skipped,
+        unknown,
+        failed,
+    })
+}
+
+/// Process a file with a successful detection result.
+async fn process_detected_file(
+    file: &DiscoveredFile,
+    detection: &DetectionResult,
+    store: &LanceStore,
+    dry_run: bool,
+) -> ScanImportEntry {
+    let artifact_id = resolve_artifact_id(detection, store).await;
+
+    let entry_base = ScanImportEntry {
+        relative_path: file.relative_path.display().to_string(),
+        detected_kind: Some(detection.kind.clone()),
+        detection_tier: Some(detection.tier.clone()),
+        artifact_id: Some(artifact_id.clone()),
+        status: ImportStatus::Imported, // will be overwritten
+    };
+
+    if dry_run {
+        return ScanImportEntry {
+            status: ImportStatus::Imported, // preview: would be imported
+            ..entry_base
+        };
+    }
+
+    // Check if artifact already exists
+    match store.get_artifact(&artifact_id).await {
+        Ok(Some(_)) => {
+            return ScanImportEntry {
+                status: ImportStatus::Skipped,
+                ..entry_base
+            };
+        }
+        Ok(None) => {} // proceed with import
+        Err(e) => {
+            return ScanImportEntry {
+                status: ImportStatus::Failed(format!("Check existing: {e}")),
+                ..entry_base
+            };
+        }
+    }
+
+    // Build title: prefer detection → filename → "Untitled"
+    let title = detection
+        .suggested_title
+        .clone()
+        .or_else(|| {
+            file.path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.replace('-', " ").replace('_', " "))
+        })
+        .unwrap_or_else(|| "Untitled".to_string());
+
+    let new_artifact = NewArtifact {
+        id: artifact_id.clone(),
+        kind: detection.kind.template_key().to_string(),
+        status: "draft".to_string(),
+        title,
+        body: file.content.clone(),
+        depth: "standard".to_string(),
+        author: Some("scan-import".to_string()),
+        parent_epic: None,
+        valid_until: None,
+    };
+
+    match store.create_artifact(&new_artifact).await {
+        Ok(_) => ScanImportEntry {
+            status: ImportStatus::Imported,
+            ..entry_base
+        },
+        Err(e) => ScanImportEntry {
+            status: ImportStatus::Failed(format!("{e}")),
+            ..entry_base
+        },
+    }
+}
+
+/// Resolve the artifact ID: use suggested_id from detection, or generate next available.
+async fn resolve_artifact_id(detection: &DetectionResult, store: &LanceStore) -> String {
+    // If detection found an ID, use it (normalized to uppercase)
+    if let Some(ref id) = detection.suggested_id {
+        return id.to_uppercase();
+    }
+
+    // Otherwise, generate next available ID for this kind
+    let kind_prefix = detection.kind.prefix().trim_end_matches('-').to_uppercase();
+    for n in 1..=999 {
+        let candidate = format!("{}-{:03}", kind_prefix, n);
+        match store.get_artifact(&candidate).await {
+            Ok(None) => return candidate,
+            Ok(Some(_)) => continue,
+            Err(_) => return candidate, // on error, try anyway
+        }
+    }
+
+    // Fallback
+    format!(
+        "{}-999",
+        detection.kind.prefix().trim_end_matches('-').to_uppercase()
+    )
+}

--- a/crates/forgeplan-core/src/scan/mod.rs
+++ b/crates/forgeplan-core/src/scan/mod.rs
@@ -1,0 +1,7 @@
+pub mod detect;
+pub mod discovery;
+pub mod import;
+
+pub use detect::{detect_kind, DetectionResult, DetectionTier};
+pub use discovery::{discover_markdown_files, DiscoveredFile};
+pub use import::{ScanImportOptions, ScanImportResult, ScanImportEntry, ImportStatus};


### PR DESCRIPTION
## Summary

- **3-tier detection pipeline**: frontmatter → filename → content heuristics for automatic artifact type detection
- **`forgeplan init --scan`**: auto-discovers and imports existing docs during workspace initialization
- **`forgeplan scan-import [--path] [--dry-run]`**: standalone scan + import command for existing workspaces
- **20 new tests** (13 unit + 7 E2E), 316 total PASS

## Details

| Component | Files | LOC |
|-----------|-------|-----|
| `scan/discovery.rs` | File discovery with skip rules | 176 |
| `scan/detect.rs` | 3-tier detection + 8 unit tests | 275 |
| `scan/import.rs` | Bulk import pipeline | 232 |
| `scan_import.rs` (CLI) | Standalone command | 111 |
| `init.rs` (modified) | `--scan` flag integration | +73 |
| E2E tests | 7 integration tests | 218 |

## Refs

- PRD-012 (Project Onboarding)
- FR-001..010
- EVID-017 (R_eff = 1.00)

## Test plan

- [x] `cargo test --workspace` — 316 PASS
- [x] `forgeplan init -y --scan` with fixture docs → imports correctly
- [x] `forgeplan scan-import --dry-run` → preview without changes
- [x] Conflict resolution: skip existing artifacts
- [x] Unknown files: reported but not imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)