### PR TITLE
[RFC-004] Phase 4: Git integration — git-sync command + commit_hash

### DIFF
--- a/crates/forgeplan-cli/src/commands/git_sync.rs
+++ b/crates/forgeplan-cli/src/commands/git_sync.rs
@@ -164,7 +164,9 @@ pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
                 synced += 1;
             }
             _ => {
-                // R (rename), C (copy), etc. — treat as modified
+                // R (rename), C (copy), etc. — skip silently.
+                // Renames produce two-path output that our parser doesn't handle.
+                // The renamed file will be picked up on next reindex.
                 continue;
             }
         }
@@ -182,8 +184,11 @@ pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
 fn extract_id_from_path(path: &str) -> Option<String> {
     let filename = path.rsplit('/').next()?;
     let stem = filename.strip_suffix(".md")?;
-    // ID is everything before the first '-' after the prefix
-    // e.g., "PRD-001-auth-system" → "PRD-001"
+    // mem- IDs are full slugs (mem-llm-routing), not "PREFIX-NNN"
+    if stem.starts_with("mem-") {
+        return Some(stem.to_string());
+    }
+    // Standard IDs: PREFIX-NNN-slug → "PREFIX-NNN"
     let parts: Vec<&str> = stem.splitn(3, '-').collect();
     if parts.len() >= 2 {
         Some(format!("{}-{}", parts[0], parts[1]))
@@ -223,8 +228,19 @@ mod tests {
 
     #[test]
     fn extract_id_basic() {
-        // Actually test the real logic
         assert_eq!(extract_id_from_path("prds/PRD-001-foo.md"), Some("PRD-001".to_string()));
         assert_eq!(extract_id_from_path("RFC-004-bar.md"), Some("RFC-004".to_string()));
+    }
+
+    #[test]
+    fn extract_id_memory_slug() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/memory/mem-llm-routing.md"),
+            Some("mem-llm-routing".to_string())
+        );
+        assert_eq!(
+            extract_id_from_path(".forgeplan/memory/mem-api-prefix-is-v1.md"),
+            Some("mem-api-prefix-is-v1".to_string())
+        );
     }
 }

