### PR TITLE
[PRD-008] CLI UX Redesign — unified output helpers + --json

### DIFF
--- a/crates/forgeplan-cli/src/commands/get.rs
+++ b/crates/forgeplan-cli/src/commands/get.rs
@@ -3,7 +3,9 @@ use std::env;
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::workspace;
 
-pub async fn run(id: &str) -> anyhow::Result<()> {
+use crate::ui;
+
+pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -14,26 +16,43 @@ pub async fn run(id: &str) -> anyhow::Result<()> {
         .await?
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' not found", id))?;
 
-    println!();
-    println!("ID:           {}", record.id);
-    println!("Kind:         {}", record.kind);
-    println!("Status:       {}", record.status);
-    println!("Title:        {}", record.title);
-    println!("Depth:        {}", record.depth);
+    if json {
+        let json_data = serde_json::json!({
+            "id": record.id,
+            "kind": record.kind,
+            "status": record.status,
+            "title": record.title,
+            "depth": record.depth,
+            "author": record.author,
+            "parent_epic": record.parent_epic,
+            "valid_until": record.valid_until,
+            "r_eff": record.r_eff_score,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+            "body": record.body,
+        });
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
+        return Ok(());
+    }
+
+    ui::header(&record.id, &record.title);
+    ui::kv("Kind", &record.kind);
+    ui::kv("Status", &ui::styled_status(&record.status));
+    ui::kv("Depth", &ui::styled_depth(&record.depth));
     if let Some(ref author) = record.author {
-        println!("Author:       {}", author);
+        ui::kv("Author", author);
     }
     if let Some(ref epic) = record.parent_epic {
         if !epic.is_empty() {
-            println!("Parent Epic:  {}", epic);
+            ui::kv("Parent Epic", epic);
         }
     }
     if let Some(ref vu) = record.valid_until {
-        println!("Valid Until:   {}", vu);
+        ui::kv("Valid Until", vu);
     }
-    println!("R_eff:        {:.2}", record.r_eff_score);
-    println!("Created:      {}", record.created_at);
-    println!("Updated:      {}", record.updated_at);
+    ui::kv("R_eff", &ui::styled_reff(record.r_eff_score));
+    ui::kv("Created", &record.created_at);
+    ui::kv("Updated", &record.updated_at);
     println!();
     println!("{}", record.body);
 

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -10,7 +10,9 @@ use forgeplan_core::scoring::fgr;
 use forgeplan_core::scoring::reff::{self, EvidenceItem, EvidenceType, Verdict};
 use forgeplan_core::workspace;
 
-pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
+use crate::ui;
+
+pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -103,19 +105,56 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
         is_stale,
     );
 
-    // --- Display ---
-    println!();
-    println!("{} \"{}\"", target.id, target.title);
-    println!("{}", "-".repeat(50));
+    // --- JSON output ---
+    if json {
+        let evidence_json: Vec<_> = evidence_items
+            .iter()
+            .map(|item| {
+                let item_score = reff::r_eff(&[item.clone()]);
+                serde_json::json!({
+                    "id": item.id,
+                    "verdict": format!("{:?}", item.verdict),
+                    "congruence_level": item.congruence_level,
+                    "score": item_score,
+                    "expired": item.valid_until.map(|dt| Utc::now().naive_utc() > dt).unwrap_or(false),
+                })
+            })
+            .collect();
+
+        let json_data = serde_json::json!({
+            "id": target.id,
+            "title": target.title,
+            "r_eff": report.r_eff,
+            "weakest_link": report.weakest_link,
+            "factors": report.factors,
+            "evidence": evidence_json,
+            "fgr": {
+                "formality": fgr_score.formality,
+                "granularity": fgr_score.granularity,
+                "reliability": fgr_score.reliability,
+                "overall": fgr_score.overall(),
+                "grade": fgr_score.grade(),
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
+        return Ok(());
+    }
+
+    // --- Styled display ---
+    ui::header(&target.id, &target.title);
 
     if evidence_items.is_empty() {
-        println!("  No evidence linked. R_eff = 0.0");
+        ui::info("No evidence linked. R_eff = 0.0");
         println!();
-        println!("  Hint: Create an EvidencePack and link it:");
-        println!("    forgeplan new evidence \"Benchmark for {}\"", target.id);
-        println!("    forgeplan link EVID-001 {} --relation informs", target.id);
+        ui::error_hint(
+            "No evidence found",
+            &format!(
+                "forgeplan new evidence \"Benchmark for {}\" && forgeplan link EVID-XXX {} --relation informs",
+                target.id, target.id
+            ),
+        );
     } else {
-        println!("  Evidence breakdown:");
+        ui::section("Evidence breakdown");
         for item in &evidence_items {
             let expired = item
                 .valid_until
@@ -141,15 +180,13 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
             "AT RISK"
         };
 
-        println!("  R_eff = {:.2} -- {}", report.r_eff, status);
+        ui::kv("R_eff", &format!("{} -- {}", ui::styled_reff(report.r_eff), status));
     }
 
-    // Weakest link
     if let Some(ref wl) = report.weakest_link {
-        println!("  Weakest link: {}", wl);
+        ui::kv("Weakest link", wl);
     }
 
-    // Factors
     if !report.factors.is_empty() {
         println!();
         for factor in &report.factors {
@@ -157,9 +194,7 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
         }
     }
 
-    // F-G-R breakdown
-    println!();
-    println!("  Quality (F-G-R):");
+    ui::section("Quality (F-G-R)");
     println!(
         "    Formality:    {:.2} ({})",
         fgr_score.formality,
@@ -182,22 +217,14 @@ pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
     );
 
     // Hints for low scores
-    let mut hints: Vec<&str> = Vec::new();
     if fgr_score.formality < 0.4 {
-        hints.push("Hint: Fill in required sections to improve formality");
+        ui::warning("Fill in required sections to improve formality");
     }
     if fgr_score.granularity < 0.4 {
-        hints.push("Hint: Add more FR checkboxes to improve granularity");
+        ui::warning("Add more FR checkboxes to improve granularity");
     }
     if fgr_score.reliability < 0.3 {
-        hints.push("Hint: Add evidence with `forgeplan new evidence`");
-    }
-
-    if !hints.is_empty() {
-        println!();
-        for hint in &hints {
-            println!("  {}", hint);
-        }
+        ui::warning("Add evidence with `forgeplan new evidence`");
     }
 
     println!();

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -3,7 +3,9 @@ use std::env;
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::workspace;
 
-pub async fn run(query: &str, kind: Option<&str>, semantic: bool) -> anyhow::Result<()> {
+use crate::ui;
+
+pub async fn run(query: &str, kind: Option<&str>, semantic: bool, json: bool) -> anyhow::Result<()> {
     let cwd = env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
@@ -28,7 +30,25 @@ pub async fn run(query: &str, kind: Option<&str>, semantic: bool) -> anyhow::Res
     let hits = store.search_body(query, kind).await?;
 
     if hits.is_empty() {
-        println!("No results for \"{}\"", query);
+        if json {
+            println!("[]");
+        } else {
+            ui::info(&format!("No results for \"{}\"", query));
+        }
+        return Ok(());
+    }
+
+    if json {
+        let json_data: Vec<_> = hits
+            .iter()
+            .map(|r| serde_json::json!({
+                "id": r.id,
+                "kind": r.kind,
+                "status": r.status,
+                "title": r.title,
+            }))
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
         return Ok(());
     }
 

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -58,6 +58,9 @@ enum Commands {
     Score {
         /// Artifact ID
         id: Option<String>,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Link two artifacts with a typed relationship
     Link {
@@ -81,6 +84,9 @@ enum Commands {
         /// Use semantic (vector) search instead of substring match
         #[arg(long)]
         semantic: bool,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Detect stale artifacts with expired valid_until
     Stale,
@@ -126,6 +132,9 @@ enum Commands {
     Get {
         /// Artifact ID
         id: String,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
     },
     /// Update artifact metadata or body
     Update {
@@ -307,7 +316,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Validate { id, json, adversarial } => {
             commands::validate::run(id.as_deref(), json, adversarial).await
         }
-        Commands::Score { id } => commands::score::run(id.as_deref()).await,
+        Commands::Score { id, json } => commands::score::run(id.as_deref(), json).await,
         Commands::Link {
             source,
             target,
@@ -318,8 +327,9 @@ async fn main() -> anyhow::Result<()> {
             query,
             r#type,
             semantic,
+            json,
         } => {
-            commands::search::run(&query, r#type.as_deref(), semantic).await
+            commands::search::run(&query, r#type.as_deref(), semantic, json).await
         }
         Commands::Stale => commands::stale::run().await,
         Commands::Progress { id } => commands::progress::run(id.as_deref()).await,
@@ -335,7 +345,7 @@ async fn main() -> anyhow::Result<()> {
             fpf,
         } => commands::reason::run(&id, json, save, fpf).await,
         Commands::Decompose { id } => commands::decompose::run(&id).await,
-        Commands::Get { id } => commands::get::run(&id).await,
+        Commands::Get { id, json } => commands::get::run(&id, json).await,
         Commands::Update {
             id,
             status,

--- a/crates/forgeplan-cli/src/ui.rs
+++ b/crates/forgeplan-cli/src/ui.rs
@@ -63,6 +63,70 @@ pub fn styled_count(count: usize, is_problem: bool) -> String {
     }
 }
 
+/// Style an R_eff score with color: green >= 0.5, yellow 0.1-0.5, red < 0.1.
+pub fn styled_reff(score: f64) -> String {
+    let text = format!("{:.2}", score);
+    if score >= 0.5 {
+        style(text).green().bold().to_string()
+    } else if score >= 0.1 {
+        style(text).yellow().to_string()
+    } else {
+        style(text).red().to_string()
+    }
+}
+
+// ─── Unified Output Helpers ──────────────────────────────────────
+
+/// Print a command header with title and optional separator.
+/// Example: `Forgeplan Health — ProjectName`
+pub fn header(title: &str, subtitle: &str) {
+    println!();
+    if subtitle.is_empty() {
+        println!("{}", style(title).bold());
+    } else {
+        println!("{} — {}", style(title).bold(), style(subtitle).cyan());
+    }
+    println!("{}", style("─".repeat(50)).dim());
+}
+
+/// Print a key-value pair with consistent alignment.
+/// Example: `  ID:           PRD-001`
+pub fn kv(key: &str, value: &str) {
+    println!("  {:<14}{}", style(format!("{}:", key)).bold(), value);
+}
+
+/// Print a section heading within command output.
+/// Example: `  Evidence breakdown:`
+pub fn section(title: &str) {
+    println!();
+    println!("  {}:", style(title).bold());
+}
+
+/// Print an error with an actionable hint.
+/// Example: `  ✗ Artifact 'X' not found`
+///          `    → Run `forgeplan list` to see available artifacts`
+pub fn error_hint(message: &str, hint: &str) {
+    eprintln!("  {} {}", style("✗").red(), message);
+    if !hint.is_empty() {
+        eprintln!("    {} {}", style("→").dim(), style(hint).dim());
+    }
+}
+
+/// Print a success message.
+pub fn success(message: &str) {
+    println!("  {} {}", style("✓").green(), message);
+}
+
+/// Print a warning message.
+pub fn warning(message: &str) {
+    println!("  {} {}", style("!").yellow(), message);
+}
+
+/// Print a dimmed info message.
+pub fn info(message: &str) {
+    println!("  {}", style(message).dim());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -107,5 +171,27 @@ mod tests {
     fn banner_contains_fpl() {
         assert!(BANNER.contains("███████╗"));
         assert!(BANNER.contains("██████╔╝"));
+    }
+
+    #[test]
+    fn styled_reff_colors() {
+        let high = styled_reff(1.0);
+        let mid = styled_reff(0.3);
+        let low = styled_reff(0.0);
+        assert!(!high.is_empty());
+        assert!(!mid.is_empty());
+        assert!(!low.is_empty());
+        // Different values should produce different styled output
+        assert_ne!(styled_reff(1.0), styled_reff(0.0));
+    }
+
+    #[test]
+    fn styled_reff_boundary_values() {
+        // 0.5 is green boundary
+        assert!(!styled_reff(0.5).is_empty());
+        // 0.1 is yellow boundary
+        assert!(!styled_reff(0.1).is_empty());
+        // 0.09 is red
+        assert!(!styled_reff(0.09).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- **8 new output helpers** in `ui.rs`: `header()`, `kv()`, `section()`, `error_hint()`, `success()`, `warning()`, `info()`, `styled_reff()`
- **`--json` flag** added to `get`, `score`, `search` commands (total: 7 commands with JSON output)
- **Styled output** for `get` and `score` using unified helpers: colored status, depth, R_eff
- **2 new unit tests** for `styled_reff` boundary values

## Refs

- PRD-008 (CLI UX Redesign)
- FR-001..004
- EVID-018 (R_eff = 1.00)

## Test plan

- [x] `cargo test --workspace` — 298 PASS
- [x] `forgeplan get PRD-001 --json` → valid JSON with all fields
- [x] `forgeplan score PRD-001 --json` → JSON with r_eff, evidence, fgr breakdown
- [x] `forgeplan search "test" --json` → JSON array of matching artifacts
- [x] Styled output renders correctly in TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)