### PR TITLE
[PROB-014] Real cosine similarity from LanceDB distance

### DIFF
--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -107,7 +107,7 @@ async fn run_semantic_only(query: &str, kind: Option<&str>, json: bool) -> anyho
         let query_vec = embedder.embed(query)?;
         let all_hits = store.vector_search(&query_vec, 50).await?;
         let hits: Vec<_> = if let Some(k) = kind {
-            all_hits.into_iter().filter(|r| r.kind.eq_ignore_ascii_case(k)).take(10).collect()
+            all_hits.into_iter().filter(|h| h.record.kind.eq_ignore_ascii_case(k)).take(10).collect()
         } else {
             all_hits.into_iter().take(10).collect()
         };
@@ -125,12 +125,14 @@ async fn run_semantic_only(query: &str, kind: Option<&str>, json: bool) -> anyho
         if json {
             let json_data: Vec<_> = hits
                 .iter()
-                .map(|r| {
+                .map(|h| {
                     serde_json::json!({
-                        "id": r.id,
-                        "kind": r.kind,
-                        "status": r.status,
-                        "title": r.title,
+                        "id": h.record.id,
+                        "kind": h.record.kind,
+                        "status": h.record.status,
+                        "title": h.record.title,
+                        "similarity": (h.similarity() * 100.0).round() / 100.0,
+                        "distance": (h.distance * 1000.0).round() / 1000.0,
                         "mode": "semantic",
                     })
                 })
@@ -144,8 +146,8 @@ async fn run_semantic_only(query: &str, kind: Option<&str>, json: bool) -> anyho
             hits.len(),
             query
         );
-        for record in &hits {
-            println!("  {} [{}] \"{}\"", record.id, record.kind, record.title);
+        for h in &hits {
+            println!("  {:.2}  {} [{}] \"{}\"", h.similarity(), h.record.id, h.record.kind, h.record.title);
         }
 
         Ok(())
@@ -292,14 +294,10 @@ async fn get_semantic_scores(
             _ => return (None, false),
         };
 
-        // Normalize cosine distances to similarity scores [0..1]
-        // LanceDB returns distance (lower = more similar), convert to similarity
+        // Use real cosine similarity from LanceDB distance column
         let mut map = std::collections::HashMap::new();
-        let max_rank = hits.len() as f64;
-        for (i, record) in hits.iter().enumerate() {
-            // Rank-based score: top result = 1.0, last = close to 0
-            let score = 1.0 - (i as f64 / max_rank);
-            map.insert(record.id.clone(), score);
+        for hit in &hits {
+            map.insert(hit.record.id.clone(), hit.similarity());
         }
 
         (Some(map), true)

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -51,6 +51,26 @@ pub struct ArtifactRecord {
     pub updated_at: String,
 }
 
+/// Vector search result: an artifact record paired with its distance from the query.
+///
+/// `distance` is the raw value from LanceDB (L2 or cosine distance).
+/// For cosine distance: 0.0 = identical, 2.0 = opposite.
+/// Convert to similarity via `similarity()` method.
+#[derive(Debug, Clone)]
+pub struct VectorSearchHit {
+    pub record: ArtifactRecord,
+    pub distance: f64,
+}
+
+impl VectorSearchHit {
+    /// Convert cosine distance to similarity score in [0.0, 1.0].
+    ///
+    /// cosine_distance ∈ [0, 2], similarity = 1.0 - distance/2.0
+    pub fn similarity(&self) -> f64 {
+        (1.0 - self.distance / 2.0).clamp(0.0, 1.0)
+    }
+}
+
 impl ArtifactRecord {
     /// Build the text used for embedding: title + first `chunk_size` chars of body.
     ///
@@ -552,34 +572,38 @@ impl LanceStore {
     }
 
     /// Vector similarity search using pre-computed embedding.
-    /// Returns artifacts sorted by cosine distance (closest first).
+    /// Returns artifacts with distance scores, sorted by cosine distance (closest first).
     #[cfg(feature = "semantic-search")]
     pub async fn vector_search(
         &self,
         query_embedding: &[f32],
         limit: usize,
-    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+    ) -> anyhow::Result<Vec<VectorSearchHit>> {
         use lancedb::query::QueryBase;
 
         let results = self
             .artifacts
             .vector_search(query_embedding)
             .map_err(|e| anyhow::anyhow!("Vector search failed: {e}"))?
+            .distance_type(lancedb::DistanceType::Cosine)
             .limit(limit)
             .execute()
             .await?;
 
         let batches: Vec<_> = futures::StreamExt::collect::<Vec<_>>(results).await;
-        let mut records = Vec::new();
+        let mut hits = Vec::new();
         for batch_result in batches {
             let batch = batch_result?;
             for row in 0..batch.num_rows() {
                 if let Some(record) = extract_record(&batch, row) {
-                    records.push(record);
+                    let distance = get_f32(&batch, "_distance", row)
+                        .map(|d| d as f64)
+                        .unwrap_or(1.0); // fallback: mid-range distance
+                    hits.push(VectorSearchHit { record, distance });
                 }
             }
         }
-        Ok(records)
+        Ok(hits)
     }
 
     /// Update the embedding column for an artifact.
@@ -958,6 +982,23 @@ fn get_large_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String
             None
         } else {
             Some(arr.value(row).to_string())
+        }
+    } else {
+        None
+    }
+}
+
+/// Read a Float32 column value from a RecordBatch row.
+fn get_f32(batch: &RecordBatch, col: &str, row: usize) -> Option<f32> {
+    let array = batch.column_by_name(col)?;
+    if let Some(arr) = array
+        .as_any()
+        .downcast_ref::<arrow_array::Float32Array>()
+    {
+        if arr.is_null(row) {
+            None
+        } else {
+            Some(arr.value(row))
         }
     } else {
         None
@@ -1656,5 +1697,68 @@ mod tests {
         let text_small = record.embedding_text(500);
         let body_small = text_small.strip_prefix("Title ").unwrap();
         assert_eq!(body_small.len(), 500, "body should respect custom chunk_size");
+    }
+
+    // ── VectorSearchHit similarity ──────────────────────────────────
+
+    fn make_record(id: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            id: id.to_string(),
+            kind: "prd".to_string(),
+            status: "Draft".to_string(),
+            title: "Test".to_string(),
+            body: String::new(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            r_eff_score: 0.0,
+            valid_until: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn similarity_identical_vectors() {
+        let hit = VectorSearchHit {
+            record: make_record("PRD-001"),
+            distance: 0.0, // cosine distance 0 = identical
+        };
+        assert_eq!(hit.similarity(), 1.0);
+    }
+
+    #[test]
+    fn similarity_opposite_vectors() {
+        let hit = VectorSearchHit {
+            record: make_record("PRD-001"),
+            distance: 2.0, // cosine distance 2 = opposite
+        };
+        assert_eq!(hit.similarity(), 0.0);
+    }
+
+    #[test]
+    fn similarity_mid_distance() {
+        let hit = VectorSearchHit {
+            record: make_record("PRD-001"),
+            distance: 1.0, // cosine distance 1 = orthogonal
+        };
+        assert!((hit.similarity() - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn similarity_clamps_out_of_range() {
+        // Distance > 2.0 (shouldn't happen, but defensive)
+        let hit = VectorSearchHit {
+            record: make_record("PRD-001"),
+            distance: 3.0,
+        };
+        assert_eq!(hit.similarity(), 0.0);
+
+        // Negative distance (shouldn't happen)
+        let hit2 = VectorSearchHit {
+            record: make_record("PRD-001"),
+            distance: -0.5,
+        };
+        assert_eq!(hit2.similarity(), 1.0);
     }
 }

--- a/crates/forgeplan-core/src/driver/lance.rs
+++ b/crates/forgeplan-core/src/driver/lance.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, LanceStore, NewArtifact};
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, LanceStore, NewArtifact, VectorSearchHit};
 use crate::driver::StorageDriver;
 
 /// LanceDB-backed storage driver.
@@ -158,7 +158,7 @@ impl StorageDriver for LanceDriver {
         &self,
         query_embedding: &[f32],
         limit: usize,
-    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+    ) -> anyhow::Result<Vec<VectorSearchHit>> {
         self.store.vector_search(query_embedding, limit).await
     }
 

--- a/crates/forgeplan-core/src/driver/mod.rs
+++ b/crates/forgeplan-core/src/driver/mod.rs
@@ -12,7 +12,7 @@ pub mod types;
 pub use types::*;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, NewArtifact};
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, NewArtifact, VectorSearchHit};
 
 use std::path::Path;
 
@@ -129,11 +129,12 @@ pub trait StorageDriver: Send + Sync {
     }
 
     /// Vector similarity search using a pre-computed embedding.
+    /// Returns hits with distance scores for real similarity computation.
     async fn vector_search(
         &self,
         _query_embedding: &[f32],
         _limit: usize,
-    ) -> anyhow::Result<Vec<ArtifactRecord>> {
+    ) -> anyhow::Result<Vec<VectorSearchHit>> {
         Ok(Vec::new())
     }
 


### PR DESCRIPTION
## Summary
- **VectorSearchHit**: new struct pairing ArtifactRecord with real distance from LanceDB
- **Real similarity**: `1.0 - distance/2.0` (cosine) instead of fake rank-based scores
- **DistanceType::Cosine** set explicitly in vector_search query
- Semantic-only mode now shows similarity scores in output
- 4 new tests for similarity conversion edge cases

## Why
Previously `get_semantic_scores()` assigned fake scores based on result position (1st=1.0, 2nd=0.95...). Two completely different artifacts could both get high scores just because few embeddings existed. Now scores reflect actual cosine similarity from the embedding model.

## Refs
- PROB-014 H4 (audit finding)
- PR #63 (parent sprint)

## Test plan
- [x] `cargo test` — 528 tests pass
- [x] similarity(distance=0.0) = 1.0 (identical)
- [x] similarity(distance=2.0) = 0.0 (opposite)
- [x] similarity(distance=1.0) = 0.5 (orthogonal)
- [x] Out-of-range distances clamped to [0, 1]

🤖 Generated with [Claude Code](https://claude.com/claude-code)