### PR TITLE
[RFC-003] StorageDriver trait abstraction — Phase 1

### DIFF
--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -18,3 +18,13 @@ pub async fn store() -> anyhow::Result<LanceStore> {
     let (_, store) = open_store().await?;
     Ok(store)
 }
+
+/// Open storage using driver trait (new API — will replace open_store over time).
+pub async fn open_driver() -> anyhow::Result<std::sync::Arc<dyn forgeplan_core::driver::StorageDriver>> {
+    let cwd = std::env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ workspace found"))?;
+    let config = workspace::load_config(&ws)?;
+    let storage_config = config.storage.unwrap_or_default();
+    forgeplan_core::driver::factory::create_storage(&storage_config, &ws).await
+}

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -12,6 +12,10 @@ pub struct Config {
     pub llm: Option<LlmConfig>,
     #[serde(default)]
     pub embedding: Option<EmbeddingConfig>,
+    #[serde(default)]
+    pub storage: Option<StorageConfig>,
+    #[serde(default)]
+    pub memory: Option<MemoryConfig>,
 }
 
 impl Default for Config {
@@ -24,6 +28,8 @@ impl Default for Config {
             created_at: chrono::Utc::now().date_naive(),
             llm: None,
             embedding: None,
+            storage: None,
+            memory: None,
         }
     }
 }
@@ -170,6 +176,66 @@ impl EmbeddingConfig {
     pub fn with_env_overrides(mut self) -> Self {
         if let Ok(v) = std::env::var("FORGEPLAN_EMBEDDING_MODEL") {
             self.model = v;
+        }
+        self
+    }
+}
+
+/// Storage backend configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Backend driver: "lancedb" (default) | "sqlite" | "memory"
+    #[serde(default = "default_storage_driver")]
+    pub driver: String,
+}
+
+fn default_storage_driver() -> String {
+    "lancedb".into()
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            driver: default_storage_driver(),
+        }
+    }
+}
+
+impl StorageConfig {
+    /// Apply env override: FORGEPLAN_STORAGE_DRIVER
+    pub fn with_env_overrides(mut self) -> Self {
+        if let Ok(v) = std::env::var("FORGEPLAN_STORAGE_DRIVER") {
+            self.driver = v;
+        }
+        self
+    }
+}
+
+/// Memory bank configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryConfig {
+    /// Memory driver: "file" (default) | "none"
+    #[serde(default = "default_memory_driver")]
+    pub driver: String,
+}
+
+fn default_memory_driver() -> String {
+    "file".into()
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            driver: default_memory_driver(),
+        }
+    }
+}
+
+impl MemoryConfig {
+    /// Apply env override: FORGEPLAN_MEMORY_DRIVER
+    pub fn with_env_overrides(mut self) -> Self {
+        if let Ok(v) = std::env::var("FORGEPLAN_MEMORY_DRIVER") {
+            self.driver = v;
         }
         self
     }

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -187,6 +187,10 @@ pub struct StorageConfig {
     /// Backend driver: "lancedb" (default) | "sqlite" | "memory"
     #[serde(default = "default_storage_driver")]
     pub driver: String,
+    /// Custom path for DB storage. If None, uses .forgeplan/lance/ (default).
+    /// Useful to keep DB cache outside the project directory.
+    #[serde(default)]
+    pub path: Option<String>,
 }
 
 fn default_storage_driver() -> String {
@@ -197,17 +201,30 @@ impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             driver: default_storage_driver(),
+            path: None,
         }
     }
 }
 
 impl StorageConfig {
-    /// Apply env override: FORGEPLAN_STORAGE_DRIVER
+    /// Apply env overrides: FORGEPLAN_STORAGE_DRIVER, FORGEPLAN_STORAGE_PATH
     pub fn with_env_overrides(mut self) -> Self {
         if let Ok(v) = std::env::var("FORGEPLAN_STORAGE_DRIVER") {
             self.driver = v;
         }
+        if let Ok(v) = std::env::var("FORGEPLAN_STORAGE_PATH") {
+            self.path = Some(v);
+        }
         self
+    }
+
+    /// Resolve storage path: custom path or default .forgeplan/ subdirectory.
+    pub fn resolve_path(&self, workspace_path: &std::path::Path) -> std::path::PathBuf {
+        if let Some(ref custom) = self.path {
+            std::path::PathBuf::from(custom)
+        } else {
+            workspace_path.to_path_buf()
+        }
     }
 }
 

