### PR TITLE
[PROB-014] Smart search — keyword + semantic + graph boosters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -72,12 +72,15 @@ Fixed in commit d84bc69 (fix/prob-012-integrity-remediation). 2 audit rounds, 40
 - [x] **F1 (P0)**: Embed title + body snippet — embedding_text() + forgeplan embed command
 - [x] **F2 (P0)**: Graph walk shows relation types — neighbors_with_relations()
 - [x] **F3 (P1)**: `forgeplan embed` — batch embed all artifacts (persistent in LanceDB)
-- [ ] **F4 (P1)**: Combined score (vector * 0.5 + R_eff * 0.3 + graph_centrality * 0.2)
+- [x] **F4 (P1)**: Smart search — text-first + boosters (Algolia-style, not weighted sum). EVID-033.
 - [x] **F5 (P1)**: `forgeplan gaps` — 18 MUST gaps found on real data! Audit: 4 fixes.
 - [ ] **F6 (P2)**: Fix evidence blind spots (EVID-015, EVID-025, EVID-026, EVID-027)
-- [ ] `forgeplan search --semantic` — vector search by meaning
-- [ ] `forgeplan search --smart` — keyword + vector + graph combined
+- [x] `forgeplan search --semantic` — vector-only search
+- [x] `forgeplan search` — smart by default (keyword + semantic + R_eff + status + graph boosters)
+- [x] `forgeplan search --keyword` — forced keyword grep
 - [x] Configurable embedding model via config.yaml (BGE-M3 default)
+- [x] Configurable chunk_size via config.yaml (default 2000)
+- [ ] **Future**: Reciprocal Rank Fusion (RRF) for production-grade hybrid search
 
 ### P1: Driver Abstraction — RFC-003
 - [x] **Phase 1**: StorageDriver trait + LanceDriver + InMemoryStore + factory — PR #61 merged

--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use forgeplan_core::config::types::Config;
 use forgeplan_core::db::store::LanceStore;
 use forgeplan_core::workspace;
 
@@ -11,6 +12,14 @@ pub async fn open_store() -> anyhow::Result<(PathBuf, LanceStore)> {
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
     let store = LanceStore::open(&ws).await?;
     Ok((ws, store))
+}
+
+/// Load workspace config.
+pub fn config() -> anyhow::Result<Config> {
+    let cwd = std::env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    workspace::load_config(&ws)
 }
 
 /// Open workspace store, returning only the store (most common case).

--- a/crates/forgeplan-cli/src/commands/embed.rs
+++ b/crates/forgeplan-cli/src/commands/embed.rs
@@ -6,6 +6,12 @@ pub async fn run() -> anyhow::Result<()> {
     use forgeplan_core::embed::Embedder;
 
     let store = common::store().await?;
+    let config = common::config().unwrap_or_default();
+    let chunk_size = config
+        .embedding
+        .as_ref()
+        .map(|e| e.chunk_size)
+        .unwrap_or(2000);
 
     ui::info("Loading embedding model...");
     let mut embedder = Embedder::new()?;
@@ -16,13 +22,17 @@ pub async fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    println!("Embedding {} artifact(s) (title + body)...\n", records.len());
+    println!(
+        "Embedding {} artifact(s) (title + body, chunk_size={})...\n",
+        records.len(),
+        chunk_size
+    );
 
     let mut ok = 0usize;
     let mut err = 0usize;
 
     for record in &records {
-        let text = record.embedding_text();
+        let text = record.embedding_text(chunk_size);
         match embedder.embed(&text) {
             Ok(vec) => {
                 store.update_embedding(&record.id, &vec).await?;

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -1,25 +1,33 @@
-
 use crate::commands::common;
 use crate::ui;
 
-pub async fn run(query: &str, kind: Option<&str>, semantic: bool, json: bool) -> anyhow::Result<()> {
-    let store = common::store().await?;
+/// Search mode determined by CLI flags.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SearchMode {
+    /// Default: keyword + semantic + boosters (graceful degradation if no embeddings)
+    Smart,
+    /// Forced keyword-only (substring grep)
+    Keyword,
+    /// Forced semantic-only (vector similarity)
+    Semantic,
+}
 
-    if semantic {
-        #[cfg(feature = "semantic-search")]
-        {
-            return run_semantic(&store, query).await;
-        }
-        #[cfg(not(feature = "semantic-search"))]
-        {
-            anyhow::bail!(
-                "Semantic search not available. Rebuild with: \
-                 cargo build --features semantic-search"
-            );
-        }
+pub async fn run(
+    query: &str,
+    kind: Option<&str>,
+    mode: SearchMode,
+    json: bool,
+) -> anyhow::Result<()> {
+    match mode {
+        SearchMode::Keyword => run_keyword(query, kind, json).await,
+        SearchMode::Semantic => run_semantic_only(query, json).await,
+        SearchMode::Smart => run_smart(query, kind, json).await,
     }
+}
 
-    // Substring search (default)
+/// Keyword-only search (substring grep on title + body).
+async fn run_keyword(query: &str, kind: Option<&str>, json: bool) -> anyhow::Result<()> {
+    let store = common::store().await?;
     let hits = store.search_body(query, kind).await?;
 
     if hits.is_empty() {
@@ -34,12 +42,15 @@ pub async fn run(query: &str, kind: Option<&str>, semantic: bool, json: bool) ->
     if json {
         let json_data: Vec<_> = hits
             .iter()
-            .map(|r| serde_json::json!({
-                "id": r.id,
-                "kind": r.kind,
-                "status": r.status,
-                "title": r.title,
-            }))
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "kind": r.kind,
+                    "status": r.status,
+                    "title": r.title,
+                    "mode": "keyword",
+                })
+            })
             .collect();
         println!("{}", serde_json::to_string_pretty(&json_data)?);
         return Ok(());
@@ -81,34 +92,211 @@ pub async fn run(query: &str, kind: Option<&str>, semantic: bool, json: bool) ->
     Ok(())
 }
 
-#[cfg(feature = "semantic-search")]
-async fn run_semantic(
-    store: &LanceStore,
-    query: &str,
-) -> anyhow::Result<()> {
-    use forgeplan_core::embed::Embedder;
+/// Semantic-only search (vector similarity).
+async fn run_semantic_only(query: &str, json: bool) -> anyhow::Result<()> {
+    #[cfg(feature = "semantic-search")]
+    {
+        use forgeplan_core::embed::Embedder;
 
-    println!("  Embedding query...");
-    let mut embedder = Embedder::new()?;
-    let query_vec = embedder.embed(query)?;
+        let store = common::store().await?;
 
-    let hits = store.vector_search(&query_vec, 10).await?;
+        let mut embedder = Embedder::new()?;
+        let query_vec = embedder.embed(query)?;
+        let hits = store.vector_search(&query_vec, 10).await?;
 
-    if hits.is_empty() {
-        println!("No semantic results for \"{}\"", query);
-        println!("Hint: Artifacts need embeddings. Use `forgeplan embed` to generate them.");
+        if hits.is_empty() {
+            if json {
+                println!("[]");
+            } else {
+                ui::info(&format!("No semantic results for \"{}\"", query));
+                println!("  Hint: run `forgeplan embed` to generate embeddings.");
+            }
+            return Ok(());
+        }
+
+        if json {
+            let json_data: Vec<_> = hits
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "id": r.id,
+                        "kind": r.kind,
+                        "status": r.status,
+                        "title": r.title,
+                        "mode": "semantic",
+                    })
+                })
+                .collect();
+            println!("{}", serde_json::to_string_pretty(&json_data)?);
+            return Ok(());
+        }
+
+        println!(
+            "Found {} artifact(s) semantically similar to \"{}\":\n",
+            hits.len(),
+            query
+        );
+        for record in &hits {
+            println!("  {} [{}] \"{}\"", record.id, record.kind, record.title);
+        }
+
+        Ok(())
+    }
+    #[cfg(not(feature = "semantic-search"))]
+    {
+        let _ = (query, json);
+        anyhow::bail!(
+            "Semantic search not available. Rebuild with: \
+             cargo build --features semantic-search"
+        );
+    }
+}
+
+/// Smart search: keyword + semantic + graph boosters.
+/// Graceful degradation: if embeddings unavailable, uses keyword only + hint.
+async fn run_smart(query: &str, kind: Option<&str>, json: bool) -> anyhow::Result<()> {
+    use forgeplan_core::graph::knowledge::KnowledgeGraph;
+    use forgeplan_core::search::smart;
+
+    let store = common::store().await?;
+
+    // Load all records (with optional kind filter applied after scoring)
+    let records = store.list_records(None).await?;
+    if records.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            ui::info("No artifacts found.");
+        }
         return Ok(());
     }
 
