### PR TITLE
[RFC-005] Phase 3: LLM-based complexity scorer + --llm-score flag

### DIFF
--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -9,6 +9,7 @@ pub async fn run(
     id: &str,
     grade: Option<&str>,
     my_grade: bool,
+    llm_score: bool,
     json: bool,
 ) -> Result<()> {
     let store = common::store().await?;
@@ -28,8 +29,19 @@ pub async fn run(
         return Ok(());
     }
 
-    // Score complexity (rule-based L0)
-    let scored_items = scorer::score_items(&work_items);
+    // Score complexity: LLM L1 (opt-in) or rule-based L0 (default)
+    let scored_items = if llm_score {
+        let llm_config = common::require_llm_config()?;
+        if !json {
+            eprintln!(
+                "  Using LLM scorer ({}/{}). Fallback to rules if LLM fails.",
+                llm_config.provider, llm_config.model
+            );
+        }
+        scorer::score_items_with_llm(&work_items, &llm_config).await
+    } else {
+        scorer::score_items(&work_items)
+    };
 
     // Calculate confidence
     let fr_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Fr).collect();

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -78,6 +78,9 @@ enum Commands {
         /// Use grade profile from config (domain-aware)
         #[arg(long)]
         my_grade: bool,
+        /// Use LLM-based complexity scoring instead of rule-based heuristics
+        #[arg(long)]
+        llm_score: bool,
         /// Output as JSON for machine consumption
         #[arg(long)]
         json: bool,
@@ -473,8 +476,8 @@ async fn main() -> anyhow::Result<()> {
                 commands::score::run(id.as_deref(), json).await
             }
         }
