### PR TITLE
[PRD-022] Estimate Engine — Multi-Grade Effort Scoring

### DIFF
--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+
+use forgeplan_core::estimate::{calculator, confidence, display, extractor, scorer};
+use forgeplan_core::estimate::types::{EstimateConfig, Grade};
+
+use crate::commands::common;
+
+pub async fn run(
+    id: &str,
+    grade: Option<&str>,
+    my_grade: bool,
+    json: bool,
+) -> Result<()> {
+    let store = common::store().await?;
+
+    // Fetch artifact
+    let record = store
+        .get_record(id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Artifact '{}' not found", id))?;
+
+    // Extract work items from artifact body
+    let work_items = extractor::extract_work_items(&record.body);
+
+    if work_items.is_empty() && !json {
+        println!("  No FR or Phase items found in {}.", id);
+        println!("  Add FR table to PRD or Phase checklist to RFC.");
+        return Ok(());
+    }
+
+    // Score complexity (rule-based L0)
+    let scored_items = scorer::score_items(&work_items);
+
+    // Calculate confidence
+    let fr_items: Vec<_> = work_items.iter().filter(|w| w.id.starts_with("FR-")).collect();
+    let phase_items: Vec<_> = work_items.iter().filter(|w| w.id.starts_with("P")).collect();
+
+    let (conf, conf_reasons) = confidence::score_confidence(
+        !fr_items.is_empty(),
+        fr_items.len(),
+        !phase_items.is_empty(),
+        phase_items.len(),
+        false, // TODO: check linked Spec
+        false, // TODO: check linked Evidence
+    );
+
+    // Build config (defaults for now, TODO: read from config.yaml)
+    let config = EstimateConfig::default();
+
+    // Calculate hours
+    let result = calculator::calculate(
+        &record.id,
+        &record.title,
+        &scored_items,
+        &config,
+        conf,
+        conf_reasons,
+    );
+
+    // Determine highlight grade
+    let highlight_grade = if my_grade {
+        // TODO: read from config grade profile + artifact domain
+        Some(Grade::Senior)
+    } else if let Some(g) = grade {
+        Some(g.parse::<Grade>().map_err(|e| anyhow::anyhow!("{}", e))?)
+    } else {
+        None
+    };
+
+    // Output
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        print!("{}", display::format_table(&result, highlight_grade));
+    }
+
+    Ok(())
+}

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod decompose;
 pub mod delete;
 pub mod deprecate;
 pub mod embed;
+pub mod estimate;
 pub mod drift;
 pub mod export;
 

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -68,6 +68,20 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Estimate effort for an artifact based on FR and Phase items
+    Estimate {
+        /// Artifact ID to estimate
+        id: String,
+        /// Override grade for all items (junior|middle|senior|principal|ai)
+        #[arg(long)]
+        grade: Option<String>,
+        /// Use grade profile from config (domain-aware)
+        #[arg(long)]
+        my_grade: bool,
+        /// Output as JSON for machine consumption
+        #[arg(long)]
+        json: bool,
+    },
     /// Link two artifacts with a typed relationship
     Link {
         /// Source artifact ID
@@ -430,6 +444,9 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 commands::score::run(id.as_deref(), json).await
             }