-    println!(
-        "Found {} artifact(s) semantically similar to \"{}\":\n",
-        hits.len(),
-        query
+    // Try to get semantic scores (graceful degradation)
+    let (semantic_scores, has_embeddings) = get_semantic_scores(&store, query).await;
+
+    // Build knowledge graph for centrality booster
+    let graph = KnowledgeGraph::from_store(&store).await.ok();
+
+    // Run smart search
+    let results = smart::smart_search(
+        &records,
+        query,
+        semantic_scores.as_ref(),
+        graph.as_ref(),
+        20,
     );
 
-    for record in &hits {
-        println!("  {} [{}] \"{}\"", record.id, record.kind, record.title);
+    // Apply kind filter post-scoring (so boosters still use full graph)
+    let results: Vec<_> = if let Some(k) = kind {
+        results
+            .into_iter()
+            .filter(|r| r.kind.eq_ignore_ascii_case(k))
+            .collect()
+    } else {
+        results
+    };
+
+    if results.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            ui::info(&format!("No results for \"{}\"", query));
+        }
+        return Ok(());
+    }
+
+    if json {
+        let json_data: Vec<_> = results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "kind": r.kind,
+                    "status": r.status,
+                    "title": r.title,
+                    "score": format!("{:.2}", r.score),
+                    "keyword_score": format!("{:.2}", r.keyword_score),
+                    "semantic_score": format!("{:.2}", r.semantic_score),
+                    "r_eff": format!("{:.2}", r.r_eff),
+                    "graph_centrality": format!("{:.2}", r.graph_centrality),
+                    "mode": "smart",
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&json_data)?);
+    } else {
+        println!(
+            "Found {} result(s) for \"{}\" (smart search):\n",
+            results.len(),
+            query
+        );
+        for r in &results {
+            let signals = format!(
+                "kw={:.1} sem={:.1} r={:.1} g={:.1}",
+                r.keyword_score, r.semantic_score, r.r_eff, r.graph_centrality
+            );
+            println!(
+                "  {:.2}  {} [{}|{}] \"{}\"",
+                r.score, r.id, r.kind, r.status, r.title
+            );
+            println!("        {}", signals);
+        }
+
+        if !has_embeddings {
+            println!();
+            println!(
+                "  Tip: run `forgeplan embed` to enable semantic search for better results."
+            );
+        }
     }
 
     Ok(())