-        Commands::Estimate { id, grade, my_grade, json } => {
-            commands::estimate::run(&id, grade.as_deref(), my_grade, json).await
+        Commands::Estimate { id, grade, my_grade, llm_score, json } => {
+            commands::estimate::run(&id, grade.as_deref(), my_grade, llm_score, json).await
         }
         Commands::Link {
             source,

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -1,9 +1,130 @@
+use crate::config::LlmConfig;
+use crate::llm::LlmClient;
+
 use super::types::{Complexity, ScoredItem, TaskType, WorkItem};
 
 /// Score work items with rule-based heuristics.
 /// Assigns Fibonacci complexity and task type based on description keywords.
 pub fn score_items(items: &[WorkItem]) -> Vec<ScoredItem> {
     items.iter().map(|item| score_single(item)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// LLM-based scoring (L1 opt-in)
+// ---------------------------------------------------------------------------
+
+/// System prompt for the LLM scorer.
+const LLM_SCORER_SYSTEM: &str = "\
+You are a senior engineering estimator. For each work item you receive, assign:
+1. A Fibonacci complexity score: 1 (trivial), 2 (simple), 3 (medium), 5 (complex), 8 (hard), 13 (epic).
+2. A task type: pure_coding, coding_infra, design_coding, pure_infra, coordination.
+
+Respond ONLY with one line per item in exactly this format (no extra text):
+ID|COMPLEXITY|TASK_TYPE
+
+Example:
+FR-001|3|pure_coding
+FR-002|8|coding_infra
+";
+
+/// Build the user prompt listing all items for the LLM.
+fn build_llm_prompt(items: &[WorkItem]) -> String {
+    let mut prompt = String::from("Score the following work items:\n\n");
+    for item in items {
+        prompt.push_str(&format!(
+            "- {} [{}] (priority: {}): {}\n",
+            item.id, item.category, item.priority, item.description
+        ));
+    }
+    prompt
+}
+
+/// Parse a single LLM response line like "FR-001|3|pure_coding" into (id, Complexity, TaskType).
+/// Returns None if the line cannot be parsed.
+pub fn parse_llm_line(line: &str) -> Option<(String, Complexity, TaskType)> {
+    let parts: Vec<&str> = line.split('|').map(|s| s.trim()).collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let id = parts[0].to_string();
+    let complexity = parts[1].parse::<u32>().ok().and_then(Complexity::from_value)?;
+    let task_type = parse_task_type(parts[2])?;
+    Some((id, complexity, task_type))
+}
+
+/// Parse a task type string from the LLM response.
+fn parse_task_type(s: &str) -> Option<TaskType> {
+    match s.to_lowercase().replace('-', "_").as_str() {
+        "pure_coding" | "purecoding" | "coding" => Some(TaskType::PureCoding),
+        "coding_infra" | "codinginfra" => Some(TaskType::CodingInfra),
+        "design_coding" | "designcoding" => Some(TaskType::DesignCoding),
+        "pure_infra" | "pureinfra" | "infra" => Some(TaskType::PureInfra),
+        "coordination" | "coord" => Some(TaskType::Coordination),
+        _ => None,
+    }
+}
+
+/// Parse the full LLM response into a map of id -> (Complexity, TaskType).
+fn parse_llm_response(
+    response: &str,
+    items: &[WorkItem],
+) -> Vec<ScoredItem> {
+    use std::collections::HashMap;
+
+    // Build a lookup from parsed LLM lines
+    let mut llm_map: HashMap<String, (Complexity, TaskType)> = HashMap::new();
+    for line in response.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((id, complexity, task_type)) = parse_llm_line(line) {
+            llm_map.insert(id, (complexity, task_type));
+        }
+    }
+
+    // For each work item, use LLM result if available, else fall back to rule-based
+    items
+        .iter()
+        .map(|item| {
+            if let Some((complexity, task_type)) = llm_map.get(&item.id) {
+                ScoredItem {
+                    id: item.id.clone(),
+                    description: item.description.clone(),
+                    complexity: *complexity,
+                    task_type: *task_type,
+                }
+            } else {
+                // Fallback to rule-based for items the LLM missed
+                score_single(item)
+            }
+        })
+        .collect()
+}
+
+/// Score work items using an LLM (L1).
+/// Falls back to rule-based scoring if the LLM call fails.
+pub async fn score_items_with_llm(
+    items: &[WorkItem],
+    llm_config: &LlmConfig,
+) -> Vec<ScoredItem> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let client = LlmClient::new(llm_config.clone());
+    let prompt = build_llm_prompt(items);
+
+    match client.generate(&prompt, Some(LLM_SCORER_SYSTEM)).await {
+        Ok(response) => {
+            let scored = parse_llm_response(&response, items);
+            scored
+        }
+        Err(_) => {
+            // LLM failed — graceful fallback to rule-based
+            score_items(items)
+        }
+    }
 }
 
 fn score_single(item: &WorkItem) -> ScoredItem {
@@ -164,5 +285,92 @@ mod tests {
     fn empty_items() {
         let scored = score_items(&[]);
         assert!(scored.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // LLM scorer tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_llm_line_valid() {
+        let result = parse_llm_line("FR-001|3|pure_coding");
+        assert!(result.is_some());
+        let (id, complexity, task_type) = result.unwrap();
+        assert_eq!(id, "FR-001");
+        assert_eq!(complexity, Complexity::Medium);
+        assert_eq!(task_type, TaskType::PureCoding);
+    }
+
+    #[test]
+    fn parse_llm_line_all_task_types() {
+        assert_eq!(parse_llm_line("A|1|pure_coding").unwrap().2, TaskType::PureCoding);
+        assert_eq!(parse_llm_line("B|2|coding_infra").unwrap().2, TaskType::CodingInfra);
+        assert_eq!(parse_llm_line("C|3|design_coding").unwrap().2, TaskType::DesignCoding);
+        assert_eq!(parse_llm_line("D|5|pure_infra").unwrap().2, TaskType::PureInfra);
+        assert_eq!(parse_llm_line("E|8|coordination").unwrap().2, TaskType::Coordination);
+    }
+
+    #[test]
+    fn parse_llm_line_invalid_complexity() {
+        assert!(parse_llm_line("FR-001|4|pure_coding").is_none()); // 4 is not Fibonacci
+    }
+
+    #[test]
+    fn parse_llm_line_invalid_task_type() {
+        assert!(parse_llm_line("FR-001|3|unknown_type").is_none());
+    }
+
+    #[test]
+    fn parse_llm_line_wrong_format() {
+        assert!(parse_llm_line("just some text").is_none());
+        assert!(parse_llm_line("FR-001|3").is_none()); // missing task type
+        assert!(parse_llm_line("").is_none());
+    }
+
+    #[test]
+    fn parse_llm_response_with_fallback() {
+        // Simulate an LLM response where only FR-001 is scored; FR-002 is missing
+        let items = vec![
+            work_item("FR-001", "Implement auth system with security encryption", "Must"),
+            work_item("FR-002", "Add button", "Could"),
+        ];
+        let llm_response = "FR-001|8|coding_infra\n";
+
+        let scored = parse_llm_response(llm_response, &items);
+        assert_eq!(scored.len(), 2);
+
+        // FR-001 should use LLM values
+        assert_eq!(scored[0].id, "FR-001");
+        assert_eq!(scored[0].complexity, Complexity::Hard);
+        assert_eq!(scored[0].task_type, TaskType::CodingInfra);
+
+        // FR-002 should fall back to rule-based
+        assert_eq!(scored[1].id, "FR-002");
+        // Rule-based would assign low complexity for "Add button"
+        assert!(scored[1].complexity.value() <= 3);
+    }
+
+    #[test]
+    fn parse_llm_response_all_garbage_falls_back() {
+        let items = vec![
+            work_item("FR-001", "Build search engine with validation pipeline", "Must"),
+        ];
+        let llm_response = "This is not valid output at all\nNeither is this";
+
+        let scored = parse_llm_response(llm_response, &items);
+        assert_eq!(scored.len(), 1);
+        // Should fall back to rule-based scoring
+        assert_eq!(scored[0].id, "FR-001");
+        assert!(scored[0].complexity.value() >= 1);
+    }
+
+    #[test]
+    fn parse_llm_line_with_whitespace() {
+        let result = parse_llm_line("  FR-001 | 5 | pure_coding  ");
+        assert!(result.is_some());
+        let (id, complexity, task_type) = result.unwrap();
+        assert_eq!(id, "FR-001");
+        assert_eq!(complexity, Complexity::Complex);
+        assert_eq!(task_type, TaskType::PureCoding);
     }
 }


### PR DESCRIPTION
## Summary
- `score_items_with_llm()` — sends work items to LLM for Fibonacci complexity + task type scoring
- Per-item fallback: if LLM scores only some items, rest use rule-based
- Full fallback: if LLM call fails, all items scored by rules
- `--llm-score` flag on `forgeplan estimate` command
- Structured `ID|COMPLEXITY|TASK_TYPE` format for reliable parsing
- 8 new tests (15 total scorer tests)

## Refs
- RFC-005 Phase 3, ADR-004 (Hybrid: rule-based L0 + LLM L1)

## Test plan
- [x] `cargo test -p forgeplan-core -- estimate::scorer` — 15/15 pass
- [x] `cargo build` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)