### PR TITLE
[PRD-020] LLM-first Smart Routing — Level 0/1/2

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,11 +3,12 @@
 ## Current: v0.11.0 Released
 
 ### Stats
-- ~37 CLI commands (tree, context, scan-import, coverage --backfill), 28 MCP tools, 428 tests
-- 77 dogfood artifacts (51 active, 20 draft, 6 deprecated)
-- ~21K LOC Rust
-- v0.11.0 tagged, PRs #35-#55 merged
+- ~37 CLI commands (tree, context, scan-import, coverage --backfill), 28 MCP tools, 444 tests
+- 82 dogfood artifacts (52 active, 20 draft, 6 deprecated)
+- ~22K LOC Rust
+- v0.11.0 tagged, PRs #35-#55 merged, PR #59 pending (LLM-first route)
 - 0 compiler warnings, 5 enforcement hooks
+- 3-level routing: L0 keywords, L1 LLM classify, L2 FPF ADI reasoning
 
 ### P0: Integrity Issues (PROB-012 dogfood audit) ✅
 - [x] **Semantic search broken** — feature flag propagated CLI→core via Cargo.toml
@@ -63,7 +64,7 @@ Fixed in commit d84bc69 (fix/prob-012-integrity-remediation). 2 audit rounds, 40
 ### P2: Route & Enforcement (from usability testing)
 - [x] **Route gap**: added "new command/feature" keywords (English)
 - [x] **Batch score CLI**: `forgeplan score --all` implemented
-- [ ] **LLM-first route**: replace keyword matching with LLM classification (supports any language, no declension issues)
+- [x] **LLM-first route**: 3-level routing (L0 keywords, L1 LLM classify, L2 FPF ADI reasoning) — PRD-020, 444 tests
 - [ ] **PRD-019 Layer 3**: MCP session state machine — агент не может пропустить Shape phase
 - [ ] **Duplicate notes cleanup**: NOTE-004 и NOTE-005 → deprecate один
 

--- a/crates/forgeplan-cli/src/commands/route.rs
+++ b/crates/forgeplan-cli/src/commands/route.rs
@@ -13,15 +13,25 @@ pub async fn run(description: &str, explain: bool, level: Option<u8>) -> anyhow:
     let result = if requested_level == 0 {
         // Forced Level 0: rule-based routing (instant, offline, no LLM)
         routing::route(description)
+    } else if requested_level == 2 {
+        // Forced Level 2: LLM + ADI reasoning
+        try_llm_route_with_reasoning(description).await
     } else {
-        // Level 1 (explicit or auto): try LLM, falls back to Level 0 internally
-        try_llm_route(description).await
+        // Level 1 or auto: try LLM, auto-escalate to Level 2 if Deep
+        let r = try_llm_route(description).await;
+        // Auto-escalate: if Level 1 says Deep and we're in auto mode, run Level 2
+        if r.level == 1 && matches!(r.depth, forgeplan_core::artifact::types::Mode::Deep) && level.is_none() {
+            try_llm_route_with_reasoning(description).await
+        } else {
+            r
+        }
     };
 
     // Styled level
     let level_label = match result.level {
         0 => style("Level 0 (keywords)").dim().to_string(),
         1 => style("Level 1 (LLM)").cyan().to_string(),
+        2 => style("Level 2 (FPF reasoning)").magenta().to_string(),
         _ => "Unknown".to_string(),
     };
     println!("## Level: {}", level_label);
@@ -120,6 +130,28 @@ pub async fn run(description: &str, explain: bool, level: Option<u8>) -> anyhow:
     }
 
     Ok(())
+}
+
+/// Attempt LLM routing with Level 2 FPF reasoning.
+async fn try_llm_route_with_reasoning(description: &str) -> routing::RoutingResult {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return routing::route(description),
+    };
+    let ws = match workspace::find_workspace(&cwd) {
+        Some(ws) => ws,
+        None => return routing::route(description),
+    };
+    let config = match workspace::load_config(&ws) {
+        Ok(c) => c,
+        Err(_) => return routing::route(description),
+    };
+    let llm_config = match config.llm {
+        Some(c) => c.with_env_overrides(),
+        None => return routing::route(description),
+    };
+
+    routing::route_with_reasoning(description, &llm_config, None).await
 }
 
 /// Attempt LLM-based routing (Level 1). Falls back to Level 0 if no config/key available.