+}
+
+/// Try to compute semantic scores for all artifacts.
+/// Returns (Some(map), true) if embeddings available, (None, false) otherwise.
+async fn get_semantic_scores(
+    store: &forgeplan_core::db::store::LanceStore,
+    query: &str,
+) -> (
+    Option<std::collections::HashMap<String, f64>>,
+    bool,
+) {
+    #[cfg(feature = "semantic-search")]
+    {
+        use forgeplan_core::embed::Embedder;
+
+        // Try to create embedder — if model not available, degrade gracefully
+        let mut embedder = match Embedder::new() {
+            Ok(e) => e,
+            Err(_) => return (None, false),
+        };
+
+        let query_vec = match embedder.embed(query) {
+            Ok(v) => v,
+            Err(_) => return (None, false),
+        };
+
+        let hits = match store.vector_search(&query_vec, 50).await {
+            Ok(h) if !h.is_empty() => h,
+            _ => return (None, false),
+        };
+
+        // Normalize cosine distances to similarity scores [0..1]
+        // LanceDB returns distance (lower = more similar), convert to similarity
+        let mut map = std::collections::HashMap::new();
+        let max_rank = hits.len() as f64;
+        for (i, record) in hits.iter().enumerate() {
+            // Rank-based score: top result = 1.0, last = close to 0
+            let score = 1.0 - (i as f64 / max_rank);
+            map.insert(record.id.clone(), score);
+        }
+
+        (Some(map), true)
+    }
+    #[cfg(not(feature = "semantic-search"))]
+    {
+        let _ = (store, query);
+        (None, false)
+    }
 }

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -18,9 +18,12 @@ pub async fn run(
     mode: SearchMode,
     json: bool,
 ) -> anyhow::Result<()> {
+    if query.trim().is_empty() {
+        anyhow::bail!("Search query cannot be empty.");
+    }
     match mode {
         SearchMode::Keyword => run_keyword(query, kind, json).await,
-        SearchMode::Semantic => run_semantic_only(query, json).await,
+        SearchMode::Semantic => run_semantic_only(query, kind, json).await,
         SearchMode::Smart => run_smart(query, kind, json).await,
     }
 }
@@ -93,7 +96,7 @@ async fn run_keyword(query: &str, kind: Option<&str>, json: bool) -> anyhow::Res
 }
 
 /// Semantic-only search (vector similarity).
