### PR TITLE
fix(v0.11): audit fixes — section matching, parse warnings, memory

### DIFF
--- a/crates/forgeplan-cli/src/commands/context.rs
+++ b/crates/forgeplan-cli/src/commands/context.rs
@@ -24,8 +24,14 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' not found", id))?;
 
     // 2. Parse kind and depth
-    let kind: ArtifactKind = record.kind.parse().unwrap_or(ArtifactKind::Note);
-    let depth: Mode = record.depth.parse().unwrap_or(Mode::Standard);
+    let kind: ArtifactKind = record.kind.parse().unwrap_or_else(|_| {
+        eprintln!("  Warning: unknown kind '{}', defaulting to Note", record.kind);
+        ArtifactKind::Note
+    });
+    let depth: Mode = record.depth.parse().unwrap_or_else(|_| {
+        eprintln!("  Warning: unknown depth '{}', defaulting to Standard", record.depth);
+        Mode::Standard
+    });
 
     // 3. Relations — outgoing and incoming
     let outgoing = store.get_relations(id).await?;

--- a/crates/forgeplan-core/src/graph/knowledge.rs
+++ b/crates/forgeplan-core/src/graph/knowledge.rs
@@ -36,21 +36,22 @@ pub struct KnowledgeGraph {
 impl KnowledgeGraph {
     /// Build a knowledge graph by loading all artifacts and relations from the store.
     pub async fn from_store(store: &LanceStore) -> anyhow::Result<Self> {
-        let records = store.list_records(None).await?;
+        // Use list_artifacts (summary, no body) to avoid loading full bodies into memory
+        let artifacts = store.list_artifacts(None).await?;
         let relations = store.get_all_relations().await?;
 
         let mut graph = DiGraph::new();
         let mut index = HashMap::new();
 
         // Add all artifacts as nodes.
-        for record in &records {
+        for artifact in &artifacts {
             let node = ArtifactNode {
-                id: record.id.clone(),
-                kind: record.kind.clone(),
-                status: record.status.clone(),
+                id: artifact.id.clone(),
+                kind: artifact.kind.clone(),
+                status: artifact.status.clone(),
             };
             let idx = graph.add_node(node);
-            index.insert(record.id.clone(), idx);
+            index.insert(artifact.id.clone(), idx);
         }
 
         // Add all relations as directed edges (source -> target).

--- a/crates/forgeplan-core/src/status/derived.rs
+++ b/crates/forgeplan-core/src/status/derived.rs
@@ -106,7 +106,7 @@ fn has_must_sections(body: &str, kind: &str) -> bool {
         }
         "spec" => {
             section_present(body, &["Summary"])
-                && section_present(body, &["API", "Data Model", "Contracts"])
+                && section_present(body, &["API", "API Endpoints", "API Contracts", "Data Model", "Contracts"])
         }
         // Lightweight types: note, problem, solution, evidence, refresh
         // These are considered SHAPED if they have any meaningful content
@@ -126,9 +126,9 @@ fn section_present(body: &str, headings: &[&str]) -> bool {
         if trimmed.starts_with('#') {
             let after_hashes = trimmed.trim_start_matches('#').trim_start();
             for heading in headings {
-                if after_hashes.eq_ignore_ascii_case(heading)
-                    || after_hashes.to_lowercase().starts_with(&heading.to_lowercase())
-                {
+                // Exact match only (case-insensitive) — no starts_with
+                // to avoid false positives like "API Gateway" matching "API"
+                if after_hashes.eq_ignore_ascii_case(heading) {
                     return true;
                 }
             }


### PR DESCRIPTION
4-agent audit (7.5/10). 3 fixes:
1. section_present exact match (no false positives)
2. context.rs parse warnings (not silent)
3. KnowledgeGraph uses summary (no body in memory)

382 tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)