--- a/crates/forgeplan-cli/src/commands/route.rs
+++ b/crates/forgeplan-cli/src/commands/route.rs
@@ -5,15 +5,17 @@ use forgeplan_core::workspace;
 use crate::ui;
 
 pub async fn run(description: &str, explain: bool, level: Option<u8>) -> anyhow::Result<()> {
-    // Determine effective level: --level flag takes priority, --explain implies level 1
-    let requested_level = level.unwrap_or(if explain { 1 } else { 0 });
+    // Determine effective level:
+    // --level flag takes priority, --explain implies level 1,
+    // otherwise auto-detect: use Level 1 if LLM config with API key is available
+    let requested_level = level.unwrap_or(if explain { 1 } else { 99 }); // 99 = auto
 
-    let result = if requested_level >= 1 {
-        // Try Level 1 (LLM) — falls back to Level 0 internally
-        try_llm_route(description).await
-    } else {
-        // Level 0: rule-based routing (instant, offline, no LLM)
+    let result = if requested_level == 0 {
+        // Forced Level 0: rule-based routing (instant, offline, no LLM)
         routing::route(description)
+    } else {
+        // Level 1 (explicit or auto): try LLM, falls back to Level 0 internally
+        try_llm_route(description).await
     };
 
     // Styled level
@@ -99,8 +101,8 @@ pub async fn run(description: &str, explain: bool, level: Option<u8>) -> anyhow:
         println!("{explanation}");
     }
 
-    // Legacy --explain behavior (Level 0 + --explain without --level)
-    if explain && level.is_none() && result.level == 0 {
+    // Legacy --explain behavior (Level 0 + --explain + forced --level 0)
+    if explain && level == Some(0) && result.level == 0 {
         let cwd = std::env::current_dir()?;
         let ws = workspace::find_workspace(&cwd);
         if let Some(ws) = ws {

--- a/crates/forgeplan-cli/src/commands/route.rs
+++ b/crates/forgeplan-cli/src/commands/route.rs
@@ -4,9 +4,26 @@ use forgeplan_core::workspace;
 
 use crate::ui;
 
-pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
-    // Rule-based routing (instant, offline, no LLM)
-    let result = routing::route(description);
+pub async fn run(description: &str, explain: bool, level: Option<u8>) -> anyhow::Result<()> {
+    // Determine effective level: --level flag takes priority, --explain implies level 1
+    let requested_level = level.unwrap_or(if explain { 1 } else { 0 });
+
+    let result = if requested_level >= 1 {
+        // Try Level 1 (LLM) — falls back to Level 0 internally
+        try_llm_route(description).await
+    } else {
+        // Level 0: rule-based routing (instant, offline, no LLM)
+        routing::route(description)
+    };
+
+    // Styled level
+    let level_label = match result.level {
+        0 => style("Level 0 (keywords)").dim().to_string(),
+        1 => style("Level 1 (LLM)").cyan().to_string(),
+        _ => "Unknown".to_string(),
+    };
+    println!("## Level: {}", level_label);
+    println!();
 
     // Styled depth
     println!(
@@ -32,24 +49,26 @@ pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
     }
     println!();
 
-    // Styled triggers
-    println!("{}", style("## Triggers Matched").bold());
-    if result.triggers.is_empty() {
-        println!(
-            "{}",
-            style("No escalation triggers — defaults to Tactical").dim()
-        );
-    } else {
-        for t in &result.triggers {
+    // Styled triggers (only for Level 0)
+    if result.level == 0 {
+        println!("{}", style("## Triggers Matched").bold());
+        if result.triggers.is_empty() {
             println!(
-                "- {}: {} → {}+",
-                style(&t.id).yellow(),
-                t.description,
-                ui::styled_depth(&format!("{}", depth_display(&t.minimum_depth)))
+                "{}",
+                style("No escalation triggers — defaults to Tactical").dim()
             );
+        } else {
+            for t in &result.triggers {
+                println!(
+                    "- {}: {} → {}+",
+                    style(&t.id).yellow(),
+                    t.description,
+                    ui::styled_depth(&format!("{}", depth_display(&t.minimum_depth)))
+                );
+            }
         }
+        println!();
     }
-    println!();
 
     // Styled confidence
     let conf_pct = result.confidence * 100.0;
@@ -73,8 +92,15 @@ pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
         );
     }
 
-    // Optional LLM explanation
-    if explain {
+    // LLM explanation (Level 1)
+    if let Some(ref explanation) = result.explanation {
+        println!();
+        println!("{}", style("## Explanation").bold());
+        println!("{explanation}");
+    }
+
+    // Legacy --explain behavior (Level 0 + --explain without --level)
+    if explain && level.is_none() && result.level == 0 {
         let cwd = std::env::current_dir()?;
         let ws = workspace::find_workspace(&cwd);
         if let Some(ws) = ws {
@@ -92,6 +118,28 @@ pub async fn run(description: &str, explain: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Attempt LLM-based routing (Level 1). Falls back to Level 0 if no config/key available.
+async fn try_llm_route(description: &str) -> routing::RoutingResult {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return routing::route(description),
+    };
+    let ws = match workspace::find_workspace(&cwd) {
+        Some(ws) => ws,
+        None => return routing::route(description),
+    };
+    let config = match workspace::load_config(&ws) {
+        Ok(c) => c,
+        Err(_) => return routing::route(description),
+    };
+    let llm_config = match config.llm {
+        Some(c) => c.with_env_overrides(),
+        None => return routing::route(description),
+    };
+
+    routing::route_with_llm(description, &llm_config).await
 }
 
 fn depth_display(mode: &forgeplan_core::artifact::types::Mode) -> &'static str {

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -186,13 +186,16 @@ enum Commands {
         #[arg(long)]
         yes: bool,
     },
-    /// Suggest depth level and artifact pipeline for a task description (rule-based, no LLM)
+    /// Suggest depth level and artifact pipeline for a task description
     Route {
         /// Task description in natural language
         description: String,
-        /// Optional: use LLM to explain the routing decision
+        /// Optional: use LLM to explain the routing decision (deprecated, use --level 1)
         #[arg(long)]
         explain: bool,
+        /// Routing level: 0 = keywords (default), 1 = LLM-classified
+        #[arg(long)]
+        level: Option<u8>,
     },
     /// Review an artifact — run validation and show lifecycle checklist
     Review {
@@ -455,7 +458,8 @@ async fn main() -> anyhow::Result<()> {
         Commands::Route {
             description,
             explain,
-        } => commands::route::run(&description, explain).await,
+            level,
+        } => commands::route::run(&description, explain, level).await,
         Commands::Review { id } => commands::review::run(&id).await,
         Commands::Activate { id, force } => commands::activate::run(&id, force).await,
         Commands::Supersede { id, by } => commands::supersede::run(&id, &by).await,

--- a/crates/forgeplan-core/src/llm/route.rs
+++ b/crates/forgeplan-core/src/llm/route.rs
@@ -43,6 +43,15 @@ Write in the same language as the user's description."#;
 
 /// Route a task description to appropriate depth and artifact pipeline.
 pub async fn route(config: &LlmConfig, description: &str) -> anyhow::Result<String> {
+    route_with_context(config, description, None).await
+}
+
+/// Route a task description with optional FPF context injected into the system prompt.
+pub async fn route_with_context(
+    config: &LlmConfig,
+    description: &str,
+    fpf_context: Option<&str>,
+) -> anyhow::Result<String> {
     let client = LlmClient::new(config.clone());
 
     let prompt = format!(
@@ -50,6 +59,11 @@ pub async fn route(config: &LlmConfig, description: &str) -> anyhow::Result<Stri
         description
     );
 
-    let system = crate::llm::load_prompt("route", ROUTE_SYSTEM_PROMPT);
+    let mut system = crate::llm::load_prompt("route", ROUTE_SYSTEM_PROMPT);
+    if let Some(ctx) = fpf_context {
+        system.push_str("\n\n");
+        system.push_str(ctx);
+    }
+
     client.generate(&prompt, Some(&system)).await
 }

--- a/crates/forgeplan-core/src/routing/mod.rs
+++ b/crates/forgeplan-core/src/routing/mod.rs
@@ -157,13 +157,25 @@ pub fn calibrate_artifact(body: &str, link_count: usize, has_epic: bool) -> Rout
 ///
 /// If the LLM call succeeds and returns a parseable depth, returns a Level 1 result.
 /// On any error (no API key, network, unparseable response), falls back to Level 0 keywords.
+///
+/// `fpf_context` — optional FPF knowledge base context to inject into the LLM prompt.
+/// Build it via `llm::reason::build_fpf_context()` if a LanceStore is available.
 pub async fn route_with_llm(description: &str, llm_config: &LlmConfig) -> RoutingResult {
+    route_with_llm_and_context(description, llm_config, None).await
+}
+
+/// Route with optional FPF context injection into the LLM prompt.
+pub async fn route_with_llm_and_context(
+    description: &str,
+    llm_config: &LlmConfig,
+    fpf_context: Option<&str>,
+) -> RoutingResult {
     // Check if API key is available before making the call
     if llm_config.resolve_api_key().is_none() && !llm_config.provider.eq("ollama") {
         return route(description);
     }
 
-    match crate::llm::route::route(llm_config, description).await {
+    match crate::llm::route::route_with_context(llm_config, description, fpf_context).await {
         Ok(response) => match parse_llm_route_response(&response) {
             Some((depth, explanation)) => {
                 let pipeline = pipeline::for_depth(&depth);

--- a/crates/forgeplan-core/src/routing/mod.rs
+++ b/crates/forgeplan-core/src/routing/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Level 0: deterministic keyword rules (offline, instant).
 //! Level 1: LLM-classified with graceful fallback to Level 0.
+//! Level 2: FPF ADI reasoning for complex/ambiguous cases (Deep/Critical).
 
 pub mod pipeline;
 pub mod rules;
@@ -297,6 +298,111 @@ fn kind_display(kind: &ArtifactKind) -> &'static str {
         ArtifactKind::RefreshReport => "Refresh",
     }
 }
+
+/// Route with Level 2 FPF reasoning for complex cases.
+///
+/// Flow: Level 1 (LLM classify) → if Deep/Critical → Level 2 (ADI reasoning).
+/// Level 2 adds structured analysis: hypotheses about correct depth, risks, recommendation.
+/// On any error, returns Level 1 result as-is.
+pub async fn route_with_reasoning(
+    description: &str,
+    llm_config: &LlmConfig,
+    fpf_context: Option<&str>,
+) -> RoutingResult {
+    // First, get Level 1 result
+    let mut result = route_with_llm_and_context(description, llm_config, fpf_context).await;
+
+    // Only escalate to Level 2 for Deep/Critical (complex cases worth reasoning about)
+    if !matches!(result.depth, Mode::Deep) {
+        return result;
+    }
+
+    // Level 2: ADI reasoning on the routing decision itself
+    let reasoning_prompt = format!(
+        "Analyze this task for depth classification using ADI:\n\n\
+         **Task**: {}\n\n\
+         **Current assessment**: Deep/Critical\n\n\
+         Evaluate using 4 FPF criteria:\n\
+         1. **Reversibility** — can the decision be rolled back? Less reversible = deeper.\n\
+         2. **Scope** — how many modules/files/teams affected? >5 modules = Deep.\n\
+         3. **Dependencies** — external deps, cross-team, API contracts, compliance?\n\
+         4. **Decision space** — obvious solution or multiple viable alternatives?\n\n\
+         Should this really be Deep/Critical, or could Standard suffice?",
+        description
+    );
+
+    let client = crate::llm::LlmClient::new(llm_config.clone());
+
+    let mut system = crate::llm::load_prompt("route_reasoning", ROUTE_REASONING_PROMPT);
+    if let Some(ctx) = fpf_context {
+        system.push_str("\n\n");
+        system.push_str(ctx);
+    }
+
+    // 30s timeout for Level 2 (more generous than Level 1, but not unbounded)
+    let llm_future = client.generate(&reasoning_prompt, Some(&system));
+    let timeout_result = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        llm_future,
+    ).await;
+
+    match timeout_result {
+        Ok(Ok(response)) => {
+            // Parse ADI output
+            let adi = crate::llm::reason::parse_adi_output(&response);
+
+            // Check if ADI recommends downgrading from Deep
+            let downgrade = adi.recommendation.to_lowercase();
+            if downgrade.contains("standard") && !downgrade.contains("deep") {
+                result.depth = Mode::Standard;
+                result.pipeline = pipeline::for_depth(&Mode::Standard);
+            }
+
+            // Enrich result with Level 2 reasoning
+            let reasoning_text = if !adi.recommendation.is_empty() {
+                format!(
+                    "{}\n\n### ADI Analysis\n{}",
+                    result.explanation.unwrap_or_default(),
+                    adi.recommendation
+                )
+            } else if let Some(raw) = &adi.raw_markdown {
+                format!(
+                    "{}\n\n### ADI Analysis\n{}",
+                    result.explanation.unwrap_or_default(),
+                    raw.chars().take(500).collect::<String>()
+                )
+            } else {
+                result.explanation.unwrap_or_default()
+            };
+
+            result.level = 2;
+            result.explanation = Some(reasoning_text);
+            result
+        }
+        _ => {
+            // Timeout or error — return Level 1 result as-is
+            result
+        }
+    }
+}
+
+const ROUTE_REASONING_PROMPT: &str = r#"You are an FPF reasoning engine evaluating task complexity for depth classification.
+
+Use the ADI cycle:
+- Abduction: Generate 3 hypotheses about the correct depth (Tactical, Standard, Deep)
+- Deduction: For each, evaluate consequences and risks
+- Induction: Recommend the best depth with confidence
+
+Return JSON:
+{
+  "hypotheses": [{"id": "H1", "description": "...", "assumptions": ["..."], "confidence": "Low|Medium|High"}],
+  "deductions": [{"hypothesis_id": "H1", "consequence": "...", "risks": ["..."], "feasibility": "Low|Medium|High"}],
+  "evidence_needed": [{"for_hypothesis": "H1", "test": "...", "effort": "Low|Medium|High"}],
+  "recommendation": "Standard|Deep|Critical with explanation",
+  "confidence": "Low|Medium|High"
+}
+
+Be concise. Write in the same language as the task description."#;
 
 #[cfg(test)]
 mod tests {

--- a/crates/forgeplan-core/src/routing/mod.rs
+++ b/crates/forgeplan-core/src/routing/mod.rs
@@ -170,33 +170,46 @@ pub async fn route_with_llm_and_context(
     llm_config: &LlmConfig,
     fpf_context: Option<&str>,
 ) -> RoutingResult {
+    // Short-circuit: empty or very short descriptions don't need LLM
+    if description.trim().len() < 3 {
+        return route(description);
+    }
+
     // Check if API key is available before making the call
     if llm_config.resolve_api_key().is_none() && !llm_config.provider.eq("ollama") {
         return route(description);
     }
 
-    match crate::llm::route::route_with_context(llm_config, description, fpf_context).await {
-        Ok(response) => match parse_llm_route_response(&response) {
-            Some((depth, explanation)) => {
-                let pipeline = pipeline::for_depth(&depth);
-                RoutingResult {
-                    depth,
-                    pipeline,
-                    triggers: vec![],
-                    confidence: 0.9, // LLM classification assumed high confidence
-                    level: 1,
-                    explanation: Some(explanation),
-                }
-            }
-            None => {
-                // Unparseable LLM response — fallback to Level 0
-                route(description)
-            }
-        },
-        Err(_) => {
-            // LLM call failed — fallback to Level 0
+    // Route-specific timeout: 15 seconds (vs 120s global LLM timeout).
+    // Route should be fast — if LLM takes too long, fall back to keywords.
+    let llm_future = crate::llm::route::route_with_context(llm_config, description, fpf_context);
+    let timeout_result = tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        llm_future,
+    ).await;
+
+    match timeout_result {
+        Err(_elapsed) => {
+            // Timeout — fallback to Level 0
             route(description)
         }
+        Ok(llm_result) => match llm_result {
+            Ok(response) => match parse_llm_route_response(&response) {
+                Some((depth, explanation)) => {
+                    let pipeline = pipeline::for_depth(&depth);
+                    RoutingResult {
+                        depth,
+                        pipeline,
+                        triggers: vec![],
+                        confidence: 0.9,
+                        level: 1,
+                        explanation: Some(explanation),
+                    }
+                }
+                None => route(description),
+            },
+            Err(_) => route(description),
+        },
     }
 }
 
@@ -400,5 +413,30 @@ mod tests {
         let result = route("Simple task");
         let display = format!("{result}");
         assert!(display.contains("## Level: Level 0 (keywords)"));
+    }
+
+    #[test]
+    fn test_route_with_llm_short_input_skips_llm() {
+        // Very short inputs (<3 chars) should skip LLM and use Level 0
+        let config = LlmConfig {
+            provider: "openai".into(),
+            api_key_env: Some("GEMINI_API_KEY".into()),
+            ..Default::default()
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(route_with_llm("ab", &config));
+        assert_eq!(result.level, 0, "Short input should skip LLM");
+    }
+
+    #[test]
+    fn test_route_with_llm_empty_input_skips_llm() {
+        let config = LlmConfig {
+            provider: "openai".into(),
+            api_key_env: Some("GEMINI_API_KEY".into()),
+            ..Default::default()
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(route_with_llm("", &config));
+        assert_eq!(result.level, 0, "Empty input should skip LLM");
     }
 }

--- a/crates/forgeplan-core/src/routing/mod.rs
+++ b/crates/forgeplan-core/src/routing/mod.rs
@@ -1,13 +1,14 @@
 //! Smart Routing v2 — rule-based depth calibration and pipeline suggestion.
 //!
-//! Replaces LLM-based routing with deterministic rules.
-//! LLM is used ONLY for optional --explain enrichment.
+//! Level 0: deterministic keyword rules (offline, instant).
+//! Level 1: LLM-classified with graceful fallback to Level 0.
 
 pub mod pipeline;
 pub mod rules;
 pub mod signals;
 
 use crate::artifact::types::{ArtifactKind, Mode};
+use crate::config::LlmConfig;
 
 /// Result of routing a task description through the rule engine.
 #[derive(Debug, Clone)]
@@ -20,6 +21,10 @@ pub struct RoutingResult {
     pub triggers: Vec<Signal>,
     /// Confidence score (0.0-1.0). More matching signals = higher confidence.
     pub confidence: f64,
+    /// Routing level: 0 = keywords (rule-based), 1 = LLM-classified.
+    pub level: u8,
+    /// LLM explanation of the routing decision (only present at level 1).
+    pub explanation: Option<String>,
 }
 
 /// A signal extracted from input that influences depth.
@@ -37,6 +42,13 @@ pub struct Signal {
 
 impl std::fmt::Display for RoutingResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let level_label = match self.level {
+            0 => "Level 0 (keywords)",
+            1 => "Level 1 (LLM)",
+            _ => "Unknown",
+        };
+        writeln!(f, "## Level: {}", level_label)?;
+        writeln!(f)?;
         writeln!(f, "## Depth: {}", depth_display(&self.depth))?;
         writeln!(f)?;
 
@@ -84,6 +96,12 @@ impl std::fmt::Display for RoutingResult {
             writeln!(f, "```")?;
         }
 
+        if let Some(ref explanation) = self.explanation {
+            writeln!(f)?;
+            writeln!(f, "## Explanation")?;
+            writeln!(f, "{}", explanation)?;
+        }
+
         Ok(())
     }
 }
@@ -97,6 +115,8 @@ pub fn route(description: &str) -> RoutingResult {
             pipeline: vec![],
             triggers: vec![],
             confidence: 0.0,
+            level: 0,
+            explanation: None,
         };
     }
 
@@ -110,6 +130,8 @@ pub fn route(description: &str) -> RoutingResult {
         pipeline,
         triggers: signals,
         confidence,
+        level: 0,
+        explanation: None,
     }
 }
 
@@ -126,7 +148,105 @@ pub fn calibrate_artifact(body: &str, link_count: usize, has_epic: bool) -> Rout
         pipeline,
         triggers: signals,
         confidence,
+        level: 0,
+        explanation: None,
     }
+}
+
+/// Route a task description using LLM classification (Level 1) with fallback to Level 0.
+///
+/// If the LLM call succeeds and returns a parseable depth, returns a Level 1 result.
+/// On any error (no API key, network, unparseable response), falls back to Level 0 keywords.
+pub async fn route_with_llm(description: &str, llm_config: &LlmConfig) -> RoutingResult {
+    // Check if API key is available before making the call
+    if llm_config.resolve_api_key().is_none() && !llm_config.provider.eq("ollama") {
+        return route(description);
+    }
+
+    match crate::llm::route::route(llm_config, description).await {
+        Ok(response) => match parse_llm_route_response(&response) {
+            Some((depth, explanation)) => {
+                let pipeline = pipeline::for_depth(&depth);
+                RoutingResult {
+                    depth,
+                    pipeline,
+                    triggers: vec![],
+                    confidence: 0.9, // LLM classification assumed high confidence
+                    level: 1,
+                    explanation: Some(explanation),
+                }
+            }
+            None => {
+                // Unparseable LLM response — fallback to Level 0
+                route(description)
+            }
+        },
+        Err(_) => {
+            // LLM call failed — fallback to Level 0
+            route(description)
+        }
+    }
+}
+
+/// Parse LLM route response markdown to extract depth and reasoning.
+///
+/// Expected format from llm/route.rs:
+/// ```text
+/// ## Depth: Tactical|Standard|Deep|Critical
+/// ...
+/// ## Reasoning
+/// Some explanation text
+/// ```
+///
+/// Returns (Mode, explanation_text) or None if depth cannot be parsed.
+pub fn parse_llm_route_response(response: &str) -> Option<(Mode, String)> {
+    let mut depth: Option<Mode> = None;
+    let mut reasoning_lines: Vec<&str> = Vec::new();
+    let mut in_reasoning = false;
+
+    for line in response.lines() {
+        let trimmed = line.trim();
+
+        // Parse "## Depth: <level>" line
+        if let Some(rest) = trimmed.strip_prefix("## Depth:") {
+            let level_str = rest.trim().to_lowercase();
+            depth = match level_str.as_str() {
+                "tactical" => Some(Mode::Tactical),
+                "standard" => Some(Mode::Standard),
+                "deep" | "deep/critical" => Some(Mode::Deep),
+                "critical" => Some(Mode::Deep), // Critical maps to Deep (Mode enum)
+                "note" => Some(Mode::Note),
+                _ => None,
+            };
+            in_reasoning = false;
+            continue;
+        }
+
+        // Detect reasoning section
+        if trimmed.starts_with("## Reasoning") {
+            in_reasoning = true;
+            continue;
+        }
+
+        // Stop reasoning at next section header
+        if in_reasoning && trimmed.starts_with("## ") {
+            in_reasoning = false;
+            continue;
+        }
+
+        if in_reasoning && !trimmed.is_empty() {
+            reasoning_lines.push(trimmed);
+        }
+    }
+
+    let explanation = if reasoning_lines.is_empty() {
+        // Use full response as explanation if no Reasoning section found
+        response.to_string()
+    } else {
+        reasoning_lines.join("\n")
+    };
+
+    depth.map(|d| (d, explanation))
 }
 
 fn depth_display(mode: &Mode) -> &'static str {
@@ -150,5 +270,123 @@ fn kind_display(kind: &ArtifactKind) -> &'static str {
         ArtifactKind::SolutionPortfolio => "Solution",
         ArtifactKind::EvidencePack => "Evidence",
         ArtifactKind::RefreshReport => "Refresh",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_routing_result_has_level_field() {
+        let result = route("Fix a typo");
+        assert_eq!(result.level, 0);
+        assert!(result.explanation.is_none());
+    }
+
+    #[test]
+    fn test_route_level0_unchanged() {
+        // Existing behavior: security keyword → Deep
+        let result = route("Implement OAuth2 authentication");
+        assert_eq!(result.level, 0);
+        assert!(result.explanation.is_none());
+        assert!(matches!(result.depth, Mode::Deep));
+        assert!(!result.pipeline.is_empty());
+    }
+
+    #[test]
+    fn test_route_level0_empty_input() {
+        let result = route("");
+        assert_eq!(result.level, 0);
+        assert!(matches!(result.depth, Mode::Tactical));
+        assert!(result.pipeline.is_empty());
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_tactical() {
+        let response = "## Depth: Tactical\n\n## Artifacts\n- None\n\n## Pipeline\nNone\n\n## Reasoning\nSimple typo fix, no artifacts needed.";
+        let (depth, explanation) = parse_llm_route_response(response).unwrap();
+        assert!(matches!(depth, Mode::Tactical));
+        assert!(explanation.contains("typo fix"));
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_standard() {
+        let response = "## Depth: Standard\n\n## Artifacts\n- PRD: requirements\n- RFC: design\n\n## Pipeline\nPRD → RFC\n\n## Reasoning\nFeature requires planning across multiple files.";
+        let (depth, explanation) = parse_llm_route_response(response).unwrap();
+        assert!(matches!(depth, Mode::Standard));
+        assert!(explanation.contains("planning"));
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_deep() {
+        let response = "## Depth: Deep\n\n## Reasoning\nSecurity-critical change requiring thorough review.";
+        let (depth, explanation) = parse_llm_route_response(response).unwrap();
+        assert!(matches!(depth, Mode::Deep));
+        assert!(explanation.contains("Security"));
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_critical() {
+        let response = "## Depth: Critical\n\n## Reasoning\nCross-team strategic initiative.";
+        let (depth, _) = parse_llm_route_response(response).unwrap();
+        // Critical maps to Mode::Deep (highest in Mode enum)
+        assert!(matches!(depth, Mode::Deep));
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_malformed() {
+        // No "## Depth:" line
+        let response = "This is some random text without proper formatting.";
+        assert!(parse_llm_route_response(response).is_none());
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_unknown_depth() {
+        let response = "## Depth: SuperDeep\n\n## Reasoning\nSome text.";
+        assert!(parse_llm_route_response(response).is_none());
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_no_reasoning_section() {
+        // When no ## Reasoning section, full response is used as explanation
+        let response = "## Depth: Standard\n\nSome extra context here.";
+        let (depth, explanation) = parse_llm_route_response(response).unwrap();
+        assert!(matches!(depth, Mode::Standard));
+        assert!(explanation.contains("Depth: Standard"));
+    }
+
+    #[test]
+    fn test_parse_llm_route_response_deep_critical_variant() {
+        let response = "## Depth: Deep/Critical\n\n## Reasoning\nComplex module.";
+        let (depth, _) = parse_llm_route_response(response).unwrap();
+        assert!(matches!(depth, Mode::Deep));
+    }
+
+    #[test]
+    fn test_route_with_llm_fallback_on_missing_key() {
+        // route_with_llm with a config that has no API key should fallback to Level 0
+        let config = LlmConfig {
+            provider: "openai".into(),
+            api_key_env: Some("NONEXISTENT_ENV_VAR_FOR_TEST_12345".into()),
+            ..Default::default()
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(route_with_llm("Fix a typo in readme", &config));
+        assert_eq!(result.level, 0, "Should fallback to Level 0 when no API key");
+    }
+
+    #[test]
+    fn test_calibrate_artifact_has_level_zero() {
+        let result = calibrate_artifact("## FR\n- [ ] FR-001\n- [ ] FR-002\n- [ ] FR-003\n- [ ] FR-004\n", 3, true);
+        assert_eq!(result.level, 0);
+        assert!(result.explanation.is_none());
+    }
+
+    #[test]
+    fn test_display_includes_level() {
+        let result = route("Simple task");
+        let display = format!("{result}");
+        assert!(display.contains("## Level: Level 0 (keywords)"));
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -847,18 +847,43 @@ impl ForgeplanServer {
         })))
     }
 
-    #[tool(description = "Suggest depth level (Tactical/Standard/Deep/Critical) and artifact pipeline for a task description. Rule-based, instant, no LLM needed.")]
+    #[tool(description = "Suggest depth level (Tactical/Standard/Deep/Critical) and artifact pipeline for a task description. Uses LLM classification (Level 1) when API key is configured, falls back to rule-based keywords (Level 0).")]
     async fn forgeplan_route(
         &self,
         Parameters(p): Parameters<RouteParams>,
     ) -> Result<CallToolResult, McpError> {
-        let result = forgeplan_core::routing::route(&p.description);
+        // Try Level 1 (LLM) if workspace has LLM config, with FPF context if available
+        let result = if let Ok(ws) = self.require_workspace().await {
+            if let Ok(config) = workspace::load_config(&ws) {
+                if let Some(llm_cfg) = config.llm {
+                    let llm_cfg = llm_cfg.with_env_overrides();
+                    // Try to build FPF context from store
+                    let fpf_ctx = if let Ok(store) = self.require_store().await {
+                        forgeplan_core::llm::reason::build_fpf_context(
+                            &store, &p.description, "",
+                        ).await.ok().flatten()
+                    } else {
+                        None
+                    };
+                    forgeplan_core::routing::route_with_llm_and_context(
+                        &p.description, &llm_cfg, fpf_ctx.as_deref(),
+                    ).await
+                } else {
+                    forgeplan_core::routing::route(&p.description)
+                }
+            } else {
+                forgeplan_core::routing::route(&p.description)
+            }
+        } else {
+            forgeplan_core::routing::route(&p.description)
+        };
         Ok(json_result(&serde_json::json!({
             "depth": format!("{:?}", result.depth),
             "pipeline": result.pipeline.iter().map(|k| k.template_key()).collect::<Vec<_>>(),
             "triggers": result.triggers.iter().map(|t| &t.id).collect::<Vec<_>>(),
             "confidence": result.confidence,
             "level": result.level,
+            "explanation": result.explanation,
             "display": format!("{result}"),
         })))
     }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -858,6 +858,7 @@ impl ForgeplanServer {
             "pipeline": result.pipeline.iter().map(|k| k.template_key()).collect::<Vec<_>>(),
             "triggers": result.triggers.iter().map(|t| &t.id).collect::<Vec<_>>(),
             "confidence": result.confidence,
+            "level": result.level,
             "display": format!("{result}"),
         })))
     }


### PR DESCRIPTION
## Summary
- 3-level routing: L0 keywords (offline), L1 LLM classify, L2 FPF ADI reasoning
- `route_with_llm()` + `route_with_reasoning()` with graceful fallback chain
- FPF KB context injection into LLM route prompt
- MCP server upgraded from Level 0 to Level 1 + FPF context
- CLI: `--level 0|1|2`, auto-detect, auto-escalate Deep→Level 2
- 15s timeout L1, 30s timeout L2, empty input guard
- Tested: Russian, English, Chinese, no workspace, edge cases

## Refs
- PRD-020 (LLM-first Smart Routing) — active, R_eff=1.00
- EVID-029 — 444 tests, 10 scenario test matrix

## Test plan
- [x] cargo test — 444 pass, 0 fail
- [x] Level 1 with Gemini (Russian, English, Chinese) — correct depth
- [x] Level 2 ADI reasoning (complex task) — structured analysis
- [x] Fallback: no API key → Level 0
- [x] Fallback: timeout → Level 0
- [x] No workspace → Level 0
- [x] health + score --all — no regression

**IMPORTANT: Merge commit, NOT squash** (5 semantic commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>