-async fn run_semantic_only(query: &str, json: bool) -> anyhow::Result<()> {
+async fn run_semantic_only(query: &str, kind: Option<&str>, json: bool) -> anyhow::Result<()> {
     #[cfg(feature = "semantic-search")]
     {
         use forgeplan_core::embed::Embedder;
@@ -102,7 +105,12 @@ async fn run_semantic_only(query: &str, json: bool) -> anyhow::Result<()> {
 
         let mut embedder = Embedder::new()?;
         let query_vec = embedder.embed(query)?;
-        let hits = store.vector_search(&query_vec, 10).await?;
+        let all_hits = store.vector_search(&query_vec, 50).await?;
+        let hits: Vec<_> = if let Some(k) = kind {
+            all_hits.into_iter().filter(|r| r.kind.eq_ignore_ascii_case(k)).take(10).collect()
+        } else {
+            all_hits.into_iter().take(10).collect()
+        };
 
         if hits.is_empty() {
             if json {
@@ -144,10 +152,11 @@ async fn run_semantic_only(query: &str, json: bool) -> anyhow::Result<()> {
     }
     #[cfg(not(feature = "semantic-search"))]
     {
-        let _ = (query, json);
+        let _ = (query, kind, json);
         anyhow::bail!(
             "Semantic search not available. Rebuild with: \
-             cargo build --features semantic-search"
+             cargo build --features semantic-search\n\
+             For automatic fallback, use smart search (default) without --semantic."
         );
     }
 }
@@ -214,12 +223,13 @@ async fn run_smart(query: &str, kind: Option<&str>, json: bool) -> anyhow::Resul
                     "kind": r.kind,
                     "status": r.status,
                     "title": r.title,
-                    "score": format!("{:.2}", r.score),
-                    "keyword_score": format!("{:.2}", r.keyword_score),
-                    "semantic_score": format!("{:.2}", r.semantic_score),
-                    "r_eff": format!("{:.2}", r.r_eff),
-                    "graph_centrality": format!("{:.2}", r.graph_centrality),
+                    "score": (r.score * 100.0).round() / 100.0,
+                    "keyword_score": (r.keyword_score * 100.0).round() / 100.0,
+                    "semantic_score": (r.semantic_score * 100.0).round() / 100.0,
+                    "r_eff": (r.r_eff * 100.0).round() / 100.0,
+                    "graph_centrality": (r.graph_centrality * 100.0).round() / 100.0,
                     "mode": "smart",
+                    "semantic_available": has_embeddings,
                 })
             })
             .collect();

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -94,15 +94,18 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Search artifacts by keyword (or --semantic for vector similarity search)
+    /// Search artifacts (smart by default: keyword + semantic + boosters)
     Search {
         /// Search query
         query: String,
         /// Filter by kind
         #[arg(long, short = 't')]
         r#type: Option<String>,
-        /// Use semantic (vector) search instead of substring match
-        #[arg(long)]
+        /// Force keyword-only search (substring grep)
+        #[arg(long, conflicts_with = "semantic")]
+        keyword: bool,
+        /// Force semantic-only search (vector similarity)
+        #[arg(long, conflicts_with = "keyword")]
         semantic: bool,
         /// Output as JSON for machine consumption
         #[arg(long)]
@@ -421,10 +424,18 @@ async fn main() -> anyhow::Result<()> {
         Commands::Search {
             query,
             r#type,
+            keyword,
             semantic,
             json,
         } => {
-            commands::search::run(&query, r#type.as_deref(), semantic, json).await
+            let mode = if keyword {
+                commands::search::SearchMode::Keyword
+            } else if semantic {
+                commands::search::SearchMode::Semantic
+            } else {
+                commands::search::SearchMode::Smart
+            };
+            commands::search::run(&query, r#type.as_deref(), mode, json).await
         }
         Commands::Stale { json } => commands::stale::run(json).await,
         Commands::Progress { id, json } => commands::progress::run(id.as_deref(), json).await,

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -157,16 +157,24 @@ pub struct EmbeddingConfig {
     /// Model name: bge-m3, bge-small-en, multilingual-e5-small, multilingual-e5-base
     #[serde(default = "default_embedding_model")]
     pub model: String,
+    /// Max characters of body to include in embedding text. Default: 2000.
+    #[serde(default = "default_chunk_size")]
+    pub chunk_size: usize,
 }
 
 fn default_embedding_model() -> String {
     "bge-m3".into()
 }
 
+fn default_chunk_size() -> usize {
+    2000
+}
+
 impl Default for EmbeddingConfig {
     fn default() -> Self {
         Self {
             model: default_embedding_model(),
+            chunk_size: default_chunk_size(),
         }
     }
 }

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -52,13 +52,14 @@ pub struct ArtifactRecord {
 }
 
 impl ArtifactRecord {
-    /// Build the text used for embedding: id + title + first 300 chars of body.
+    /// Build the text used for embedding: title + first `chunk_size` chars of body.
     ///
-    /// This ensures semantic search can find artifacts based on body content
-    /// (FR, Goals, Problem sections), not just the title.
-    pub fn embedding_text(&self) -> String {
-        let body_preview: String = self.body.chars().take(300).collect();
-        format!("{} {} {}", self.id, self.title, body_preview)
+    /// ID is excluded — it has no semantic meaning and pollutes the vector space.
+    /// Default chunk_size=2000 captures Problem/Goals/FR sections.
+    /// Configurable via `embedding.chunk_size` in config.yaml.
+    pub fn embedding_text(&self, chunk_size: usize) -> String {
+        let body_preview: String = self.body.chars().take(chunk_size).collect();
+        format!("{} {}", self.title, body_preview)
     }
 
     /// Convert to a lightweight ArtifactSummary (drops body and most metadata).
@@ -1621,16 +1622,16 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".to_string(),
         };
 
-        let text = record.embedding_text();
-        assert!(text.contains("PRD-042"), "should contain artifact id");
+        let text = record.embedding_text(2000);
+        assert!(!text.contains("PRD-042"), "should NOT contain artifact id (no semantic value)");
         assert!(text.contains("Authentication Module"), "should contain title");
         assert!(text.contains("OAuth2"), "should contain body content");
         assert!(text.contains("Google and GitHub"), "should contain body goals");
     }
 
     #[test]
-    fn embedding_text_truncates_long_body_at_300_chars() {
-        let long_body = "x".repeat(500);
+    fn embedding_text_truncates_body_at_chunk_size() {
+        let long_body = "x".repeat(5000);
         let record = ArtifactRecord {
             id: "PRD-001".to_string(),
             kind: "prd".to_string(),
@@ -1646,10 +1647,14 @@ mod tests {
             updated_at: "2026-01-01T00:00:00Z".to_string(),
         };
 
-        let text = record.embedding_text();
-        // "PRD-001 Title " = 15 chars + 300 body chars = 315
-        // But we count chars, not bytes, so check total body part
-        let body_part = text.strip_prefix("PRD-001 Title ").unwrap();
-        assert_eq!(body_part.len(), 300, "body should be truncated to 300 chars");
+        // Default chunk_size=2000
+        let text = record.embedding_text(2000);
+        let body_part = text.strip_prefix("Title ").unwrap();
+        assert_eq!(body_part.len(), 2000, "body should be truncated to chunk_size");
+
+        // Custom chunk_size=500
+        let text_small = record.embedding_text(500);
+        let body_small = text_small.strip_prefix("Title ").unwrap();
+        assert_eq!(body_small.len(), 500, "body should respect custom chunk_size");
     }
 }

--- a/crates/forgeplan-core/src/graph/knowledge.rs
+++ b/crates/forgeplan-core/src/graph/knowledge.rs
@@ -183,8 +183,9 @@ impl KnowledgeGraph {
         self.graph.edge_count()
     }
 
-    /// Normalized degree centrality for an artifact: (in_degree + out_degree) / (N - 1).
+    /// Normalized degree centrality for an artifact: (unique_neighbors) / (N - 1).
     ///
+    /// Deduplicates parallel edges (multiple relation types between same pair).
     /// Returns 0.0 for unknown IDs or graphs with fewer than 2 nodes.
     /// Result is in [0.0, 1.0] — suitable as a search booster.
     pub fn degree_centrality(&self, id: &str) -> f64 {
@@ -195,15 +196,14 @@ impl KnowledgeGraph {
         let Some(&idx) = self.index.get(id) else {
             return 0.0;
         };
-        let in_deg = self
-            .graph
-            .neighbors_directed(idx, Direction::Incoming)
-            .count();
-        let out_deg = self
-            .graph
-            .neighbors_directed(idx, Direction::Outgoing)
-            .count();
-        (in_deg + out_deg) as f64 / (n - 1) as f64
+        let mut unique_neighbors = std::collections::HashSet::new();
+        for neighbor in self.graph.neighbors_directed(idx, Direction::Incoming) {
+            unique_neighbors.insert(neighbor);
+        }
+        for neighbor in self.graph.neighbors_directed(idx, Direction::Outgoing) {
+            unique_neighbors.insert(neighbor);
+        }
+        unique_neighbors.len() as f64 / (n - 1) as f64
     }
 }
 
@@ -422,6 +422,25 @@ mod tests {
         let kg = KnowledgeGraph::from_parts(nodes, vec![]);
         // N < 2 => 0.0
         assert_eq!(kg.degree_centrality("PRD-001"), 0.0);
+    }
+
+    #[test]
+    fn degree_centrality_parallel_edges_deduped() {
+        let nodes = vec![
+            make_node("PRD-001", "prd", "active"),
+            make_node("RFC-001", "rfc", "active"),
+        ];
+        // Two parallel edges: RFC-001 -> PRD-001 with different relation types
+        let edges = vec![
+            ("RFC-001".into(), "PRD-001".into(), "based_on".into()),
+            ("RFC-001".into(), "PRD-001".into(), "informs".into()),
+        ];
+        let kg = KnowledgeGraph::from_parts(nodes, edges);
+
+        // PRD-001 has 1 unique neighbor (RFC-001), not 2
+        let c = kg.degree_centrality("PRD-001");
+        assert!(c <= 1.0, "centrality must be <= 1.0 even with parallel edges");
+        assert!((c - 1.0).abs() < 0.001, "1 unique neighbor / (2-1) = 1.0");
     }
 
     #[test]

--- a/crates/forgeplan-core/src/graph/knowledge.rs
+++ b/crates/forgeplan-core/src/graph/knowledge.rs
@@ -182,6 +182,29 @@ impl KnowledgeGraph {
     pub fn edge_count(&self) -> usize {
         self.graph.edge_count()
     }
+
+    /// Normalized degree centrality for an artifact: (in_degree + out_degree) / (N - 1).
+    ///
+    /// Returns 0.0 for unknown IDs or graphs with fewer than 2 nodes.
+    /// Result is in [0.0, 1.0] — suitable as a search booster.
+    pub fn degree_centrality(&self, id: &str) -> f64 {
+        let n = self.graph.node_count();
+        if n < 2 {
+            return 0.0;
+        }
+        let Some(&idx) = self.index.get(id) else {
+            return 0.0;
+        };
+        let in_deg = self
+            .graph
+            .neighbors_directed(idx, Direction::Incoming)
+            .count();
+        let out_deg = self
+            .graph
+            .neighbors_directed(idx, Direction::Outgoing)
+            .count();
+        (in_deg + out_deg) as f64 / (n - 1) as f64
+    }
 }
 
 #[cfg(test)]
@@ -360,6 +383,45 @@ mod tests {
         let nodes = vec![make_node("PRD-001", "prd", "active")];
         let kg = KnowledgeGraph::from_parts(nodes, vec![]);
         assert!(kg.get("NONEXISTENT").is_none());
+    }
+
+    #[test]
+    fn degree_centrality_basic() {
+        let nodes = vec![
+            make_node("PRD-001", "prd", "active"),
+            make_node("RFC-001", "rfc", "active"),
+            make_node("EVID-001", "evidence", "active"),
+            make_node("ADR-001", "adr", "active"),
+        ];
+        let edges = vec![
+            ("RFC-001".into(), "PRD-001".into(), "based_on".into()),
+            ("EVID-001".into(), "PRD-001".into(), "informs".into()),
+            ("ADR-001".into(), "RFC-001".into(), "decides".into()),
+        ];
+        let kg = KnowledgeGraph::from_parts(nodes, edges);
+
+        // PRD-001: 2 incoming edges, 0 outgoing => degree = 2 / (4-1) = 0.667
+        let prd_c = kg.degree_centrality("PRD-001");
+        assert!((prd_c - 2.0 / 3.0).abs() < 0.001);
+
+        // RFC-001: 1 outgoing + 1 incoming => degree = 2 / 3 = 0.667
+        let rfc_c = kg.degree_centrality("RFC-001");
+        assert!((rfc_c - 2.0 / 3.0).abs() < 0.001);
+
+        // ADR-001: 1 outgoing, 0 incoming => degree = 1 / 3 = 0.333
+        let adr_c = kg.degree_centrality("ADR-001");
+        assert!((adr_c - 1.0 / 3.0).abs() < 0.001);
+
+        // Unknown ID => 0.0
+        assert_eq!(kg.degree_centrality("NONEXISTENT"), 0.0);
+    }
+
+    #[test]
+    fn degree_centrality_single_node() {
+        let nodes = vec![make_node("PRD-001", "prd", "active")];
+        let kg = KnowledgeGraph::from_parts(nodes, vec![]);
+        // N < 2 => 0.0
+        assert_eq!(kg.degree_centrality("PRD-001"), 0.0);
     }
 
     #[test]

--- a/crates/forgeplan-core/src/search/mod.rs
+++ b/crates/forgeplan-core/src/search/mod.rs
@@ -1,3 +1,5 @@
+pub mod smart;
+
 use std::path::Path;
 
 use regex::RegexBuilder;

--- a/crates/forgeplan-core/src/search/smart.rs
+++ b/crates/forgeplan-core/src/search/smart.rs
@@ -35,14 +35,16 @@ pub struct SmartSearchResult {
 /// Case-insensitive matching.
 pub fn keyword_score(record: &ArtifactRecord, query: &str) -> f64 {
     let q = query.to_lowercase();
+    if q.trim().is_empty() {
+        return 0.0;
+    }
     let title_lower = record.title.to_lowercase();
-    let body_lower = record.body.to_lowercase();
 
     if title_lower == q {
         1.0
     } else if title_lower.contains(&q) {
         0.8
-    } else if body_lower.contains(&q) {
+    } else if record.body.to_lowercase().contains(&q) {
         0.5
     } else {
         0.0
@@ -62,14 +64,15 @@ pub fn combined_score(
     is_active: bool,
     graph_centrality: f64,
 ) -> f64 {
-    let base = keyword.max(semantic);
+    let safe = |v: f64| if v.is_finite() { v.clamp(0.0, 1.0) } else { 0.0 };
+    let base = safe(keyword).max(safe(semantic));
     if base == 0.0 {
         return 0.0;
     }
     let boost = 1.0
-        + (r_eff.clamp(0.0, 1.0) * 0.2)
+        + (safe(r_eff) * 0.2)
         + (if is_active { 0.1 } else { 0.0 })
-        + (graph_centrality.clamp(0.0, 1.0) * 0.1);
+        + (safe(graph_centrality) * 0.1);
     base * boost
 }
 
@@ -116,7 +119,12 @@ pub fn smart_search(
         })
         .collect();
 
-    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.id.cmp(&b.id))
+    });
     results.truncate(limit);
     results
 }
@@ -276,9 +284,132 @@ mod tests {
     }
 
     #[test]
-    fn smart_search_empty_query_returns_nothing() {
+    fn keyword_no_match_returns_nothing() {
         let records = vec![make_record("PRD-001", "Auth", "body", "active", 0.0)];
         let results = smart_search(&records, "zzz-no-match", None, None, 10);
         assert!(results.is_empty());
+    }
+
+    // ── audit findings: edge cases ──────────────────────────────────
+
+    #[test]
+    fn keyword_empty_query_returns_zero() {
+        let r = make_record("PRD-001", "Auth", "body", "active", 0.0);
+        assert_eq!(keyword_score(&r, ""), 0.0);
+        assert_eq!(keyword_score(&r, "  "), 0.0);
+    }
+
+    #[test]
+    fn combined_nan_inputs_return_finite() {
+        let score = combined_score(f64::NAN, 0.5, 0.5, true, 0.5);
+        assert!(score.is_finite(), "NaN keyword should be sanitized");
+
+        let score2 = combined_score(0.5, f64::NAN, 0.5, true, 0.5);
+        assert!(score2.is_finite(), "NaN semantic should be sanitized");
+
+        let score3 = combined_score(0.5, 0.5, f64::NAN, true, 0.5);
+        assert!(score3.is_finite(), "NaN r_eff should be sanitized");
+
+        let score4 = combined_score(0.5, 0.5, 0.5, true, f64::NAN);
+        assert!(score4.is_finite(), "NaN centrality should be sanitized");
+    }
+
+    #[test]
+    fn combined_infinity_inputs_sanitized() {
+        // INFINITY is not finite → safe() returns 0.0 → base = 0.0 → early return 0.0
+        let score = combined_score(f64::INFINITY, 0.0, 0.0, false, 0.0);
+        assert!(score.is_finite());
+        assert_eq!(score, 0.0, "infinite keyword treated as no match");
+
+        // With a valid semantic, infinity keyword is ignored, semantic used as base
+        let score2 = combined_score(f64::INFINITY, 0.8, 0.0, false, 0.0);
+        assert!(score2.is_finite());
+        assert!((score2 - 0.8).abs() < 0.001, "valid semantic used as base");
+    }
+
+    #[test]
+    fn combined_negative_inputs_clamped() {
+        let score = combined_score(0.5, 0.0, -1.0, false, -1.0);
+        // negative r_eff and centrality clamped to 0.0, boost = 1.0
+        assert!((score - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn smart_search_empty_records() {
+        let results = smart_search(&[], "auth", None, None, 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn smart_search_empty_query() {
+        let records = vec![make_record("PRD-001", "Auth", "body", "active", 0.0)];
+        let results = smart_search(&records, "", None, None, 10);
+        assert!(results.is_empty(), "empty query should return nothing");
+    }
+
+    #[test]
+    fn smart_search_limit_zero() {
+        let records = vec![make_record("PRD-001", "Auth", "", "active", 0.0)];
+        let results = smart_search(&records, "auth", None, None, 0);
+        assert!(results.is_empty(), "limit=0 returns nothing");
+    }
+
+    #[test]
+    fn smart_search_nan_r_eff_handled() {
+        let records = vec![make_record("PRD-001", "Auth", "", "active", f64::NAN)];
+        let results = smart_search(&records, "auth", None, None, 10);
+        assert_eq!(results.len(), 1);
+        assert!(results[0].score.is_finite(), "NaN r_eff must not corrupt score");
+    }
+
+    #[test]
+    fn smart_search_all_three_signals() {
+        use crate::graph::knowledge::{ArtifactNode, KnowledgeGraph};
+
+        let records = vec![
+            make_record("PRD-001", "Auth System", "", "active", 0.0),
+            make_record("PRD-002", "Perf System", "", "active", 1.0),
+        ];
+
+        // PRD-002 has high semantic, high r_eff, high centrality but no keyword match
+        // PRD-001 has keyword match but no semantic, no r_eff, no centrality
+        let mut sem = HashMap::new();
+        sem.insert("PRD-002".to_string(), 0.95);
+
+        let nodes = vec![
+            ArtifactNode { id: "PRD-001".into(), kind: "prd".into(), status: "active".into() },
+            ArtifactNode { id: "PRD-002".into(), kind: "prd".into(), status: "active".into() },
+            ArtifactNode { id: "RFC-001".into(), kind: "rfc".into(), status: "active".into() },
+        ];
+        let edges = vec![
+            ("RFC-001".into(), "PRD-002".into(), "based_on".into()),
+        ];
+        let graph = KnowledgeGraph::from_parts(nodes, edges);
+
+        let results = smart_search(&records, "auth", Some(&sem), Some(&graph), 10);
+        assert_eq!(results.len(), 2);
+        // PRD-002: sem=0.95 * boost(r_eff=1.0, active, centrality=0.5)
+        // PRD-001: kw=0.8 * boost(r_eff=0.0, active, centrality=0.0)
+        assert_eq!(results[0].id, "PRD-002", "semantic+boosters should outrank keyword-only");
+    }
+
+    #[test]
+    fn smart_search_sort_stability_tiebreaker() {
+        let records = vec![
+            make_record("PRD-002", "Auth", "", "active", 0.0),
+            make_record("PRD-001", "Auth", "", "active", 0.0),
+        ];
+        let results = smart_search(&records, "auth", None, None, 10);
+        assert_eq!(results.len(), 2);
+        // Same score — tiebreaker by id ascending
+        assert_eq!(results[0].id, "PRD-001");
+        assert_eq!(results[1].id, "PRD-002");
+    }
+
+    #[test]
+    fn keyword_unicode_cyrillic() {
+        let r = make_record("PRD-001", "Аутентификация", "Логин через OAuth", "active", 0.0);
+        assert_eq!(keyword_score(&r, "аутентификация"), 1.0);
+        assert!((keyword_score(&r, "логин") - 0.5).abs() < 0.001);
     }
 }

--- a/crates/forgeplan-core/src/search/smart.rs
+++ b/crates/forgeplan-core/src/search/smart.rs
@@ -1,0 +1,284 @@
+//! Smart search: combines keyword, semantic, and graph signals.
+//!
+//! Scoring model: text-first + boosters.
+//! base_score = max(keyword_score, semantic_score)
+//! boost = 1.0 + (r_eff * 0.2) + (is_active * 0.1) + (graph_centrality * 0.1)
+//! final_score = base_score * boost
+//!
+//! If embeddings are unavailable, gracefully degrades to keyword-only.
+
+use crate::db::store::ArtifactRecord;
+use crate::graph::knowledge::KnowledgeGraph;
+
+/// A search result with combined score and signal breakdown.
+#[derive(Debug, Clone)]
+pub struct SmartSearchResult {
+    pub id: String,
+    pub title: String,
+    pub kind: String,
+    pub status: String,
+    pub score: f64,
+    pub keyword_score: f64,
+    pub semantic_score: f64,
+    pub r_eff: f64,
+    pub graph_centrality: f64,
+}
+
+/// Compute keyword relevance score for a record against a query.
+///
+/// Returns a score in [0.0, 1.0] based on:
+/// - Title exact match: 1.0
+/// - Title contains query: 0.8
+/// - Body contains query: 0.5
+/// - No match: 0.0
+///
+/// Case-insensitive matching.
+pub fn keyword_score(record: &ArtifactRecord, query: &str) -> f64 {
+    let q = query.to_lowercase();
+    let title_lower = record.title.to_lowercase();
+    let body_lower = record.body.to_lowercase();
+
+    if title_lower == q {
+        1.0
+    } else if title_lower.contains(&q) {
+        0.8
+    } else if body_lower.contains(&q) {
+        0.5
+    } else {
+        0.0
+    }
+}
+
+/// Combine keyword score, semantic score, and boosters into a final score.
+///
+/// Formula: max(keyword, semantic) * (1.0 + r_eff_boost + status_boost + graph_boost)
+/// - r_eff_boost: r_eff * 0.2 (quality artifacts rank higher)
+/// - status_boost: 0.1 if active, 0.0 otherwise
+/// - graph_boost: degree_centrality * 0.1 (well-connected artifacts rank higher)
+pub fn combined_score(
+    keyword: f64,
+    semantic: f64,
+    r_eff: f64,
+    is_active: bool,
+    graph_centrality: f64,
+) -> f64 {
+    let base = keyword.max(semantic);
+    if base == 0.0 {
+        return 0.0;
+    }
+    let boost = 1.0
+        + (r_eff.clamp(0.0, 1.0) * 0.2)
+        + (if is_active { 0.1 } else { 0.0 })
+        + (graph_centrality.clamp(0.0, 1.0) * 0.1);
+    base * boost
+}
+
+/// Run smart search across all records.
+///
+/// `semantic_scores` is an optional map of artifact_id -> cosine_similarity.
+/// If None (embeddings unavailable), only keyword + boosters are used.
+pub fn smart_search(
+    records: &[ArtifactRecord],
+    query: &str,
+    semantic_scores: Option<&std::collections::HashMap<String, f64>>,
+    graph: Option<&KnowledgeGraph>,
+    limit: usize,
+) -> Vec<SmartSearchResult> {
+    let mut results: Vec<SmartSearchResult> = records
+        .iter()
+        .filter_map(|record| {
+            let kw = keyword_score(record, query);
+            let sem = semantic_scores
+                .and_then(|m| m.get(&record.id))
+                .copied()
+                .unwrap_or(0.0);
+            let centrality = graph
+                .map(|g| g.degree_centrality(&record.id))
+                .unwrap_or(0.0);
+            let is_active = record.status.eq_ignore_ascii_case("active");
+            let score = combined_score(kw, sem, record.r_eff_score, is_active, centrality);
+
+            if score > 0.0 {
+                Some(SmartSearchResult {
+                    id: record.id.clone(),
+                    title: record.title.clone(),
+                    kind: record.kind.clone(),
+                    status: record.status.clone(),
+                    score,
+                    keyword_score: kw,
+                    semantic_score: sem,
+                    r_eff: record.r_eff_score,
+                    graph_centrality: centrality,
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results.truncate(limit);
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_record(id: &str, title: &str, body: &str, status: &str, r_eff: f64) -> ArtifactRecord {
+        ArtifactRecord {
+            id: id.to_string(),
+            kind: "prd".to_string(),
+            status: status.to_string(),
+            title: title.to_string(),
+            body: body.to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            r_eff_score: r_eff,
+            valid_until: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    // ── keyword_score ───────────────────────────────────────────────
+
+    #[test]
+    fn keyword_exact_title_match() {
+        let r = make_record("PRD-001", "Auth System", "", "active", 0.0);
+        assert_eq!(keyword_score(&r, "auth system"), 1.0);
+    }
+
+    #[test]
+    fn keyword_title_contains() {
+        let r = make_record("PRD-001", "Auth System Design", "", "active", 0.0);
+        assert!((keyword_score(&r, "auth system") - 0.8).abs() < 0.001);
+    }
+
+    #[test]
+    fn keyword_body_match() {
+        let r = make_record("PRD-001", "Title", "OAuth2 integration needed", "active", 0.0);
+        assert!((keyword_score(&r, "oauth2") - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn keyword_no_match() {
+        let r = make_record("PRD-001", "Title", "Body text", "active", 0.0);
+        assert_eq!(keyword_score(&r, "nonexistent"), 0.0);
+    }
+
+    #[test]
+    fn keyword_case_insensitive() {
+        let r = make_record("PRD-001", "Authentication", "", "active", 0.0);
+        assert_eq!(keyword_score(&r, "AUTHENTICATION"), 1.0);
+    }
+
+    // ── combined_score ──────────────────────────────────────────────
+
+    #[test]
+    fn combined_zero_when_no_text_match() {
+        assert_eq!(combined_score(0.0, 0.0, 1.0, true, 1.0), 0.0);
+    }
+
+    #[test]
+    fn combined_boosters_increase_score() {
+        let base_only = combined_score(0.8, 0.0, 0.0, false, 0.0);
+        let with_boosters = combined_score(0.8, 0.0, 1.0, true, 0.5);
+        assert!(with_boosters > base_only);
+    }
+
+    #[test]
+    fn combined_semantic_can_be_base() {
+        let score = combined_score(0.0, 0.9, 0.0, false, 0.0);
+        assert!((score - 0.9).abs() < 0.001);
+    }
+
+    #[test]
+    fn combined_uses_max_of_keyword_semantic() {
+        let score = combined_score(0.5, 0.9, 0.0, false, 0.0);
+        assert!((score - 0.9).abs() < 0.001, "should use semantic (0.9) not keyword (0.5)");
+    }
+
+    #[test]
+    fn combined_full_boosters() {
+        // base=1.0, r_eff=1.0 (+0.2), active (+0.1), centrality=1.0 (+0.1) = 1.0 * 1.4 = 1.4
+        let score = combined_score(1.0, 0.0, 1.0, true, 1.0);
+        assert!((score - 1.4).abs() < 0.001);
+    }
+
+    #[test]
+    fn combined_clamps_inputs() {
+        // r_eff and centrality clamped to [0, 1]
+        let score = combined_score(1.0, 0.0, 5.0, true, 5.0);
+        assert!((score - 1.4).abs() < 0.001, "should clamp to max 1.0");
+    }
+
+    // ── smart_search ────────────────────────────────────────────────
+
+    #[test]
+    fn smart_search_keyword_only() {
+        let records = vec![
+            make_record("PRD-001", "Auth System", "OAuth2 login", "active", 0.8),
+            make_record("PRD-002", "Performance", "Load testing", "draft", 0.0),
+        ];
+        let results = smart_search(&records, "auth", None, None, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "PRD-001");
+        assert!(results[0].score > 0.0);
+    }
+
+    #[test]
+    fn smart_search_with_semantic() {
+        let records = vec![
+            make_record("PRD-001", "Auth", "login", "active", 0.0),
+            make_record("PRD-002", "Perf", "speed", "active", 0.0),
+        ];
+        let mut sem = HashMap::new();
+        sem.insert("PRD-001".to_string(), 0.3);
+        sem.insert("PRD-002".to_string(), 0.95);
+
+        let results = smart_search(&records, "nonexistent-keyword", Some(&sem), None, 10);
+        // Keyword matches nothing, but semantic finds PRD-002
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id, "PRD-002", "highest semantic score wins");
+    }
+
+    #[test]
+    fn smart_search_respects_limit() {
+        let records: Vec<_> = (0..20)
+            .map(|i| make_record(&format!("PRD-{i:03}"), &format!("Auth variant {i}"), "", "active", 0.0))
+            .collect();
+        let results = smart_search(&records, "auth", None, None, 5);
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn smart_search_active_ranks_higher() {
+        let records = vec![
+            make_record("PRD-001", "Auth System", "", "draft", 0.0),
+            make_record("PRD-002", "Auth System", "", "active", 0.0),
+        ];
+        let results = smart_search(&records, "auth system", None, None, 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id, "PRD-002", "active should rank higher");
+    }
+
+    #[test]
+    fn smart_search_r_eff_boosts() {
+        let records = vec![
+            make_record("PRD-001", "Auth System", "", "active", 0.0),
+            make_record("PRD-002", "Auth System", "", "active", 1.0),
+        ];
+        let results = smart_search(&records, "auth system", None, None, 10);
+        assert_eq!(results[0].id, "PRD-002", "higher R_eff should rank higher");
+    }
+
+    #[test]
+    fn smart_search_empty_query_returns_nothing() {
+        let records = vec![make_record("PRD-001", "Auth", "body", "active", 0.0)];
+        let results = smart_search(&records, "zzz-no-match", None, None, 10);
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- **Smart search by default**: `forgeplan search` combines keyword match, semantic similarity, R_eff quality, artifact status, and graph centrality
- **Text-first + boosters** (Algolia-style): text relevance always dominates, boosters only amplify
- **Graceful degradation**: works without embeddings (keyword only + hint)
- **Configurable**: `embedding.chunk_size` in config.yaml (default 2000)
- **3 modes**: default=smart, `--keyword` for grep, `--semantic` for vector-only
- **3-agent audit**: 8 findings fixed (NaN guard, empty query, parallel edge dedup, sort stability)
- **+12 new tests** (524 total), 0 failures

## Design Decisions
- Combined score = `max(keyword, semantic) × (1 + r_eff×0.2 + active×0.1 + centrality×0.1)`
- RRF deferred to backlog (overkill for 90 artifacts)
- ID removed from embedding_text (no semantic value for vectors)

## Refs
- PROB-014 F4
- EVID-033

## Test plan
- [x] `cargo test` — 524 tests pass
- [x] `forgeplan search "R_eff"` — smart results with signal breakdown
- [x] `forgeplan search ""` — error "query cannot be empty"
- [x] `forgeplan search "auth" --json` — numeric scores, semantic_available flag
- [x] `forgeplan search "auth" --keyword` — grep mode works
- [x] NaN/Infinity inputs sanitized (12 audit edge case tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)