### PR TITLE
[RFC-004] Files-First Phase 1 — lazy sync + reindex + audit fixes

### DIFF
--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -1,10 +1,27 @@
 use forgeplan_core::lifecycle;
+use forgeplan_core::projection;
 
 use crate::commands::common;
 
 pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
-    let store = common::store().await?;
+    let (ws, store) = common::open_store().await?;
+
+    // Sync file→LanceDB before lifecycle call (preserve user edits)
+    if let Some(record) = store.get_record(id).await? {
+        projection::sync_file_to_store(&store, &ws, &record).await?;
+    }
+
     let result = lifecycle::activate(&store, id, force).await?;
+
+    // Re-render projection with updated status
+    if let Some(record) = store.get_record(id).await? {
+        let links = store.get_relations(id).await.unwrap_or_default();
+        projection::render_projection(
+            &ws, &record.id, &record.kind, &record.title, &record.status,
+            &record.depth, record.author.as_deref(), record.parent_epic.as_deref(),
+            record.valid_until.as_deref(), &record.body, &links,
+        ).await?;
+    }
 
     if result.forced {
         println!("  Activated {id} (draft → active)");

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -1,10 +1,27 @@
 use forgeplan_core::lifecycle;
+use forgeplan_core::projection;
 
 use crate::commands::common;
 
 pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
-    let store = common::store().await?;
+    let (ws, store) = common::open_store().await?;
+
+    // Sync file→LanceDB before lifecycle call (preserve user edits)
+    if let Some(record) = store.get_record(id).await? {
+        projection::sync_file_to_store(&store, &ws, &record).await?;
+    }
+
     let dependents = lifecycle::deprecate(&store, id, reason).await?;
+
+    // Re-render projection with updated status
+    if let Some(record) = store.get_record(id).await? {
+        let links = store.get_relations(id).await.unwrap_or_default();
+        projection::render_projection(
+            &ws, &record.id, &record.kind, &record.title, &record.status,
+            &record.depth, record.author.as_deref(), record.parent_epic.as_deref(),
+            record.valid_until.as_deref(), &record.body, &links,
+        ).await?;
+    }
 
     println!("  Deprecated {id}: {reason}");
 

--- a/crates/forgeplan-cli/src/commands/link.rs
+++ b/crates/forgeplan-cli/src/commands/link.rs
@@ -26,8 +26,11 @@ pub async fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Re
     // Add relation in LanceDB
     store.add_relation(source_id, target_id, &relation).await?;
 
-    // Update projection with new link
+    // Sync file→LanceDB if user edited the file, then update projection
     if let Some(record) = store.get_record(source_id).await? {
+        forgeplan_core::projection::sync_file_to_store(&store, &ws, &record).await?;
+        // Re-read record after potential sync
+        let record = store.get_record(source_id).await?.unwrap();
         let all_relations = store.get_relations(source_id).await?;
         let links: Vec<(String, String)> = all_relations;
         forgeplan_core::projection::render_projection(
@@ -47,8 +50,10 @@ pub async fn run_unlink(source_id: &str, target_id: &str, relation: &str) -> any
 
     store.delete_relation(source_id, target_id, &relation).await?;
 
-    // Update projection to reflect removed link
+    // Sync file→LanceDB if user edited the file, then update projection
     if let Some(record) = store.get_record(source_id).await? {
+        forgeplan_core::projection::sync_file_to_store(&store, &ws, &record).await?;
+        let record = store.get_record(source_id).await?.unwrap();
         let all_relations = store.get_relations(source_id).await?;
         let links: Vec<(String, String)> = all_relations;
         forgeplan_core::projection::render_projection(

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub mod new;
 pub mod order;
 pub mod progress;
 pub mod reason;
+pub mod reindex;
 pub mod review;
 pub mod route;
 pub mod scan_import;

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -1,0 +1,97 @@
+use crate::commands::common;
+use crate::ui;
+
+/// Rebuild LanceDB index from .md files (files-first, RFC-004).
+///
+/// Walks all artifact directories, parses frontmatter + body from each .md file,
+/// and upserts into LanceDB. Safety net when lazy sync missed changes.
+pub async fn run() -> anyhow::Result<()> {
+    let (ws, store) = common::open_store().await?;
+
+    println!("Reindexing from .forgeplan/ markdown files...\n");
+
+    let mut synced = 0usize;
+    let mut skipped = 0usize;
+    let mut errors = 0usize;
+
+    for dir_name in forgeplan_core::workspace::ARTIFACT_DIRS {
+        let dir = ws.join(dir_name);
+        if !dir.exists() {
+            continue;
+        }
+        let mut read_dir = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            let path = entry.path();
+            if path.extension().map_or(true, |e| e != "md") {
+                continue;
+            }
+
+            let content = match tokio::fs::read_to_string(&path).await {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("  SKIP {}: read error: {}", path.display(), e);
+                    errors += 1;
+                    continue;
+                }
+            };
+
+            let (fm, body) = match forgeplan_core::artifact::frontmatter::parse_frontmatter(&content) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("  SKIP {}: parse error: {}", path.display(), e);
+                    errors += 1;
+                    continue;
+                }
+            };
+
+            let id = match fm.get("id").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => {
+                    eprintln!("  SKIP {}: no id in frontmatter", path.display());
+                    errors += 1;
+                    continue;
+                }
+            };
+
+            // Check if artifact exists in LanceDB
+            match store.get_record(&id).await? {
+                Some(record) => {
+                    // Compare body — sync if different
+                    if record.body.trim() != body.trim() {
+                        store.update_body(&id, &body).await?;
+                        println!("  SYNC {} — body updated from file", id);
+                        synced += 1;
+                    } else {
+                        skipped += 1;
+                    }
+                }
+                None => {
+                    // Artifact in file but not in LanceDB — create it
+                    let kind = fm.get("kind").and_then(|v| v.as_str()).unwrap_or(dir_name.trim_end_matches('s'));
+                    let status = fm.get("status").and_then(|v| v.as_str()).unwrap_or("draft");
+                    let title = fm.get("title").and_then(|v| v.as_str()).unwrap_or(&id);
+                    let depth = fm.get("depth").and_then(|v| v.as_str()).unwrap_or("standard");
+
+                    let artifact = forgeplan_core::db::store::NewArtifact {
+                        id: id.clone(),
+                        kind: kind.to_string(),
+                        status: status.to_lowercase(),
+                        title: title.to_string(),
+                        body: body.to_string(),
+                        depth: depth.to_string(),
+                        author: fm.get("author").and_then(|v| v.as_str()).map(String::from),
+                        parent_epic: fm.get("parent_epic").and_then(|v| v.as_str()).map(String::from),
+                        valid_until: fm.get("valid_until").and_then(|v| v.as_str()).map(String::from),
+                    };
+
+                    store.create_artifact(&artifact).await?;
+                    println!("  NEW  {} — created from file", id);
+                    synced += 1;
+                }
+            }
+        }
+    }
+
+    println!("\nReindex complete: {} synced, {} unchanged, {} errors.", synced, skipped, errors);
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -1,10 +1,27 @@
 use forgeplan_core::lifecycle;
+use forgeplan_core::projection;
 
 use crate::commands::common;
 
 pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
-    let store = common::store().await?;
+    let (ws, store) = common::open_store().await?;
+
+    // Sync file→LanceDB before lifecycle call (preserve user edits)
+    if let Some(record) = store.get_record(id).await? {
+        projection::sync_file_to_store(&store, &ws, &record).await?;
+    }
+
     let result = lifecycle::supersede(&store, id, by).await?;
+
+    // Re-render projection with updated status
+    if let Some(record) = store.get_record(id).await? {
+        let links = store.get_relations(id).await.unwrap_or_default();
+        projection::render_projection(
+            &ws, &record.id, &record.kind, &record.title, &record.status,
+            &record.depth, record.author.as_deref(), record.parent_epic.as_deref(),
+            record.valid_until.as_deref(), &record.body, &links,
+        ).await?;
+    }
 
     println!("  Superseded {id} → {by}");
 

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -65,7 +65,14 @@ pub async fn run(
         let _ = projection::remove_projection(&ws, id, &original.kind).await;
     }
 
-    // Re-render projection
+    // Sync file→LanceDB if user edited the file before this command
+    let pre_sync = store
+        .get_record(id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Artifact '{}' disappeared after update", id))?;
+    projection::sync_file_to_store(&store, &ws, &pre_sync).await?;
+
+    // Re-render projection with synced data
     let updated = store
         .get_record(id)
         .await?

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -32,11 +32,6 @@ pub async fn run(
         }
     }
 
-    // Update metadata (status, title)
-    if status.is_some() || title.is_some() {
-        store.update_artifact(id, status, title).await?;
-    }
-
     // Depth update not supported — fail explicitly instead of silently continuing
     if let Some(d) = depth {
         // Validate the value first for a better error message
@@ -44,6 +39,15 @@ pub async fn run(
             .parse()
             .map_err(|_| anyhow::anyhow!("Invalid depth '{}'. Use: tactical, standard, deep", d))?;
         anyhow::bail!("Depth update not yet supported. Use `forgeplan new` with the correct depth.");
+    }
+
+    // Sync file→LanceDB BEFORE any mutations — capture user edits from the OLD file
+    // (must happen before title change which removes the old projection file)
+    projection::sync_file_to_store(&store, &ws, &original).await?;
+
+    // Update metadata (status, title)
+    if status.is_some() || title.is_some() {
+        store.update_artifact(id, status, title).await?;
     }
 
     // Update body
@@ -64,13 +68,6 @@ pub async fn run(
     if title.is_some() {
         let _ = projection::remove_projection(&ws, id, &original.kind).await;
     }
-
-    // Sync file→LanceDB if user edited the file before this command
-    let pre_sync = store
-        .get_record(id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Artifact '{}' disappeared after update", id))?;
-    projection::sync_file_to_store(&store, &ws, &pre_sync).await?;
 
     // Re-render projection with synced data
     let updated = store

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -354,6 +354,8 @@ enum Commands {
     },
     /// Run schema migrations on existing workspace
     Migrate,
+    /// Rebuild LanceDB index from .md files (files-first sync)
+    Reindex,
     /// Generate embeddings for all artifacts (semantic search)
     Embed,
     /// Start MCP server (stdio transport) for AI agent integration
@@ -520,6 +522,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Order { json } => commands::order::run(json).await,
         Commands::Migrate => commands::migrate::run().await,
+        Commands::Reindex => commands::reindex::run().await,
         Commands::Embed => commands::embed::run().await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -1,13 +1,16 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use crate::artifact::frontmatter;
 use crate::artifact::types::{ArtifactKind, slugify};
 
 /// Render an artifact record as a markdown file in the workspace.
 /// Returns the path where the file was written.
 ///
-/// This is a write-only projection: LanceDB is the source of truth,
-/// markdown files are git-tracked projections for human reading.
+/// **Files-first (RFC-004)**: If the file already exists and the user has edited
+/// the body (body differs from what LanceDB has), the file body is preserved.
+/// Only frontmatter (status, links, metadata) is updated from LanceDB.
+/// This prevents data loss when a user edits a file then runs forgeplan link/update.
 pub async fn render_projection(
     workspace: &Path,
     id: &str,
@@ -29,12 +32,90 @@ pub async fn render_projection(
     let filename = format!("{}-{}.md", id, slug);
     let filepath = dir.join(&filename);
 
+    // Files-first: if file exists and body was edited by user, preserve file body
+    let effective_body = if filepath.exists() {
+        match tokio::fs::read_to_string(&filepath).await {
+            Ok(file_content) => {
+                if let Ok((_fm, file_body)) = frontmatter::parse_frontmatter(&file_content) {
+                    let file_body_trimmed = file_body.trim();
+                    let db_body_trimmed = body.trim();
+                    if !file_body_trimmed.is_empty()
+                        && file_body_trimmed != db_body_trimmed
+                    {
+                        // File body differs from LanceDB body — user edited the file.
+                        // Preserve the file version.
+                        file_body.to_string()
+                    } else {
+                        body.to_string()
+                    }
+                } else {
+                    body.to_string()
+                }
+            }
+            Err(_) => body.to_string(),
+        }
+    } else {
+        body.to_string()
+    };
+
     let content = render_markdown(
-        id, kind, title, status, depth, author, parent_epic, valid_until, body, links,
+        id, kind, title, status, depth, author, parent_epic, valid_until, &effective_body, links,
     )?;
     tokio::fs::write(&filepath, &content).await?;
 
     Ok(filepath)
+}
+
+/// Sync file body to LanceDB store if file was edited by user.
+/// Call this before render_projection to ensure LanceDB has the latest body.
+/// Returns true if sync happened (file was newer).
+pub async fn sync_file_to_store(
+    store: &crate::db::store::LanceStore,
+    workspace: &Path,
+    record: &crate::db::store::ArtifactRecord,
+) -> anyhow::Result<bool> {
+    if let Some(file_body) = read_file_body_if_newer(
+        workspace,
+        &record.id,
+        &record.kind,
+        &record.title,
+        &record.body,
+    )
+    .await
+    {
+        store.update_body(&record.id, &file_body).await?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Check if a file's body differs from the LanceDB body.
+/// Returns Some(file_body) if the file was edited by the user, None otherwise.
+pub async fn read_file_body_if_newer(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    db_body: &str,
+) -> Option<String> {
+    let artifact_kind = kind.parse::<ArtifactKind>().ok()?;
+    let dir = workspace.join(artifact_kind.dir_name());
+    let slug = slugify(title);
+    let filename = format!("{}-{}.md", id, slug);
+    let filepath = dir.join(&filename);
+
+    let file_content = tokio::fs::read_to_string(&filepath).await.ok()?;
+    let (_fm, file_body) = frontmatter::parse_frontmatter(&file_content).ok()?;
+
+    let file_trimmed = file_body.trim();
+    let db_trimmed = db_body.trim();
+
+    if !file_trimmed.is_empty() && file_trimmed != db_trimmed {
+        Some(file_body.to_string())
+    } else {
+        None
+    }
 }
 
 /// Render markdown content with YAML frontmatter + body.
@@ -222,5 +303,97 @@ mod tests {
 
         remove_projection(&ws, "PRD-001", "prd").await.unwrap();
         assert!(!prds.join("PRD-001-auth.md").exists());
+    }
+
+    #[tokio::test]
+    async fn render_projection_preserves_user_edited_body() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        // Step 1: create projection with template body
+        let template_body = "## Summary\n\n{Fill in summary here}";
+        let path = render_projection(
+            &ws, "PRD-001", "prd", "Auth System", "draft", "standard",
+            None, None, None, template_body, &[],
+        ).await.unwrap();
+
+        // Step 2: user edits the file with real content
+        let user_content = "---\nid: PRD-001\ntitle: Auth System\nkind: prd\nstatus: draft\ndepth: standard\n---\n\n## Summary\n\nReal user content that should be preserved.\n\n## Goals\n\n- Support OAuth2\n";
+        tokio::fs::write(&path, user_content).await.unwrap();
+
+        // Step 3: forgeplan link triggers render_projection with LanceDB body (template)
+        let path2 = render_projection(
+            &ws, "PRD-001", "prd", "Auth System", "draft", "standard",
+            None, None, None, template_body,
+            &[("RFC-001".to_string(), "based_on".to_string())],
+        ).await.unwrap();
+
+        // Verify: user body preserved, NOT overwritten with template
+        let result = tokio::fs::read_to_string(&path2).await.unwrap();
+        assert!(result.contains("Real user content"), "user body must be preserved");
+        assert!(result.contains("Support OAuth2"), "user goals must be preserved");
+        assert!(!result.contains("{Fill in summary"), "template must NOT overwrite user content");
+        // But frontmatter should have the new link
+        assert!(result.contains("RFC-001"), "new link should be in frontmatter");
+    }
+
+    #[tokio::test]
+    async fn render_projection_overwrites_when_body_matches() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        let body = "## Summary\n\nSame content.";
+
+        // Create initial projection
+        render_projection(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, body, &[],
+        ).await.unwrap();
+
+        // Re-render with same body but updated status — should overwrite (body unchanged)
+        let path = render_projection(
+            &ws, "PRD-001", "prd", "Test", "active", "standard",
+            None, None, None, body, &[],
+        ).await.unwrap();
+
+        let result = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(result.contains("status: active"), "status should be updated");
+    }
+
+    #[tokio::test]
+    async fn read_file_body_if_newer_detects_edit() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        let db_body = "## Template\n\n{placeholder}";
+        render_projection(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, db_body, &[],
+        ).await.unwrap();
+
+        // Simulate user editing the file
+        let prds = ws.join("prds");
+        let filepath = prds.join("PRD-001-test.md");
+        let edited = "---\nid: PRD-001\nkind: prd\nstatus: draft\ndepth: standard\ntitle: Test\n---\n\n## Real Content\n\nUser wrote this.\n";
+        tokio::fs::write(&filepath, edited).await.unwrap();
+
+        let result = read_file_body_if_newer(&ws, "PRD-001", "prd", "Test", db_body).await;
+        assert!(result.is_some(), "should detect user edit");
+        assert!(result.unwrap().contains("User wrote this"));
+    }
+
+    #[tokio::test]
+    async fn read_file_body_if_newer_returns_none_when_same() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        let body = "## Summary\n\nSame content.";
+        render_projection(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, body, &[],
+        ).await.unwrap();
+
+        let result = read_file_body_if_newer(&ws, "PRD-001", "prd", "Test", body).await;
+        assert!(result.is_none(), "should return None when body matches");
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -730,8 +730,12 @@ impl ForgeplanServer {
             return Ok(err_result(&format!("{e}")));
         }
 
-        // Update markdown projection
+        // Sync file→LanceDB (preserve user edits), then re-render projection
         if let Ok(Some(record)) = store.get_record(&p.source).await {
+            let _ = projection::sync_file_to_store(&store, &ws, &record).await;
+            // Re-read after sync
+            let record = store.get_record(&p.source).await
+                .unwrap_or(Some(record)).unwrap();
             let links = store.get_relations(&p.source).await.unwrap_or_default();
             let _ = projection::render_projection(
                 &ws, &record.id, &record.kind, &record.title, &record.status,
@@ -778,13 +782,19 @@ impl ForgeplanServer {
         };
 
         // Verify exists
-        if store.get_record(&p.id).await.map_err(|e| McpError::internal_error(format!("{e}"), None))?.is_none() {
-            return Ok(err_result(&format!("Artifact '{}' not found", p.id)));
-        }
+        let pre_record = store.get_record(&p.id).await
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        let pre_record = match pre_record {
+            Some(r) => r,
+            None => return Ok(err_result(&format!("Artifact '{}' not found", p.id))),
+        };
 
         if p.status.is_none() && p.title.is_none() && p.body.is_none() {
             return Ok(err_result("Nothing to update. Provide status, title, or body."));
         }
+
+        // Sync file→LanceDB BEFORE mutations — capture user edits
+        let _ = projection::sync_file_to_store(&store, &ws, &pre_record).await;
 
         if p.status.is_some() || p.title.is_some() {
             store


### PR DESCRIPTION
## Summary

Inverts source of truth: .md files are now authoritative, LanceDB is index/cache.
Eliminates data loss when users edit .md files then run forgeplan commands.

### Core changes
- **render_projection()** reads file body before overwriting — preserves user edits
- **sync_file_to_store()** syncs file→LanceDB when file body differs
- **`forgeplan reindex`** — full rebuild of LanceDB from .md files
- Lazy sync in: link, unlink, update, activate, supersede, deprecate (CLI + MCP)

### Audit fixes (2-agent verification)
- **F1**: MCP server link+update now sync before render
- **F2**: Lifecycle commands (activate/supersede/deprecate) now re-render projection
- **F3**: update.rs syncs BEFORE remove_projection (title rename data loss fixed)

### Verification (5 real-data tests)
- Edit file → link: **PASS** (original PROB-017 bug fixed)
- Edit file → update title: **PASS** (after F3 fix)
- Reindex: **PASS**
- Empty body: **PASS** (graceful fallback)
- Corrupt frontmatter: **PASS** (graceful fallback)

## Stats
- +369 LOC, 4 new tests
- 4 verification agents, 9 audit findings (3 fixed, 4 deferred, 2 confirmed safe)

## Refs
- RFC-004 Phase 1
- ADR-003 (files as source of truth)
- PROB-017 (data loss on link)

## Test plan
- [x] All projection tests pass (9/9)
- [x] 5 real-data tests pass
- [x] `cargo test` — 536 pass, 1 preexisting failure (coverage backfill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)