--- a/crates/forgeplan-cli/src/commands/git_sync.rs
+++ b/crates/forgeplan-cli/src/commands/git_sync.rs
@@ -1,0 +1,230 @@
+use forgeplan_core::git;
+use forgeplan_core::artifact::frontmatter;
+
+use crate::commands::common;
+
+/// `forgeplan git-sync [--since <ref>]` — sync artifact changes from git operations.
+///
+/// Detects .forgeplan/ files changed since a git ref (default: ORIG_HEAD from last pull/merge)
+/// and syncs them into LanceDB with source=git_sync and commit_hash.
+pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
+    let (ws, store) = common::open_store().await?;
+
+    // Find repo root (parent of .forgeplan/)
+    let repo_root = ws.parent()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine repo root from workspace"))?;
+
+    // Determine the reference point
+    let since_ref = if let Some(s) = since {
+        s.to_string()
+    } else {
+        // Try ORIG_HEAD (set after git pull/merge/rebase)
+        git::orig_head(repo_root)
+            .ok_or_else(|| anyhow::anyhow!(
+                "No ORIG_HEAD found (no recent git pull/merge).\n\
+                 Specify a ref: forgeplan git-sync --since HEAD~3"
+            ))?
+    };
+
+    let commit_hash = git::head_commit_hash(repo_root)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("  Git sync: {}..HEAD (commit {})", since_ref.chars().take(10).collect::<String>(), commit_hash);
+
+    let changed = git::changed_artifact_files(repo_root, &since_ref)?;
+
+    if changed.is_empty() {
+        println!("  No .forgeplan/ files changed since {}.", since_ref.chars().take(10).collect::<String>());
+        return Ok(());
+    }
+
+    let mut synced = 0usize;
+    let mut deleted = 0usize;
+    let mut errors = 0usize;
+
+    for file in &changed {
+        let full_path = repo_root.join(&file.path);
+
+        match file.status {
+            'D' => {
+                // File deleted in git — extract ID from filename
+                if let Some(id) = extract_id_from_path(&file.path) {
+                    if store.get_record(&id).await?.is_some() {
+                        store.delete_artifact(&id).await?;
+                        let entry = forgeplan_core::changelog::ChangeLogEntry::new(&id, "delete", "git_sync")
+                            .with_commit(&commit_hash);
+                        if let Err(e) = store.log_change(&entry).await {
+                            eprintln!("  Warning: changelog write failed for {}: {}", id, e);
+                        }
+                        println!("  DEL  {} (removed in git)", id);
+                        deleted += 1;
+                    }
+                }
+            }
+            'A' | 'M' => {
+                // File added or modified — sync to LanceDB
+                if !full_path.exists() {
+                    eprintln!("  SKIP {} — file not found on disk", file.path);
+                    errors += 1;
+                    continue;
+                }
+
+                let content = match tokio::fs::read_to_string(&full_path).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("  SKIP {} — read error: {}", file.path, e);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let (fm, body) = match frontmatter::parse_frontmatter(&content) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!("  SKIP {} — parse error: {}", file.path, e);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let id = match fm.get("id").and_then(|v| v.as_str()) {
+                    Some(id) => id.to_string(),
+                    None => {
+                        eprintln!("  SKIP {} — no id in frontmatter", file.path);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let action = match store.get_record(&id).await? {
+                    Some(record) => {
+                        // Existing artifact — update body if changed
+                        if record.body.trim() != body.trim() {
+                            store.update_body(&id, &body).await?;
+                            // Also sync frontmatter fields
+                            if let Some(status) = fm.get("status").and_then(|v| v.as_str()) {
+                                let status_lower = status.to_lowercase();
+                                if record.status != status_lower {
+                                    store.update_artifact(&id, Some(&status_lower), None).await?;
+                                }
+                            }
+                            "update"
+                        } else {
+                            continue; // No changes
+                        }
+                    }
+                    None => {
+                        // New artifact from git
+                        let kind = fm.get("kind").and_then(|v| v.as_str()).unwrap_or("note");
+                        let status = fm.get("status").and_then(|v| v.as_str()).unwrap_or("draft");
+                        let title = fm.get("title").and_then(|v| v.as_str()).unwrap_or(&id);
+                        let depth = fm.get("depth").and_then(|v| v.as_str()).unwrap_or("standard");
+
+                        let artifact = forgeplan_core::db::store::NewArtifact {
+                            id: id.clone(),
+                            kind: kind.to_string(),
+                            status: status.to_lowercase(),
+                            title: title.to_string(),
+                            body: body.to_string(),
+                            depth: depth.to_string(),
+                            author: fm.get("author").and_then(|v| v.as_str()).map(String::from),
+                            parent_epic: fm.get("parent_epic").and_then(|v| v.as_str()).map(String::from),
+                            valid_until: fm.get("valid_until").and_then(|v| v.as_str()).map(String::from),
+                        };
+
+                        store.create_artifact(&artifact).await?;
+                        "create"
+                    }
+                };
+
+                // Restore links from frontmatter
+                if let Some(links_val) = fm.get("links") {
+                    if let Some(links_arr) = links_val.as_sequence() {
+                        let existing = store.get_relations(&id).await.unwrap_or_default();
+                        for link in links_arr {
+                            let target = link.get("target").and_then(|v| v.as_str());
+                            let relation = link.get("relation").and_then(|v| v.as_str());
+                            if let (Some(t), Some(r)) = (target, relation) {
+                                if !existing.iter().any(|(et, er)| et == t && er == r) {
+                                    let _ = store.add_relation(&id, t, r).await;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let entry = forgeplan_core::changelog::ChangeLogEntry::new(&id, action, "git_sync")
+                    .with_commit(&commit_hash);
+                if let Err(e) = store.log_change(&entry).await {
+                    eprintln!("  Warning: changelog write failed for {}: {}", id, e);
+                }
+
+                let status_char = if action == "create" { "NEW " } else { "SYNC" };
+                println!("  {} {} (from git, commit {})", status_char, id, commit_hash);
+                synced += 1;
+            }
+            _ => {
+                // R (rename), C (copy), etc. — treat as modified
+                continue;
+            }
+        }
+    }
+
+    println!(
+        "\nGit sync complete: {} synced, {} deleted, {} errors (commit {})",
+        synced, deleted, errors, commit_hash
+    );
+
+    Ok(())
+}
+
+/// Extract artifact ID from a path like ".forgeplan/prds/PRD-001-auth-system.md"
+fn extract_id_from_path(path: &str) -> Option<String> {
+    let filename = path.rsplit('/').next()?;
+    let stem = filename.strip_suffix(".md")?;
+    // ID is everything before the first '-' after the prefix
+    // e.g., "PRD-001-auth-system" → "PRD-001"
+    let parts: Vec<&str> = stem.splitn(3, '-').collect();
+    if parts.len() >= 2 {
+        Some(format!("{}-{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_id_from_path_basic() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/prds/PRD-001-auth-system.md"),
+            Some("PRD-001".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_from_path_evidence() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/evidence/EVID-037-e2e-verification.md"),
+            Some("EVID-037".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_from_path_no_slug() {
+        // NOTE-001.md has no slug suffix — still extracts ID correctly
+        assert_eq!(
+            extract_id_from_path(".forgeplan/notes/NOTE-001.md"),
+            Some("NOTE-001".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_basic() {
+        // Actually test the real logic
+        assert_eq!(extract_id_from_path("prds/PRD-001-foo.md"), Some("PRD-001".to_string()));
+        assert_eq!(extract_id_from_path("RFC-004-bar.md"), Some("RFC-004".to_string()));
+    }
+}

--- a/crates/forgeplan-cli/src/commands/log_cmd.rs
+++ b/crates/forgeplan-cli/src/commands/log_cmd.rs
@@ -21,10 +21,10 @@ pub async fn run(
 
     // Header
     println!(
-        "{:<18} {:<10} {:<9} {:<8} {:<20} {}",
-        "TIMESTAMP", "ARTIFACT", "ACTION", "FIELD", "CHANGE", "SOURCE"
+        "{:<18} {:<10} {:<9} {:<8} {:<20} {:<10} {}",
+        "TIMESTAMP", "ARTIFACT", "ACTION", "FIELD", "CHANGE", "SOURCE", "COMMIT"
     );
-    println!("{}", "-".repeat(80));
+    println!("{}", "-".repeat(90));
 
     for entry in &entries {
         // Shorten timestamp: "2026-03-31T10:15:00+00:00" → "2026-03-31 10:15"
@@ -48,9 +48,11 @@ pub async fn run(
             (None, None) => "-".to_string(),
         };
 
+        let commit = entry.commit_hash.as_deref().unwrap_or("-");
+
         println!(
-            "{:<18} {:<10} {:<9} {:<8} {:<20} {}",
-            ts, entry.artifact_id, entry.action, field, change, entry.source
+            "{:<18} {:<10} {:<9} {:<8} {:<20} {:<10} {}",
+            ts, entry.artifact_id, entry.action, field, change, entry.source, commit
         );
     }
 

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod gaps;
 pub mod fpf;
 pub mod generate;
 pub mod get;
+pub mod git_sync;
 pub mod graph;
 pub mod health;
 pub mod import_cmd;

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -422,6 +422,12 @@ enum Commands {
     },
     /// Watch .forgeplan/ files and sync changes to LanceDB in real time
     Watch,
+    /// Sync artifact changes from git operations (pull/merge) into LanceDB
+    GitSync {
+        /// Git ref to diff against (default: ORIG_HEAD from last pull/merge)
+        #[arg(long)]
+        since: Option<String>,
+    },
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -609,6 +615,7 @@ async fn main() -> anyhow::Result<()> {
             commands::recall::run(query.as_deref(), category.as_deref(), limit, json).await
         }
         Commands::Watch => commands::watch::run().await,
+        Commands::GitSync { since } => commands::git_sync::run(since.as_deref()).await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -17,6 +17,8 @@ pub struct ChangeLogEntry {
     pub new_value: Option<String>,
     /// cli, file_edit, git_sync, reindex
     pub source: String,
+    /// Git commit hash (short, 7 chars) — set when source is git_sync
+    pub commit_hash: Option<String>,
 }
 
 impl ChangeLogEntry {
@@ -30,6 +32,7 @@ impl ChangeLogEntry {
             old_value: None,
             new_value: None,
             source: source.to_string(),
+            commit_hash: None,
         }
     }
 
@@ -43,6 +46,12 @@ impl ChangeLogEntry {
     pub fn with_values(mut self, old: Option<&str>, new: Option<&str>) -> Self {
         self.old_value = old.map(|s| s.to_string());
         self.new_value = new.map(|s| s.to_string());
+        self
+    }
+
+    /// Set git commit hash (short form, 7 chars).
+    pub fn with_commit(mut self, hash: &str) -> Self {
+        self.commit_hash = Some(hash.to_string());
         self
     }
 }

--- a/crates/forgeplan-core/src/db/migrate.rs
+++ b/crates/forgeplan-core/src/db/migrate.rs
@@ -7,7 +7,7 @@ use lancedb::table::NewColumnTransform;
 use lancedb::Table;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Run all pending migrations on the artifacts table.
 /// Idempotent — safe to run multiple times.
@@ -78,6 +78,7 @@ pub async fn ensure_change_log(
                 Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
                 Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
                 Arc::new(StringArray::from(Vec::<&str>::new())),
+                Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // commit_hash
             ],
         ).map_err(|e: ArrowError| anyhow::anyhow!("Failed to create change_log batch: {}", e))?;
         db.create_table("change_log", vec![batch]).execute().await?;
@@ -86,9 +87,37 @@ pub async fn ensure_change_log(
     Ok(())
 }
 
+/// Migrate existing change_log table to add commit_hash column (v2→v3).
+pub async fn migrate_change_log(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    if !field_names.contains(&"commit_hash".to_string()) {
+        eprintln!("[migrate] Adding commit_hash column to change_log");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "commit_hash".to_string(),
+                    "CAST(NULL AS STRING)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
 /// Run all migrations on all tables. Call from LanceStore::open().
-pub async fn run_migrations(artifacts: &Table, relations: &Table) -> anyhow::Result<()> {
+pub async fn run_migrations(
+    artifacts: &Table,
+    relations: &Table,
+    change_log: Option<&Table>,
+) -> anyhow::Result<()> {
     migrate_artifacts(artifacts).await?;
     migrate_relations(relations).await?;
+    if let Some(cl) = change_log {
+        migrate_change_log(cl).await?;
+    }
     Ok(())
 }

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -124,6 +124,7 @@ pub fn fpf_spec_schema() -> Arc<Schema> {
 /// - old_value     Utf8 (nullable) — previous value (hash for body)
 /// - new_value     Utf8 (nullable) — new value (hash for body)
 /// - source        Utf8 (not null) — cli/file_edit/git_sync/reindex
+/// - commit_hash   Utf8 (nullable) — git commit hash (short, 7 chars)
 pub fn change_log_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("timestamp", DataType::Utf8, false),
@@ -133,6 +134,7 @@ pub fn change_log_schema() -> Arc<Schema> {
         Field::new("old_value", DataType::Utf8, true),
         Field::new("new_value", DataType::Utf8, true),
         Field::new("source", DataType::Utf8, false),
+        Field::new("commit_hash", DataType::Utf8, true),
     ]))
 }
 

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -183,12 +183,12 @@ impl LanceStore {
         let relations = db.open_table("relations").execute().await?;
         let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
 
-        // Run migrations (idempotent — safe on every open)
-        migrate::run_migrations(&artifacts, &relations).await?;
-
         // Ensure change_log table exists (migration for older workspaces)
         migrate::ensure_change_log(&db).await?;
         let change_log = db.open_table("change_log").execute().await.ok();
+
+        // Run migrations (idempotent — safe on every open)
+        migrate::run_migrations(&artifacts, &relations, change_log.as_ref()).await?;
 
         Ok(Self {
             _db: db,

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -772,6 +772,7 @@ impl LanceStore {
                 Arc::new(StringArray::from(vec![entry.old_value.as_deref()])),
                 Arc::new(StringArray::from(vec![entry.new_value.as_deref()])),
                 Arc::new(StringArray::from(vec![entry.source.as_str()])),
+                Arc::new(StringArray::from(vec![entry.commit_hash.as_deref()])),
             ],
         )?;
 
@@ -1217,6 +1218,7 @@ fn extract_change_log_entry(batch: &RecordBatch, row: usize) -> Option<ChangeLog
     let old_value = get_string(batch, "old_value", row);
     let new_value = get_string(batch, "new_value", row);
     let source = get_string(batch, "source", row)?;
+    let commit_hash = get_string(batch, "commit_hash", row);
 
     Some(ChangeLogEntry {
         timestamp,
@@ -1226,6 +1228,7 @@ fn extract_change_log_entry(batch: &RecordBatch, row: usize) -> Option<ChangeLog
         old_value,
         new_value,
         source,
+        commit_hash,
     })
 }
 
@@ -1243,6 +1246,7 @@ fn empty_change_log_batch(
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // old_value (nullable)
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // new_value (nullable)
             Arc::new(StringArray::from(Vec::<&str>::new())),       // source
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // commit_hash (nullable)
         ],
     )
 }

--- a/crates/forgeplan-core/src/git/mod.rs
+++ b/crates/forgeplan-core/src/git/mod.rs
@@ -1,0 +1,130 @@
+//! Git integration — detect changed .forgeplan/ files from git operations.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Files changed in .forgeplan/ between two git refs.
+#[derive(Debug, Clone)]
+pub struct GitChangedFile {
+    /// Relative path from repo root (e.g., ".forgeplan/prds/PRD-001-auth.md")
+    pub path: String,
+    /// Git change status: A (added), M (modified), D (deleted)
+    pub status: char,
+}
+
+/// Get the current HEAD commit hash (short, 7 chars).
+pub fn head_commit_hash(repo_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Get the merge base (common ancestor) between HEAD and a ref.
+pub fn merge_base(repo_root: &Path, ref_name: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["merge-base", "HEAD", ref_name])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Detect .forgeplan/ files changed between two git refs (or since last N commits).
+/// Returns list of changed files with their status.
+pub fn changed_artifact_files(
+    repo_root: &Path,
+    since_ref: &str,
+) -> anyhow::Result<Vec<GitChangedFile>> {
+    let output = Command::new("git")
+        .args([
+            "diff",
+            "--name-status",
+            since_ref,
+            "HEAD",
+            "--",
+            ".forgeplan/",
+        ])
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git diff failed: {}", stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut files = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        if parts.len() == 2 {
+            let status = parts[0].chars().next().unwrap_or('M');
+            let path = parts[1].to_string();
+            // Only .md files in artifact dirs
+            if path.ends_with(".md") {
+                files.push(GitChangedFile { path, status });
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// Get the ORIG_HEAD ref (set after git pull/merge/rebase).
+/// Returns None if ORIG_HEAD doesn't exist (no recent merge).
+pub fn orig_head(repo_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "ORIG_HEAD"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn head_commit_hash_returns_7_chars() {
+        // Run in current repo which is a git repo
+        let hash = head_commit_hash(Path::new("."));
+        assert!(hash.is_some(), "should find HEAD in git repo");
+        let h = hash.unwrap();
+        assert!(h.len() >= 7 && h.len() <= 12, "short hash should be 7-12 chars, got {}", h.len());
+    }
+
+    #[test]
+    fn head_commit_hash_returns_none_for_non_repo() {
+        let tmp = TempDir::new().unwrap();
+        let hash = head_commit_hash(tmp.path());
+        assert!(hash.is_none());
+    }
+
+    #[test]
+    fn changed_artifact_files_no_diff() {
+        // HEAD..HEAD = no changes
+        let files = changed_artifact_files(Path::new("."), "HEAD");
+        assert!(files.is_ok());
+        assert!(files.unwrap().is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/git/mod.rs
+++ b/crates/forgeplan-core/src/git/mod.rs
@@ -58,7 +58,8 @@ pub fn changed_artifact_files(
             ".forgeplan/",
         ])
         .current_dir(repo_root)
-        .output()?;
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run git (is git installed?): {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod lifecycle;
 pub mod llm;
 pub mod error;
 pub mod gaps;
+pub mod git;
 pub mod graph;
 pub mod link;
 pub mod progress;


### PR DESCRIPTION
## Summary
- **New `forgeplan git-sync` command** — detects .forgeplan/ files changed since ORIG_HEAD or `--since <ref>`, syncs to LanceDB with source=git_sync
- **commit_hash in change_log** — nullable column, recorded for all git_sync entries
- **New `forgeplan-core::git` module** — head_commit_hash(), orig_head(), changed_artifact_files()
- **Schema migration v2→v3** — existing change_log tables get commit_hash column automatically
- **`forgeplan log` shows COMMIT column** — displays short commit hash when present
- **`forgeplan log --source git_sync`** — filter by git operations

## Audit
- 2-agent review (code reviewer + Rust expert)
- 2 CRITICAL + 2 IMPORTANT findings — all fixed
- Fixes: ensure_change_log column count, schema migration, mem- ID extraction, git error messages

## Stats
- 630 tests, 0 failures, 0 warnings
- ~440 LOC added across 11 files
- 10 new tests

## Refs
- RFC-004 Phase 4

## Test plan
- [x] cargo test — 630 pass, 0 fail
- [x] cargo check — 0 warnings
- [x] `forgeplan git-sync --help` — works
- [x] `forgeplan git-sync --since HEAD~3` — no changes (expected)
- [x] `forgeplan log --source git_sync` — empty (expected)
- [x] 2-agent audit + all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)