### PR TITLE
[PRD-022] Estimate audit fixes + config integration + guide

### DIFF
--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -44,8 +44,8 @@ pub async fn run(
         false, // TODO: check linked Evidence
     );
 
-    // Build config (defaults for now, TODO: read from config.yaml)
-    let config = EstimateConfig::default();
+    // Build config from .forgeplan/config.yaml or defaults
+    let config = load_estimate_config();
 
     // Calculate hours
     let result = calculator::calculate(
@@ -59,11 +59,15 @@ pub async fn run(
 
     // Determine highlight grade
     let highlight_grade = if my_grade {
-        anyhow::bail!(
-            "--my-grade is not yet configured.\n\
-             Set estimate.grade_profile in .forgeplan/config.yaml, or use --grade <level>.\n\
-             Valid grades: junior, middle, senior, principal, ai"
-        );
+        let domain = infer_domain(&record.kind);
+        let resolved = config.resolve_grade(&domain);
+        if !json {
+            eprintln!(
+                "  Using grade: {} (domain: {}, from config grade_profile)",
+                resolved, domain
+            );
+        }
+        Some(resolved)
     } else if let Some(g) = grade {
         Some(g.parse::<Grade>().map_err(|e| anyhow::anyhow!("{}", e))?)
     } else {
@@ -78,4 +82,27 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+/// Load EstimateConfig from .forgeplan/config.yaml, falling back to defaults.
+fn load_estimate_config() -> EstimateConfig {
+    match common::config() {
+        Ok(cfg) => {
+            if let Some(ref yaml) = cfg.estimate {
+                EstimateConfig::from_yaml(yaml)
+            } else {
+                EstimateConfig::default()
+            }
+        }
+        Err(_) => EstimateConfig::default(),
+    }
+}
+
+/// Infer work domain from artifact kind for grade profile lookup.
+fn infer_domain(kind: &str) -> String {
+    match kind {
+        "prd" | "epic" | "spec" => "backend".to_string(),
+        "rfc" | "adr" => "backend".to_string(),
+        _ => "default".to_string(),
+    }
 }

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use forgeplan_core::estimate::{calculator, confidence, display, extractor, scorer};
-use forgeplan_core::estimate::types::{EstimateConfig, Grade};
+use forgeplan_core::estimate::types::{EstimateConfig, Grade, ItemSource};
 
 use crate::commands::common;
 
@@ -32,8 +32,8 @@ pub async fn run(
     let scored_items = scorer::score_items(&work_items);
 
     // Calculate confidence
-    let fr_items: Vec<_> = work_items.iter().filter(|w| w.id.starts_with("FR-")).collect();
-    let phase_items: Vec<_> = work_items.iter().filter(|w| w.id.starts_with("P")).collect();
+    let fr_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Fr).collect();
+    let phase_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Phase).collect();
 
     let (conf, conf_reasons) = confidence::score_confidence(
         !fr_items.is_empty(),
@@ -59,8 +59,11 @@ pub async fn run(
 
     // Determine highlight grade
     let highlight_grade = if my_grade {
-        // TODO: read from config grade profile + artifact domain
-        Some(Grade::Senior)
+        anyhow::bail!(
+            "--my-grade is not yet configured.\n\
+             Set estimate.grade_profile in .forgeplan/config.yaml, or use --grade <level>.\n\
+             Valid grades: junior, middle, senior, principal, ai"
+        );
     } else if let Some(g) = grade {
         Some(g.parse::<Grade>().map_err(|e| anyhow::anyhow!("{}", e))?)
     } else {

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub storage: Option<StorageConfig>,
     #[serde(default)]
     pub memory: Option<MemoryConfig>,
+    #[serde(default)]
+    pub estimate: Option<EstimateConfigYaml>,
 }
 
 impl Default for Config {
@@ -30,8 +32,38 @@ impl Default for Config {
             embedding: None,
             storage: None,
             memory: None,
+            estimate: None,
         }
     }
+}
+
+/// Estimate engine configuration — YAML-friendly version.
+/// All fields optional with sensible defaults. Converts to EstimateConfig for runtime use.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EstimateConfigYaml {
+    /// Per-domain grade profile: "backend" → "middle", "devops" → "senior"
+    #[serde(default)]
+    pub grade_profile: Option<GradeProfileYaml>,
+    /// Override grade multipliers: "junior" → 2.0, etc.
+    #[serde(default)]
+    pub grade_multipliers: Option<std::collections::HashMap<String, f64>>,
+    /// Override AI task-type multipliers: "pure_coding" → 0.10, etc.
+    #[serde(default)]
+    pub ai_task_multipliers: Option<std::collections::HashMap<String, f64>>,
+    /// Fraction of AI time added for human review (default: 0.30 = 30%)
+    #[serde(default)]
+    pub review_overhead: Option<f64>,
+    /// Sprint load threshold — warn if capacity exceeds this (default: 0.50 = 50%)
+    #[serde(default)]
+    pub safety_margin: Option<f64>,
+}
+
+/// User's grade profile — maps work domains to developer grades.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GradeProfileYaml {
+    /// Domain → grade string (e.g., "backend" → "middle")
+    #[serde(flatten)]
+    pub domains: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/forgeplan-core/src/estimate/calculator.rs
+++ b/crates/forgeplan-core/src/estimate/calculator.rs
@@ -154,4 +154,16 @@ mod tests {
         assert_eq!(result.confidence, 0.65);
         assert_eq!(result.confidence_reasons.len(), 2);
     }
+
+    #[test]
+    fn missing_grade_in_config_uses_default() {
+        let mut config = default_config();
+        config.grade_multipliers.remove(&Grade::Junior); // remove Junior
+
+        let items = vec![scored("FR-001", Complexity::Trivial)]; // 3h Senior
+        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![]);
+
+        // Junior falls back to default multiplier 2.0
+        assert_eq!(result.items[0].hours[&Grade::Junior], 6.0); // 3 × 2.0
+    }
 }