--- a/crates/forgeplan-core/src/driver/factory.rs
+++ b/crates/forgeplan-core/src/driver/factory.rs
@@ -16,7 +16,8 @@ pub async fn create_storage(
 ) -> anyhow::Result<Arc<dyn StorageDriver>> {
     match config.driver.as_str() {
         "lancedb" | "lance" => {
-            let driver = LanceDriver::open(workspace_path).await?;
+            let resolved = config.resolve_path(workspace_path);
+            let driver = LanceDriver::open(&resolved).await?;
             Ok(Arc::new(driver))
         }
         "memory" | "in_memory" => Ok(Arc::new(InMemoryStore::new())),
@@ -36,7 +37,8 @@ pub async fn init_storage(
 ) -> anyhow::Result<Arc<dyn StorageDriver>> {
     match config.driver.as_str() {
         "lancedb" | "lance" => {
-            let driver = LanceDriver::init(workspace_path).await?;
+            let resolved = config.resolve_path(workspace_path);
+            let driver = LanceDriver::init(&resolved).await?;
             Ok(Arc::new(driver))
         }
         "memory" | "in_memory" => Ok(Arc::new(InMemoryStore::new())),
@@ -61,6 +63,7 @@ mod tests {
 
         let config = StorageConfig {
             driver: "lancedb".to_string(),
+            path: None,
         };
 
         // First init to create tables
@@ -75,6 +78,7 @@ mod tests {
     async fn test_create_memory_driver() {
         let config = StorageConfig {
             driver: "memory".to_string(),
+            path: None,
         };
 
         let driver = create_storage(&config, Path::new("/unused")).await.unwrap();
@@ -85,6 +89,7 @@ mod tests {
     async fn test_unknown_driver_returns_error() {
         let config = StorageConfig {
             driver: "postgres".to_string(),
+            path: None,
         };
 
         let result = create_storage(&config, Path::new("/unused")).await;

--- a/crates/forgeplan-core/src/driver/factory.rs
+++ b/crates/forgeplan-core/src/driver/factory.rs
@@ -1,0 +1,98 @@
+//! Factory for creating StorageDriver instances from config.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::config::types::StorageConfig;
+use crate::driver::in_memory::InMemoryStore;
+use crate::driver::lance::LanceDriver;
+use crate::driver::StorageDriver;
+
+/// Create a StorageDriver based on config.
+/// Returns Arc<dyn StorageDriver> for shared ownership.
+pub async fn create_storage(
+    config: &StorageConfig,
+    workspace_path: &Path,
+) -> anyhow::Result<Arc<dyn StorageDriver>> {
+    match config.driver.as_str() {
+        "lancedb" | "lance" => {
+            let driver = LanceDriver::open(workspace_path).await?;
+            Ok(Arc::new(driver))
+        }
+        "memory" | "in_memory" => Ok(Arc::new(InMemoryStore::new())),
+        other => {
+            anyhow::bail!(
+                "Unknown storage driver: '{}'. Supported: lancedb, memory",
+                other
+            )
+        }
+    }
+}
+
+/// Create and initialize a NEW storage (for forgeplan init).
+pub async fn init_storage(
+    config: &StorageConfig,
+    workspace_path: &Path,
+) -> anyhow::Result<Arc<dyn StorageDriver>> {
+    match config.driver.as_str() {
+        "lancedb" | "lance" => {
+            let driver = LanceDriver::init(workspace_path).await?;
+            Ok(Arc::new(driver))
+        }
+        "memory" | "in_memory" => Ok(Arc::new(InMemoryStore::new())),
+        other => {
+            anyhow::bail!(
+                "Unknown storage driver: '{}'. Supported: lancedb, memory",
+                other
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create_lance_driver() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path().join("lance");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let config = StorageConfig {
+            driver: "lancedb".to_string(),
+        };
+
+        // First init to create tables
+        let _driver = init_storage(&config, &ws).await.unwrap();
+
+        // Then open existing
+        let driver = create_storage(&config, &ws).await.unwrap();
+        assert!(Arc::strong_count(&driver) == 1);
+    }
+
+    #[tokio::test]
+    async fn test_create_memory_driver() {
+        let config = StorageConfig {
+            driver: "memory".to_string(),
+        };
+
+        let driver = create_storage(&config, Path::new("/unused")).await.unwrap();
+        assert!(!driver.supports_vectors());
+    }
+
+    #[tokio::test]
+    async fn test_unknown_driver_returns_error() {
+        let config = StorageConfig {
+            driver: "postgres".to_string(),
+        };
+
+        let result = create_storage(&config, Path::new("/unused")).await;
+        let err = match result {
+            Ok(_) => panic!("expected error for unknown driver"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("Unknown storage driver"));
+        assert!(err.contains("postgres"));
+    }
+}

--- a/crates/forgeplan-core/src/driver/in_memory.rs
+++ b/crates/forgeplan-core/src/driver/in_memory.rs
@@ -1,0 +1,773 @@
+//! In-memory implementation of StorageDriver for testing.
+//! Uses HashMap + RwLock for thread-safe access. No disk I/O.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::RwLock;
+
+use chrono::Utc;
+
+use crate::artifact::store::ArtifactSummary;
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, NewArtifact};
+use crate::driver::StorageDriver;
+
+/// Thread-safe in-memory store for testing.
+pub struct InMemoryStore {
+    artifacts: RwLock<HashMap<String, ArtifactRecord>>,
+    relations: RwLock<Vec<(String, String, String)>>, // source, target, relation_type
+    fpf_chunks: RwLock<Vec<FpfChunk>>,
+    id_counters: RwLock<HashMap<String, u32>>,
+}
+
+impl InMemoryStore {
+    pub fn new() -> Self {
+        Self {
+            artifacts: RwLock::new(HashMap::new()),
+            relations: RwLock::new(Vec::new()),
+            fpf_chunks: RwLock::new(Vec::new()),
+            id_counters: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageDriver for InMemoryStore {
+    // ── Lifecycle ────────────────────────────────────────────────────
+
+    async fn open(_workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self::new())
+    }
+
+    async fn init(_workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self::new())
+    }
+
+    // ── Artifact CRUD ────────────────────────────────────────────────
+
+    async fn create_artifact(&self, artifact: &NewArtifact) -> anyhow::Result<String> {
+        let now = Utc::now().to_rfc3339();
+        let record = ArtifactRecord {
+            id: artifact.id.clone(),
+            kind: artifact.kind.clone(),
+            status: artifact.status.clone(),
+            title: artifact.title.clone(),
+            body: artifact.body.clone(),
+            depth: artifact.depth.clone(),
+            author: artifact.author.clone(),
+            parent_epic: artifact.parent_epic.clone(),
+            r_eff_score: 0.0,
+            valid_until: artifact.valid_until.clone(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        let id = record.id.clone();
+        self.artifacts
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?
+            .insert(id.clone(), record);
+        Ok(id)
+    }
+
+    async fn get_artifact(&self, id: &str) -> anyhow::Result<Option<ArtifactSummary>> {
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(arts.get(id).map(|r| r.to_summary()))
+    }
+
+    async fn list_artifacts(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactSummary>> {
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let iter = arts.values().filter(|r| {
+            if let Some(f) = filter {
+                if let Some(ref k) = f.kind {
+                    if !r.kind.eq_ignore_ascii_case(k) {
+                        return false;
+                    }
+                }
+                if let Some(ref s) = f.status {
+                    if !r.status.eq_ignore_ascii_case(s) {
+                        return false;
+                    }
+                }
+            }
+            true
+        });
+        let mut summaries: Vec<ArtifactSummary> = iter.map(|r| r.to_summary()).collect();
+        summaries.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(summaries)
+    }
+
+    async fn update_artifact(
+        &self,
+        id: &str,
+        status: Option<&str>,
+        title: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let mut arts = self
+            .artifacts
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let record = arts
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact not found: {id}"))?;
+        if let Some(s) = status {
+            record.status = s.to_string();
+        }
+        if let Some(t) = title {
+            record.title = t.to_string();
+        }
+        record.updated_at = Utc::now().to_rfc3339();
+        Ok(())
+    }
+
+    async fn update_r_eff_score(&self, id: &str, score: f64) -> anyhow::Result<()> {
+        let mut arts = self
+            .artifacts
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let record = arts
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact not found: {id}"))?;
+        record.r_eff_score = score;
+        record.updated_at = Utc::now().to_rfc3339();
+        Ok(())
+    }
+
+    async fn delete_artifact(&self, id: &str) -> anyhow::Result<()> {
+        let mut arts = self
+            .artifacts
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        arts.remove(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact not found: {id}"))?;
+        // Also clean up relations involving this artifact
+        drop(arts);
+        let mut rels = self
+            .relations
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        rels.retain(|(s, t, _)| s != id && t != id);
+        Ok(())
+    }
+
+    // ── Full records ─────────────────────────────────────────────────
+
+    async fn get_record(&self, id: &str) -> anyhow::Result<Option<ArtifactRecord>> {
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(arts.get(id).cloned())
+    }
+
+    async fn list_records(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let iter = arts.values().filter(|r| {
+            if let Some(f) = filter {
+                if let Some(ref k) = f.kind {
+                    if !r.kind.eq_ignore_ascii_case(k) {
+                        return false;
+                    }
+                }
+                if let Some(ref s) = f.status {
+                    if !r.status.eq_ignore_ascii_case(s) {
+                        return false;
+                    }
+                }
+            }
+            true
+        });
+        let mut records: Vec<ArtifactRecord> = iter.cloned().collect();
+        records.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(records)
+    }
+
+    async fn update_body(&self, id: &str, body: &str) -> anyhow::Result<()> {
+        let mut arts = self
+            .artifacts
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let record = arts
+            .get_mut(id)
+            .ok_or_else(|| anyhow::anyhow!("artifact not found: {id}"))?;
+        record.body = body.to_string();
+        record.updated_at = Utc::now().to_rfc3339();
+        Ok(())
+    }
+
+    // ── Relations ────────────────────────────────────────────────────
+
+    async fn add_relation(
+        &self,
+        source: &str,
+        target: &str,
+        relation: &str,
+    ) -> anyhow::Result<()> {
+        let mut rels = self
+            .relations
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        // Reject duplicates
+        let exists = rels
+            .iter()
+            .any(|(s, t, r)| s == source && t == target && r == relation);
+        if exists {
+            anyhow::bail!("relation already exists: {source} -> {target} ({relation})");
+        }
+        rels.push((source.to_string(), target.to_string(), relation.to_string()));
+        Ok(())
+    }
+
+    async fn get_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        let rels = self
+            .relations
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(rels
+            .iter()
+            .filter(|(s, _, _)| s == id)
+            .map(|(_, t, r)| (t.clone(), r.clone()))
+            .collect())
+    }
+
+    async fn get_incoming_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        let rels = self
+            .relations
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(rels
+            .iter()
+            .filter(|(_, t, _)| t == id)
+            .map(|(s, _, r)| (s.clone(), r.clone()))
+            .collect())
+    }
+
+    async fn get_all_relations(&self) -> anyhow::Result<Vec<(String, String, String)>> {
+        let rels = self
+            .relations
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(rels.clone())
+    }
+
+    // ── Search ───────────────────────────────────────────────────────
+
+    async fn search_body(
+        &self,
+        query: &str,
+        kind_filter: Option<&str>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let query_lower = query.to_lowercase();
+        let mut results: Vec<ArtifactRecord> = arts
+            .values()
+            .filter(|r| {
+                if let Some(k) = kind_filter {
+                    if !r.kind.eq_ignore_ascii_case(k) {
+                        return false;
+                    }
+                }
+                r.title.to_lowercase().contains(&query_lower)
+                    || r.body.to_lowercase().contains(&query_lower)
+            })
+            .cloned()
+            .collect();
+        results.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(results)
+    }
+
+    async fn find_stale(&self) -> anyhow::Result<Vec<ArtifactRecord>> {
+        let now = Utc::now().to_rfc3339();
+        let arts = self
+            .artifacts
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let mut stale: Vec<ArtifactRecord> = arts
+            .values()
+            .filter(|r| {
+                if let Some(ref vu) = r.valid_until {
+                    vu.as_str() < now.as_str()
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect();
+        stale.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(stale)
+    }
+
+    async fn next_id(&self, kind_prefix: &str) -> anyhow::Result<String> {
+        let mut counters = self
+            .id_counters
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let counter = counters.entry(kind_prefix.to_uppercase()).or_insert(0);
+        *counter += 1;
+        Ok(format!("{}-{:03}", kind_prefix.to_uppercase(), *counter))
+    }
+
+    // ── FPF Knowledge Base ───────────────────────────────────────────
+
+    fn has_fpf(&self) -> bool {
+        let chunks = self.fpf_chunks.read().unwrap_or_else(|e| e.into_inner());
+        !chunks.is_empty()
+    }
+
+    async fn insert_fpf_chunks(&self, chunks: &[FpfChunk]) -> anyhow::Result<usize> {
+        let mut store = self
+            .fpf_chunks
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let count = chunks.len();
+        store.extend(chunks.iter().cloned());
+        Ok(count)
+    }
+
+    async fn search_fpf(&self, query: &str, limit: usize) -> anyhow::Result<Vec<FpfChunk>> {
+        let store = self
+            .fpf_chunks
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        let query_lower = query.to_lowercase();
+        let results: Vec<FpfChunk> = store
+            .iter()
+            .filter(|c| {
+                c.title.to_lowercase().contains(&query_lower)
+                    || c.body.to_lowercase().contains(&query_lower)
+                    || c.section_id.to_lowercase().contains(&query_lower)
+            })
+            .take(limit)
+            .cloned()
+            .collect();
+        Ok(results)
+    }
+
+    async fn get_fpf_section(&self, section_id: &str) -> anyhow::Result<Option<FpfChunk>> {
+        let store = self
+            .fpf_chunks
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(store.iter().find(|c| c.section_id == section_id).cloned())
+    }
+
+    async fn list_fpf_sections(&self) -> anyhow::Result<Vec<FpfChunkSummary>> {
+        let store = self
+            .fpf_chunks
+            .read()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        Ok(store
+            .iter()
+            .map(|c| FpfChunkSummary {
+                section_id: c.section_id.clone(),
+                title: c.title.clone(),
+                line_count: c.line_count,
+            })
+            .collect())
+    }
+
+    async fn clear_fpf(&self) -> anyhow::Result<()> {
+        let mut store = self
+            .fpf_chunks
+            .write()
+            .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+        store.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_new_artifact(kind: &str, title: &str, body: &str) -> NewArtifact {
+        NewArtifact {
+            id: String::new(), // will be replaced by next_id in tests
+            kind: kind.to_string(),
+            status: "draft".to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            depth: "standard".to_string(),
+            author: Some("test".to_string()),
+            parent_epic: None,
+            valid_until: None,
+        }
+    }
+
+    async fn create_with_id(store: &InMemoryStore, kind: &str, title: &str, body: &str) -> String {
+        let id = store.next_id(kind).await.unwrap();
+        let mut art = make_new_artifact(kind, title, body);
+        art.id = id.clone();
+        store.create_artifact(&art).await.unwrap();
+        id
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_artifact() {
+        let store = InMemoryStore::new();
+        let id = create_with_id(&store, "PRD", "Auth System", "Login flow").await;
+
+        assert_eq!(id, "PRD-001");
+
+        let summary = store.get_artifact(&id).await.unwrap().unwrap();
+        assert_eq!(summary.id, "PRD-001");
+        assert_eq!(summary.title, "Auth System");
+        assert_eq!(summary.kind, "PRD");
+        assert_eq!(summary.status, "draft");
+
+        let record = store.get_record(&id).await.unwrap().unwrap();
+        assert_eq!(record.body, "Login flow");
+        assert_eq!(record.r_eff_score, 0.0);
+        assert!(record.author.as_deref() == Some("test"));
+
+        // Not found
+        assert!(store.get_artifact("PRD-999").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_artifacts_with_filter() {
+        let store = InMemoryStore::new();
+        create_with_id(&store, "PRD", "PRD One", "body1").await;
+        create_with_id(&store, "RFC", "RFC One", "body2").await;
+        create_with_id(&store, "PRD", "PRD Two", "body3").await;
+
+        // No filter — all 3
+        let all = store.list_artifacts(None).await.unwrap();
+        assert_eq!(all.len(), 3);
+
+        // Filter by kind
+        let filter = ArtifactFilter {
+            kind: Some("PRD".to_string()),
+            status: None,
+        };
+        let prds = store.list_artifacts(Some(&filter)).await.unwrap();
+        assert_eq!(prds.len(), 2);
+        assert!(prds.iter().all(|s| s.kind == "PRD"));
+
+        // Filter by status
+        let filter = ArtifactFilter {
+            kind: None,
+            status: Some("active".to_string()),
+        };
+        let active = store.list_artifacts(Some(&filter)).await.unwrap();
+        assert_eq!(active.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_update_artifact_status() {
+        let store = InMemoryStore::new();
+        let id = create_with_id(&store, "PRD", "Title", "body").await;
+
+        store
+            .update_artifact(&id, Some("active"), Some("New Title"))
+            .await
+            .unwrap();
+
+        let summary = store.get_artifact(&id).await.unwrap().unwrap();
+        assert_eq!(summary.status, "active");
+        assert_eq!(summary.title, "New Title");
+
+        // Update r_eff
+        store.update_r_eff_score(&id, 0.85).await.unwrap();
+        let record = store.get_record(&id).await.unwrap().unwrap();
+        assert!((record.r_eff_score - 0.85).abs() < f64::EPSILON);
+
+        // Update body
+        store.update_body(&id, "updated body").await.unwrap();
+        let record = store.get_record(&id).await.unwrap().unwrap();
+        assert_eq!(record.body, "updated body");
+
+        // Non-existent artifact
+        assert!(store
+            .update_artifact("NOPE-001", Some("x"), None)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_artifact() {
+        let store = InMemoryStore::new();
+        let id = create_with_id(&store, "PRD", "To Delete", "body").await;
+        let id2 = create_with_id(&store, "RFC", "Keep", "body").await;
+
+        // Add a relation involving the deleted artifact
+        store.add_relation(&id, &id2, "informs").await.unwrap();
+
+        store.delete_artifact(&id).await.unwrap();
+
+        assert!(store.get_artifact(&id).await.unwrap().is_none());
+        assert!(store.get_artifact(&id2).await.unwrap().is_some());
+
+        // Relations cleaned up
+        let rels = store.get_all_relations().await.unwrap();
+        assert!(rels.is_empty());
+
+        // Double delete errors
+        assert!(store.delete_artifact(&id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_relations_crud() {
+        let store = InMemoryStore::new();
+        let prd = create_with_id(&store, "PRD", "PRD", "body").await;
+        let rfc = create_with_id(&store, "RFC", "RFC", "body").await;
+        let adr = create_with_id(&store, "ADR", "ADR", "body").await;
+
+        store.add_relation(&prd, &rfc, "informs").await.unwrap();
+        store
+            .add_relation(&rfc, &adr, "implements")
+            .await
+            .unwrap();
+
+        // Outgoing from prd
+        let out = store.get_relations(&prd).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], ("RFC-001".to_string(), "informs".to_string()));
+
+        // Incoming to rfc
+        let inc = store.get_incoming_relations(&rfc).await.unwrap();
+        assert_eq!(inc.len(), 1);
+        assert_eq!(inc[0], ("PRD-001".to_string(), "informs".to_string()));
+
+        // All relations
+        let all = store.get_all_relations().await.unwrap();
+        assert_eq!(all.len(), 2);
+
+        // Duplicate rejection
+        assert!(store.add_relation(&prd, &rfc, "informs").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_search_body() {
+        let store = InMemoryStore::new();
+        create_with_id(&store, "PRD", "Auth System", "OAuth2 login flow").await;
+        create_with_id(&store, "RFC", "DB Migration", "PostgreSQL schema changes").await;
+        create_with_id(&store, "PRD", "Search Feature", "Full-text search with PostgreSQL").await;
+
+        // Search by body content (case-insensitive)
+        let results = store.search_body("postgresql", None).await.unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Search with kind filter
+        let results = store.search_body("postgresql", Some("PRD")).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Search Feature");
+
+        // Search by title
+        let results = store.search_body("auth", None).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Auth System");
+
+        // No match
+        let results = store.search_body("nonexistent", None).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_next_id_increments() {
+        let store = InMemoryStore::new();
+
+        assert_eq!(store.next_id("prd").await.unwrap(), "PRD-001");
+        assert_eq!(store.next_id("prd").await.unwrap(), "PRD-002");
+        assert_eq!(store.next_id("prd").await.unwrap(), "PRD-003");
+
+        // Different prefix has its own counter
+        assert_eq!(store.next_id("rfc").await.unwrap(), "RFC-001");
+        assert_eq!(store.next_id("rfc").await.unwrap(), "RFC-002");
+
+        // Case-insensitive prefix
+        assert_eq!(store.next_id("PRD").await.unwrap(), "PRD-004");
+    }
+
+    #[tokio::test]
+    async fn test_thread_safety() {
+        use std::sync::Arc;
+
+        let store = Arc::new(InMemoryStore::new());
+
+        let store1 = Arc::clone(&store);
+        let t1 = tokio::spawn(async move {
+            for i in 0..50 {
+                let id = store1.next_id("TST").await.unwrap();
+                let art = NewArtifact {
+                    id,
+                    kind: "TST".to_string(),
+                    status: "draft".to_string(),
+                    title: format!("Task A-{i}"),
+                    body: "body".to_string(),
+                    depth: "tactical".to_string(),
+                    author: None,
+                    parent_epic: None,
+                    valid_until: None,
+                };
+                store1.create_artifact(&art).await.unwrap();
+            }
+        });
+
+        let store2 = Arc::clone(&store);
+        let t2 = tokio::spawn(async move {
+            for i in 0..50 {
+                let id = store2.next_id("TST").await.unwrap();
+                let art = NewArtifact {
+                    id,
+                    kind: "TST".to_string(),
+                    status: "draft".to_string(),
+                    title: format!("Task B-{i}"),
+                    body: "body".to_string(),
+                    depth: "tactical".to_string(),
+                    author: None,
+                    parent_epic: None,
+                    valid_until: None,
+                };
+                store2.create_artifact(&art).await.unwrap();
+            }
+        });
+
+        t1.await.unwrap();
+        t2.await.unwrap();
+
+        // All 100 artifacts created with unique IDs
+        let all = store.list_artifacts(None).await.unwrap();
+        assert_eq!(all.len(), 100);
+
+        // All IDs unique
+        let mut ids: Vec<String> = all.iter().map(|s| s.id.clone()).collect();
+        ids.sort();
+        ids.dedup();
+        assert_eq!(ids.len(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_find_stale() {
+        let store = InMemoryStore::new();
+
+        // Create artifact with expired valid_until
+        let id = store.next_id("PRD").await.unwrap();
+        let art = NewArtifact {
+            id: id.clone(),
+            kind: "PRD".to_string(),
+            status: "active".to_string(),
+            title: "Stale".to_string(),
+            body: "old".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: Some("2020-01-01T00:00:00Z".to_string()),
+        };
+        store.create_artifact(&art).await.unwrap();
+
+        // Create artifact without valid_until
+        let id2 = store.next_id("PRD").await.unwrap();
+        let art2 = NewArtifact {
+            id: id2,
+            kind: "PRD".to_string(),
+            status: "active".to_string(),
+            title: "Fresh".to_string(),
+            body: "new".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+        };
+        store.create_artifact(&art2).await.unwrap();
+
+        let stale = store.find_stale().await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].id, id);
+    }
+
+    #[tokio::test]
+    async fn test_fpf_operations() {
+        let store = InMemoryStore::new();
+        assert!(!store.has_fpf());
+
+        let chunks = vec![
+            FpfChunk {
+                id: "1".to_string(),
+                section_id: "B.3".to_string(),
+                parent_section: Some("B".to_string()),
+                title: "Trust Calculus".to_string(),
+                body: "Trust is earned through evidence".to_string(),
+                line_count: 5,
+                file_path: "fpf.md".to_string(),
+                created_at: Utc::now().to_rfc3339(),
+            },
+            FpfChunk {
+                id: "2".to_string(),
+                section_id: "A.1".to_string(),
+                parent_section: Some("A".to_string()),
+                title: "ADI Cycle".to_string(),
+                body: "Abduction, Deduction, Induction".to_string(),
+                line_count: 3,
+                file_path: "fpf.md".to_string(),
+                created_at: Utc::now().to_rfc3339(),
+            },
+        ];
+
+        let inserted = store.insert_fpf_chunks(&chunks).await.unwrap();
+        assert_eq!(inserted, 2);
+        assert!(store.has_fpf());
+
+        // Search
+        let found = store.search_fpf("trust", 10).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].section_id, "B.3");
+
+        // Get section
+        let section = store.get_fpf_section("A.1").await.unwrap().unwrap();
+        assert_eq!(section.title, "ADI Cycle");
+        assert!(store.get_fpf_section("Z.9").await.unwrap().is_none());
+
+        // List sections
+        let list = store.list_fpf_sections().await.unwrap();
+        assert_eq!(list.len(), 2);
+
+        // Clear
+        store.clear_fpf().await.unwrap();
+        assert!(!store.has_fpf());
+    }
+
+    #[tokio::test]
+    async fn test_list_records_with_filter() {
+        let store = InMemoryStore::new();
+        create_with_id(&store, "PRD", "P1", "b1").await;
+        create_with_id(&store, "RFC", "R1", "b2").await;
+
+        let filter = ArtifactFilter {
+            kind: Some("RFC".to_string()),
+            status: None,
+        };
+        let records = store.list_records(Some(&filter)).await.unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, "RFC");
+        assert_eq!(records[0].body, "b2");
+    }
+}

--- a/crates/forgeplan-core/src/driver/lance.rs
+++ b/crates/forgeplan-core/src/driver/lance.rs
@@ -1,0 +1,207 @@
+//! LanceDB implementation of StorageDriver.
+//! Thin wrapper delegating all calls to the existing LanceStore.
+
+use std::path::Path;
+
+use crate::artifact::store::ArtifactSummary;
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, LanceStore, NewArtifact};
+use crate::driver::StorageDriver;
+
+/// LanceDB-backed storage driver.
+pub struct LanceDriver {
+    store: LanceStore,
+}
+
+impl LanceDriver {
+    pub async fn open(workspace_path: &Path) -> anyhow::Result<Self> {
+        let store = LanceStore::open(workspace_path).await?;
+        Ok(Self { store })
+    }
+
+    pub async fn init(workspace_path: &Path) -> anyhow::Result<Self> {
+        let store = LanceStore::init(workspace_path).await?;
+        Ok(Self { store })
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageDriver for LanceDriver {
+    // ── Lifecycle ────────────────────────────────────────────────────
+
+    async fn open(workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        LanceDriver::open(workspace_path).await
+    }
+
+    async fn init(workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        LanceDriver::init(workspace_path).await
+    }
+
+    // ── Artifact CRUD ────────────────────────────────────────────────
+
+    async fn create_artifact(&self, artifact: &NewArtifact) -> anyhow::Result<String> {
+        self.store.create_artifact(artifact).await
+    }
+
+    async fn get_artifact(&self, id: &str) -> anyhow::Result<Option<ArtifactSummary>> {
+        self.store.get_artifact(id).await
+    }
+
+    async fn list_artifacts(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactSummary>> {
+        self.store.list_artifacts(filter).await
+    }
+
+    async fn update_artifact(
+        &self,
+        id: &str,
+        status: Option<&str>,
+        title: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.store.update_artifact(id, status, title).await
+    }
+
+    async fn update_r_eff_score(&self, id: &str, score: f64) -> anyhow::Result<()> {
+        self.store.update_r_eff_score(id, score).await
+    }
+
+    async fn delete_artifact(&self, id: &str) -> anyhow::Result<()> {
+        self.store.delete_artifact(id).await
+    }
+
+    // ── Full records ─────────────────────────────────────────────────
+
+    async fn get_record(&self, id: &str) -> anyhow::Result<Option<ArtifactRecord>> {
+        self.store.get_record(id).await
+    }
+
+    async fn list_records(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+        self.store.list_records(filter).await
+    }
+
+    async fn update_body(&self, id: &str, body: &str) -> anyhow::Result<()> {
+        self.store.update_body(id, body).await
+    }
+
+    // ── Relations ────────────────────────────────────────────────────
+
+    async fn add_relation(
+        &self,
+        source: &str,
+        target: &str,
+        relation: &str,
+    ) -> anyhow::Result<()> {
+        self.store.add_relation(source, target, relation).await
+    }
+
+    async fn get_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        self.store.get_relations(id).await
+    }
+
+    async fn get_incoming_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>> {
+        self.store.get_incoming_relations(id).await
+    }
+
+    async fn get_all_relations(&self) -> anyhow::Result<Vec<(String, String, String)>> {
+        self.store.get_all_relations().await
+    }
+
+    // ── Search ───────────────────────────────────────────────────────
+
+    async fn search_body(
+        &self,
+        query: &str,
+        kind_filter: Option<&str>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+        self.store.search_body(query, kind_filter).await
+    }
+
+    async fn find_stale(&self) -> anyhow::Result<Vec<ArtifactRecord>> {
+        self.store.find_stale().await
+    }
+
+    async fn next_id(&self, kind_prefix: &str) -> anyhow::Result<String> {
+        self.store.next_id(kind_prefix).await
+    }
+
+    // ── Vectors ──────────────────────────────────────────────────────
+
+    fn supports_vectors(&self) -> bool {
+        true
+    }
+
+    async fn update_embedding(&self, id: &str, embedding: &[f32]) -> anyhow::Result<()> {
+        self.store.update_embedding(id, embedding).await
+    }
+
+    // ── FPF Knowledge Base ───────────────────────────────────────────
+
+    fn has_fpf(&self) -> bool {
+        self.store.has_fpf()
+    }
+
+    async fn insert_fpf_chunks(&self, chunks: &[FpfChunk]) -> anyhow::Result<usize> {
+        self.store.insert_fpf_chunks(chunks).await
+    }
+
+    async fn search_fpf(&self, query: &str, limit: usize) -> anyhow::Result<Vec<FpfChunk>> {
+        self.store.search_fpf(query, limit).await
+    }
+
+    async fn get_fpf_section(&self, section_id: &str) -> anyhow::Result<Option<FpfChunk>> {
+        self.store.get_fpf_section(section_id).await
+    }
+
+    async fn list_fpf_sections(&self) -> anyhow::Result<Vec<FpfChunkSummary>> {
+        self.store.list_fpf_sections().await
+    }
+
+    async fn clear_fpf(&self) -> anyhow::Result<()> {
+        self.store.clear_fpf().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that LanceDriver can be used as `&dyn StorageDriver`.
+    #[allow(dead_code)]
+    fn assert_lance_driver_is_storage_driver(_: &dyn StorageDriver) {}
+
+    #[tokio::test]
+    async fn lance_driver_open_tempdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ws = tmp.path();
+
+        // First init to create tables
+        let driver = LanceDriver::init(ws).await.unwrap();
+        // Verify FPF defaults to false (no fpf_spec table created by default init)
+        // has_fpf depends on whether init creates fpf_spec table
+        let _ = driver.has_fpf();
+
+        // Re-open existing workspace
+        let driver2 = LanceDriver::open(ws).await.unwrap();
+        assert!(driver2.supports_vectors());
+    }
+
+    #[tokio::test]
+    async fn lance_driver_as_dyn_trait() {
+        let tmp = tempfile::tempdir().unwrap();
+        let driver = LanceDriver::init(tmp.path()).await.unwrap();
+        let dyn_ref: &dyn StorageDriver = &driver;
+        // Should be able to call trait methods through dyn reference
+        let artifacts = dyn_ref.list_artifacts(None).await.unwrap();
+        assert!(artifacts.is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/driver/mod.rs
+++ b/crates/forgeplan-core/src/driver/mod.rs
@@ -1,0 +1,247 @@
+//! Storage driver traits for pluggable backends (LanceDB, SQLite, InMemory).
+//!
+//! These traits abstract the storage, embedding, memory, and LLM layers
+//! so that implementations can be swapped without changing business logic.
+
+pub mod factory;
+pub mod in_memory;
+pub mod lance;
+pub mod types;
+
+// Re-export key types for convenience
+pub use types::*;
+
+use crate::artifact::store::ArtifactSummary;
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, NewArtifact};
+
+use std::path::Path;
+
+/// Core storage abstraction over artifact CRUD, relations, search, scoring, and FPF.
+///
+/// Every pub async method on `LanceStore` is mirrored here so that any backend
+/// (LanceDB, SQLite, in-memory) can fulfil the contract.
+#[async_trait::async_trait]
+pub trait StorageDriver: Send + Sync {
+    // ── Lifecycle ────────────────────────────────────────────────────
+
+    /// Open an existing workspace at `workspace_path`.
+    async fn open(workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    /// Create tables / schema if needed, then open the store.
+    async fn init(workspace_path: &Path) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    // ── Artifact CRUD ────────────────────────────────────────────────
+
+    /// Insert a new artifact, returning its ID.
+    async fn create_artifact(&self, artifact: &NewArtifact) -> anyhow::Result<String>;
+
+    /// Get a single artifact by ID as a summary. Returns `None` if not found.
+    async fn get_artifact(&self, id: &str) -> anyhow::Result<Option<ArtifactSummary>>;
+
+    /// List artifacts with optional kind/status filter.
+    async fn list_artifacts(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactSummary>>;
+
+    /// Update artifact metadata (status, title). Always bumps `updated_at`.
+    async fn update_artifact(
+        &self,
+        id: &str,
+        status: Option<&str>,
+        title: Option<&str>,
+    ) -> anyhow::Result<()>;
+
+    /// Update `r_eff_score` for an artifact.
+    async fn update_r_eff_score(&self, id: &str, score: f64) -> anyhow::Result<()>;
+
+    /// Delete an artifact by ID.
+    async fn delete_artifact(&self, id: &str) -> anyhow::Result<()>;
+
+    // ── Full records ─────────────────────────────────────────────────
+
+    /// Get a single artifact by ID as a full record. Returns `None` if not found.
+    async fn get_record(&self, id: &str) -> anyhow::Result<Option<ArtifactRecord>>;
+
+    /// List artifacts as full records with optional kind/status filter.
+    async fn list_records(
+        &self,
+        filter: Option<&ArtifactFilter>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>>;
+
+    /// Update the body column of an artifact.
+    async fn update_body(&self, id: &str, body: &str) -> anyhow::Result<()>;
+
+    // ── Relations ────────────────────────────────────────────────────
+
+    /// Add a typed relation between two artifacts. Rejects duplicates.
+    async fn add_relation(
+        &self,
+        source: &str,
+        target: &str,
+        relation: &str,
+    ) -> anyhow::Result<()>;
+
+    /// Get outgoing relations for an artifact (source -> targets).
+    /// Returns `Vec<(target_id, relation_type)>`.
+    async fn get_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>>;
+
+    /// Get incoming relations where this artifact is the target.
+    /// Returns `Vec<(source_id, relation_type)>`.
+    async fn get_incoming_relations(&self, id: &str) -> anyhow::Result<Vec<(String, String)>>;
+
+    /// Get all relations across all artifacts.
+    /// Returns `Vec<(source_id, target_id, relation_type)>`.
+    async fn get_all_relations(&self) -> anyhow::Result<Vec<(String, String, String)>>;
+
+    // ── Search ───────────────────────────────────────────────────────
+
+    /// Search artifacts by body/title content (case-insensitive substring).
+    async fn search_body(
+        &self,
+        query: &str,
+        kind_filter: Option<&str>,
+    ) -> anyhow::Result<Vec<ArtifactRecord>>;
+
+    /// Find artifacts whose `valid_until` has expired.
+    async fn find_stale(&self) -> anyhow::Result<Vec<ArtifactRecord>>;
+
+    /// Compute the next sequential ID for a given kind prefix (e.g. "PRD" -> "PRD-003").
+    async fn next_id(&self, kind_prefix: &str) -> anyhow::Result<String>;
+
+    // ── Vectors (optional) ───────────────────────────────────────────
+
+    /// Whether this backend supports vector similarity search.
+    fn supports_vectors(&self) -> bool {
+        false
+    }
+
+    /// Vector similarity search using a pre-computed embedding.
+    async fn vector_search(
+        &self,
+        _query_embedding: &[f32],
+        _limit: usize,
+    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+        Ok(Vec::new())
+    }
+
+    /// Update the embedding column for an artifact.
+    async fn update_embedding(&self, _id: &str, _embedding: &[f32]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    // ── FPF Knowledge Base (optional) ────────────────────────────────
+
+    /// Whether FPF knowledge base is available.
+    fn has_fpf(&self) -> bool {
+        false
+    }
+
+    /// Insert FPF chunks in batch. Returns number inserted.
+    async fn insert_fpf_chunks(&self, _chunks: &[FpfChunk]) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+
+    /// Search FPF spec by keyword.
+    async fn search_fpf(&self, _query: &str, _limit: usize) -> anyhow::Result<Vec<FpfChunk>> {
+        Ok(Vec::new())
+    }
+
+    /// Get a specific FPF section by section_id.
+    async fn get_fpf_section(
+        &self,
+        _section_id: &str,
+    ) -> anyhow::Result<Option<FpfChunk>> {
+        Ok(None)
+    }
+
+    /// List all FPF sections (without body content).
+    async fn list_fpf_sections(&self) -> anyhow::Result<Vec<FpfChunkSummary>> {
+        Ok(Vec::new())
+    }
+
+    /// Delete all FPF chunks (for re-ingestion).
+    async fn clear_fpf(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// Embedding driver — wraps a text embedding model.
+pub trait EmbedDriver: Send {
+    /// Embed a single text string into a vector.
+    fn embed(&mut self, text: &str) -> anyhow::Result<Vec<f32>>;
+
+    /// Embed multiple texts in a single batch.
+    fn embed_batch(&mut self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>>;
+
+    /// Dimensionality of the output vectors.
+    fn dim(&self) -> usize;
+
+    /// Name of the underlying model.
+    fn model_name(&self) -> &str;
+}
+
+/// Agent memory driver — log and recall contextual entries across sessions.
+#[async_trait::async_trait]
+pub trait MemoryDriver: Send + Sync {
+    /// Append a memory entry.
+    async fn log(&self, entry: MemoryEntry) -> anyhow::Result<()>;
+
+    /// Recall entries matching a query, up to `limit`.
+    async fn recall(&self, query: &str, limit: usize) -> anyhow::Result<Vec<MemoryEntry>>;
+
+    /// Get the most recent entries.
+    async fn recent(&self, count: usize) -> anyhow::Result<Vec<MemoryEntry>>;
+}
+
+/// LLM driver — unified text generation interface.
+#[async_trait::async_trait]
+pub trait LlmDriver: Send + Sync {
+    /// Generate text from a prompt with an optional system message.
+    async fn generate(&self, prompt: &str, system: Option<&str>) -> anyhow::Result<String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that StorageDriver is object-safe (can be used as `dyn`).
+    #[allow(dead_code)]
+    fn assert_storage_driver_object_safe(_: &dyn StorageDriver) {}
+
+    /// Verify that EmbedDriver is object-safe.
+    #[allow(dead_code)]
+    fn assert_embed_driver_object_safe(_: &dyn EmbedDriver) {}
+
+    /// Verify that MemoryDriver is object-safe.
+    #[allow(dead_code)]
+    fn assert_memory_driver_object_safe(_: &dyn MemoryDriver) {}
+
+    /// Verify that LlmDriver is object-safe.
+    #[allow(dead_code)]
+    fn assert_llm_driver_object_safe(_: &dyn LlmDriver) {}
+
+    #[test]
+    fn memory_kind_equality() {
+        assert_eq!(MemoryKind::Decision, MemoryKind::Decision);
+        assert_ne!(MemoryKind::Decision, MemoryKind::Context);
+    }
+
+    #[test]
+    fn memory_entry_debug() {
+        let entry = MemoryEntry {
+            timestamp: chrono::Utc::now(),
+            kind: MemoryKind::Insight,
+            content: "test".to_string(),
+            source: "cli".to_string(),
+            artifact_id: None,
+            metadata: std::collections::HashMap::new(),
+        };
+        let debug = format!("{:?}", entry);
+        assert!(debug.contains("Insight"));
+    }
+}

--- a/crates/forgeplan-core/src/driver/types.rs
+++ b/crates/forgeplan-core/src/driver/types.rs
@@ -1,0 +1,32 @@
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+/// Entry in the agent memory log (decisions, context, insights).
+#[derive(Debug, Clone)]
+pub struct MemoryEntry {
+    /// When the entry was created.
+    pub timestamp: DateTime<Utc>,
+    /// Category of the memory entry.
+    pub kind: MemoryKind,
+    /// Free-form content of the entry.
+    pub content: String,
+    /// Origin of this entry (e.g. "cli", "mcp", "llm").
+    pub source: String,
+    /// Optional artifact ID this entry relates to.
+    pub artifact_id: Option<String>,
+    /// Arbitrary key-value metadata.
+    pub metadata: HashMap<String, String>,
+}
+
+/// Category of a memory entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryKind {
+    /// A decision that was made.
+    Decision,
+    /// Contextual information captured for future reference.
+    Context,
+    /// An insight derived from analysis.
+    Insight,
+    /// An action that was taken.
+    Action,
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod coverage;
 pub mod db;
 pub mod depth;
+pub mod driver;
 pub mod drift;
 pub mod embed;
 pub mod fpf;

--- a/crates/forgeplan-core/tests/driver_test.rs
+++ b/crates/forgeplan-core/tests/driver_test.rs
@@ -1,0 +1,279 @@
+//! Integration tests: same operations on Lance vs InMemory drivers.
+//! Verifies that StorageDriver trait abstraction preserves behavior.
+
+use forgeplan_core::db::store::{ArtifactFilter, NewArtifact};
+use forgeplan_core::driver::in_memory::InMemoryStore;
+use forgeplan_core::driver::lance::LanceDriver;
+use forgeplan_core::driver::StorageDriver;
+use tempfile::TempDir;
+
+/// Helper: create a NewArtifact with given fields.
+fn make_artifact(id: &str, kind: &str, title: &str, body: &str) -> NewArtifact {
+    NewArtifact {
+        id: id.to_string(),
+        kind: kind.to_string(),
+        status: "draft".to_string(),
+        title: title.to_string(),
+        body: body.to_string(),
+        depth: "standard".to_string(),
+        author: Some("test".to_string()),
+        parent_epic: None,
+        valid_until: None,
+    }
+}
+
+/// Helper: create artifact using next_id for consistent ID generation.
+async fn create_with_next_id(
+    driver: &dyn StorageDriver,
+    kind: &str,
+    title: &str,
+    body: &str,
+) -> String {
+    let id = driver.next_id(kind).await.unwrap();
+    let art = make_artifact(&id, kind, title, body);
+    driver.create_artifact(&art).await.unwrap();
+    id
+}
+
+// ── Test 1: CRUD lifecycle ─────────────────────────────────────────────
+
+async fn crud_lifecycle(driver: &dyn StorageDriver, label: &str) {
+    // create
+    let id = create_with_next_id(driver, "PRD", "Auth System", "Login flow").await;
+    assert_eq!(id, "PRD-001", "[{label}] first ID should be PRD-001");
+
+    // get
+    let summary = driver.get_artifact(&id).await.unwrap();
+    assert!(summary.is_some(), "[{label}] artifact must exist after create");
+    let summary = summary.unwrap();
+    assert_eq!(summary.title, "Auth System", "[{label}] title mismatch");
+    assert_eq!(summary.status, "draft", "[{label}] default status should be draft");
+
+    // update status
+    driver
+        .update_artifact(&id, Some("active"), None)
+        .await
+        .unwrap();
+    let updated = driver.get_artifact(&id).await.unwrap().unwrap();
+    assert_eq!(updated.status, "active", "[{label}] status should be updated");
+
+    // delete
+    driver.delete_artifact(&id).await.unwrap();
+    let gone = driver.get_artifact(&id).await.unwrap();
+    assert!(gone.is_none(), "[{label}] artifact should be None after delete");
+}
+
+#[tokio::test]
+async fn test_crud_lifecycle_inmemory() {
+    let store = InMemoryStore::new();
+    crud_lifecycle(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_crud_lifecycle_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    crud_lifecycle(&driver, "Lance").await;
+}
+
+// ── Test 2: List with kind filter ──────────────────────────────────────
+
+async fn list_with_kind_filter(driver: &dyn StorageDriver, label: &str) {
+    create_with_next_id(driver, "PRD", "PRD One", "body1").await;
+    create_with_next_id(driver, "RFC", "RFC One", "body2").await;
+    create_with_next_id(driver, "ADR", "ADR One", "body3").await;
+
+    let filter = ArtifactFilter {
+        kind: Some("PRD".to_string()),
+        status: None,
+    };
+    let prds = driver.list_artifacts(Some(&filter)).await.unwrap();
+    assert_eq!(prds.len(), 1, "[{label}] should find exactly 1 PRD");
+    assert_eq!(prds[0].kind, "PRD", "[{label}] filtered item should be PRD");
+
+    // No filter returns all
+    let all = driver.list_artifacts(None).await.unwrap();
+    assert_eq!(all.len(), 3, "[{label}] should have 3 total artifacts");
+}
+
+#[tokio::test]
+async fn test_list_with_kind_filter_inmemory() {
+    let store = InMemoryStore::new();
+    list_with_kind_filter(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_list_with_kind_filter_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    list_with_kind_filter(&driver, "Lance").await;
+}
+
+// ── Test 3: Relations ──────────────────────────────────────────────────
+
+async fn relations(driver: &dyn StorageDriver, label: &str) {
+    let prd = create_with_next_id(driver, "PRD", "PRD", "body").await;
+    let rfc = create_with_next_id(driver, "RFC", "RFC", "body").await;
+
+    driver.add_relation(&prd, &rfc, "informs").await.unwrap();
+
+    let outgoing = driver.get_relations(&prd).await.unwrap();
+    assert_eq!(outgoing.len(), 1, "[{label}] should have 1 outgoing relation");
+    assert_eq!(outgoing[0].0, rfc, "[{label}] target should be RFC");
+    assert_eq!(outgoing[0].1, "informs", "[{label}] relation type mismatch");
+
+    let incoming = driver.get_incoming_relations(&rfc).await.unwrap();
+    assert_eq!(incoming.len(), 1, "[{label}] should have 1 incoming relation");
+    assert_eq!(incoming[0].0, prd, "[{label}] source should be PRD");
+}
+
+#[tokio::test]
+async fn test_relations_inmemory() {
+    let store = InMemoryStore::new();
+    relations(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_relations_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    relations(&driver, "Lance").await;
+}
+
+// ── Test 4: Search body ────────────────────────────────────────────────
+
+async fn search_body(driver: &dyn StorageDriver, label: &str) {
+    create_with_next_id(driver, "PRD", "Auth", "OAuth2 authentication flow").await;
+    create_with_next_id(driver, "RFC", "DB Schema", "PostgreSQL migration").await;
+
+    let results = driver.search_body("oauth", None).await.unwrap();
+    assert_eq!(results.len(), 1, "[{label}] should find 1 result for 'oauth'");
+    assert_eq!(results[0].title, "Auth", "[{label}] found artifact should be Auth");
+
+    // No match
+    let empty = driver.search_body("nonexistent_xyz", None).await.unwrap();
+    assert!(empty.is_empty(), "[{label}] should find nothing for gibberish query");
+}
+
+#[tokio::test]
+async fn test_search_body_inmemory() {
+    let store = InMemoryStore::new();
+    search_body(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_search_body_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    search_body(&driver, "Lance").await;
+}
+
+// ── Test 5: next_id sequence ───────────────────────────────────────────
+
+async fn next_id_sequence(driver: &dyn StorageDriver, label: &str) {
+    // For LanceDB, next_id scans existing artifacts. We must create artifacts
+    // with the returned IDs so subsequent calls see them.
+    let id1 = driver.next_id("prd").await.unwrap();
+    assert_eq!(id1, "PRD-001", "[{label}] first should be PRD-001");
+    driver
+        .create_artifact(&make_artifact(&id1, "PRD", "T1", "b"))
+        .await
+        .unwrap();
+
+    let id2 = driver.next_id("prd").await.unwrap();
+    assert_eq!(id2, "PRD-002", "[{label}] second should be PRD-002");
+    driver
+        .create_artifact(&make_artifact(&id2, "PRD", "T2", "b"))
+        .await
+        .unwrap();
+
+    let id3 = driver.next_id("prd").await.unwrap();
+    assert_eq!(id3, "PRD-003", "[{label}] third should be PRD-003");
+}
+
+#[tokio::test]
+async fn test_next_id_sequence_inmemory() {
+    let store = InMemoryStore::new();
+    next_id_sequence(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_next_id_sequence_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    next_id_sequence(&driver, "Lance").await;
+}
+
+// ── Test 6: update_r_eff_score ─────────────────────────────────────────
+
+async fn update_r_eff(driver: &dyn StorageDriver, label: &str) {
+    let id = create_with_next_id(driver, "PRD", "Scored", "body").await;
+
+    // Default r_eff should be 0.0
+    let record = driver.get_record(&id).await.unwrap().unwrap();
+    assert!(
+        (record.r_eff_score - 0.0).abs() < f64::EPSILON,
+        "[{label}] default r_eff should be 0.0"
+    );
+
+    // Update to 0.75
+    driver.update_r_eff_score(&id, 0.75).await.unwrap();
+    let record = driver.get_record(&id).await.unwrap().unwrap();
+    assert!(
+        (record.r_eff_score - 0.75).abs() < f64::EPSILON,
+        "[{label}] r_eff should be 0.75 after update"
+    );
+}
+
+#[tokio::test]
+async fn test_update_r_eff_inmemory() {
+    let store = InMemoryStore::new();
+    update_r_eff(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_update_r_eff_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    update_r_eff(&driver, "Lance").await;
+}
+
+// ── Test 7: get_all_relations ──────────────────────────────────────────
+
+async fn get_all_relations(driver: &dyn StorageDriver, label: &str) {
+    let prd = create_with_next_id(driver, "PRD", "PRD", "body").await;
+    let rfc = create_with_next_id(driver, "RFC", "RFC", "body").await;
+    let adr = create_with_next_id(driver, "ADR", "ADR", "body").await;
+
+    driver.add_relation(&prd, &rfc, "informs").await.unwrap();
+    driver
+        .add_relation(&rfc, &adr, "implements")
+        .await
+        .unwrap();
+
+    let all = driver.get_all_relations().await.unwrap();
+    assert_eq!(all.len(), 2, "[{label}] should have 2 relations total");
+
+    // Verify both relations are present (order may vary)
+    let has_informs = all
+        .iter()
+        .any(|(s, t, r)| s == &prd && t == &rfc && r == "informs");
+    let has_implements = all
+        .iter()
+        .any(|(s, t, r)| s == &rfc && t == &adr && r == "implements");
+    assert!(has_informs, "[{label}] should contain informs relation");
+    assert!(has_implements, "[{label}] should contain implements relation");
+}
+
+#[tokio::test]
+async fn test_get_all_relations_inmemory() {
+    let store = InMemoryStore::new();
+    get_all_relations(&store, "InMemory").await;
+}
+
+#[tokio::test]
+async fn test_get_all_relations_lance() {
+    let tmp = TempDir::new().unwrap();
+    let driver = LanceDriver::init(tmp.path()).await.unwrap();
+    get_all_relations(&driver, "Lance").await;
+}


### PR DESCRIPTION
## Summary
- 4 trait definitions: StorageDriver, EmbedDriver, MemoryDriver, LlmDriver
- LanceDriver adapter (thin wrapper around existing LanceStore)
- InMemoryStore (HashMap-based, for tests)
- Factory: create_storage(config) → Arc<dyn StorageDriver>
- StorageConfig + MemoryConfig in config.yaml
- open_driver() in CLI common.rs (alongside existing open_store)
- 14 integration tests (7 scenarios x 2 backends)

## Refs
- RFC-003 Layered Architecture Phase 1
- ADR-003 Files as source of truth

## Test plan
- [x] cargo test — 476 pass, 0 fail
- [x] InMemory: 11 unit tests
- [x] Lance: 2 adapter tests  
- [x] Integration: 14 cross-driver tests (same ops on both backends)
- [x] Factory: 3 tests (lance, memory, unknown error)
- [x] Zero breaking changes (existing code untouched)

**IMPORTANT: Merge commit, NOT squash**

🤖 Generated with [Claude Code](https://claude.com/claude-code)