### PR TITLE
test(audit): 13 new tests + REF- prefix fix

### DIFF
--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -29,3 +29,4 @@ semantic-search = []
 assert_cmd = "2"
 tempfile = "3"
 predicates = "3"
+serde_json = "1"

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -1427,3 +1427,152 @@ fn scan_import_multiple_types() {
     forgeplan().args(["get", "RFC-001"]).current_dir(tmp.path()).assert().success();
     forgeplan().args(["get", "ADR-001"]).current_dir(tmp.path()).assert().success();
 }
+
+// ─── JSON Output Structural Tests ────────────────────────────────
+
+#[test]
+fn json_get_is_valid_and_has_required_fields() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Test PRD"]).current_dir(tmp.path()).assert().success();
+
+    let output = forgeplan()
+        .args(["get", "PRD-001", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(json["id"], "PRD-001");
+    assert_eq!(json["kind"], "prd");
+    assert!(json["status"].is_string());
+    assert!(json["title"].is_string());
+    assert!(json["body"].is_string());
+    assert!(json["r_eff"].is_number());
+}
+
+#[test]
+fn json_score_is_valid_and_has_reff() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Test PRD"]).current_dir(tmp.path()).assert().success();
+
+    let output = forgeplan()
+        .args(["score", "PRD-001", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert!(json["r_eff"].is_number());
+    assert!(json["fgr"].is_object());
+    assert!(json["fgr"]["formality"].is_number());
+}
+
+#[test]
+fn json_list_is_valid_array() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "prd", "Test"]).current_dir(tmp.path()).assert().success();
+
+    let output = forgeplan()
+        .args(["list", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert!(json.is_array());
+    assert!(json.as_array().unwrap().len() >= 1);
+    assert!(json[0]["id"].is_string());
+}
+
+#[test]
+fn json_health_has_required_fields() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    let output = forgeplan()
+        .args(["health", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert!(json["total"].is_number());
+    assert!(json["blind_spots"].is_array());
+    assert!(json["at_risk"].is_array());
+}
+
+#[test]
+fn json_blocked_is_valid() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    let output = forgeplan()
+        .args(["blocked", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert!(json["ready"].is_array());
+    assert!(json["blocked"].is_array());
+}
+
+// ─── Dry-Run Side-Effect Test ────────────────────────────────────
+
+#[test]
+fn scan_import_dry_run_does_not_persist() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    let docs = tmp.path().join("docs");
+    std::fs::create_dir_all(&docs).unwrap();
+    std::fs::write(
+        docs.join("PRD-099-test.md"),
+        "---\nkind: prd\nid: PRD-099\ntitle: Dry Run Test\n---\n# Test",
+    ).unwrap();
+
+    // Dry-run should show preview
+    forgeplan()
+        .args(["scan-import", "--dry-run"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Artifact should NOT exist
+    forgeplan()
+        .args(["get", "PRD-099"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+// ─── R_eff Bidirectional Evidence E2E Test ────────────────────────
+
+#[test]
+fn reff_finds_incoming_evidence() {
+    let tmp = TempDir::new().unwrap();
+    forgeplan().args(["init", "-y"]).current_dir(tmp.path()).assert().success();
+
+    // Create PRD and evidence
+    forgeplan().args(["new", "prd", "Target PRD"]).current_dir(tmp.path()).assert().success();
+    forgeplan().args(["new", "evidence", "Proof"]).current_dir(tmp.path()).assert().success();
+
+    // Link evidence → PRD (incoming direction for PRD)
+    forgeplan()
+        .args(["link", "EVID-001", "PRD-001", "--relation", "informs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Score should find evidence via incoming link
+    forgeplan()
+        .args(["score", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("EVID-001"));
+}

--- a/crates/forgeplan-core/src/scan/detect.rs
+++ b/crates/forgeplan-core/src/scan/detect.rs
@@ -84,11 +84,20 @@ fn detect_from_filename(filename: &str) -> Option<DetectionResult> {
         ("PROB-", ArtifactKind::ProblemCard),
         ("SOL-", ArtifactKind::SolutionPortfolio),
         ("EVID-", ArtifactKind::EvidencePack),
+        ("REFRESH-", ArtifactKind::RefreshReport),
         ("REF-", ArtifactKind::RefreshReport),
     ];
 
     for (prefix, kind) in patterns {
         if upper.starts_with(prefix) {
+            // For REF- prefix, require digits after prefix to avoid false positives
+            // (e.g., REF-DOCS-ANALYSIS.md is NOT a RefreshReport)
+            if *prefix == "REF-" {
+                let after = &upper[prefix.len()..];
+                if after.is_empty() || !after.starts_with(|c: char| c.is_ascii_digit()) {
+                    continue;
+                }
+            }
             // Extract ID: everything before first non-ID character
             let id = extract_id_from_name(&upper, prefix);
             let title = extract_title_from_name(name, prefix);
@@ -271,5 +280,47 @@ mod tests {
         let result = detect_kind("PRD-001-looks-like-prd.md", content).unwrap();
         assert_eq!(result.kind, ArtifactKind::Rfc); // frontmatter wins
         assert_eq!(result.tier, DetectionTier::Frontmatter);
+    }
+
+    #[test]
+    fn ref_prefix_requires_digits() {
+        // REF-001 should detect as RefreshReport
+        let content = "No frontmatter";
+        let result = detect_kind("REF-001-review.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::RefreshReport);
+        assert_eq!(result.tier, DetectionTier::Filename);
+    }
+
+    #[test]
+    fn ref_docs_not_detected_as_refresh() {
+        // REF-DOCS-ANALYSIS.md should NOT be RefreshReport
+        let content = "# Reference Analysis\nSome analysis...";
+        assert!(detect_kind("REF-DOCS-ANALYSIS.md", content).is_none());
+    }
+
+    #[test]
+    fn refresh_prefix_detected() {
+        let content = "No frontmatter";
+        let result = detect_kind("REFRESH-001-quarterly.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::RefreshReport);
+    }
+
+    #[test]
+    fn tier3_content_spec() {
+        let content = "# Payment API\n\n## API\nREST endpoints.\n\n## Schema\nJSON schema.\n\n## Request\nPOST /pay";
+        let result = detect_kind("payment.md", content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Spec);
+        assert_eq!(result.tier, DetectionTier::Content);
+    }
+
+    #[test]
+    fn empty_content_returns_none() {
+        assert!(detect_kind("empty.md", "").is_none());
+    }
+
+    #[test]
+    fn binary_looking_content_returns_none() {
+        let content = "\0\0\0binary garbage\x01\x02";
+        assert!(detect_kind("binary.md", content).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **5 JSON structural tests**: validate output fields for get, score, list, health, blocked
- **Dry-run side-effect test**: verify scan-import --dry-run does NOT persist artifacts
- **R_eff bidirectional E2E**: verify incoming evidence is found by score
- **REF- prefix fix**: require digits after REF- to avoid false positives (REF-DOCS-ANALYSIS.md)
- **3 detect tests**: REF- variants, Spec content, empty/binary

331 tests PASS (was 318, +13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)