--- a/crates/forgeplan-core/src/estimate/calculator.rs
+++ b/crates/forgeplan-core/src/estimate/calculator.rs
@@ -42,12 +42,27 @@ fn calculate_item(scored: &ScoredItem, config: &EstimateConfig) -> EstimateItem 
     let mut hours = HashMap::new();
 
     for grade in Grade::all() {
-        let multiplier = config
+        let grade_mult = config
             .grade_multipliers
             .get(grade)
             .copied()
             .unwrap_or(grade.default_multiplier());
-        hours.insert(*grade, base_hours * multiplier);
+
+        let effective_hours = if *grade == Grade::Ai {
+            // AI gets task-type-specific multiplier on top of grade multiplier
+            let task_mult = config
+                .ai_task_multipliers
+                .get(&scored.task_type)
+                .copied()
+                .unwrap_or(scored.task_type.ai_multiplier());
+            let ai_hours = base_hours * task_mult;
+            // Add review overhead (human reviewing AI output)
+            ai_hours * (1.0 + config.review_overhead)
+        } else {
+            base_hours * grade_mult
+        };
+
+        hours.insert(*grade, effective_hours);
     }
 
     let senior_hours = base_hours;
@@ -66,7 +81,7 @@ fn calculate_item(scored: &ScoredItem, config: &EstimateConfig) -> EstimateItem 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::estimate::types::{Complexity, TaskType};
+    use crate::estimate::types::{Complexity, ScoredItem, TaskType};
 
     fn default_config() -> EstimateConfig {
         EstimateConfig::default()
@@ -100,7 +115,25 @@ mod tests {
         assert_eq!(item.hours[&Grade::Middle], 12.0);   // 8 × 1.5
         assert_eq!(item.hours[&Grade::Senior], 8.0);    // 8 × 1.0
         assert!((item.hours[&Grade::Principal] - 5.6).abs() < 0.01); // 8 × 0.7
-        assert!((item.hours[&Grade::Ai] - 3.2).abs() < 0.01);       // 8 × 0.4
+        // AI: base_hours(8) × task_ai_mult(0.10 for PureCoding) × (1 + review_overhead(0.30))
+        // = 8 × 0.10 × 1.30 = 1.04
+        assert!((item.hours[&Grade::Ai] - 1.04).abs() < 0.01);
+    }
+
+    #[test]
+    fn ai_uses_task_type_multiplier() {
+        let items = vec![ScoredItem {
+            id: "FR-001".to_string(),
+            description: "Infra task".to_string(),
+            complexity: Complexity::Medium, // 8h base
+            task_type: TaskType::PureInfra, // AI ×0.50
+        }];
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+
+        // AI: 8 × 0.50 × 1.30 = 5.2
+        assert!((result.items[0].hours[&Grade::Ai] - 5.2).abs() < 0.01);
+        // Senior unchanged: 8 × 1.0
+        assert_eq!(result.items[0].hours[&Grade::Senior], 8.0);
     }
 
     #[test]
@@ -155,6 +188,7 @@ mod tests {
         assert_eq!(result.confidence_reasons.len(), 2);
     }
 
+    #[test]
     #[test]
     fn missing_grade_in_config_uses_default() {
         let mut config = default_config();

--- a/crates/forgeplan-core/src/estimate/confidence.rs
+++ b/crates/forgeplan-core/src/estimate/confidence.rs
@@ -75,4 +75,20 @@ mod tests {
         let (score, _) = score_confidence(true, 5, true, 3, false, false);
         assert!((score - 0.65).abs() < 0.01); // 0.30 + 0.25 + 0.10
     }
+
+    #[test]
+    fn has_fr_but_zero_count_is_negative() {
+        let (score, reasons) = score_confidence(true, 0, false, 0, false, false);
+        assert!((score - 0.10).abs() < 0.01); // baseline only, has_fr=true but count=0 → no bonus
+        assert!(reasons.iter().any(|r| r.contains("no FR")));
+    }
+
+    #[test]
+    fn clamp_at_one() {
+        // Even if we somehow exceed 1.0 (e.g., future bonus added), it should clamp
+        // Currently full_confidence = exactly 1.0, so this is a guard test
+        let (score, _) = score_confidence(true, 10, true, 20, true, true);
+        assert!(score <= 1.0);
+        assert!(score >= 0.99); // should be exactly 1.0
+    }
 }

--- a/crates/forgeplan-core/src/estimate/confidence.rs
+++ b/crates/forgeplan-core/src/estimate/confidence.rs
@@ -16,7 +16,7 @@ pub fn score_confidence(
         score += 0.30;
         reasons.push(format!("has {} FR items (+30%)", fr_count));
     } else {
-        reasons.push("no FR items found (-30%)".to_string());
+        reasons.push("no FR items found".to_string());
     }
 
     // RFC phases (+25%)
@@ -24,7 +24,7 @@ pub fn score_confidence(
         score += 0.25;
         reasons.push(format!("has {} RFC phase steps (+25%)", phase_count));
     } else {
-        reasons.push("no RFC phases (-25%)".to_string());
+        reasons.push("no RFC phases".to_string());
     }
 
     // Spec presence (+15%)
@@ -76,6 +76,7 @@ mod tests {
         assert!((score - 0.65).abs() < 0.01); // 0.30 + 0.25 + 0.10
     }
 
+    #[test]
     #[test]
     fn has_fr_but_zero_count_is_negative() {
         let (score, reasons) = score_confidence(true, 0, false, 0, false, false);

--- a/crates/forgeplan-core/src/estimate/extractor.rs
+++ b/crates/forgeplan-core/src/estimate/extractor.rs
@@ -1,6 +1,8 @@
+use std::sync::OnceLock;
+
 use regex::Regex;
 
-use super::types::WorkItem;
+use super::types::{ItemSource, WorkItem};
 
 /// Extract work items from an artifact's markdown body.
 /// Supports: FR table rows from PRD, Phase checklist items from RFC.
@@ -19,9 +21,10 @@ pub fn extract_work_items(body: &str) -> Vec<WorkItem> {
 /// Extract FR rows from a markdown table in PRD.
 /// Expected format: | FR-001 | Core | Must | [Actor] can [capability] | Journey 1 |
 fn extract_fr_table(body: &str) -> Vec<WorkItem> {
-    let re = Regex::new(
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(
         r"(?m)^\|\s*(FR-\d+)\s*\|\s*(\w[\w\s]*?)\s*\|\s*(Must|Should|Could|Won't)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|"
-    ).expect("valid regex");
+    ).expect("valid regex"));
 
     re.captures_iter(body)
         .map(|cap| WorkItem {
@@ -29,6 +32,7 @@ fn extract_fr_table(body: &str) -> Vec<WorkItem> {
             description: cap[4].trim().to_string(),
             category: cap[2].trim().to_string(),
             priority: cap[3].trim().to_string(),
+            source: ItemSource::Fr,
         })
         .collect()
 }
@@ -37,9 +41,10 @@ fn extract_fr_table(body: &str) -> Vec<WorkItem> {
 /// Expected format: - [ ] **1.1** Description here
 ///                  - [x] **2.3** Already done
 fn extract_phase_items(body: &str) -> Vec<WorkItem> {
-    let re = Regex::new(
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(
         r"(?m)^- \[[ x]\] \*\*(\d+\.\d+)\*\*\s+(.+)$"
-    ).expect("valid regex");
+    ).expect("valid regex"));
 
     re.captures_iter(body)
         .map(|cap| WorkItem {
@@ -47,6 +52,7 @@ fn extract_phase_items(body: &str) -> Vec<WorkItem> {
             description: cap[2].trim().to_string(),
             category: "Implementation".to_string(),
             priority: "Must".to_string(),
+            source: ItemSource::Phase,
         })
         .collect()
 }

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -92,9 +92,6 @@ fn infer_task_type(item: &WorkItem) -> TaskType {
     if infra_hits > 0 {
         return TaskType::PureInfra;
     }
-    if design_hits > 0 && coding_hits > 0 {
-        return TaskType::DesignCoding;
-    }
     if design_hits > 0 {
         return TaskType::DesignCoding;
     }

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -108,6 +108,7 @@ mod tests {
             description: desc.to_string(),
             category: "Core".to_string(),
             priority: priority.to_string(),
+            source: crate::estimate::types::ItemSource::Fr,
         }
     }
 

--- a/crates/forgeplan-core/src/estimate/types.rs
+++ b/crates/forgeplan-core/src/estimate/types.rs
@@ -156,6 +156,15 @@ impl fmt::Display for TaskType {
     }
 }
 
+/// Source of a work item — allows typed filtering instead of string prefix checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ItemSource {
+    /// Functional Requirement from PRD table
+    Fr,
+    /// Phase checklist item from RFC
+    Phase,
+}
+
 /// A single work item extracted from an artifact (FR from PRD or Phase step from RFC).
 #[derive(Debug, Clone, Serialize)]
 pub struct WorkItem {
@@ -163,6 +172,7 @@ pub struct WorkItem {
     pub description: String,
     pub category: String,
     pub priority: String,
+    pub source: ItemSource,
 }
 
 /// A work item with assigned complexity and task type.

--- a/crates/forgeplan-core/src/estimate/types.rs
+++ b/crates/forgeplan-core/src/estimate/types.rs
@@ -271,6 +271,71 @@ fn default_safety_margin() -> f64 {
     0.50
 }
 
+impl EstimateConfig {
+    /// Build EstimateConfig from YAML config, falling back to defaults for missing fields.
+    pub fn from_yaml(yaml: &crate::config::types::EstimateConfigYaml) -> Self {
+        let mut config = Self::default();
+
+        // Override grade multipliers
+        if let Some(ref overrides) = yaml.grade_multipliers {
+            for (key, value) in overrides {
+                if let Ok(grade) = key.parse::<Grade>() {
+                    config.grade_multipliers.insert(grade, *value);
+                }
+            }
+        }
+
+        // Override AI task multipliers
+        if let Some(ref overrides) = yaml.ai_task_multipliers {
+            let task_map: HashMap<&str, TaskType> = [
+                ("pure_coding", TaskType::PureCoding),
+                ("coding_infra", TaskType::CodingInfra),
+                ("design_coding", TaskType::DesignCoding),
+                ("pure_infra", TaskType::PureInfra),
+                ("coordination", TaskType::Coordination),
+            ].into_iter().collect();
+
+            for (key, value) in overrides {
+                if let Some(tt) = task_map.get(key.as_str()) {
+                    config.ai_task_multipliers.insert(*tt, *value);
+                }
+            }
+        }
+
+        if let Some(v) = yaml.review_overhead {
+            config.review_overhead = v;
+        }
+        if let Some(v) = yaml.safety_margin {
+            config.safety_margin = v;
+        }
+
+        // Grade profile
+        if let Some(ref profile) = yaml.grade_profile {
+            for (domain, grade_str) in &profile.domains {
+                if domain == "default" {
+                    if let Ok(g) = grade_str.parse::<Grade>() {
+                        config.grade_profile.default_grade = g;
+                    }
+                } else if let Ok(g) = grade_str.parse::<Grade>() {
+                    config.grade_profile.domains.insert(domain.clone(), g);
+                }
+            }
+        }
+
+        config
+    }
+
+    /// Resolve the grade for a given domain using the grade profile.
+    /// Falls back to default_grade if domain not in profile.
+    pub fn resolve_grade(&self, domain: &str) -> Grade {
+        self.grade_profile
+            .domains
+            .get(domain)
+            .copied()
+            .unwrap_or(self.grade_profile.default_grade)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,5 +448,63 @@ mod tests {
         assert_eq!(profile.domains.get("backend"), Some(&Grade::Middle));
         assert_eq!(profile.domains.get("devops"), Some(&Grade::Senior));
         assert_eq!(profile.domains.get("frontend"), None);
+    }
+
+    #[test]
+    fn from_yaml_overrides_grade_multipliers() {
+        use crate::config::types::{EstimateConfigYaml, GradeProfileYaml};
+
+        let yaml = EstimateConfigYaml {
+            grade_multipliers: Some([
+                ("junior".to_string(), 3.0),
+            ].into_iter().collect()),
+            grade_profile: Some(GradeProfileYaml {
+                domains: [
+                    ("backend".to_string(), "middle".to_string()),
+                    ("devops".to_string(), "senior".to_string()),
+                    ("default".to_string(), "middle".to_string()),
+                ].into_iter().collect(),
+            }),
+            ..Default::default()
+        };
+
+        let config = EstimateConfig::from_yaml(&yaml);
+        assert_eq!(config.grade_multipliers[&Grade::Junior], 3.0); // overridden
+        assert_eq!(config.grade_multipliers[&Grade::Senior], 1.0); // default kept
+        assert_eq!(config.grade_profile.domains["backend"], Grade::Middle);
+        assert_eq!(config.grade_profile.domains["devops"], Grade::Senior);
+        assert_eq!(config.grade_profile.default_grade, Grade::Middle); // "default" key
+    }
+
+    #[test]
+    fn from_yaml_empty_uses_defaults() {
+        use crate::config::types::EstimateConfigYaml;
+
+        let yaml = EstimateConfigYaml::default();
+        let config = EstimateConfig::from_yaml(&yaml);
+        assert_eq!(config.grade_multipliers[&Grade::Senior], 1.0);
+        assert_eq!(config.review_overhead, 0.30);
+        assert_eq!(config.grade_profile.default_grade, Grade::Senior);
+    }
+
+    #[test]
+    fn resolve_grade_uses_profile() {
+        use crate::config::types::{EstimateConfigYaml, GradeProfileYaml};
+
+        let yaml = EstimateConfigYaml {
+            grade_profile: Some(GradeProfileYaml {
+                domains: [
+                    ("backend".to_string(), "middle".to_string()),
+                    ("devops".to_string(), "senior".to_string()),
+                    ("default".to_string(), "junior".to_string()),
+                ].into_iter().collect(),
+            }),
+            ..Default::default()
+        };
+
+        let config = EstimateConfig::from_yaml(&yaml);
+        assert_eq!(config.resolve_grade("backend"), Grade::Middle);
+        assert_eq!(config.resolve_grade("devops"), Grade::Senior);
+        assert_eq!(config.resolve_grade("unknown"), Grade::Junior); // falls back to "default"
     }
 }

--- a/crates/forgeplan-core/src/estimate/types.rs
+++ b/crates/forgeplan-core/src/estimate/types.rs
@@ -291,6 +291,26 @@ mod tests {
     }
 
     #[test]
+    fn grade_parse_error() {
+        let err = "expert".parse::<Grade>();
+        assert!(err.is_err());
+        let msg = "expert".parse::<Grade>().unwrap_err();
+        assert!(msg.contains("Unknown grade"), "Error should mention 'Unknown grade': {}", msg);
+
+        assert!("".parse::<Grade>().is_err());
+        assert!("INVALID".parse::<Grade>().is_err());
+    }
+
+    #[test]
+    fn grade_profile_fallback_to_default() {
+        let profile = GradeProfile::default();
+        let grade = profile.domains.get("unknown_domain")
+            .copied()
+            .unwrap_or(profile.default_grade);
+        assert_eq!(grade, Grade::Senior); // default fallback
+    }
+
+    #[test]
     fn complexity_fibonacci_values() {
         assert_eq!(Complexity::Trivial.value(), 1);
         assert_eq!(Complexity::Simple.value(), 2);

--- a/crates/forgeplan-core/src/workspace/init.rs
+++ b/crates/forgeplan-core/src/workspace/init.rs
@@ -6,6 +6,32 @@ use crate::error::ForgeplanError;
 
 pub const FORGEPLAN_DIR: &str = ".forgeplan";
 
+/// Commented estimate config appended to config.yaml on init.
+const ESTIMATE_CONFIG_TEMPLATE: &str = r#"
+# Estimate engine configuration (uncomment to customize)
+# estimate:
+#   grade_profile:
+#     backend: middle      # your grade in backend development
+#     frontend: junior     # your grade in frontend
+#     devops: senior       # your grade in devops/infra
+#     ai_ml: principal     # your grade in AI/ML
+#     default: senior      # fallback for unspecified domains
+#   grade_multipliers:
+#     junior: 2.0          # relative to senior (baseline 1.0)
+#     middle: 1.5
+#     senior: 1.0
+#     principal: 0.7
+#     ai: 0.4              # conservative AI base multiplier
+#   ai_task_multipliers:
+#     pure_coding: 0.10    # AI does coding tasks ~10x faster
+#     coding_infra: 0.25   # mixed coding + infrastructure
+#     design_coding: 0.30  # design + implementation
+#     pure_infra: 0.50     # infrastructure only
+#     coordination: 1.00   # meetings, reviews — AI can't help
+#   review_overhead: 0.30  # 30% added to AI time for human review
+#   safety_margin: 0.50    # warn if sprint > 50% loaded
+"#;
+
 /// All artifact subdirectories created inside `.forgeplan/`.
 pub const ARTIFACT_DIRS: &[&str] = &[
     "prds", "epics", "specs", "rfcs", "adrs", "problems", "solutions", "evidence", "notes",
@@ -23,12 +49,14 @@ pub fn init_workspace(root: &Path, project_name: &str) -> anyhow::Result<PathBuf
     for dir in ARTIFACT_DIRS {
         fs::create_dir_all(fp_dir.join(dir))?;
     }
-    // Write config.yaml
+    // Write config.yaml with commented estimate section
     let config = Config {
         project_name: project_name.into(),
         ..Config::default()
     };
-    let yaml = serde_yml::to_string(&config)?;
+    let mut yaml = serde_yml::to_string(&config)?;
+    // Append commented estimate config template
+    yaml.push_str(ESTIMATE_CONFIG_TEMPLATE);
     fs::write(fp_dir.join("config.yaml"), yaml)?;
     Ok(fp_dir)
 }

--- a/docs/guides/FORGEPLAN-GUIDE.md
+++ b/docs/guides/FORGEPLAN-GUIDE.md
@@ -159,6 +159,9 @@ forgeplan review PRD-001
 | `forgeplan validate [id]` | Проверить полноту | `forgeplan validate PRD-001` |
 | `forgeplan score [id]` | R_eff quality score | `forgeplan score PRD-001` |
 | `forgeplan fgr [id]` | F-G-R scores (Formality, Granularity, Reliability) | `forgeplan fgr` |
+| `forgeplan estimate <id>` | Effort estimate по грейдам (Jun/Mid/Sen/PS/AI) | `forgeplan estimate PRD-022` |
+| `forgeplan estimate <id> --grade mid` | Подсветить конкретный грейд | `forgeplan estimate PRD-022 --grade junior` |
+| `forgeplan estimate <id> --my-grade` | Грейд из config grade_profile | `forgeplan estimate PRD-022 --my-grade` |
 
 ### Lifecycle
 
@@ -209,6 +212,133 @@ forgeplan serve  # запустить MCP server (stdio transport)
 ```
 
 26 MCP tools — все команды выше доступны через MCP protocol.
+
+---
+
+## Estimate Engine — оценка трудозатрат
+
+### Зачем
+
+Превращает документацию (FR в PRD, Phases в RFC) в эстимейты трудозатрат. Не нужна отдельная Excel-таблица — estimate живёт рядом с артефактами.
+
+### Базовая команда
+
+```bash
+forgeplan estimate PRD-022
+```
+
+Выводит таблицу:
+
+```
+Estimate for PRD-022: AI Estimation Engine
+Confidence: 40%
+
+  ID      Description                  Cmpl   Jun    Mid  Senior    PS     AI
+  ---------------------------------------------------------------------------
+  FR-001  User can run estimate          3    16h    12h    8.0h  5.6h   1.0h
+  FR-002  System extracts work items     3    16h    12h    8.0h  5.6h   1.0h
+  FR-003  Fibonacci complexity           2    10h   7.5h    5.0h  3.5h   0.7h
+  ---------------------------------------------------------------------------
+  TOTAL                                  8    42h    32h     21h   15h   2.7h
+                                              5.3d   3.9d   2.6d  1.8d  0.3d
+```
+
+### Флаги
+
+```bash
+forgeplan estimate PRD-022 --grade middle   # подсветить конкретный грейд
+forgeplan estimate PRD-022 --my-grade       # грейд из config.yaml (домен-aware)
+forgeplan estimate PRD-022 --json           # машинный вывод
+```
+
+### Модель расчёта
+
+**Base = Senior** (baseline ×1.0). Все грейды — множители от Senior:
+
+| Грейд | Множитель | Пример (Medium=8h Senior) |
+|-------|-----------|---------------------------|
+| Junior | ×2.0 | 16h |
+| Middle | ×1.5 | 12h |
+| **Senior** | **×1.0** | **8h** (baseline) |
+| Principal | ×0.7 | 5.6h |
+| AI | task-type | 1.0h (PureCoding) |
+
+**AI считается по-другому** — учитывает тип задачи:
+
+| Тип задачи | AI множитель | Пример (8h base) | С review (+30%) |
+|------------|-------------|-------------------|-----------------|
+| PureCoding | ×0.10 | 0.8h | **1.04h** |
+| CodingInfra | ×0.25 | 2.0h | 2.6h |
+| DesignCoding | ×0.30 | 2.4h | 3.1h |
+| PureInfra | ×0.50 | 4.0h | 5.2h |
+| Coordination | ×1.00 | 8.0h | 10.4h |
+
+**Fibonacci complexity** (1, 2, 3, 5, 8, 13) → base Senior hours (3h, 5h, 8h, 13h, 21h, 34h).
+
+**Confidence** зависит от полноты артефакта:
+- Есть FR в PRD: +30%
+- Есть Implementation Phases в RFC: +25%
+- Есть Spec: +15%
+- Есть evidence из прошлых задач: +20%
+
+### Настройка в config.yaml
+
+Раскомментируй и настрой под себя:
+
+```yaml
+# .forgeplan/config.yaml
+estimate:
+  grade_profile:
+    backend: middle        # твой грейд в бэкенде
+    frontend: junior       # твой грейд во фронте
+    devops: senior         # твой грейд в devops
+    ai_ml: principal       # твой грейд в AI/ML
+    default: senior        # fallback для незнакомых доменов
+  grade_multipliers:       # override defaults если нужно
+    junior: 2.0
+    middle: 1.5
+    senior: 1.0
+    principal: 0.7
+    ai: 0.4
+  ai_task_multipliers:     # скорость AI по типам задач
+    pure_coding: 0.10      # AI делает кодинг в ~10x быстрее
+    coding_infra: 0.25     # код + инфраструктура
+    design_coding: 0.30    # дизайн + реализация
+    pure_infra: 0.50       # чистая инфра (K8s, CI/CD)
+    coordination: 1.00     # meetings — AI не помогает
+  review_overhead: 0.30    # +30% к AI time на human review
+  safety_margin: 0.50      # предупреждать если спринт > 50%
+```
+
+После настройки `--my-grade` автоматически подставит правильный грейд:
+
+```bash
+forgeplan estimate PRD-022 --my-grade
+# → "Using grade: Middle (domain: backend, from config grade_profile)"
+```
+
+### Multi-grade профиль: зачем
+
+Ты можешь быть **Senior в DevOps** и **Junior во Frontend** одновременно. Одна задача на K8s занимает 5h (Senior), а такая же по сложности задача на React — 10h (Junior). Forgeplan учитывает это через `grade_profile`.
+
+### Рабочий цикл с estimate
+
+```bash
+# 1. Создал PRD с FR
+forgeplan new prd "Auth System"
+# → заполнил FR-001..FR-005
+
+# 2. Оценил трудозатрат
+forgeplan estimate PRD-022
+# → Senior: 52h (6.5 дней), AI: 6.9h (0.9 дня)
+
+# 3. Создал RFC, дополнил estimate
+forgeplan estimate RFC-005
+# → 12 phase steps, confidence +25%
+
+# 4. Планируешь спринт с safety margin 40-50%
+# Senior capacity = 80h/sprint → берём задач на 40h max
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Lost commits from PR #73 merge — cherry-picked 4 commits:
- Audit fix round 1: dead branch, error tests, confidence clamp (+5 tests)
- Audit fix round 2: AI task multipliers, --my-grade bail→works, OnceLock regex, ItemSource
- Config integration: EstimateConfigYaml, GradeProfileYaml, --my-grade reads config
- FORGEPLAN-GUIDE.md: full Estimate Engine section

## Refs
- PRD-022, RFC-005, ADR-004
- 50 estimate tests (was 39 after PR #73 merge)

## Test plan
- [x] `cargo test -p forgeplan-core -- estimate` — 50/50 pass
- [x] `forgeplan estimate PRD-022 --my-grade` — works with config

🤖 Generated with [Claude Code](https://claude.com/claude-code)