### PR TITLE
refactor: migrate 24 commands to common::store() (-128 LOC)

### DIFF
--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::lifecycle;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     lifecycle::activate(&store, id).await?;
     println!("  Activated {id} (draft → active)");
 

--- a/crates/forgeplan-cli/src/commands/blindspots.rs
+++ b/crates/forgeplan-cli/src/commands/blindspots.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::health;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run() -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let report = health::health_report(&store).await?;
 
     if report.blind_spots.is_empty() && report.orphans.is_empty() {

--- a/crates/forgeplan-cli/src/commands/calibrate.rs
+++ b/crates/forgeplan-cli/src/commands/calibrate.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::depth;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: Option<&str>) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let records = store.list_records(None).await?;
 
     if records.is_empty() {

--- a/crates/forgeplan-cli/src/commands/capture.rs
+++ b/crates/forgeplan-cli/src/commands/capture.rs
@@ -1,21 +1,18 @@
-use std::env;
-
 use anyhow::Context;
 
 use forgeplan_core::artifact::types::ArtifactKind;
-use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::db::store::NewArtifact;
 use forgeplan_core::llm::capture;
 use forgeplan_core::projection;
-use forgeplan_core::workspace::{self, load_config};
+use forgeplan_core::workspace::load_config;
+
+use crate::commands::common;
 
 pub async fn run(decision: &str, context: Option<&str>) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let workspace = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let (workspace, store) = common::open_store().await?;
 
     let config = load_config(&workspace)?;
     let llm_config = config.llm.unwrap_or_default().with_env_overrides();
-    let store = LanceStore::open(&workspace).await?;
 
     println!(
         "  Capturing decision with {}/{}...",

--- a/crates/forgeplan-cli/src/commands/decay.rs
+++ b/crates/forgeplan-cli/src/commands/decay.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::scoring::decay;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run() -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let entries = decay::decay_report(&store).await?;
 
     if entries.is_empty() {

--- a/crates/forgeplan-cli/src/commands/decompose.rs
+++ b/crates/forgeplan-cli/src/commands/decompose.rs
@@ -1,18 +1,13 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::llm::decompose;
-use forgeplan_core::workspace::{self, load_config};
+use forgeplan_core::workspace::load_config;
+
+use crate::commands::common;
 
 pub async fn run(prd_id: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let (ws, store) = common::open_store().await?;
 
     let config = load_config(&ws)?;
     let llm_config = config.llm.unwrap_or_default().with_env_overrides();
-
-    let store = LanceStore::open(&ws).await?;
     let record = store
         .get_record(prd_id)
         .await?

--- a/crates/forgeplan-cli/src/commands/delete.rs
+++ b/crates/forgeplan-cli/src/commands/delete.rs
@@ -1,15 +1,9 @@
-use std::env;
-
 use forgeplan_core::artifact::types::ArtifactKind;
-use forgeplan_core::db::store::LanceStore;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: &str, yes: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let (ws, store) = common::open_store().await?;
 
     let record = store
         .get_record(id)

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::lifecycle;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let dependents = lifecycle::deprecate(&store, id, reason).await?;
 
     println!("  Deprecated {id}: {reason}");

--- a/crates/forgeplan-cli/src/commands/export.rs
+++ b/crates/forgeplan-cli/src/commands/export.rs
@@ -1,14 +1,8 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
-use forgeplan_core::workspace;
+use crate::commands::common;
 
 pub async fn run(output: Option<&str>) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
+    let cwd = std::env::current_dir()?;
 
     let records = store.list_records(None).await?;
     let artifacts: Vec<serde_json::Value> = records

--- a/crates/forgeplan-cli/src/commands/generate.rs
+++ b/crates/forgeplan-cli/src/commands/generate.rs
@@ -1,26 +1,22 @@
-use std::env;
-
 use anyhow::Context;
 
 use forgeplan_core::artifact::types::ArtifactKind;
-use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::db::store::NewArtifact;
 use forgeplan_core::llm::generate::generate_body;
 use forgeplan_core::projection;
-use forgeplan_core::workspace::{self, load_config};
+use forgeplan_core::workspace::load_config;
+
+use crate::commands::common;
 
 pub async fn run(kind_str: &str, description: &str) -> anyhow::Result<()> {
     let kind: ArtifactKind = kind_str
         .parse()
         .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let cwd = env::current_dir()?;
-    let workspace = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
+    let (workspace, store) = common::open_store().await?;
 
     let config = load_config(&workspace)?;
     let llm_config = config.llm.unwrap_or_default().with_env_overrides();
-
-    let store = LanceStore::open(&workspace).await?;
 
     // Generate title from first line of description (truncated)
     let title = description

--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -1,19 +1,14 @@
-use std::env;
-
 use console::style;
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::health;
 use forgeplan_core::workspace;
 
+use crate::commands::common;
 use crate::ui;
 
 pub async fn run(compact: bool, json: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let (ws, store) = common::open_store().await?;
 
     let config = workspace::load_config(&ws)?;
-    let store = LanceStore::open(&ws).await?;
     let report = health::health_report(&store).await?;
 
     if json {

--- a/crates/forgeplan-cli/src/commands/import_cmd.rs
+++ b/crates/forgeplan-cli/src/commands/import_cmd.rs
@@ -1,12 +1,10 @@
-use std::env;
+use forgeplan_core::db::store::NewArtifact;
 
-use forgeplan_core::db::store::{LanceStore, NewArtifact};
-use forgeplan_core::workspace;
+use crate::commands::common;
 
 pub async fn run(path: &str, force: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let (_ws, store) = common::open_store().await?;
+    let cwd = std::env::current_dir()?;
 
     let full_path = if std::path::Path::new(path).is_absolute() {
         std::path::PathBuf::from(path)
@@ -30,8 +28,6 @@ pub async fn run(path: &str, force: bool) -> anyhow::Result<()> {
     let artifacts = data["artifacts"]
         .as_array()
         .ok_or_else(|| anyhow::anyhow!("Missing 'artifacts' array in export file"))?;
-
-    let store = LanceStore::open(&ws).await?;
 
     let mut imported = 0usize;
     let mut skipped = 0usize;

--- a/crates/forgeplan-cli/src/commands/journal.rs
+++ b/crates/forgeplan-cli/src/commands/journal.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::journal;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(kind: Option<&str>, risk: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let entries = journal::build_journal(&store, kind, risk).await?;
 
     if entries.is_empty() {

--- a/crates/forgeplan-cli/src/commands/link.rs
+++ b/crates/forgeplan-cli/src/commands/link.rs
@@ -1,18 +1,12 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::link;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
     // Normalize relation
     let relation = link::normalize_relation(relation)?;
 
-    let store = LanceStore::open(&ws).await?;
+    let (ws, store) = common::open_store().await?;
 
     // Verify source exists
     let source = store.get_artifact(source_id).await?;

--- a/crates/forgeplan-cli/src/commands/list.rs
+++ b/crates/forgeplan-cli/src/commands/list.rs
@@ -1,19 +1,13 @@
-use std::env;
-
 use anyhow::Result;
 use console::style;
 
-use forgeplan_core::db::store::{ArtifactFilter, LanceStore};
-use forgeplan_core::workspace::find_workspace;
+use forgeplan_core::db::store::ArtifactFilter;
 
+use crate::commands::common;
 use crate::ui;
 
 pub async fn run(kind_filter: Option<&str>, status_filter: Option<&str>, json: bool) -> Result<()> {
-    let cwd = env::current_dir()?;
-    let workspace = find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&workspace).await?;
+    let store = common::store().await?;
 
     let filter = if kind_filter.is_some() || status_filter.is_some() {
         Some(ArtifactFilter {

--- a/crates/forgeplan-cli/src/commands/migrate.rs
+++ b/crates/forgeplan-cli/src/commands/migrate.rs
@@ -1,15 +1,8 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
-use forgeplan_core::workspace;
+use crate::commands::common;
 
 pub async fn run() -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
     println!("  Running schema migrations...");
-    let _store = LanceStore::open(&ws).await?; // open() runs migrations
+    let _store = common::store().await?; // open() runs migrations
     println!("  Migrations complete. Schema up to date.");
 
     Ok(())

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -1,22 +1,18 @@
 use std::collections::HashMap;
-use std::env;
 
 use anyhow::{Context, Result};
 
 use forgeplan_core::artifact::types::ArtifactKind;
-use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::db::store::NewArtifact;
 use forgeplan_core::projection;
 use forgeplan_core::template::{get_embedded_template, render_template};
-use forgeplan_core::workspace::find_workspace;
+
+use crate::commands::common;
 
 pub async fn run(kind_str: &str, title: &str) -> Result<()> {
     let kind: ArtifactKind = kind_str.parse().map_err(|e| anyhow::anyhow!("{}", e))?;
 
-    let cwd = env::current_dir()?;
-    let workspace = find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&workspace).await?;
+    let (workspace, store) = common::open_store().await?;
 
     // Get next sequential ID from LanceDB
     let prefix = kind.prefix().trim_end_matches('-').to_uppercase();

--- a/crates/forgeplan-cli/src/commands/reason.rs
+++ b/crates/forgeplan-cli/src/commands/reason.rs
@@ -1,18 +1,14 @@
-use std::env;
-
-use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::db::store::NewArtifact;
 use forgeplan_core::llm::reason;
-use forgeplan_core::workspace::{self, load_config};
+use forgeplan_core::workspace::load_config;
+
+use crate::commands::common;
 
 pub async fn run(id: &str, json: bool, save: bool, fpf: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let (ws, store) = common::open_store().await?;
 
     let config = load_config(&ws)?;
     let llm_config = config.llm.unwrap_or_default().with_env_overrides();
-
-    let store = LanceStore::open(&ws).await?;
     let record = store
         .get_record(id)
         .await?

--- a/crates/forgeplan-cli/src/commands/review.rs
+++ b/crates/forgeplan-cli/src/commands/review.rs
@@ -1,16 +1,10 @@
-use std::env;
-
 use console::style;
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::lifecycle;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let result = lifecycle::review(&store, id).await?;
 
     // Styled output instead of plain Display

--- a/crates/forgeplan-cli/src/commands/route.rs
+++ b/crates/forgeplan-cli/src/commands/route.rs
@@ -1,5 +1,3 @@
-use std::env;
-
 use console::style;
 use forgeplan_core::routing;
 use forgeplan_core::workspace;
@@ -7,8 +5,6 @@ use forgeplan_core::workspace;
 use crate::ui;
 
 pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
-    let _cwd = env::current_dir()?;
-
     // Rule-based routing (instant, offline, no LLM)
     let result = routing::route(description);
 
@@ -79,7 +75,7 @@ pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
 
     // Optional LLM explanation
     if explain {
-        let cwd = env::current_dir()?;
+        let cwd = std::env::current_dir()?;
         let ws = workspace::find_workspace(&cwd);
         if let Some(ws) = ws {
             let config = workspace::load_config(&ws)?;

--- a/crates/forgeplan-cli/src/commands/status.rs
+++ b/crates/forgeplan-cli/src/commands/status.rs
@@ -1,18 +1,15 @@
 use std::collections::BTreeMap;
-use std::env;
 
 use anyhow::Result;
 
-use forgeplan_core::db::store::LanceStore;
-use forgeplan_core::workspace::{find_workspace, load_config};
+use forgeplan_core::workspace::load_config;
+
+use crate::commands::common;
 
 pub async fn run() -> Result<()> {
-    let cwd = env::current_dir()?;
-    let workspace = find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("Not in a forgeplan workspace. Run `forgeplan init` first."))?;
+    let (workspace, store) = common::open_store().await?;
 
     let config = load_config(&workspace)?;
-    let store = LanceStore::open(&workspace).await?;
     let artifacts = store.list_artifacts(None).await?;
 
     // Count by kind

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -1,15 +1,9 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::lifecycle;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let dependents = lifecycle::supersede(&store, id, by).await?;
 
     println!("  Superseded {id} → {by}");

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -1,8 +1,6 @@
-use std::env;
-
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::projection;
-use forgeplan_core::workspace;
+
+use crate::commands::common;
 
 pub async fn run(
     id: &str,
@@ -11,11 +9,7 @@ pub async fn run(
     depth: Option<&str>,
     body: Option<&str>,
 ) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let (ws, store) = common::open_store().await?;
 
     // Verify artifact exists (keep original for old projection cleanup)
     let original = store

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -1,19 +1,12 @@
-use std::env;
-
 use console::style;
 use forgeplan_core::artifact::types::{ArtifactKind, Mode};
-use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::validation::{self, adversarial, Severity, ValidationResult};
-use forgeplan_core::workspace;
 
+use crate::commands::common;
 use crate::ui;
 
 pub async fn run(id: Option<&str>, json: bool, adversarial: bool) -> anyhow::Result<()> {
-    let cwd = env::current_dir()?;
-    let ws = workspace::find_workspace(&cwd)
-        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
-
-    let store = LanceStore::open(&ws).await?;
+    let store = common::store().await?;
     let all_records = store.list_records(None).await?;
 
     if all_records.is_empty() {


### PR DESCRIPTION
## Summary

- 24 command files migrated to `common::store()` / `common::open_store()`
- **-128 LOC** boilerplate removed
- 318 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)