+        }
+        Commands::Estimate { id, grade, my_grade, json } => {
+            commands::estimate::run(&id, grade.as_deref(), my_grade, json).await
         }
         Commands::Link {
             source,

--- a/crates/forgeplan-core/src/estimate/calculator.rs
+++ b/crates/forgeplan-core/src/estimate/calculator.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+use super::types::{EstimateConfig, EstimateItem, EstimateResult, Grade, ScoredItem};
+
+/// Calculate hours for each grade from scored items.
+pub fn calculate(
+    artifact_id: &str,
+    artifact_title: &str,
+    scored_items: &[ScoredItem],
+    config: &EstimateConfig,
+    confidence: f64,
+    confidence_reasons: Vec<String>,
+) -> EstimateResult {
+    let items: Vec<EstimateItem> = scored_items
+        .iter()
+        .map(|si| calculate_item(si, config))
+        .collect();
+
+    let mut totals: HashMap<Grade, f64> = HashMap::new();
+    let mut total_score = 0.0;
+
+    for item in &items {
+        for (grade, hours) in &item.hours {
+            *totals.entry(*grade).or_default() += hours;
+        }
+        total_score += item.score;
+    }
+
+    EstimateResult {
+        artifact_id: artifact_id.to_string(),
+        artifact_title: artifact_title.to_string(),
+        items,
+        totals,
+        total_score,
+        confidence,
+        confidence_reasons,
+    }
+}
+
+fn calculate_item(scored: &ScoredItem, config: &EstimateConfig) -> EstimateItem {
+    let base_hours = scored.complexity.base_senior_hours();
+    let mut hours = HashMap::new();
+
+    for grade in Grade::all() {
+        let multiplier = config
+            .grade_multipliers
+            .get(grade)
+            .copied()
+            .unwrap_or(grade.default_multiplier());
+        hours.insert(*grade, base_hours * multiplier);
+    }
+
+    let senior_hours = base_hours;
+    let score = scored.complexity.value() as f64 * senior_hours;
+
+    EstimateItem {
+        id: scored.id.clone(),
+        description: scored.description.clone(),
+        complexity: scored.complexity,
+        task_type: scored.task_type,
+        hours,
+        score,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estimate::types::{Complexity, TaskType};
+
+    fn default_config() -> EstimateConfig {
+        EstimateConfig::default()
+    }
+
+    fn scored(id: &str, complexity: Complexity) -> ScoredItem {
+        ScoredItem {
+            id: id.to_string(),
+            description: format!("Task {}", id),
+            complexity,
+            task_type: TaskType::PureCoding,
+        }
+    }
+
+    #[test]
+    fn single_item_senior_baseline() {
+        let items = vec![scored("FR-001", Complexity::Medium)];
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+
+        let senior_hours = result.items[0].hours[&Grade::Senior];
+        assert_eq!(senior_hours, 8.0); // Medium = 8h Senior
+    }
+
+    #[test]
+    fn grade_multipliers_applied() {
+        let items = vec![scored("FR-001", Complexity::Medium)];
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+
+        let item = &result.items[0];
+        assert_eq!(item.hours[&Grade::Junior], 16.0);  // 8 × 2.0
+        assert_eq!(item.hours[&Grade::Middle], 12.0);   // 8 × 1.5
+        assert_eq!(item.hours[&Grade::Senior], 8.0);    // 8 × 1.0
+        assert!((item.hours[&Grade::Principal] - 5.6).abs() < 0.01); // 8 × 0.7
+        assert!((item.hours[&Grade::Ai] - 3.2).abs() < 0.01);       // 8 × 0.4
+    }
+
+    #[test]
+    fn totals_sum_correctly() {
+        let items = vec![
+            scored("FR-001", Complexity::Medium),   // 8h Senior
+            scored("FR-002", Complexity::Complex),   // 13h Senior
+        ];
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+
+        assert_eq!(result.totals[&Grade::Senior], 21.0); // 8 + 13
+        assert_eq!(result.totals[&Grade::Junior], 42.0);  // 21 × 2.0
+    }
+
+    #[test]
+    fn score_calculation() {
+        let items = vec![scored("FR-001", Complexity::Complex)];
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+
+        // Score = complexity_value × senior_hours = 5 × 13 = 65
+        assert_eq!(result.items[0].score, 65.0);
+        assert_eq!(result.total_score, 65.0);
+    }
+
+    #[test]
+    fn custom_multipliers() {
+        let mut config = default_config();
+        config.grade_multipliers.insert(Grade::Junior, 3.0); // override
+
+        let items = vec![scored("FR-001", Complexity::Trivial)]; // 3h Senior
+        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![]);
+
+        assert_eq!(result.items[0].hours[&Grade::Junior], 9.0); // 3 × 3.0
+        assert_eq!(result.items[0].hours[&Grade::Senior], 3.0); // unchanged
+    }
+
+    #[test]
+    fn empty_items() {
+        let result = calculate("PRD-001", "Test", &[], &default_config(), 0.0, vec![]);
+        assert!(result.items.is_empty());
+        assert!(result.totals.is_empty());
+        assert_eq!(result.total_score, 0.0);
+    }
+
+    #[test]
+    fn confidence_passed_through() {
+        let result = calculate(
+            "PRD-001", "Test", &[], &default_config(),
+            0.65, vec!["has FR".to_string(), "no RFC phases".to_string()],
+        );
+        assert_eq!(result.confidence, 0.65);
+        assert_eq!(result.confidence_reasons.len(), 2);
+    }
+}

--- a/crates/forgeplan-core/src/estimate/confidence.rs
+++ b/crates/forgeplan-core/src/estimate/confidence.rs
@@ -1,0 +1,78 @@
+/// Score confidence of an estimate based on artifact completeness.
+/// Returns (confidence 0.0-1.0, reasons).
+pub fn score_confidence(
+    has_fr: bool,
+    fr_count: usize,
+    has_rfc_phases: bool,
+    phase_count: usize,
+    has_spec: bool,
+    has_evidence: bool,
+) -> (f64, Vec<String>) {
+    let mut score: f64 = 0.0;
+    let mut reasons = Vec::new();
+
+    // FR presence (+30%)
+    if has_fr && fr_count > 0 {
+        score += 0.30;
+        reasons.push(format!("has {} FR items (+30%)", fr_count));
+    } else {
+        reasons.push("no FR items found (-30%)".to_string());
+    }
+
+    // RFC phases (+25%)
+    if has_rfc_phases && phase_count > 0 {
+        score += 0.25;
+        reasons.push(format!("has {} RFC phase steps (+25%)", phase_count));
+    } else {
+        reasons.push("no RFC phases (-25%)".to_string());
+    }
+
+    // Spec presence (+15%)
+    if has_spec {
+        score += 0.15;
+        reasons.push("has Spec (+15%)".to_string());
+    }
+
+    // Evidence from past estimates (+20%)
+    if has_evidence {
+        score += 0.20;
+        reasons.push("has calibration evidence (+20%)".to_string());
+    }
+
+    // Baseline: even without anything, there's 10% from having the artifact at all
+    score += 0.10;
+
+    (score.min(1.0), reasons)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_confidence() {
+        let (score, reasons) = score_confidence(true, 5, true, 10, true, true);
+        assert!((score - 1.0).abs() < 0.01);
+        assert_eq!(reasons.len(), 4);
+    }
+
+    #[test]
+    fn only_fr() {
+        let (score, _reasons) = score_confidence(true, 3, false, 0, false, false);
+        assert!((score - 0.40).abs() < 0.01); // 0.30 + 0.10 baseline
+    }
+
+    #[test]
+    fn nothing() {
+        let (score, reasons) = score_confidence(false, 0, false, 0, false, false);
+        assert!((score - 0.10).abs() < 0.01); // baseline only
+        assert!(reasons.iter().any(|r| r.contains("no FR")));
+        assert!(reasons.iter().any(|r| r.contains("no RFC")));
+    }
+
+    #[test]
+    fn fr_plus_rfc() {
+        let (score, _) = score_confidence(true, 5, true, 3, false, false);
+        assert!((score - 0.65).abs() < 0.01); // 0.30 + 0.25 + 0.10
+    }
+}

--- a/crates/forgeplan-core/src/estimate/display.rs
+++ b/crates/forgeplan-core/src/estimate/display.rs
@@ -1,0 +1,225 @@
+use super::types::{EstimateResult, Grade};
+
+/// Format estimate result as a terminal-friendly table.
+pub fn format_table(result: &EstimateResult, highlight_grade: Option<Grade>) -> String {
+    let mut out = String::new();
+
+    // Header
+    out.push_str(&format!(
+        "Estimate for {}: {}\n",
+        result.artifact_id, result.artifact_title
+    ));
+    if let Some(grade) = highlight_grade {
+        out.push_str(&format!(
+            "Grade: {} | Confidence: {:.0}%\n\n",
+            grade,
+            result.confidence * 100.0
+        ));
+    } else {
+        out.push_str(&format!(
+            "Confidence: {:.0}%\n\n",
+            result.confidence * 100.0
+        ));
+    }
+
+    if result.items.is_empty() {
+        out.push_str("  No work items found. Add FR to PRD or Phase items to RFC.\n");
+        return out;
+    }
+
+    // Column widths
+    let id_width = result
+        .items
+        .iter()
+        .map(|i| i.id.len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+    let desc_width = result
+        .items
+        .iter()
+        .map(|i| i.description.chars().count().min(35))
+        .max()
+        .unwrap_or(20)
+        .max(20);
+
+    // Table header
+    out.push_str(&format!(
+        "  {:<id_w$}  {:<desc_w$}  {:>4}  {:>6}  {:>6}  {:>6}  {:>6}  {:>6}\n",
+        "ID", "Description", "Cmpl", "Jun", "Mid", "Senior", "PS", "AI",
+        id_w = id_width, desc_w = desc_width,
+    ));
+    let line_width = id_width + desc_width + 50;
+    out.push_str(&format!("  {}\n", "-".repeat(line_width)));
+
+    // Rows
+    for item in &result.items {
+        let desc_truncated: String = item.description.chars().take(desc_width).collect();
+
+        out.push_str(&format!(
+            "  {:<id_w$}  {:<desc_w$}  {:>4}  {:>5}h  {:>5}h  {:>5}h  {:>5}h  {:>5}h\n",
+            item.id,
+            desc_truncated,
+            item.complexity.value(),
+            format_hours(item.hours.get(&Grade::Junior).copied().unwrap_or(0.0)),
+            format_hours(item.hours.get(&Grade::Middle).copied().unwrap_or(0.0)),
+            format_hours(item.hours.get(&Grade::Senior).copied().unwrap_or(0.0)),
+            format_hours(item.hours.get(&Grade::Principal).copied().unwrap_or(0.0)),
+            format_hours(item.hours.get(&Grade::Ai).copied().unwrap_or(0.0)),
+            id_w = id_width, desc_w = desc_width,
+        ));
+    }
+
+    // Separator
+    out.push_str(&format!("  {}\n", "-".repeat(line_width)));
+
+    // Totals
+    out.push_str(&format!(
+        "  {:<id_w$}  {:<desc_w$}  {:>4}  {:>5}h  {:>5}h  {:>5}h  {:>5}h  {:>5}h\n",
+        "TOTAL", "",
+        format!("{}", result.items.iter().map(|i| i.complexity.value()).sum::<u32>()),
+        format_hours(result.totals.get(&Grade::Junior).copied().unwrap_or(0.0)),
+        format_hours(result.totals.get(&Grade::Middle).copied().unwrap_or(0.0)),
+        format_hours(result.totals.get(&Grade::Senior).copied().unwrap_or(0.0)),
+        format_hours(result.totals.get(&Grade::Principal).copied().unwrap_or(0.0)),
+        format_hours(result.totals.get(&Grade::Ai).copied().unwrap_or(0.0)),
+        id_w = id_width, desc_w = desc_width,
+    ));
+
+    // Days row
+    out.push_str(&format!(
+        "  {:<id_w$}  {:<desc_w$}  {:>4}  {:>5}d  {:>5}d  {:>5}d  {:>5}d  {:>5}d\n",
+        "", "", "",
+        format_days(result.totals.get(&Grade::Junior).copied().unwrap_or(0.0)),
+        format_days(result.totals.get(&Grade::Middle).copied().unwrap_or(0.0)),
+        format_days(result.totals.get(&Grade::Senior).copied().unwrap_or(0.0)),
+        format_days(result.totals.get(&Grade::Principal).copied().unwrap_or(0.0)),
+        format_days(result.totals.get(&Grade::Ai).copied().unwrap_or(0.0)),
+        id_w = id_width, desc_w = desc_width,
+    ));
+
+    // Confidence footer
+    out.push('\n');
+    if !result.confidence_reasons.is_empty() {
+        out.push_str(&format!(
+            "  Confidence: {:.0}% — {}\n",
+            result.confidence * 100.0,
+            result.confidence_reasons.join(", ")
+        ));
+    }
+
+    out
+}
+
+fn format_hours(h: f64) -> String {
+    if h < 10.0 {
+        format!("{:.1}", h)
+    } else {
+        format!("{:.0}", h)
+    }
+}
+
+fn format_days(h: f64) -> String {
+    let days = h / 8.0;
+    if days < 10.0 {
+        format!("{:.1}", days)
+    } else {
+        format!("{:.0}", days)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::estimate::types::{Complexity, EstimateItem, TaskType};
+    use std::collections::HashMap;
+
+    fn make_result() -> EstimateResult {
+        let mut hours1 = HashMap::new();
+        hours1.insert(Grade::Junior, 16.0);
+        hours1.insert(Grade::Middle, 12.0);
+        hours1.insert(Grade::Senior, 8.0);
+        hours1.insert(Grade::Principal, 5.6);
+        hours1.insert(Grade::Ai, 3.2);
+
+        let mut totals = HashMap::new();
+        totals.insert(Grade::Junior, 16.0);
+        totals.insert(Grade::Middle, 12.0);
+        totals.insert(Grade::Senior, 8.0);
+        totals.insert(Grade::Principal, 5.6);
+        totals.insert(Grade::Ai, 3.2);
+
+        EstimateResult {
+            artifact_id: "PRD-022".to_string(),
+            artifact_title: "AI Estimation Engine".to_string(),
+            items: vec![EstimateItem {
+                id: "FR-001".to_string(),
+                description: "User can run estimate".to_string(),
+                complexity: Complexity::Medium,
+                task_type: TaskType::PureCoding,
+                hours: hours1,
+                score: 24.0,
+            }],
+            totals,
+            total_score: 24.0,
+            confidence: 0.75,
+            confidence_reasons: vec!["has FR".to_string(), "no RFC phases".to_string()],
+        }
+    }
+
+    #[test]
+    fn table_contains_artifact_id() {
+        let output = format_table(&make_result(), None);
+        assert!(output.contains("PRD-022"));
+        assert!(output.contains("AI Estimation Engine"));
+    }
+
+    #[test]
+    fn table_contains_fr_id() {
+        let output = format_table(&make_result(), None);
+        assert!(output.contains("FR-001"));
+    }
+
+    #[test]
+    fn table_contains_grade_headers() {
+        let output = format_table(&make_result(), None);
+        assert!(output.contains("Jun"));
+        assert!(output.contains("Mid"));
+        assert!(output.contains("Senior"));
+        assert!(output.contains("AI"));
+    }
+
+    #[test]
+    fn table_contains_confidence() {
+        let output = format_table(&make_result(), None);
+        assert!(output.contains("75%"));
+        assert!(output.contains("has FR"));
+    }
+
+    #[test]
+    fn table_contains_total() {
+        let output = format_table(&make_result(), None);
+        assert!(output.contains("TOTAL"));
+    }
+
+    #[test]
+    fn table_with_highlight_grade() {
+        let output = format_table(&make_result(), Some(Grade::Middle));
+        assert!(output.contains("Grade: Middle"));
+    }
+
+    #[test]
+    fn empty_result_shows_message() {
+        let result = EstimateResult {
+            artifact_id: "PRD-001".to_string(),
+            artifact_title: "Empty".to_string(),
+            items: vec![],
+            totals: HashMap::new(),
+            total_score: 0.0,
+            confidence: 0.0,
+            confidence_reasons: vec![],
+        };
+        let output = format_table(&result, None);
+        assert!(output.contains("No work items found"));
+    }
+}

--- a/crates/forgeplan-core/src/estimate/extractor.rs
+++ b/crates/forgeplan-core/src/estimate/extractor.rs
@@ -1,0 +1,125 @@
+use regex::Regex;
+
+use super::types::WorkItem;
+
+/// Extract work items from an artifact's markdown body.
+/// Supports: FR table rows from PRD, Phase checklist items from RFC.
+pub fn extract_work_items(body: &str) -> Vec<WorkItem> {
+    let mut items = Vec::new();
+
+    // Try FR table extraction (PRD format)
+    items.extend(extract_fr_table(body));
+
+    // Try Phase checklist extraction (RFC format)
+    items.extend(extract_phase_items(body));
+
+    items
+}
+
+/// Extract FR rows from a markdown table in PRD.
+/// Expected format: | FR-001 | Core | Must | [Actor] can [capability] | Journey 1 |
+fn extract_fr_table(body: &str) -> Vec<WorkItem> {
+    let re = Regex::new(
+        r"(?m)^\|\s*(FR-\d+)\s*\|\s*(\w[\w\s]*?)\s*\|\s*(Must|Should|Could|Won't)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|"
+    ).expect("valid regex");
+
+    re.captures_iter(body)
+        .map(|cap| WorkItem {
+            id: cap[1].to_string(),
+            description: cap[4].trim().to_string(),
+            category: cap[2].trim().to_string(),
+            priority: cap[3].trim().to_string(),
+        })
+        .collect()
+}
+
+/// Extract Phase checklist items from RFC.
+/// Expected format: - [ ] **1.1** Description here
+///                  - [x] **2.3** Already done
+fn extract_phase_items(body: &str) -> Vec<WorkItem> {
+    let re = Regex::new(
+        r"(?m)^- \[[ x]\] \*\*(\d+\.\d+)\*\*\s+(.+)$"
+    ).expect("valid regex");
+
+    re.captures_iter(body)
+        .map(|cap| WorkItem {
+            id: format!("P{}", cap[1].to_string()),
+            description: cap[2].trim().to_string(),
+            category: "Implementation".to_string(),
+            priority: "Must".to_string(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_fr_from_prd_table() {
+        let body = r#"
+## Functional Requirements
+
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | User can run estimate on any artifact | Journey 1 |
+| FR-002 | Core | Must | System can extract work items from FR table | Journey 1 |
+| FR-003 | UX | Should | User can specify target grade via --grade | Journey 2 |
+"#;
+        let items = extract_fr_table(body);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].id, "FR-001");
+        assert_eq!(items[0].category, "Core");
+        assert_eq!(items[0].priority, "Must");
+        assert!(items[0].description.contains("estimate"));
+        assert_eq!(items[2].priority, "Should");
+    }
+
+    #[test]
+    fn extract_phases_from_rfc() {
+        let body = r#"
+### Phase 1: Core Types
+- [ ] **1.1** Create types.rs — Grade, Complexity enums
+- [ ] **1.2** Create extractor.rs — parse FR table
+- [x] **1.3** Create scorer.rs — rule-based scoring
+
+### Phase 2: CLI
+- [ ] **2.1** Create estimate command
+"#;
+        let items = extract_phase_items(body);
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].id, "P1.1");
+        assert!(items[0].description.contains("types.rs"));
+        assert_eq!(items[2].id, "P1.3");
+        assert_eq!(items[3].id, "P2.1");
+    }
+
+    #[test]
+    fn extract_work_items_combines_both() {
+        let body = r#"
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | User can do X | Journey 1 |
+
+### Phase 1: MVP
+- [ ] **1.1** Implement feature X
+"#;
+        let items = extract_work_items(body);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "FR-001");
+        assert_eq!(items[1].id, "P1.1");
+    }
+
+    #[test]
+    fn empty_body_returns_empty() {
+        let items = extract_work_items("");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn no_matching_patterns() {
+        let body = "# Just a title\n\nSome regular text without FR or Phase items.";
+        let items = extract_work_items(body);
+        assert!(items.is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/estimate/mod.rs
+++ b/crates/forgeplan-core/src/estimate/mod.rs
@@ -1,4 +1,5 @@
 pub mod calculator;
+pub mod confidence;
 pub mod display;
 pub mod extractor;
 pub mod scorer;

--- a/crates/forgeplan-core/src/estimate/mod.rs
+++ b/crates/forgeplan-core/src/estimate/mod.rs
@@ -1,0 +1,5 @@
+pub mod calculator;
+pub mod display;
+pub mod extractor;
+pub mod scorer;
+pub mod types;

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -1,0 +1,170 @@
+use super::types::{Complexity, ScoredItem, TaskType, WorkItem};
+
+/// Score work items with rule-based heuristics.
+/// Assigns Fibonacci complexity and task type based on description keywords.
+pub fn score_items(items: &[WorkItem]) -> Vec<ScoredItem> {
+    items.iter().map(|item| score_single(item)).collect()
+}
+
+fn score_single(item: &WorkItem) -> ScoredItem {
+    let complexity = infer_complexity(item);
+    let task_type = infer_task_type(item);
+    ScoredItem {
+        id: item.id.clone(),
+        description: item.description.clone(),
+        complexity,
+        task_type,
+    }
+}
+
+/// Infer Fibonacci complexity from description keywords and priority.
+fn infer_complexity(item: &WorkItem) -> Complexity {
+    let desc = item.description.to_lowercase();
+    let words = desc.split_whitespace().count();
+
+    // High complexity indicators
+    let hard_keywords = [
+        "migration", "redesign", "refactor", "integrate", "distributed",
+        "concurrent", "security", "encryption", "authentication", "state machine",
+    ];
+    let complex_keywords = [
+        "engine", "parser", "scoring", "search", "validation", "workflow",
+        "pipeline", "orchestrat", "aggregate", "transform",
+    ];
+    let medium_keywords = [
+        "extract", "convert", "calculate", "display", "format", "filter",
+        "sort", "command", "handler", "endpoint",
+    ];
+
+    let hard_count = hard_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+    let complex_count = complex_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+    let medium_count = medium_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+
+    // Priority boost: Must items tend to be more complex than Could
+    let priority_boost: i32 = match item.priority.to_lowercase().as_str() {
+        "must" => 1,
+        "should" => 0,
+        "could" => -1,
+        _ => 0,
+    };
+
+    // Description length contributes to complexity
+    let length_score: i32 = if words > 20 { 2 } else if words > 10 { 1 } else { 0 };
+
+    let raw_score = (hard_count as i32 * 3)
+        + (complex_count as i32 * 2)
+        + (medium_count as i32)
+        + priority_boost
+        + length_score;
+
+    match raw_score {
+        ..=0 => Complexity::Trivial,
+        1 => Complexity::Simple,
+        2..=3 => Complexity::Medium,
+        4..=5 => Complexity::Complex,
+        6..=8 => Complexity::Hard,
+        _ => Complexity::Epic,
+    }
+}
+
+/// Infer task type from description keywords.
+fn infer_task_type(item: &WorkItem) -> TaskType {
+    let desc = item.description.to_lowercase();
+
+    let infra_keywords = ["deploy", "k8s", "docker", "ci/cd", "pipeline", "infrastructure",
+        "kubernetes", "helm", "terraform", "vault", "registry", "runner", "namespace"];
+    let design_keywords = ["design", "ux", "ui", "layout", "wireframe", "prototype", "mockup"];
+    let coordination_keywords = ["meeting", "review", "discuss", "plan", "coordinate", "align"];
+    let coding_keywords = ["implement", "create", "add", "build", "write", "develop", "parse",
+        "extract", "calculate", "score", "validate", "convert", "format"];
+
+    let infra_hits = infra_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+    let design_hits = design_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+    let coord_hits = coordination_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+    let coding_hits = coding_keywords.iter().filter(|kw| desc.contains(*kw)).count();
+
+    if coord_hits > 0 && coding_hits == 0 {
+        return TaskType::Coordination;
+    }
+    if infra_hits > 0 && coding_hits > 0 {
+        return TaskType::CodingInfra;
+    }
+    if infra_hits > 0 {
+        return TaskType::PureInfra;
+    }
+    if design_hits > 0 && coding_hits > 0 {
+        return TaskType::DesignCoding;
+    }
+    if design_hits > 0 {
+        return TaskType::DesignCoding;
+    }
+    TaskType::PureCoding
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn work_item(id: &str, desc: &str, priority: &str) -> WorkItem {
+        WorkItem {
+            id: id.to_string(),
+            description: desc.to_string(),
+            category: "Core".to_string(),
+            priority: priority.to_string(),
+        }
+    }
+
+    #[test]
+    fn simple_coding_task() {
+        let item = work_item("FR-001", "User can add a new item", "Should");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::PureCoding);
+        // Simple task = low complexity
+        assert!(scored.complexity.value() <= 3);
+    }
+
+    #[test]
+    fn complex_integration_task() {
+        let item = work_item("FR-002", "System can integrate distributed authentication with security encryption", "Must");
+        let scored = score_single(&item);
+        assert!(scored.complexity.value() >= 5, "Expected Complex+ for integration+security+encryption");
+    }
+
+    #[test]
+    fn infra_task_detected() {
+        let item = work_item("FR-003", "Deploy to kubernetes namespace with helm charts", "Must");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::PureInfra);
+    }
+
+    #[test]
+    fn coding_infra_mixed() {
+        let item = work_item("FR-004", "Implement CI/CD pipeline build step", "Must");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::CodingInfra);
+    }
+
+    #[test]
+    fn design_task_detected() {
+        let item = work_item("FR-005", "Design UI layout for dashboard", "Should");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::DesignCoding);
+    }
+
+    #[test]
+    fn score_multiple_items() {
+        let items = vec![
+            work_item("FR-001", "Add button", "Could"),
+            work_item("FR-002", "Implement distributed authentication engine with security", "Must"),
+        ];
+        let scored = score_items(&items);
+        assert_eq!(scored.len(), 2);
+        assert!(scored[0].complexity.value() < scored[1].complexity.value());
+    }
+
+    #[test]
+    fn empty_items() {
+        let scored = score_items(&[]);
+        assert!(scored.is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/estimate/types.rs
+++ b/crates/forgeplan-core/src/estimate/types.rs
@@ -1,0 +1,357 @@
+use std::collections::HashMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Developer grade — determines the time multiplier for effort estimation.
+/// Senior is the baseline (×1.0). All other grades are relative to Senior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Grade {
+    Junior,
+    Middle,
+    #[default]
+    Senior,
+    Principal,
+    Ai,
+}
+
+impl Grade {
+    /// Default multiplier relative to Senior baseline.
+    /// Source: user's Excel model (Fibonacci × multiplier = hours).
+    pub fn default_multiplier(&self) -> f64 {
+        match self {
+            Grade::Junior => 2.0,
+            Grade::Middle => 1.5,
+            Grade::Senior => 1.0,
+            Grade::Principal => 0.7,
+            Grade::Ai => 0.4,
+        }
+    }
+
+    /// All grades in display order.
+    pub fn all() -> &'static [Grade] {
+        &[
+            Grade::Junior,
+            Grade::Middle,
+            Grade::Senior,
+            Grade::Principal,
+            Grade::Ai,
+        ]
+    }
+}
+
+impl fmt::Display for Grade {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Grade::Junior => write!(f, "Junior"),
+            Grade::Middle => write!(f, "Middle"),
+            Grade::Senior => write!(f, "Senior"),
+            Grade::Principal => write!(f, "Principal"),
+            Grade::Ai => write!(f, "AI"),
+        }
+    }
+}
+
+impl std::str::FromStr for Grade {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "junior" | "jun" => Ok(Grade::Junior),
+            "middle" | "mid" => Ok(Grade::Middle),
+            "senior" | "sen" => Ok(Grade::Senior),
+            "principal" | "ps" | "principal_senior" => Ok(Grade::Principal),
+            "ai" => Ok(Grade::Ai),
+            other => Err(format!("Unknown grade: '{}'. Valid: junior, middle, senior, principal, ai", other)),
+        }
+    }
+}
+
+/// Fibonacci complexity scale — maps to base Senior hours.
+/// Each level roughly doubles the previous in effort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Complexity {
+    Trivial = 1,
+    Simple = 2,
+    Medium = 3,
+    Complex = 5,
+    Hard = 8,
+    Epic = 13,
+}
+
+impl Complexity {
+    /// Base Senior hours for this complexity level.
+    /// Derived from user's empirical data: Complexity × ~2.6 ≈ Senior hours.
+    pub fn base_senior_hours(&self) -> f64 {
+        match self {
+            Complexity::Trivial => 3.0,
+            Complexity::Simple => 5.0,
+            Complexity::Medium => 8.0,
+            Complexity::Complex => 13.0,
+            Complexity::Hard => 21.0,
+            Complexity::Epic => 34.0,
+        }
+    }
+
+    /// Fibonacci value for scoring (Complexity × Senior = Score).
+    pub fn value(&self) -> u32 {
+        *self as u32
+    }
+
+    /// Parse from numeric Fibonacci value.
+    pub fn from_value(v: u32) -> Option<Self> {
+        match v {
+            1 => Some(Complexity::Trivial),
+            2 => Some(Complexity::Simple),
+            3 => Some(Complexity::Medium),
+            5 => Some(Complexity::Complex),
+            8 => Some(Complexity::Hard),
+            13 => Some(Complexity::Epic),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Complexity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.value())
+    }
+}
+
+/// Task type — determines the AI-specific multiplier.
+/// Coding tasks benefit most from AI; coordination tasks don't.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskType {
+    PureCoding,
+    CodingInfra,
+    DesignCoding,
+    PureInfra,
+    Coordination,
+}
+
+impl TaskType {
+    /// AI-specific multiplier (applied on top of Grade::Ai multiplier).
+    /// Represents how much faster AI is vs human for this task type.
+    pub fn ai_multiplier(&self) -> f64 {
+        match self {
+            TaskType::PureCoding => 0.10,
+            TaskType::CodingInfra => 0.25,
+            TaskType::DesignCoding => 0.30,
+            TaskType::PureInfra => 0.50,
+            TaskType::Coordination => 1.00,
+        }
+    }
+}
+
+impl fmt::Display for TaskType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TaskType::PureCoding => write!(f, "coding"),
+            TaskType::CodingInfra => write!(f, "coding+infra"),
+            TaskType::DesignCoding => write!(f, "design+coding"),
+            TaskType::PureInfra => write!(f, "infra"),
+            TaskType::Coordination => write!(f, "coordination"),
+        }
+    }
+}
+
+/// A single work item extracted from an artifact (FR from PRD or Phase step from RFC).
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkItem {
+    pub id: String,
+    pub description: String,
+    pub category: String,
+    pub priority: String,
+}
+
+/// A work item with assigned complexity and task type.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoredItem {
+    pub id: String,
+    pub description: String,
+    pub complexity: Complexity,
+    pub task_type: TaskType,
+}
+
+/// Hours estimate for a single item across all grades.
+#[derive(Debug, Clone, Serialize)]
+pub struct EstimateItem {
+    pub id: String,
+    pub description: String,
+    pub complexity: Complexity,
+    pub task_type: TaskType,
+    /// Hours per grade: grade → hours
+    pub hours: HashMap<Grade, f64>,
+    /// Score = complexity.value() × senior_hours (for prioritization)
+    pub score: f64,
+}
+
+/// Complete estimate result for an artifact.
+#[derive(Debug, Clone, Serialize)]
+pub struct EstimateResult {
+    pub artifact_id: String,
+    pub artifact_title: String,
+    pub items: Vec<EstimateItem>,
+    pub totals: HashMap<Grade, f64>,
+    pub total_score: f64,
+    pub confidence: f64,
+    pub confidence_reasons: Vec<String>,
+}
+
+/// Per-domain grade mapping for a user.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GradeProfile {
+    /// domain → grade (e.g., "backend" → Middle)
+    #[serde(default)]
+    pub domains: HashMap<String, Grade>,
+    /// default grade when domain not mapped
+    #[serde(default)]
+    pub default_grade: Grade,
+}
+
+/// Configuration for the estimate engine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EstimateConfig {
+    #[serde(default = "default_grade_multipliers")]
+    pub grade_multipliers: HashMap<Grade, f64>,
+    #[serde(default = "default_ai_task_multipliers")]
+    pub ai_task_multipliers: HashMap<TaskType, f64>,
+    #[serde(default = "default_review_overhead")]
+    pub review_overhead: f64,
+    #[serde(default = "default_safety_margin")]
+    pub safety_margin: f64,
+    #[serde(default)]
+    pub grade_profile: GradeProfile,
+}
+
+impl Default for EstimateConfig {
+    fn default() -> Self {
+        Self {
+            grade_multipliers: default_grade_multipliers(),
+            ai_task_multipliers: default_ai_task_multipliers(),
+            review_overhead: default_review_overhead(),
+            safety_margin: default_safety_margin(),
+            grade_profile: GradeProfile::default(),
+        }
+    }
+}
+
+fn default_grade_multipliers() -> HashMap<Grade, f64> {
+    Grade::all().iter().map(|g| (*g, g.default_multiplier())).collect()
+}
+
+fn default_ai_task_multipliers() -> HashMap<TaskType, f64> {
+    [
+        (TaskType::PureCoding, 0.10),
+        (TaskType::CodingInfra, 0.25),
+        (TaskType::DesignCoding, 0.30),
+        (TaskType::PureInfra, 0.50),
+        (TaskType::Coordination, 1.00),
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn default_review_overhead() -> f64 {
+    0.30
+}
+
+fn default_safety_margin() -> f64 {
+    0.50
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grade_multipliers_ordered() {
+        assert!(Grade::Junior.default_multiplier() > Grade::Middle.default_multiplier());
+        assert!(Grade::Middle.default_multiplier() > Grade::Senior.default_multiplier());
+        assert!(Grade::Senior.default_multiplier() > Grade::Principal.default_multiplier());
+        assert!(Grade::Principal.default_multiplier() > Grade::Ai.default_multiplier());
+    }
+
+    #[test]
+    fn grade_parse_roundtrip() {
+        for g in Grade::all() {
+            let s = g.to_string().to_lowercase();
+            let parsed: Grade = s.parse().unwrap();
+            assert_eq!(*g, parsed);
+        }
+    }
+
+    #[test]
+    fn grade_parse_aliases() {
+        assert_eq!("jun".parse::<Grade>().unwrap(), Grade::Junior);
+        assert_eq!("mid".parse::<Grade>().unwrap(), Grade::Middle);
+        assert_eq!("sen".parse::<Grade>().unwrap(), Grade::Senior);
+        assert_eq!("ps".parse::<Grade>().unwrap(), Grade::Principal);
+    }
+
+    #[test]
+    fn complexity_fibonacci_values() {
+        assert_eq!(Complexity::Trivial.value(), 1);
+        assert_eq!(Complexity::Simple.value(), 2);
+        assert_eq!(Complexity::Medium.value(), 3);
+        assert_eq!(Complexity::Complex.value(), 5);
+        assert_eq!(Complexity::Hard.value(), 8);
+        assert_eq!(Complexity::Epic.value(), 13);
+    }
+
+    #[test]
+    fn complexity_from_value_roundtrip() {
+        for v in [1, 2, 3, 5, 8, 13] {
+            let c = Complexity::from_value(v).unwrap();
+            assert_eq!(c.value(), v);
+        }
+        assert!(Complexity::from_value(4).is_none());
+        assert!(Complexity::from_value(0).is_none());
+    }
+
+    #[test]
+    fn complexity_base_hours_increasing() {
+        let complexities = [
+            Complexity::Trivial,
+            Complexity::Simple,
+            Complexity::Medium,
+            Complexity::Complex,
+            Complexity::Hard,
+            Complexity::Epic,
+        ];
+        for pair in complexities.windows(2) {
+            assert!(pair[0].base_senior_hours() < pair[1].base_senior_hours());
+        }
+    }
+
+    #[test]
+    fn task_type_ai_multipliers_ordered() {
+        assert!(TaskType::PureCoding.ai_multiplier() < TaskType::CodingInfra.ai_multiplier());
+        assert!(TaskType::CodingInfra.ai_multiplier() < TaskType::DesignCoding.ai_multiplier());
+        assert!(TaskType::DesignCoding.ai_multiplier() < TaskType::PureInfra.ai_multiplier());
+        assert!(TaskType::PureInfra.ai_multiplier() < TaskType::Coordination.ai_multiplier());
+    }
+
+    #[test]
+    fn estimate_config_defaults() {
+        let config = EstimateConfig::default();
+        assert_eq!(config.grade_multipliers[&Grade::Senior], 1.0);
+        assert_eq!(config.grade_multipliers[&Grade::Junior], 2.0);
+        assert_eq!(config.ai_task_multipliers[&TaskType::PureCoding], 0.10);
+        assert_eq!(config.review_overhead, 0.30);
+        assert_eq!(config.safety_margin, 0.50);
+        assert_eq!(config.grade_profile.default_grade, Grade::Senior);
+    }
+
+    #[test]
+    fn grade_profile_domain_lookup() {
+        let mut profile = GradeProfile::default();
+        profile.domains.insert("backend".to_string(), Grade::Middle);
+        profile.domains.insert("devops".to_string(), Grade::Senior);
+
+        assert_eq!(profile.domains.get("backend"), Some(&Grade::Middle));
+        assert_eq!(profile.domains.get("devops"), Some(&Grade::Senior));
+        assert_eq!(profile.domains.get("frontend"), None);
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod depth;
 pub mod driver;
 pub mod drift;
 pub mod embed;
+pub mod estimate;
 pub mod fpf;
 pub mod health;
 pub mod journal;


### PR DESCRIPTION
## Summary
- New `estimate` module in forgeplan-core (6 files, ~1040 LOC)
- `forgeplan estimate <id>` — effort breakdown by grade (Junior/Middle/Senior/PS/AI)
- `--grade middle` — highlight specific grade
- `--json` — machine-readable output
- Fibonacci complexity scoring (1,2,3,5,8,13) with rule-based heuristics
- Grade multipliers: Jun×2.0, Mid×1.5, Sen×1.0, PS×0.7, AI×0.4
- FR extraction from PRD markdown tables + Phase extraction from RFC checklists
- Confidence scoring: FR +30%, RFC phases +25%, Spec +15%, Evidence +20%
- Task type classification: pure_coding, coding_infra, design_coding, pure_infra, coordination

## Refs
- PRD-022: AI Estimation Engine — Multi-Grade Effort Scoring
- RFC-005: Estimate Engine Architecture (Phase 1 + Phase 2)
- ADR-004: Hybrid approach (rule-based default + LLM opt-in)
- 39 unit tests for estimate module

## Test plan
- [x] `cargo check` — 0 warnings
- [x] `cargo test -p forgeplan-core estimate` — 39/39 pass
- [x] `forgeplan estimate PRD-022` — shows 8 FR items with hours per grade
- [x] `forgeplan estimate RFC-005` — shows 12 Phase items
- [x] `forgeplan estimate PRD-022 --grade middle` — highlights Middle grade
- [x] `forgeplan estimate PRD-022 --json` — valid JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)