### PR TITLE
chore: 0 compiler warnings + reindex sync

### DIFF
--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -55,6 +55,7 @@ pub fn require_llm_config() -> anyhow::Result<forgeplan_core::config::types::Llm
 }
 
 /// Open storage using driver trait (new API — will replace open_store over time).
+#[allow(dead_code)]
 pub async fn open_driver() -> anyhow::Result<std::sync::Arc<dyn forgeplan_core::driver::StorageDriver>> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -1,5 +1,4 @@
 use crate::commands::common;
-use crate::ui;
 
 /// Rebuild LanceDB index from .md files (files-first, RFC-004).
 ///

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -989,6 +989,7 @@ fn get_large_string(batch: &RecordBatch, col: &str, row: usize) -> Option<String
 }
 
 /// Read a Float32 column value from a RecordBatch row.
+#[cfg(feature = "semantic-search")]
 fn get_f32(batch: &RecordBatch, col: &str, row: usize) -> Option<f32> {
     let array = batch.column_by_name(col)?;
     if let Some(arr) = array

--- a/crates/forgeplan-core/src/driver/lance.rs
+++ b/crates/forgeplan-core/src/driver/lance.rs
@@ -4,7 +4,9 @@
 use std::path::Path;
 
 use crate::artifact::store::ArtifactSummary;
-use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, LanceStore, NewArtifact, VectorSearchHit};
+#[cfg(feature = "semantic-search")]
+use crate::db::store::VectorSearchHit;
+use crate::db::store::{ArtifactFilter, ArtifactRecord, FpfChunk, FpfChunkSummary, LanceStore, NewArtifact};
 use crate::driver::StorageDriver;
 
 /// LanceDB-backed storage driver.

--- a/crates/forgeplan-core/src/lifecycle/mod.rs
+++ b/crates/forgeplan-core/src/lifecycle/mod.rs
@@ -263,7 +263,7 @@ pub async fn supersede(
     transitions::validate_transition(&record.status, "superseded")?;
 
     // Block if replacement is itself superseded or deprecated (chain risk)
-    let mut warnings = Vec::new();
+    let warnings = Vec::new();
     if replacement.status == "superseded" || replacement.status == "deprecated" {
         anyhow::bail!(
             "Replacement {} is already {}. Choose an active or draft artifact as replacement.",


### PR DESCRIPTION
## Summary
- Fixed all 5 compiler warnings → **0 warnings clean build**
- Ran `forgeplan reindex` — 4 artifacts synced from files to LanceDB

## Changes
- Feature-gated `VectorSearchHit` import and `get_f32` behind `semantic-search`
- Removed unused `mut` and `ui` import
- `#[allow(dead_code)]` on `open_driver` (planned for driver trait migration)

536 tests, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)