### PR TITLE
[RFC-004] Fix files-first bugs, wire changelog, reindex cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2252,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2256,6 +2262,7 @@ dependencies = [
  "console 0.16.3",
  "ctrlc",
  "dirs",
+ "dotenvy",
  "forgeplan-core",
  "forgeplan-mcp",
  "notify",
@@ -2269,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2293,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -6,6 +6,11 @@ use crate::commands::common;
 pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    // Capture old status before transition
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "draft".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +28,7 @@ pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("draft"), Some("active"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("active"), "cli").await;
 
     if result.forced {
         println!("  Activated {id} (draft → active)");

--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("draft"), Some("active"), "cli").await;
+
     if result.forced {
         println!("  Activated {id} (draft → active)");
         println!(

--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -116,9 +116,12 @@ pub fn require_llm_config() -> anyhow::Result<forgeplan_core::config::types::Llm
 }
 
 /// Log a change to the change_log table (best-effort, never fails the command).
+/// May reference deleted artifacts by design (audit trail).
 pub async fn log_change(store: &LanceStore, artifact_id: &str, action: &str, source: &str) {
     let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source);
-    let _ = store.log_change(&entry).await;
+    if let Err(e) = store.log_change(&entry).await {
+        eprintln!("  Warning: changelog write failed for {}: {}", artifact_id, e);
+    }
 }
 
 /// Log a change with field + values (best-effort).
@@ -134,7 +137,9 @@ pub async fn log_change_field(
     let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source)
         .with_field(field)
         .with_values(old_value, new_value);
-    let _ = store.log_change(&entry).await;
+    if let Err(e) = store.log_change(&entry).await {
+        eprintln!("  Warning: changelog write failed for {}: {}", artifact_id, e);
+    }
 }
 
 /// Open storage using driver trait (new API — will replace open_store over time).

--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -115,6 +115,28 @@ pub fn require_llm_config() -> anyhow::Result<forgeplan_core::config::types::Llm
     Ok(llm)
 }
 
+/// Log a change to the change_log table (best-effort, never fails the command).
+pub async fn log_change(store: &LanceStore, artifact_id: &str, action: &str, source: &str) {
+    let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source);
+    let _ = store.log_change(&entry).await;
+}
+
+/// Log a change with field + values (best-effort).
+pub async fn log_change_field(
+    store: &LanceStore,
+    artifact_id: &str,
+    action: &str,
+    field: &str,
+    old_value: Option<&str>,
+    new_value: Option<&str>,
+    source: &str,
+) {
+    let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source)
+        .with_field(field)
+        .with_values(old_value, new_value);
+    let _ = store.log_change(&entry).await;
+}
+
 /// Open storage using driver trait (new API — will replace open_store over time).
 #[allow(dead_code)]
 pub async fn open_driver() -> anyhow::Result<std::sync::Arc<dyn forgeplan_core::driver::StorageDriver>> {

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -6,6 +6,10 @@ use crate::commands::common;
 pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "active".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +27,7 @@ pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("active"), Some("deprecated"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("deprecated"), "cli").await;
 
     println!("  Deprecated {id}: {reason}");
 

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("active"), Some("deprecated"), "cli").await;
+
     println!("  Deprecated {id}: {reason}");
 
     if !dependents.is_empty() {

--- a/crates/forgeplan-cli/src/commands/link.rs
+++ b/crates/forgeplan-cli/src/commands/link.rs
@@ -40,6 +40,8 @@ pub async fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Re
         ).await?;
     }
 
+    common::log_change_field(&store, source_id, "link", "relation", None, Some(&format!("{}:{}", target_id, relation)), "cli").await;
+
     println!("Linked: {} --{}--> {}", source_id, relation, target_id);
     Ok(())
 }
@@ -62,6 +64,8 @@ pub async fn run_unlink(source_id: &str, target_id: &str, relation: &str) -> any
             record.valid_until.as_deref(), &record.body, &links,
         ).await?;
     }
