### PR TITLE
fix(scoring): bidirectional evidence lookup in R_eff

### DIFF
--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -382,6 +382,42 @@ impl LanceStore {
         Ok(results)
     }
 
+    /// Get incoming relations where this artifact is the TARGET.
+    /// Returns Vec<(source_id, relation_type)>.
+    pub async fn get_incoming_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        let filter = format!("target_id = '{}'", id.replace('\'', "''"));
+        let batches = collect_batches(
+            self.relations
+                .query()
+                .only_if(filter)
+                .execute()
+                .await?,
+        )
+        .await?;
+
+        let mut results = Vec::new();
+        for batch in &batches {
+            let source_col = batch
+                .column_by_name("source_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let rel_col = batch
+                .column_by_name("relation_type")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+
+            if let (Some(sources), Some(rels)) = (source_col, rel_col) {
+                for i in 0..batch.num_rows() {
+                    if !sources.is_null(i) && !rels.is_null(i) {
+                        results.push((
+                            sources.value(i).to_string(),
+                            rels.value(i).to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(results)
+    }
+
     // -----------------------------------------------------------------------
     // Full-record methods (ArtifactRecord)
     // -----------------------------------------------------------------------

--- a/crates/forgeplan-core/src/scoring/reff.rs
+++ b/crates/forgeplan-core/src/scoring/reff.rs
@@ -156,19 +156,24 @@ pub async fn r_eff_recursive(
     // ---- 1. Self score from own evidence --------------------------------
 
     // Collect evidence records that link to this artifact.
-    let relations = store.get_relations(artifact_id).await?;
+    // Check BOTH directions: outgoing (this → evidence) AND incoming (evidence → this).
+    let outgoing = store.get_relations(artifact_id).await?;
+    let incoming = store.get_incoming_relations(artifact_id).await?;
     let evidence_filter = ArtifactFilter {
         kind: Some("evidence".to_string()),
         status: None,
     };
     let all_evidence = store.list_records(Some(&evidence_filter)).await?;
 
-    // Build set of evidence IDs that inform this artifact (via any relation
-    // direction where this artifact is the target).
-    let linked_evidence_ids: HashSet<String> = relations
+    // Build set of evidence IDs linked in either direction.
+    let mut linked_evidence_ids: HashSet<String> = outgoing
         .iter()
         .map(|(target_id, _)| target_id.clone())
         .collect();
+    // Also include incoming evidence (e.g., EVID-003 --informs--> EPIC-001)
+    for (source_id, _) in &incoming {
+        linked_evidence_ids.insert(source_id.clone());
+    }
 
     let evidence_items: Vec<EvidenceItem> = all_evidence
         .iter()
@@ -200,9 +205,8 @@ pub async fn r_eff_recursive(
     let dep_relation_types: HashSet<&str> =
         ["informs", "based_on", "refines", "depends_on"].iter().copied().collect();
 
-    // Collect dependency IDs with their CL from the relation graph.
-    // Relations are stored as (target_id, relation_type) from get_relations.
-    let deps: Vec<(String, String)> = relations
+    // Collect dependency IDs from outgoing relations.
+    let deps: Vec<(String, String)> = outgoing
         .iter()
         .filter(|(_, rel_type)| dep_relation_types.contains(rel_type.as_str()))
         .cloned()


### PR DESCRIPTION
## Summary

R_eff recursive считал evidence только по outgoing связям. Evidence приходящий через incoming (EVID → artifact) не находился.

**До**: EPIC-001 с EVID-003 [CL3 = 1.0] → R_eff = 0.00
**После**: EPIC-001 → R_eff = 1.00

## Changes

- `get_incoming_relations()` — новый метод в LanceStore
- `r_eff_recursive` — объединяет outgoing + incoming для evidence search

## Test plan

- [x] 318 tests PASS
- [x] EPIC-001 R_eff: 0.00 → 1.00
- [x] PRD-008 R_eff: 0.00 → 1.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)