+
+    common::log_change_field(&store, source_id, "unlink", "relation", Some(&format!("{}:{}", target_id, relation)), None, "cli").await;
 
     println!("Unlinked: {} --{}--> {}", source_id, relation, target_id);
     Ok(())

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -96,6 +96,9 @@ pub async fn run(kind_str: &str, title: &str) -> Result<()> {
     .await
     .with_context(|| format!("Failed to write projection for {}", id))?;
 
+    // Log creation in change_log
+    common::log_change(&store, &id, "create", "cli").await;
+
     println!("  Created: {}", filepath.display());
     println!("  ID:      {}", id);
     println!("  Kind:    {}", template_key);

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -139,7 +139,8 @@ pub async fn run() -> anyhow::Result<()> {
                 if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
                     while let Ok(Some(entry)) = rd.next_entry().await {
                         let name = entry.file_name().to_string_lossy().to_string();
-                        if name.to_uppercase().starts_with(&record.id.to_uppercase()) && name.ends_with(".md") {
+                        let id_prefix = format!("{}-", record.id.to_uppercase());
+                        if name.to_uppercase().starts_with(&id_prefix) && name.ends_with(".md") {
                             found = true;
                             break;
                         }

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -58,6 +58,7 @@ pub async fn run() -> anyhow::Result<()> {
                     // Compare body — sync if different
                     if record.body.trim() != body.trim() {
                         store.update_body(&id, &body).await?;
+                        common::log_change(&store, &id, "update", "reindex").await;
                         println!("  SYNC {} — body updated from file", id);
                         synced += 1;
                     } else {
@@ -84,6 +85,7 @@ pub async fn run() -> anyhow::Result<()> {
                     };
 
                     store.create_artifact(&artifact).await?;
+                    common::log_change(&store, &id, "create", "reindex").await;
                     println!("  NEW  {} — created from file", id);
                     synced += 1;
                 }
@@ -116,6 +118,47 @@ pub async fn run() -> anyhow::Result<()> {
         }
     }
 
-    println!("\nReindex complete: {} synced, {} unchanged, {} errors.", synced, skipped, errors);
+    // Phase 2: Remove DB records whose .md file no longer exists (files-first cleanup)
+    let mut removed = 0usize;
+    let all_records = store.list_records(None).await?;
+    for record in &all_records {
+        let kind: forgeplan_core::artifact::types::ArtifactKind =
+            match record.kind.parse() {
+                Ok(k) => k,
+                Err(_) => continue,
+            };
+        let dir = ws.join(kind.dir_name());
+        let slug = forgeplan_core::artifact::types::slugify(&record.title);
+        let filename = format!("{}-{}.md", record.id, slug);
+        let filepath = dir.join(&filename);
+
+        if !filepath.exists() {
+            // Double-check: maybe file exists with different slug (title changed)
+            let mut found = false;
+            if dir.exists() {
+                if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
+                    while let Ok(Some(entry)) = rd.next_entry().await {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if name.to_uppercase().starts_with(&record.id.to_uppercase()) && name.ends_with(".md") {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if !found {
+                store.delete_artifact(&record.id).await?;
+                common::log_change(&store, &record.id, "delete", "reindex").await;
+                println!("  DEL  {} — no .md file found, removed from DB", record.id);
+                removed += 1;
+            }
+        }
+    }
+
+    println!(
+        "\nReindex complete: {} synced, {} unchanged, {} removed, {} errors.",
+        synced, skipped, removed, errors
+    );
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("active"), Some("superseded"), "cli").await;
+
     println!("  Superseded {id} → {by}");
 
     for w in &result.warnings {

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -6,6 +6,10 @@ use crate::commands::common;
 pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "active".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +27,7 @@ pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("active"), Some("superseded"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("superseded"), "cli").await;
 
     println!("  Superseded {id} → {by}");
 

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -50,9 +50,8 @@ pub async fn run(
     }
 
     // Update body
-    if let Some(b) = body {
+    let body_updated = if let Some(b) = body {
         let body_content = if b.starts_with('@') {
-            // Read from file
             let path = &b[1..];
             tokio::fs::read_to_string(path)
                 .await
@@ -61,34 +60,67 @@ pub async fn run(
             b.to_string()
         };
         store.update_body(id, &body_content).await?;
-    }
+        true
+    } else {
+        false
+    };
 
     // Remove old projection file (title change → different slug → stale file)
     if title.is_some() {
         let _ = projection::remove_projection(&ws, id, &original.kind).await;
     }
 
-    // Re-render projection with synced data
+    // Re-render projection
     let updated = store
         .get_record(id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' disappeared after update", id))?;
-
     let links = store.get_relations(id).await.unwrap_or_default();
-    projection::render_projection(
-        &ws,
-        &updated.id,
-        &updated.kind,
-        &updated.title,
-        &updated.status,
-        &updated.depth,
-        updated.author.as_deref(),
-        updated.parent_epic.as_deref(),
-        updated.valid_until.as_deref(),
-        &updated.body,
-        &links,
-    )
-    .await?;
+
+    if body_updated {
+        // Body was explicitly set via CLI — use render_projection_with_body
+        // to override file-on-disk (files-first normally reads from file).
+        projection::render_projection_with_body(
+            &ws,
+            &updated.id,
+            &updated.kind,
+            &updated.title,
+            &updated.status,
+            &updated.depth,
+            updated.author.as_deref(),
+            updated.parent_epic.as_deref(),
+            updated.valid_until.as_deref(),
+            &updated.body,
+            &links,
+        )
+        .await?;
+    } else {
+        projection::render_projection(
+            &ws,
+            &updated.id,
+            &updated.kind,
+            &updated.title,
+            &updated.status,
+            &updated.depth,
+            updated.author.as_deref(),
+            updated.parent_epic.as_deref(),
+            updated.valid_until.as_deref(),
+            &updated.body,
+            &links,
+        )
+        .await?;
+    }
+
+    // Log changes
+    if let Some(s) = status {
+        common::log_change_field(&store, id, "update", "status", Some(&original.status), Some(s), "cli").await;
+    }
+    if let Some(t) = title {
+        common::log_change_field(&store, id, "update", "title", Some(&original.title), Some(t), "cli").await;
+    }
+    if body.is_some() {
+        common::log_change(&store, id, "update", "cli").await;
+    }
 
     println!("  Updated: {}", id);
     if let Some(s) = status {

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -119,7 +119,7 @@ pub async fn run(
         common::log_change_field(&store, id, "update", "title", Some(&original.title), Some(t), "cli").await;
     }
     if body.is_some() {
-        common::log_change(&store, id, "update", "cli").await;
+        common::log_change_field(&store, id, "update", "body", None, None, "cli").await;
     }
 
     println!("  Updated: {}", id);

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -46,3 +46,38 @@ impl ChangeLogEntry {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_basic() {
+        let entry = ChangeLogEntry::new("PRD-001", "create", "cli");
+        assert_eq!(entry.artifact_id, "PRD-001");
+        assert_eq!(entry.action, "create");
+        assert_eq!(entry.source, "cli");
+        assert!(entry.field.is_none());
+        assert!(entry.old_value.is_none());
+        assert!(!entry.timestamp.is_empty());
+    }
+
+    #[test]
+    fn builder_chain() {
+        let entry = ChangeLogEntry::new("PRD-001", "update", "cli")
+            .with_field("status")
+            .with_values(Some("draft"), Some("active"));
+        assert_eq!(entry.field, Some("status".to_string()));
+        assert_eq!(entry.old_value, Some("draft".to_string()));
+        assert_eq!(entry.new_value, Some("active".to_string()));
+    }
+
+    #[test]
+    fn builder_partial_values() {
+        let entry = ChangeLogEntry::new("EVID-001", "link", "reindex")
+            .with_field("relation")
+            .with_values(None, Some("PRD-001:informs"));
+        assert!(entry.old_value.is_none());
+        assert_eq!(entry.new_value, Some("PRD-001:informs".to_string()));
+    }
+}

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -18,3 +18,31 @@ pub struct ChangeLogEntry {
     /// cli, file_edit, git_sync, reindex
     pub source: String,
 }
+
+impl ChangeLogEntry {
+    /// Create a new entry with current timestamp.
+    pub fn new(artifact_id: &str, action: &str, source: &str) -> Self {
+        Self {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            artifact_id: artifact_id.to_string(),
+            action: action.to_string(),
+            field: None,
+            old_value: None,
+            new_value: None,
+            source: source.to_string(),
+        }
+    }
+
+    /// Set the field that changed.
+    pub fn with_field(mut self, field: &str) -> Self {
+        self.field = Some(field.to_string());
+        self
+    }
+
+    /// Set old and new values.
+    pub fn with_values(mut self, old: Option<&str>, new: Option<&str>) -> Self {
+        self.old_value = old.map(|s| s.to_string());
+        self.new_value = new.map(|s| s.to_string());
+        self
+    }
+}

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -24,6 +24,42 @@ pub async fn render_projection(
     body: &str,
     links: &[(String, String)],
 ) -> anyhow::Result<PathBuf> {
+    render_projection_inner(workspace, id, kind, title, status, depth, author, parent_epic, valid_until, body, links, false).await
+}
+
+/// Like render_projection, but `force_body = true` uses the passed body
+/// instead of reading from file. Used by `update --body` to ensure the
+/// CLI-provided body takes precedence over the file on disk.
+pub async fn render_projection_with_body(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    status: &str,
+    depth: &str,
+    author: Option<&str>,
+    parent_epic: Option<&str>,
+    valid_until: Option<&str>,
+    body: &str,
+    links: &[(String, String)],
+) -> anyhow::Result<PathBuf> {
+    render_projection_inner(workspace, id, kind, title, status, depth, author, parent_epic, valid_until, body, links, true).await
+}
+
+async fn render_projection_inner(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    status: &str,
+    depth: &str,
+    author: Option<&str>,
+    parent_epic: Option<&str>,
+    valid_until: Option<&str>,
+    body: &str,
+    links: &[(String, String)],
+    force_body: bool,
+) -> anyhow::Result<PathBuf> {
     let artifact_kind = kind.parse::<ArtifactKind>().unwrap_or(ArtifactKind::Note);
     let dir = workspace.join(artifact_kind.dir_name());
     tokio::fs::create_dir_all(&dir).await?;
@@ -32,16 +68,16 @@ pub async fn render_projection(
     let filename = format!("{}-{}.md", id, slug);
     let filepath = dir.join(&filename);
 
-    // Files-first (RFC-004): ALWAYS preserve file body if file exists and has content.
+    // Files-first (RFC-004): preserve file body if file exists and has content.
     // Only frontmatter is updated from LanceDB. Body comes from the file on disk.
-    // This prevents data loss when `forgeplan link` or `forgeplan update` re-renders the projection.
-    let effective_body = if filepath.exists() {
+    // Exception: force_body=true (from `update --body`) uses the passed body.
+    let effective_body = if force_body {
+        body.to_string()
+    } else if filepath.exists() {
         match tokio::fs::read_to_string(&filepath).await {
             Ok(file_content) => {
                 if let Ok((_fm, file_body)) = frontmatter::parse_frontmatter(&file_content) {
                     if !file_body.trim().is_empty() {
-                        // File has content — always use it, regardless of whether it
-                        // matches LanceDB. The file is the source of truth for body.
                         file_body.to_string()
                     } else {
                         body.to_string()
@@ -430,5 +466,29 @@ mod tests {
 
         let result = read_file_body_if_newer(&ws, "PRD-001", "prd", "Test", body).await;
         assert!(result.is_none(), "should return None when body matches");
+    }
+
+    #[tokio::test]
+    async fn render_projection_with_body_overrides_file() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        // Step 1: create projection with template body
+        let template_body = "## Template\n\n{placeholder}";
+        render_projection(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, template_body, &[],
+        ).await.unwrap();
+
+        // Step 2: render_projection_with_body should override file content
+        let new_body = "## Problem\n\nNew body from CLI update.";
+        let path = render_projection_with_body(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, new_body, &[],
+        ).await.unwrap();
+
+        let result = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(result.contains("New body from CLI update"), "force_body must override file");
+        assert!(!result.contains("{placeholder}"), "old file body must not survive");
     }
 }


### PR DESCRIPTION
## Summary
- **fix(projection)**: `update --body` now overrides file in files-first mode via `render_projection_with_body(force_body=true)`
- **feat(changelog)**: wired `log_change()` into 7 CLI commands (new, update, activate, deprecate, supersede, link/unlink, reindex) — change_log was dead code
- **fix(reindex)**: Phase 2 cleanup removes orphaned DB records when .md file deleted
- **fix(audit)**: 5 findings from 2-agent review — ID prefix collision, hardcoded statuses, silent error swallowing, missing tests

## Stats
- 622 tests, 0 failures, 0 warnings
- ~280 LOC added across 10 files
- 4 new tests (1 projection, 3 changelog builder)
- Fixes weeks-old `e2e_coverage_backfill_adds_section` test failure

## Refs
- RFC-004 (Files-First Architecture)
- EVID-037 (evidence linked)

## Test plan
- [x] cargo test — 622 pass, 0 fail
- [x] cargo check — 0 warnings
- [x] E2E verification of 10 features
- [x] 2-agent audit (code reviewer + Rust expert)
- [x] All 5 actionable audit findings fixed
- [x] forgeplan log — change_log entries appearing correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)