### PR TITLE
Release v0.12.0 — Quality Cycle Sprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ target/
 # Node.js
 node_modules/
 
+# Environment secrets
+.env
+.env.local
+
 # OS files
 .DS_Store
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2252,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2256,6 +2262,7 @@ dependencies = [
  "console 0.16.3",
  "ctrlc",
  "dirs",
+ "dotenvy",
  "forgeplan-core",
  "forgeplan-mcp",
  "notify",
@@ -2269,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2293,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1"
 petgraph = "0.8"
 notify = "7"
 notify-debouncer-mini = "0.5"
+dotenvy = "0.15"
 
 [profile.release]
 strip = true          # strip debug symbols (-16%)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/user/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -23,6 +23,7 @@ ctrlc = "3.5.2"
 dirs = "6.0.0"
 notify.workspace = true
 notify-debouncer-mini.workspace = true
+dotenvy.workspace = true
 
 [features]
 semantic-search = ["forgeplan-core/semantic-search"]

--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -34,5 +34,19 @@ pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
         println!("  Activated {id} (draft → active)");
     }
 
+    // Hints: suggest evidence if not linked
+    if let Some(record) = store.get_record(id).await? {
+        let rels = store.get_relations(id).await.unwrap_or_default();
+        let incoming = store.get_incoming_relations(id).await.unwrap_or_default();
+        let has_evidence = rels.iter().chain(incoming.iter())
+            .any(|(t, _)| t.to_uppercase().starts_with("EVID-"));
+        let kind: forgeplan_core::artifact::types::ArtifactKind = record.kind.parse()
+            .unwrap_or(forgeplan_core::artifact::types::ArtifactKind::Note);
+        let hints = forgeplan_core::hints::activate_hints(true, has_evidence, &kind);
+        if !hints.is_empty() {
+            print!("{}", forgeplan_core::hints::format_hints(&hints));
+        }
+    }
+
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -6,6 +6,11 @@ use crate::commands::common;
 pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    // Capture old status before transition
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "draft".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +28,7 @@ pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("draft"), Some("active"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("active"), "cli").await;
 
     if result.forced {
         println!("  Activated {id} (draft → active)");

--- a/crates/forgeplan-cli/src/commands/activate.rs
+++ b/crates/forgeplan-cli/src/commands/activate.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, force: bool) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("draft"), Some("active"), "cli").await;
+
     if result.forced {
         println!("  Activated {id} (draft → active)");
         println!(

--- a/crates/forgeplan-cli/src/commands/blocked.rs
+++ b/crates/forgeplan-cli/src/commands/blocked.rs
@@ -31,9 +31,15 @@ pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
             println!("  {} is NOT blocked (all dependencies met)", artifact_id);
         } else {
             println!("  {} is BLOCKED by:", artifact_id);
+            let mut blocker_pairs = Vec::new();
             for dep in &blocked_by {
                 let status = if active_ids.contains(dep) { "active" } else { "draft" };
                 println!("    -> {} ({})", dep, status);
+                blocker_pairs.push((dep.clone(), status.to_string()));
+            }
+            let hints = forgeplan_core::hints::blocked_hints(&blocker_pairs);
+            if !hints.is_empty() {
+                print!("{}", forgeplan_core::hints::format_hints(&hints));
             }
         }
     } else {

--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -116,9 +116,12 @@ pub fn require_llm_config() -> anyhow::Result<forgeplan_core::config::types::Llm
 }
 
 /// Log a change to the change_log table (best-effort, never fails the command).
+/// May reference deleted artifacts by design (audit trail).
 pub async fn log_change(store: &LanceStore, artifact_id: &str, action: &str, source: &str) {
     let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source);
-    let _ = store.log_change(&entry).await;
+    if let Err(e) = store.log_change(&entry).await {
+        eprintln!("  Warning: changelog write failed for {}: {}", artifact_id, e);
+    }
 }
 
 /// Log a change with field + values (best-effort).
@@ -134,7 +137,9 @@ pub async fn log_change_field(
     let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source)
         .with_field(field)
         .with_values(old_value, new_value);
-    let _ = store.log_change(&entry).await;
+    if let Err(e) = store.log_change(&entry).await {
+        eprintln!("  Warning: changelog write failed for {}: {}", artifact_id, e);
+    }
 }
 
 /// Open storage using driver trait (new API — will replace open_store over time).

--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -115,6 +115,28 @@ pub fn require_llm_config() -> anyhow::Result<forgeplan_core::config::types::Llm
     Ok(llm)
 }
 
+/// Log a change to the change_log table (best-effort, never fails the command).
+pub async fn log_change(store: &LanceStore, artifact_id: &str, action: &str, source: &str) {
+    let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source);
+    let _ = store.log_change(&entry).await;
+}
+
+/// Log a change with field + values (best-effort).
+pub async fn log_change_field(
+    store: &LanceStore,
+    artifact_id: &str,
+    action: &str,
+    field: &str,
+    old_value: Option<&str>,
+    new_value: Option<&str>,
+    source: &str,
+) {
+    let entry = forgeplan_core::changelog::ChangeLogEntry::new(artifact_id, action, source)
+        .with_field(field)
+        .with_values(old_value, new_value);
+    let _ = store.log_change(&entry).await;
+}
+
 /// Open storage using driver trait (new API — will replace open_store over time).
 #[allow(dead_code)]
 pub async fn open_driver() -> anyhow::Result<std::sync::Arc<dyn forgeplan_core::driver::StorageDriver>> {

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -6,6 +6,10 @@ use crate::commands::common;
 pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "active".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +27,7 @@ pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("active"), Some("deprecated"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("deprecated"), "cli").await;
 
     println!("  Deprecated {id}: {reason}");
 

--- a/crates/forgeplan-cli/src/commands/deprecate.rs
+++ b/crates/forgeplan-cli/src/commands/deprecate.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, reason: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("active"), Some("deprecated"), "cli").await;
+
     println!("  Deprecated {id}: {reason}");
 
     if !dependents.is_empty() {

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -26,9 +26,37 @@ pub async fn run(
     // Extract work items from artifact body
     let work_items = extractor::extract_work_items(&record.body);
 
-    if work_items.is_empty() && !json {
-        println!("  No FR or Phase items found in {}.", id);
-        println!("  Add FR table to PRD or Phase checklist to RFC.");
+    // Collect hints about artifact quality
+    let hints = extractor::collect_hints(&record.body, work_items.len(), &record.kind);
+
+    if work_items.is_empty() {
+        if json {
+            // In JSON mode, return empty result with hints
+            let result = forgeplan_core::estimate::types::EstimateResult {
+                artifact_id: record.id.clone(),
+                artifact_title: record.title.clone(),
+                items: vec![],
+                totals: std::collections::HashMap::new(),
+                total_score: 0.0,
+                confidence: 0.0,
+                confidence_reasons: vec![],
+                hints,
+            };
+            println!("{}", serde_json::to_string_pretty(&result)?);
+        } else {
+            println!("  No estimable items found in {}.", id);
+            for hint in &hints {
+                let prefix = match hint.level {
+                    forgeplan_core::estimate::types::HintLevel::Warning => "!",
+                    forgeplan_core::estimate::types::HintLevel::Info => "i",
+                    forgeplan_core::estimate::types::HintLevel::Suggestion => "*",
+                };
+                println!("  {} {}", prefix, hint.message);
+                if let Some(ref action) = hint.action {
+                    println!("    -> {}", action);
+                }
+            }
+        }
         return Ok(());
     }
 
@@ -87,6 +115,7 @@ pub async fn run(
         &config,
         conf,
         conf_reasons,
+        hints,
     );
 
     // Determine highlight grade

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -91,7 +91,13 @@ pub async fn run(
 
     // Determine highlight grade
     let highlight_grade = if my_grade {
-        let domain = infer_domain(&record.kind);
+        let domain = if llm_score {
+            // LLM-assisted domain inference when --llm-score is active
+            let llm_config = common::config().ok().and_then(|c| c.llm);
+            infer_domain_with_llm(&record.title, &record.body, llm_config.as_ref()).await
+        } else {
+            infer_domain(&record.title, &record.body)
+        };
         let resolved = config.resolve_grade(&domain);
         if !json {
             eprintln!(
@@ -163,11 +169,95 @@ fn load_estimate_config() -> EstimateConfig {
     }
 }
 
-/// Infer work domain from artifact kind for grade profile lookup.
-fn infer_domain(kind: &str) -> String {
-    match kind {
-        "prd" | "epic" | "spec" => "backend".to_string(),
-        "rfc" | "adr" => "backend".to_string(),
-        _ => "default".to_string(),
+/// LLM-assisted domain inference. Falls back to keyword-based if LLM unavailable.
+async fn infer_domain_with_llm(
+    title: &str,
+    body: &str,
+    llm_config: Option<&forgeplan_core::config::types::LlmConfig>,
+) -> String {
+    // Try frontmatter first (same as non-LLM path)
+    if let Some(domain) = extract_frontmatter_domain(body) {
+        let d = domain.to_lowercase();
+        if !d.contains('/') && !d.is_empty() && d != "general" {
+            return d;
+        }
     }
+
+    // Try LLM classification
+    if let Some(config) = llm_config {
+        let snippet: String = body.chars().take(300).collect();
+        let prompt = format!(
+            "Classify this artifact into exactly ONE domain. Reply with ONLY the domain name, nothing else.\n\
+             Domains: backend, frontend, devops, ai_ml, default\n\n\
+             Title: {}\nBody: {}",
+            title, snippet
+        );
+        {
+            let client = forgeplan_core::llm::LlmClient::new(config.clone());
+            if let Ok(response) = client.generate(&prompt, Some("You are a domain classifier. Reply with exactly one word.")).await {
+                let domain = response.trim().to_lowercase().replace(' ', "_");
+                let valid = ["backend", "frontend", "devops", "ai_ml"];
+                if valid.contains(&domain.as_str()) {
+                    return domain;
+                }
+            }
+        }
+    }
+
+    // Fallback to keyword-based
+    infer_domain(title, body)
+}
+
+/// Infer work domain from artifact content for grade profile lookup.
+/// Priority: frontmatter `domain:` field > keyword inference from title+body > "default".
+fn infer_domain(title: &str, body: &str) -> String {
+    // 1. Try frontmatter domain: field
+    if let Some(domain) = extract_frontmatter_domain(body) {
+        let d = domain.to_lowercase();
+        // Skip template placeholders
+        if !d.contains('/') && !d.is_empty() && d != "general" {
+            return d;
+        }
+    }
+
+    // 2. Keyword inference from title + body (first 500 chars for performance)
+    let text = format!("{} {}", title, &body[..body.len().min(500)]).to_lowercase();
+
+    let domains = [
+        ("devops", &["k8s", "docker", "ci/cd", "deploy", "helm", "terraform", "kubernetes",
+            "pipeline", "infrastructure", "namespace", "registry", "runner"][..]),
+        ("frontend", &["react", "css", "ui", "component", "layout", "frontend", "tailwind",
+            "responsive", "browser", "dom", "jsx", "tsx", "next.js"][..]),
+        ("ai_ml", &["llm", "embedding", "model", "prompt", "ml", "ai", "vector",
+            "semantic", "scoring", "neural", "training", "inference"][..]),
+        ("backend", &["api", "database", "endpoint", "service", "backend", "crud",
+            "rest", "graphql", "grpc", "migration", "schema", "query"][..]),
+    ];
+
+    let mut best_domain = "default";
+    let mut best_score = 0usize;
+
+    for (domain, keywords) in &domains {
+        let score = keywords.iter().filter(|kw| text.contains(**kw)).count();
+        if score > best_score {
+            best_score = score;
+            best_domain = domain;
+        }
+    }
+
+    best_domain.to_string()
+}
+
+/// Extract `domain:` value from YAML frontmatter in body.
+fn extract_frontmatter_domain(body: &str) -> Option<String> {
+    for line in body.lines().take(30) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("domain:") {
+            let value = trimmed[7..].trim().trim_matches('"').trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
 }

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -220,8 +220,10 @@ fn infer_domain(title: &str, body: &str) -> String {
         }
     }
 
-    // 2. Keyword inference from title + body (first 500 chars for performance)
-    let text = format!("{} {}", title, &body[..body.len().min(500)]).to_lowercase();
+    // 2. Keyword inference from title + body (skip frontmatter, take 1000 chars of content)
+    let content = body.split("---").skip(2).collect::<Vec<_>>().join(" ");
+    let snippet: String = content.chars().take(1000).collect();
+    let text = format!("{} {}", title, snippet).to_lowercase();
 
     let domains = [
         ("devops", &["k8s", "docker", "ci/cd", "deploy", "helm", "terraform", "kubernetes",

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -9,6 +9,7 @@ pub async fn run(
     id: &str,
     grade: Option<&str>,
     my_grade: bool,
+    llm_score: bool,
     json: bool,
 ) -> Result<()> {
     let store = common::store().await?;
@@ -28,8 +29,19 @@ pub async fn run(
         return Ok(());
     }
 
-    // Score complexity (rule-based L0)
-    let scored_items = scorer::score_items(&work_items);
+    // Score complexity: LLM L1 (opt-in) or rule-based L0 (default)
+    let scored_items = if llm_score {
+        let llm_config = common::require_llm_config()?;
+        if !json {
+            eprintln!(
+                "  Using LLM scorer ({}/{}). Fallback to rules if LLM fails.",
+                llm_config.provider, llm_config.model
+            );
+        }
+        scorer::score_items_with_llm(&work_items, &llm_config).await
+    } else {
+        scorer::score_items(&work_items)
+    };
 
     // Calculate confidence
     let fr_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Fr).collect();

--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 
 use forgeplan_core::estimate::{calculator, confidence, display, extractor, scorer};
-use forgeplan_core::estimate::types::{EstimateConfig, Grade, ItemSource};
+use forgeplan_core::estimate::types::{Complexity, EstimateConfig, Grade, ItemSource, ScoredItem};
 
 use crate::commands::common;
 
@@ -10,6 +12,7 @@ pub async fn run(
     grade: Option<&str>,
     my_grade: bool,
     llm_score: bool,
+    complexity_overrides: Option<&str>,
     json: bool,
 ) -> Result<()> {
     let store = common::store().await?;
@@ -30,7 +33,7 @@ pub async fn run(
     }
 
     // Score complexity: LLM L1 (opt-in) or rule-based L0 (default)
-    let scored_items = if llm_score {
+    let mut scored_items = if llm_score {
         let llm_config = common::require_llm_config()?;
         if !json {
             eprintln!(
@@ -43,17 +46,34 @@ pub async fn run(
         scorer::score_items(&work_items)
     };
 
+    // Apply manual complexity overrides (highest priority per ADR-004)
+    if let Some(overrides) = complexity_overrides {
+        let map = parse_complexity_overrides(overrides)?;
+        apply_overrides(&mut scored_items, &map);
+        if !json {
+            eprintln!("  Applied {} manual complexity override(s)", map.len());
+        }
+    }
+
     // Calculate confidence
     let fr_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Fr).collect();
     let phase_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Phase).collect();
+
+    // Check linked Spec and Evidence for confidence boost
+    let relations = store.get_relations(&record.id).await.unwrap_or_default();
+    let incoming = store.get_incoming_relations(&record.id).await.unwrap_or_default();
+    let all_rels: Vec<_> = relations.iter().chain(incoming.iter()).collect();
+
+    let has_spec = all_rels.iter().any(|(target, _)| target.to_uppercase().starts_with("SPEC-"));
+    let has_evidence = all_rels.iter().any(|(target, _)| target.to_uppercase().starts_with("EVID-"));
 
     let (conf, conf_reasons) = confidence::score_confidence(
         !fr_items.is_empty(),
         fr_items.len(),
         !phase_items.is_empty(),
         phase_items.len(),
-        false, // TODO: check linked Spec
-        false, // TODO: check linked Evidence
+        has_spec,
+        has_evidence,
     );
 
     // Build config from .forgeplan/config.yaml or defaults
@@ -94,6 +114,39 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+/// Parse "FR-001=5,FR-002=3" into HashMap<String, Complexity>.
+fn parse_complexity_overrides(input: &str) -> Result<HashMap<String, Complexity>> {
+    let mut map = HashMap::new();
+    for pair in input.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = pair.splitn(2, '=').collect();
+        if parts.len() != 2 {
+            anyhow::bail!("Invalid complexity override '{}'. Format: FR-001=5", pair);
+        }
+        let id = parts[0].trim().to_string();
+        let value: u32 = parts[1].trim().parse()
+            .map_err(|_| anyhow::anyhow!("Invalid number '{}' in complexity override", parts[1].trim()))?;
+        let complexity = Complexity::from_value(value)
+            .ok_or_else(|| anyhow::anyhow!(
+                "Invalid Fibonacci value {}. Valid: 1, 2, 3, 5, 8, 13", value
+            ))?;
+        map.insert(id, complexity);
+    }
+    Ok(map)
+}
+
+/// Apply manual overrides to scored items — override has highest priority.
+fn apply_overrides(items: &mut [ScoredItem], overrides: &HashMap<String, Complexity>) {
+    for item in items.iter_mut() {
+        if let Some(complexity) = overrides.get(&item.id) {
+            item.complexity = *complexity;
+        }
+    }
 }
 
 /// Load EstimateConfig from .forgeplan/config.yaml, falling back to defaults.

--- a/crates/forgeplan-cli/src/commands/get.rs
+++ b/crates/forgeplan-cli/src/commands/get.rs
@@ -48,5 +48,16 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
     println!();
     println!("{}", record.body);
 
+    // Contextual hints
+    let relations = store.get_relations(id).await.unwrap_or_default();
+    let incoming = store.get_incoming_relations(id).await.unwrap_or_default();
+    let has_links = !relations.is_empty() || !incoming.is_empty();
+    let kind: forgeplan_core::artifact::types::ArtifactKind = record.kind.parse().unwrap_or(forgeplan_core::artifact::types::ArtifactKind::Note);
+    let depth: forgeplan_core::artifact::types::Mode = record.depth.parse().unwrap_or(forgeplan_core::artifact::types::Mode::Standard);
+    let get_hints = forgeplan_core::hints::get_hints(&record.status, &kind, has_links, &depth);
+    if !get_hints.is_empty() {
+        print!("{}", forgeplan_core::hints::format_hints(&get_hints));
+    }
+
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/git_sync.rs
+++ b/crates/forgeplan-cli/src/commands/git_sync.rs
@@ -164,7 +164,9 @@ pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
                 synced += 1;
             }
             _ => {
-                // R (rename), C (copy), etc. — treat as modified
+                // R (rename), C (copy), etc. — skip silently.
+                // Renames produce two-path output that our parser doesn't handle.
+                // The renamed file will be picked up on next reindex.
                 continue;
             }
         }
@@ -182,8 +184,11 @@ pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
 fn extract_id_from_path(path: &str) -> Option<String> {
     let filename = path.rsplit('/').next()?;
     let stem = filename.strip_suffix(".md")?;
-    // ID is everything before the first '-' after the prefix
-    // e.g., "PRD-001-auth-system" → "PRD-001"
+    // mem- IDs are full slugs (mem-llm-routing), not "PREFIX-NNN"
+    if stem.starts_with("mem-") {
+        return Some(stem.to_string());
+    }
+    // Standard IDs: PREFIX-NNN-slug → "PREFIX-NNN"
     let parts: Vec<&str> = stem.splitn(3, '-').collect();
     if parts.len() >= 2 {
         Some(format!("{}-{}", parts[0], parts[1]))
@@ -223,8 +228,19 @@ mod tests {
 
     #[test]
     fn extract_id_basic() {
-        // Actually test the real logic
         assert_eq!(extract_id_from_path("prds/PRD-001-foo.md"), Some("PRD-001".to_string()));
         assert_eq!(extract_id_from_path("RFC-004-bar.md"), Some("RFC-004".to_string()));
+    }
+
+    #[test]
+    fn extract_id_memory_slug() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/memory/mem-llm-routing.md"),
+            Some("mem-llm-routing".to_string())
+        );
+        assert_eq!(
+            extract_id_from_path(".forgeplan/memory/mem-api-prefix-is-v1.md"),
+            Some("mem-api-prefix-is-v1".to_string())
+        );
     }
 }

--- a/crates/forgeplan-cli/src/commands/git_sync.rs
+++ b/crates/forgeplan-cli/src/commands/git_sync.rs
@@ -1,0 +1,230 @@
+use forgeplan_core::git;
+use forgeplan_core::artifact::frontmatter;
+
+use crate::commands::common;
+
+/// `forgeplan git-sync [--since <ref>]` — sync artifact changes from git operations.
+///
+/// Detects .forgeplan/ files changed since a git ref (default: ORIG_HEAD from last pull/merge)
+/// and syncs them into LanceDB with source=git_sync and commit_hash.
+pub async fn run(since: Option<&str>) -> anyhow::Result<()> {
+    let (ws, store) = common::open_store().await?;
+
+    // Find repo root (parent of .forgeplan/)
+    let repo_root = ws.parent()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine repo root from workspace"))?;
+
+    // Determine the reference point
+    let since_ref = if let Some(s) = since {
+        s.to_string()
+    } else {
+        // Try ORIG_HEAD (set after git pull/merge/rebase)
+        git::orig_head(repo_root)
+            .ok_or_else(|| anyhow::anyhow!(
+                "No ORIG_HEAD found (no recent git pull/merge).\n\
+                 Specify a ref: forgeplan git-sync --since HEAD~3"
+            ))?
+    };
+
+    let commit_hash = git::head_commit_hash(repo_root)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("  Git sync: {}..HEAD (commit {})", since_ref.chars().take(10).collect::<String>(), commit_hash);
+
+    let changed = git::changed_artifact_files(repo_root, &since_ref)?;
+
+    if changed.is_empty() {
+        println!("  No .forgeplan/ files changed since {}.", since_ref.chars().take(10).collect::<String>());
+        return Ok(());
+    }
+
+    let mut synced = 0usize;
+    let mut deleted = 0usize;
+    let mut errors = 0usize;
+
+    for file in &changed {
+        let full_path = repo_root.join(&file.path);
+
+        match file.status {
+            'D' => {
+                // File deleted in git — extract ID from filename
+                if let Some(id) = extract_id_from_path(&file.path) {
+                    if store.get_record(&id).await?.is_some() {
+                        store.delete_artifact(&id).await?;
+                        let entry = forgeplan_core::changelog::ChangeLogEntry::new(&id, "delete", "git_sync")
+                            .with_commit(&commit_hash);
+                        if let Err(e) = store.log_change(&entry).await {
+                            eprintln!("  Warning: changelog write failed for {}: {}", id, e);
+                        }
+                        println!("  DEL  {} (removed in git)", id);
+                        deleted += 1;
+                    }
+                }
+            }
+            'A' | 'M' => {
+                // File added or modified — sync to LanceDB
+                if !full_path.exists() {
+                    eprintln!("  SKIP {} — file not found on disk", file.path);
+                    errors += 1;
+                    continue;
+                }
+
+                let content = match tokio::fs::read_to_string(&full_path).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("  SKIP {} — read error: {}", file.path, e);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let (fm, body) = match frontmatter::parse_frontmatter(&content) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        eprintln!("  SKIP {} — parse error: {}", file.path, e);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let id = match fm.get("id").and_then(|v| v.as_str()) {
+                    Some(id) => id.to_string(),
+                    None => {
+                        eprintln!("  SKIP {} — no id in frontmatter", file.path);
+                        errors += 1;
+                        continue;
+                    }
+                };
+
+                let action = match store.get_record(&id).await? {
+                    Some(record) => {
+                        // Existing artifact — update body if changed
+                        if record.body.trim() != body.trim() {
+                            store.update_body(&id, &body).await?;
+                            // Also sync frontmatter fields
+                            if let Some(status) = fm.get("status").and_then(|v| v.as_str()) {
+                                let status_lower = status.to_lowercase();
+                                if record.status != status_lower {
+                                    store.update_artifact(&id, Some(&status_lower), None).await?;
+                                }
+                            }
+                            "update"
+                        } else {
+                            continue; // No changes
+                        }
+                    }
+                    None => {
+                        // New artifact from git
+                        let kind = fm.get("kind").and_then(|v| v.as_str()).unwrap_or("note");
+                        let status = fm.get("status").and_then(|v| v.as_str()).unwrap_or("draft");
+                        let title = fm.get("title").and_then(|v| v.as_str()).unwrap_or(&id);
+                        let depth = fm.get("depth").and_then(|v| v.as_str()).unwrap_or("standard");
+
+                        let artifact = forgeplan_core::db::store::NewArtifact {
+                            id: id.clone(),
+                            kind: kind.to_string(),
+                            status: status.to_lowercase(),
+                            title: title.to_string(),
+                            body: body.to_string(),
+                            depth: depth.to_string(),
+                            author: fm.get("author").and_then(|v| v.as_str()).map(String::from),
+                            parent_epic: fm.get("parent_epic").and_then(|v| v.as_str()).map(String::from),
+                            valid_until: fm.get("valid_until").and_then(|v| v.as_str()).map(String::from),
+                        };
+
+                        store.create_artifact(&artifact).await?;
+                        "create"
+                    }
+                };
+
+                // Restore links from frontmatter
+                if let Some(links_val) = fm.get("links") {
+                    if let Some(links_arr) = links_val.as_sequence() {
+                        let existing = store.get_relations(&id).await.unwrap_or_default();
+                        for link in links_arr {
+                            let target = link.get("target").and_then(|v| v.as_str());
+                            let relation = link.get("relation").and_then(|v| v.as_str());
+                            if let (Some(t), Some(r)) = (target, relation) {
+                                if !existing.iter().any(|(et, er)| et == t && er == r) {
+                                    let _ = store.add_relation(&id, t, r).await;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let entry = forgeplan_core::changelog::ChangeLogEntry::new(&id, action, "git_sync")
+                    .with_commit(&commit_hash);
+                if let Err(e) = store.log_change(&entry).await {
+                    eprintln!("  Warning: changelog write failed for {}: {}", id, e);
+                }
+
+                let status_char = if action == "create" { "NEW " } else { "SYNC" };
+                println!("  {} {} (from git, commit {})", status_char, id, commit_hash);
+                synced += 1;
+            }
+            _ => {
+                // R (rename), C (copy), etc. — treat as modified
+                continue;
+            }
+        }
+    }
+
+    println!(
+        "\nGit sync complete: {} synced, {} deleted, {} errors (commit {})",
+        synced, deleted, errors, commit_hash
+    );
+
+    Ok(())
+}
+
+/// Extract artifact ID from a path like ".forgeplan/prds/PRD-001-auth-system.md"
+fn extract_id_from_path(path: &str) -> Option<String> {
+    let filename = path.rsplit('/').next()?;
+    let stem = filename.strip_suffix(".md")?;
+    // ID is everything before the first '-' after the prefix
+    // e.g., "PRD-001-auth-system" → "PRD-001"
+    let parts: Vec<&str> = stem.splitn(3, '-').collect();
+    if parts.len() >= 2 {
+        Some(format!("{}-{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_id_from_path_basic() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/prds/PRD-001-auth-system.md"),
+            Some("PRD-001".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_from_path_evidence() {
+        assert_eq!(
+            extract_id_from_path(".forgeplan/evidence/EVID-037-e2e-verification.md"),
+            Some("EVID-037".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_from_path_no_slug() {
+        // NOTE-001.md has no slug suffix — still extracts ID correctly
+        assert_eq!(
+            extract_id_from_path(".forgeplan/notes/NOTE-001.md"),
+            Some("NOTE-001".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_id_basic() {
+        // Actually test the real logic
+        assert_eq!(extract_id_from_path("prds/PRD-001-foo.md"), Some("PRD-001".to_string()));
+        assert_eq!(extract_id_from_path("RFC-004-bar.md"), Some("RFC-004".to_string()));
+    }
+}

--- a/crates/forgeplan-cli/src/commands/link.rs
+++ b/crates/forgeplan-cli/src/commands/link.rs
@@ -40,6 +40,8 @@ pub async fn run(source_id: &str, target_id: &str, relation: &str) -> anyhow::Re
         ).await?;
     }
 
+    common::log_change_field(&store, source_id, "link", "relation", None, Some(&format!("{}:{}", target_id, relation)), "cli").await;
+
     println!("Linked: {} --{}--> {}", source_id, relation, target_id);
     Ok(())
 }
@@ -62,6 +64,8 @@ pub async fn run_unlink(source_id: &str, target_id: &str, relation: &str) -> any
             record.valid_until.as_deref(), &record.body, &links,
         ).await?;
     }
+
+    common::log_change_field(&store, source_id, "unlink", "relation", Some(&format!("{}:{}", target_id, relation)), None, "cli").await;
 
     println!("Unlinked: {} --{}--> {}", source_id, relation, target_id);
     Ok(())

--- a/crates/forgeplan-cli/src/commands/log_cmd.rs
+++ b/crates/forgeplan-cli/src/commands/log_cmd.rs
@@ -21,10 +21,10 @@ pub async fn run(
 
     // Header
     println!(
-        "{:<18} {:<10} {:<9} {:<8} {:<20} {}",
-        "TIMESTAMP", "ARTIFACT", "ACTION", "FIELD", "CHANGE", "SOURCE"
+        "{:<18} {:<10} {:<9} {:<8} {:<20} {:<10} {}",
+        "TIMESTAMP", "ARTIFACT", "ACTION", "FIELD", "CHANGE", "SOURCE", "COMMIT"
     );
-    println!("{}", "-".repeat(80));
+    println!("{}", "-".repeat(90));
 
     for entry in &entries {
         // Shorten timestamp: "2026-03-31T10:15:00+00:00" → "2026-03-31 10:15"
@@ -48,9 +48,11 @@ pub async fn run(
             (None, None) => "-".to_string(),
         };
 
+        let commit = entry.commit_hash.as_deref().unwrap_or("-");
+
         println!(
-            "{:<18} {:<10} {:<9} {:<8} {:<20} {}",
-            ts, entry.artifact_id, entry.action, field, change, entry.source
+            "{:<18} {:<10} {:<9} {:<8} {:<20} {:<10} {}",
+            ts, entry.artifact_id, entry.action, field, change, entry.source, commit
         );
     }
 

--- a/crates/forgeplan-cli/src/commands/mod.rs
+++ b/crates/forgeplan-cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod gaps;
 pub mod fpf;
 pub mod generate;
 pub mod get;
+pub mod git_sync;
 pub mod graph;
 pub mod health;
 pub mod import_cmd;

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -100,6 +100,20 @@ pub async fn run(kind_str: &str, title: &str) -> Result<()> {
     println!("  ID:      {}", id);
     println!("  Kind:    {}", template_key);
     println!("  Title:   {}", title);
+
+    // Next-step hint based on kind
+    let hint = match template_key {
+        "prd" => Some("Next: fill Problem, Goals, Non-Goals, Target Users, FR sections → forgeplan validate"),
+        "rfc" => Some("Next: fill Summary, Motivation, Goals, Options, Implementation Phases → forgeplan validate"),
+        "adr" => Some("Next: fill Context, Decision, Consequences → forgeplan validate"),
+        "evidence" => Some("Next: fill Structured Fields (verdict, congruence_level, evidence_type) → forgeplan activate"),
+        "epic" => Some("Next: fill Vision, Children PRDs, Progress → forgeplan validate"),
+        _ => None,
+    };
+    if let Some(h) = hint {
+        println!("\n  * {}", h);
+    }
+
     Ok(())
 }
 

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -96,6 +96,9 @@ pub async fn run(kind_str: &str, title: &str) -> Result<()> {
     .await
     .with_context(|| format!("Failed to write projection for {}", id))?;
 
+    // Log creation in change_log
+    common::log_change(&store, &id, "create", "cli").await;
+
     println!("  Created: {}", filepath.display());
     println!("  ID:      {}", id);
     println!("  Kind:    {}", template_key);

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -139,7 +139,8 @@ pub async fn run() -> anyhow::Result<()> {
                 if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
                     while let Ok(Some(entry)) = rd.next_entry().await {
                         let name = entry.file_name().to_string_lossy().to_string();
-                        if name.to_uppercase().starts_with(&record.id.to_uppercase()) && name.ends_with(".md") {
+                        let id_prefix = format!("{}-", record.id.to_uppercase());
+                        if name.to_uppercase().starts_with(&id_prefix) && name.ends_with(".md") {
                             found = true;
                             break;
                         }

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -58,6 +58,7 @@ pub async fn run() -> anyhow::Result<()> {
                     // Compare body — sync if different
                     if record.body.trim() != body.trim() {
                         store.update_body(&id, &body).await?;
+                        common::log_change(&store, &id, "update", "reindex").await;
                         println!("  SYNC {} — body updated from file", id);
                         synced += 1;
                     } else {
@@ -84,6 +85,7 @@ pub async fn run() -> anyhow::Result<()> {
                     };
 
                     store.create_artifact(&artifact).await?;
+                    common::log_change(&store, &id, "create", "reindex").await;
                     println!("  NEW  {} — created from file", id);
                     synced += 1;
                 }
@@ -116,6 +118,47 @@ pub async fn run() -> anyhow::Result<()> {
         }
     }
 
-    println!("\nReindex complete: {} synced, {} unchanged, {} errors.", synced, skipped, errors);
+    // Phase 2: Remove DB records whose .md file no longer exists (files-first cleanup)
+    let mut removed = 0usize;
+    let all_records = store.list_records(None).await?;
+    for record in &all_records {
+        let kind: forgeplan_core::artifact::types::ArtifactKind =
+            match record.kind.parse() {
+                Ok(k) => k,
+                Err(_) => continue,
+            };
+        let dir = ws.join(kind.dir_name());
+        let slug = forgeplan_core::artifact::types::slugify(&record.title);
+        let filename = format!("{}-{}.md", record.id, slug);
+        let filepath = dir.join(&filename);
+
+        if !filepath.exists() {
+            // Double-check: maybe file exists with different slug (title changed)
+            let mut found = false;
+            if dir.exists() {
+                if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
+                    while let Ok(Some(entry)) = rd.next_entry().await {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if name.to_uppercase().starts_with(&record.id.to_uppercase()) && name.ends_with(".md") {
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if !found {
+                store.delete_artifact(&record.id).await?;
+                common::log_change(&store, &record.id, "delete", "reindex").await;
+                println!("  DEL  {} — no .md file found, removed from DB", record.id);
+                removed += 1;
+            }
+        }
+    }
+
+    println!(
+        "\nReindex complete: {} synced, {} unchanged, {} removed, {} errors.",
+        synced, skipped, removed, errors
+    );
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/review.rs
+++ b/crates/forgeplan-cli/src/commands/review.rs
@@ -41,5 +41,21 @@ pub async fn run(id: &str) -> anyhow::Result<()> {
         }
     }
 
+    // Contextual hints
+    let has_evidence = !result.warnings.iter().any(|w| w.contains("No evidence linked"));
+    let is_stub = result.warnings.iter().any(|w| w.contains("Body too short"));
+    let has_must_errors = !result.must_findings.is_empty();
+    let kind = store
+        .get_record(id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|r| r.kind.parse::<forgeplan_core::artifact::types::ArtifactKind>().ok())
+        .unwrap_or(forgeplan_core::artifact::types::ArtifactKind::Note);
+    let review_hints = forgeplan_core::hints::review_hints(has_evidence, is_stub, has_must_errors, &kind);
+    if !review_hints.is_empty() {
+        print!("{}", forgeplan_core::hints::format_hints(&review_hints));
+    }
+
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -293,6 +293,14 @@ pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
         ui::warning("Add evidence with `forgeplan new evidence`");
     }
 
+    // Contextual hints
+    let has_evidence = !evidence_items.is_empty();
+    let cl0_count = evidence_items.iter().filter(|e| e.congruence_level == 0).count();
+    let score_hints = forgeplan_core::hints::score_hints(report.r_eff, has_evidence, cl0_count);
+    if !score_hints.is_empty() {
+        print!("{}", forgeplan_core::hints::format_hints(&score_hints));
+    }
+
     println!();
 
     Ok(())

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -179,6 +179,8 @@ async fn run_smart(query: &str, kind: Option<&str>, limit: usize, json: bool) ->
             println!("[]");
         } else {
             ui::info("No artifacts found.");
+            let hints = forgeplan_core::hints::search_hints(query, 0);
+            print!("{}", forgeplan_core::hints::format_hints(&hints));
         }
         return Ok(());
     }

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -39,6 +39,8 @@ async fn run_keyword(query: &str, kind: Option<&str>, json: bool) -> anyhow::Res
             println!("[]");
         } else {
             ui::info(&format!("No results for \"{}\"", query));
+            let hints = forgeplan_core::hints::search_hints(query, 0);
+            print!("{}", forgeplan_core::hints::format_hints(&hints));
         }
         return Ok(());
     }
@@ -215,6 +217,8 @@ async fn run_smart(query: &str, kind: Option<&str>, limit: usize, json: bool) ->
             println!("[]");
         } else {
             ui::info(&format!("No results for \"{}\"", query));
+            let hints = forgeplan_core::hints::search_hints(query, 0);
+            print!("{}", forgeplan_core::hints::format_hints(&hints));
         }
         return Ok(());
     }

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -23,6 +23,8 @@ pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
+    common::log_change_field(&store, id, "update", "status", Some("active"), Some("superseded"), "cli").await;
+
     println!("  Superseded {id} → {by}");
 
     for w in &result.warnings {

--- a/crates/forgeplan-cli/src/commands/supersede.rs
+++ b/crates/forgeplan-cli/src/commands/supersede.rs
@@ -6,6 +6,10 @@ use crate::commands::common;
 pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 
+    let old_status = store.get_record(id).await?
+        .map(|r| r.status)
+        .unwrap_or_else(|| "active".to_string());
+
     // Sync file→LanceDB before lifecycle call (preserve user edits)
     if let Some(record) = store.get_record(id).await? {
         projection::sync_file_to_store(&store, &ws, &record).await?;
@@ -23,7 +27,7 @@ pub async fn run(id: &str, by: &str) -> anyhow::Result<()> {
         ).await?;
     }
 
-    common::log_change_field(&store, id, "update", "status", Some("active"), Some("superseded"), "cli").await;
+    common::log_change_field(&store, id, "update", "status", Some(&old_status), Some("superseded"), "cli").await;
 
     println!("  Superseded {id} → {by}");
 

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -50,9 +50,8 @@ pub async fn run(
     }
 
     // Update body
-    if let Some(b) = body {
+    let body_updated = if let Some(b) = body {
         let body_content = if b.starts_with('@') {
-            // Read from file
             let path = &b[1..];
             tokio::fs::read_to_string(path)
                 .await
@@ -61,34 +60,67 @@ pub async fn run(
             b.to_string()
         };
         store.update_body(id, &body_content).await?;
-    }
+        true
+    } else {
+        false
+    };
 
     // Remove old projection file (title change → different slug → stale file)
     if title.is_some() {
         let _ = projection::remove_projection(&ws, id, &original.kind).await;
     }
 
-    // Re-render projection with synced data
+    // Re-render projection
     let updated = store
         .get_record(id)
         .await?
         .ok_or_else(|| anyhow::anyhow!("Artifact '{}' disappeared after update", id))?;
-
     let links = store.get_relations(id).await.unwrap_or_default();
-    projection::render_projection(
-        &ws,
-        &updated.id,
-        &updated.kind,
-        &updated.title,
-        &updated.status,
-        &updated.depth,
-        updated.author.as_deref(),
-        updated.parent_epic.as_deref(),
-        updated.valid_until.as_deref(),
-        &updated.body,
-        &links,
-    )
-    .await?;
+
+    if body_updated {
+        // Body was explicitly set via CLI — use render_projection_with_body
+        // to override file-on-disk (files-first normally reads from file).
+        projection::render_projection_with_body(
+            &ws,
+            &updated.id,
+            &updated.kind,
+            &updated.title,
+            &updated.status,
+            &updated.depth,
+            updated.author.as_deref(),
+            updated.parent_epic.as_deref(),
+            updated.valid_until.as_deref(),
+            &updated.body,
+            &links,
+        )
+        .await?;
+    } else {
+        projection::render_projection(
+            &ws,
+            &updated.id,
+            &updated.kind,
+            &updated.title,
+            &updated.status,
+            &updated.depth,
+            updated.author.as_deref(),
+            updated.parent_epic.as_deref(),
+            updated.valid_until.as_deref(),
+            &updated.body,
+            &links,
+        )
+        .await?;
+    }
+
+    // Log changes
+    if let Some(s) = status {
+        common::log_change_field(&store, id, "update", "status", Some(&original.status), Some(s), "cli").await;
+    }
+    if let Some(t) = title {
+        common::log_change_field(&store, id, "update", "title", Some(&original.title), Some(t), "cli").await;
+    }
+    if body.is_some() {
+        common::log_change(&store, id, "update", "cli").await;
+    }
 
     println!("  Updated: {}", id);
     if let Some(s) = status {

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -32,13 +32,12 @@ pub async fn run(
         }
     }
 
-    // Depth update not supported — fail explicitly instead of silently continuing
+    // Depth update
     if let Some(d) = depth {
-        // Validate the value first for a better error message
         let _: forgeplan_core::artifact::types::Mode = d
             .parse()
-            .map_err(|_| anyhow::anyhow!("Invalid depth '{}'. Use: tactical, standard, deep", d))?;
-        anyhow::bail!("Depth update not yet supported. Use `forgeplan new` with the correct depth.");
+            .map_err(|_| anyhow::anyhow!("Invalid depth '{}'. Valid: tactical, standard, deep, critical", d))?;
+        store.update_depth(id, d).await?;
     }
 
     // Sync file→LanceDB BEFORE any mutations — capture user edits from the OLD file

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -119,7 +119,7 @@ pub async fn run(
         common::log_change_field(&store, id, "update", "title", Some(&original.title), Some(t), "cli").await;
     }
     if body.is_some() {
-        common::log_change(&store, id, "update", "cli").await;
+        common::log_change_field(&store, id, "update", "body", None, None, "cli").await;
     }
 
     println!("  Updated: {}", id);

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -457,6 +457,9 @@ enum FpfCommands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Load .env file (if exists) for API keys and config overrides
+    dotenvy::dotenv().ok();
+
     let cli = Cli::parse();
 
     match cli.command {

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -422,6 +422,12 @@ enum Commands {
     },
     /// Watch .forgeplan/ files and sync changes to LanceDB in real time
     Watch,
+    /// Sync artifact changes from git operations (pull/merge) into LanceDB
+    GitSync {
+        /// Git ref to diff against (default: ORIG_HEAD from last pull/merge)
+        #[arg(long)]
+        since: Option<String>,
+    },
     /// Start MCP server (stdio transport) for AI agent integration
     Serve,
 }
@@ -609,6 +615,7 @@ async fn main() -> anyhow::Result<()> {
             commands::recall::run(query.as_deref(), category.as_deref(), limit, json).await
         }
         Commands::Watch => commands::watch::run().await,
+        Commands::GitSync { since } => commands::git_sync::run(since.as_deref()).await,
         Commands::Serve => {
             let cwd = std::env::current_dir()?;
             forgeplan_mcp::run_stdio(cwd).await

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -78,6 +78,9 @@ enum Commands {
         /// Use grade profile from config (domain-aware)
         #[arg(long)]
         my_grade: bool,
+        /// Use LLM-based complexity scoring instead of rule-based heuristics
+        #[arg(long)]
+        llm_score: bool,
         /// Output as JSON for machine consumption
         #[arg(long)]
         json: bool,
@@ -473,8 +476,8 @@ async fn main() -> anyhow::Result<()> {
                 commands::score::run(id.as_deref(), json).await
             }
         }
-        Commands::Estimate { id, grade, my_grade, json } => {
-            commands::estimate::run(&id, grade.as_deref(), my_grade, json).await
+        Commands::Estimate { id, grade, my_grade, llm_score, json } => {
+            commands::estimate::run(&id, grade.as_deref(), my_grade, llm_score, json).await
         }
         Commands::Link {
             source,

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -81,6 +81,9 @@ enum Commands {
         /// Use LLM-based complexity scoring instead of rule-based heuristics
         #[arg(long)]
         llm_score: bool,
+        /// Manual complexity overrides: FR-001=5,FR-002=3 (Fibonacci: 1,2,3,5,8,13)
+        #[arg(long)]
+        complexity: Option<String>,
         /// Output as JSON for machine consumption
         #[arg(long)]
         json: bool,
@@ -479,8 +482,8 @@ async fn main() -> anyhow::Result<()> {
                 commands::score::run(id.as_deref(), json).await
             }
         }
-        Commands::Estimate { id, grade, my_grade, llm_score, json } => {
-            commands::estimate::run(&id, grade.as_deref(), my_grade, llm_score, json).await
+        Commands::Estimate { id, grade, my_grade, llm_score, complexity, json } => {
+            commands::estimate::run(&id, grade.as_deref(), my_grade, llm_score, complexity.as_deref(), json).await
         }
         Commands::Link {
             source,

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -46,3 +46,38 @@ impl ChangeLogEntry {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_basic() {
+        let entry = ChangeLogEntry::new("PRD-001", "create", "cli");
+        assert_eq!(entry.artifact_id, "PRD-001");
+        assert_eq!(entry.action, "create");
+        assert_eq!(entry.source, "cli");
+        assert!(entry.field.is_none());
+        assert!(entry.old_value.is_none());
+        assert!(!entry.timestamp.is_empty());
+    }
+
+    #[test]
+    fn builder_chain() {
+        let entry = ChangeLogEntry::new("PRD-001", "update", "cli")
+            .with_field("status")
+            .with_values(Some("draft"), Some("active"));
+        assert_eq!(entry.field, Some("status".to_string()));
+        assert_eq!(entry.old_value, Some("draft".to_string()));
+        assert_eq!(entry.new_value, Some("active".to_string()));
+    }
+
+    #[test]
+    fn builder_partial_values() {
+        let entry = ChangeLogEntry::new("EVID-001", "link", "reindex")
+            .with_field("relation")
+            .with_values(None, Some("PRD-001:informs"));
+        assert!(entry.old_value.is_none());
+        assert_eq!(entry.new_value, Some("PRD-001:informs".to_string()));
+    }
+}

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -17,6 +17,8 @@ pub struct ChangeLogEntry {
     pub new_value: Option<String>,
     /// cli, file_edit, git_sync, reindex
     pub source: String,
+    /// Git commit hash (short, 7 chars) — set when source is git_sync
+    pub commit_hash: Option<String>,
 }
 
 impl ChangeLogEntry {
@@ -30,6 +32,7 @@ impl ChangeLogEntry {
             old_value: None,
             new_value: None,
             source: source.to_string(),
+            commit_hash: None,
         }
     }
 
@@ -43,6 +46,12 @@ impl ChangeLogEntry {
     pub fn with_values(mut self, old: Option<&str>, new: Option<&str>) -> Self {
         self.old_value = old.map(|s| s.to_string());
         self.new_value = new.map(|s| s.to_string());
+        self
+    }
+
+    /// Set git commit hash (short form, 7 chars).
+    pub fn with_commit(mut self, hash: &str) -> Self {
+        self.commit_hash = Some(hash.to_string());
         self
     }
 }

--- a/crates/forgeplan-core/src/changelog/mod.rs
+++ b/crates/forgeplan-core/src/changelog/mod.rs
@@ -18,3 +18,31 @@ pub struct ChangeLogEntry {
     /// cli, file_edit, git_sync, reindex
     pub source: String,
 }
+
+impl ChangeLogEntry {
+    /// Create a new entry with current timestamp.
+    pub fn new(artifact_id: &str, action: &str, source: &str) -> Self {
+        Self {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            artifact_id: artifact_id.to_string(),
+            action: action.to_string(),
+            field: None,
+            old_value: None,
+            new_value: None,
+            source: source.to_string(),
+        }
+    }
+
+    /// Set the field that changed.
+    pub fn with_field(mut self, field: &str) -> Self {
+        self.field = Some(field.to_string());
+        self
+    }
+
+    /// Set old and new values.
+    pub fn with_values(mut self, old: Option<&str>, new: Option<&str>) -> Self {
+        self.old_value = old.map(|s| s.to_string());
+        self.new_value = new.map(|s| s.to_string());
+        self
+    }
+}

--- a/crates/forgeplan-core/src/db/migrate.rs
+++ b/crates/forgeplan-core/src/db/migrate.rs
@@ -7,7 +7,7 @@ use lancedb::table::NewColumnTransform;
 use lancedb::Table;
 
 /// Current schema version. Increment when adding migrations.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 /// Run all pending migrations on the artifacts table.
 /// Idempotent — safe to run multiple times.
@@ -78,6 +78,7 @@ pub async fn ensure_change_log(
                 Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
                 Arc::new(StringArray::from(Vec::<Option<&str>>::new())),
                 Arc::new(StringArray::from(Vec::<&str>::new())),
+                Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // commit_hash
             ],
         ).map_err(|e: ArrowError| anyhow::anyhow!("Failed to create change_log batch: {}", e))?;
         db.create_table("change_log", vec![batch]).execute().await?;
@@ -86,9 +87,37 @@ pub async fn ensure_change_log(
     Ok(())
 }
 
+/// Migrate existing change_log table to add commit_hash column (v2→v3).
+pub async fn migrate_change_log(table: &Table) -> anyhow::Result<()> {
+    let schema = table.schema().await?;
+    let field_names: Vec<String> = schema.fields().iter().map(|f| f.name().clone()).collect();
+
+    if !field_names.contains(&"commit_hash".to_string()) {
+        eprintln!("[migrate] Adding commit_hash column to change_log");
+        table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "commit_hash".to_string(),
+                    "CAST(NULL AS STRING)".to_string(),
+                )]),
+                None,
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
 /// Run all migrations on all tables. Call from LanceStore::open().
-pub async fn run_migrations(artifacts: &Table, relations: &Table) -> anyhow::Result<()> {
+pub async fn run_migrations(
+    artifacts: &Table,
+    relations: &Table,
+    change_log: Option<&Table>,
+) -> anyhow::Result<()> {
     migrate_artifacts(artifacts).await?;
     migrate_relations(relations).await?;
+    if let Some(cl) = change_log {
+        migrate_change_log(cl).await?;
+    }
     Ok(())
 }

--- a/crates/forgeplan-core/src/db/schema.rs
+++ b/crates/forgeplan-core/src/db/schema.rs
@@ -124,6 +124,7 @@ pub fn fpf_spec_schema() -> Arc<Schema> {
 /// - old_value     Utf8 (nullable) — previous value (hash for body)
 /// - new_value     Utf8 (nullable) — new value (hash for body)
 /// - source        Utf8 (not null) — cli/file_edit/git_sync/reindex
+/// - commit_hash   Utf8 (nullable) — git commit hash (short, 7 chars)
 pub fn change_log_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("timestamp", DataType::Utf8, false),
@@ -133,6 +134,7 @@ pub fn change_log_schema() -> Arc<Schema> {
         Field::new("old_value", DataType::Utf8, true),
         Field::new("new_value", DataType::Utf8, true),
         Field::new("source", DataType::Utf8, false),
+        Field::new("commit_hash", DataType::Utf8, true),
     ]))
 }
 

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -359,6 +359,20 @@ impl LanceStore {
         Ok(())
     }
 
+    /// Update the depth column of an artifact.
+    pub async fn update_depth(&self, id: &str, depth: &str) -> anyhow::Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let predicate = format!("id = '{}'", id.replace('\'', "''"));
+        self.artifacts
+            .update()
+            .only_if(predicate)
+            .column("updated_at", &format!("'{}'", now))
+            .column("depth", &format!("'{}'", depth.replace('\'', "''")))
+            .execute()
+            .await?;
+        Ok(())
+    }
+
     /// Update r_eff_score for an artifact. Verifies the artifact exists first.
     pub async fn update_r_eff_score(&self, id: &str, score: f64) -> anyhow::Result<()> {
         let score = if score.is_nan() { 0.0 } else { score.clamp(0.0, 1.0) };

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -183,12 +183,12 @@ impl LanceStore {
         let relations = db.open_table("relations").execute().await?;
         let fpf_spec = db.open_table("fpf_spec").execute().await.ok();
 
-        // Run migrations (idempotent — safe on every open)
-        migrate::run_migrations(&artifacts, &relations).await?;
-
         // Ensure change_log table exists (migration for older workspaces)
         migrate::ensure_change_log(&db).await?;
         let change_log = db.open_table("change_log").execute().await.ok();
+
+        // Run migrations (idempotent — safe on every open)
+        migrate::run_migrations(&artifacts, &relations, change_log.as_ref()).await?;
 
         Ok(Self {
             _db: db,

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -772,6 +772,7 @@ impl LanceStore {
                 Arc::new(StringArray::from(vec![entry.old_value.as_deref()])),
                 Arc::new(StringArray::from(vec![entry.new_value.as_deref()])),
                 Arc::new(StringArray::from(vec![entry.source.as_str()])),
+                Arc::new(StringArray::from(vec![entry.commit_hash.as_deref()])),
             ],
         )?;
 
@@ -1217,6 +1218,7 @@ fn extract_change_log_entry(batch: &RecordBatch, row: usize) -> Option<ChangeLog
     let old_value = get_string(batch, "old_value", row);
     let new_value = get_string(batch, "new_value", row);
     let source = get_string(batch, "source", row)?;
+    let commit_hash = get_string(batch, "commit_hash", row);
 
     Some(ChangeLogEntry {
         timestamp,
@@ -1226,6 +1228,7 @@ fn extract_change_log_entry(batch: &RecordBatch, row: usize) -> Option<ChangeLog
         old_value,
         new_value,
         source,
+        commit_hash,
     })
 }
 
@@ -1243,6 +1246,7 @@ fn empty_change_log_batch(
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // old_value (nullable)
             Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // new_value (nullable)
             Arc::new(StringArray::from(Vec::<&str>::new())),       // source
+            Arc::new(StringArray::from(Vec::<Option<&str>>::new())), // commit_hash (nullable)
         ],
     )
 }

--- a/crates/forgeplan-core/src/estimate/calculator.rs
+++ b/crates/forgeplan-core/src/estimate/calculator.rs
@@ -10,6 +10,7 @@ pub fn calculate(
     config: &EstimateConfig,
     confidence: f64,
     confidence_reasons: Vec<String>,
+    hints: Vec<super::types::EstimateHint>,
 ) -> EstimateResult {
     let items: Vec<EstimateItem> = scored_items
         .iter()
@@ -34,6 +35,7 @@ pub fn calculate(
         total_score,
         confidence,
         confidence_reasons,
+        hints,
     }
 }
 
@@ -99,7 +101,7 @@ mod tests {
     #[test]
     fn single_item_senior_baseline() {
         let items = vec![scored("FR-001", Complexity::Medium)];
-        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![], vec![]);
 
         let senior_hours = result.items[0].hours[&Grade::Senior];
         assert_eq!(senior_hours, 8.0); // Medium = 8h Senior
@@ -108,7 +110,7 @@ mod tests {
     #[test]
     fn grade_multipliers_applied() {
         let items = vec![scored("FR-001", Complexity::Medium)];
-        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![], vec![]);
 
         let item = &result.items[0];
         assert_eq!(item.hours[&Grade::Junior], 16.0);  // 8 × 2.0
@@ -128,7 +130,7 @@ mod tests {
             complexity: Complexity::Medium, // 8h base
             task_type: TaskType::PureInfra, // AI ×0.50
         }];
-        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![], vec![]);
 
         // AI: 8 × 0.50 × 1.30 = 5.2
         assert!((result.items[0].hours[&Grade::Ai] - 5.2).abs() < 0.01);
@@ -142,7 +144,7 @@ mod tests {
             scored("FR-001", Complexity::Medium),   // 8h Senior
             scored("FR-002", Complexity::Complex),   // 13h Senior
         ];
-        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![], vec![]);
 
         assert_eq!(result.totals[&Grade::Senior], 21.0); // 8 + 13
         assert_eq!(result.totals[&Grade::Junior], 42.0);  // 21 × 2.0
@@ -151,7 +153,7 @@ mod tests {
     #[test]
     fn score_calculation() {
         let items = vec![scored("FR-001", Complexity::Complex)];
-        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &default_config(), 0.75, vec![], vec![]);
 
         // Score = complexity_value × senior_hours = 5 × 13 = 65
         assert_eq!(result.items[0].score, 65.0);
@@ -164,7 +166,7 @@ mod tests {
         config.grade_multipliers.insert(Grade::Junior, 3.0); // override
 
         let items = vec![scored("FR-001", Complexity::Trivial)]; // 3h Senior
-        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![], vec![]);
 
         assert_eq!(result.items[0].hours[&Grade::Junior], 9.0); // 3 × 3.0
         assert_eq!(result.items[0].hours[&Grade::Senior], 3.0); // unchanged
@@ -172,7 +174,7 @@ mod tests {
 
     #[test]
     fn empty_items() {
-        let result = calculate("PRD-001", "Test", &[], &default_config(), 0.0, vec![]);
+        let result = calculate("PRD-001", "Test", &[], &default_config(), 0.0, vec![], vec![]);
         assert!(result.items.is_empty());
         assert!(result.totals.is_empty());
         assert_eq!(result.total_score, 0.0);
@@ -182,7 +184,7 @@ mod tests {
     fn confidence_passed_through() {
         let result = calculate(
             "PRD-001", "Test", &[], &default_config(),
-            0.65, vec!["has FR".to_string(), "no RFC phases".to_string()],
+            0.65, vec!["has FR".to_string(), "no RFC phases".to_string()], vec![],
         );
         assert_eq!(result.confidence, 0.65);
         assert_eq!(result.confidence_reasons.len(), 2);
@@ -195,7 +197,7 @@ mod tests {
         config.grade_multipliers.remove(&Grade::Junior); // remove Junior
 
         let items = vec![scored("FR-001", Complexity::Trivial)]; // 3h Senior
-        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![]);
+        let result = calculate("PRD-001", "Test", &items, &config, 0.5, vec![], vec![]);
 
         // Junior falls back to default multiplier 2.0
         assert_eq!(result.items[0].hours[&Grade::Junior], 6.0); // 3 × 2.0

--- a/crates/forgeplan-core/src/estimate/display.rs
+++ b/crates/forgeplan-core/src/estimate/display.rs
@@ -108,6 +108,22 @@ pub fn format_table(result: &EstimateResult, highlight_grade: Option<Grade>) -> 
         ));
     }
 
+    // Hints
+    if !result.hints.is_empty() {
+        out.push('\n');
+        for hint in &result.hints {
+            let prefix = match hint.level {
+                super::types::HintLevel::Warning => "!",
+                super::types::HintLevel::Info => "i",
+                super::types::HintLevel::Suggestion => "*",
+            };
+            out.push_str(&format!("  {} {}\n", prefix, hint.message));
+            if let Some(ref action) = hint.action {
+                out.push_str(&format!("    -> {}\n", action));
+            }
+        }
+    }
+
     out
 }
 
@@ -164,6 +180,7 @@ mod tests {
             total_score: 24.0,
             confidence: 0.75,
             confidence_reasons: vec!["has FR".to_string(), "no RFC phases".to_string()],
+            hints: vec![],
         }
     }
 
@@ -218,6 +235,7 @@ mod tests {
             total_score: 0.0,
             confidence: 0.0,
             confidence_reasons: vec![],
+            hints: vec![],
         };
         let output = format_table(&result, None);
         assert!(output.contains("No work items found"));

--- a/crates/forgeplan-core/src/estimate/extractor.rs
+++ b/crates/forgeplan-core/src/estimate/extractor.rs
@@ -2,7 +2,7 @@ use std::sync::OnceLock;
 
 use regex::Regex;
 
-use super::types::{ItemSource, WorkItem};
+use super::types::{EstimateHint, HintLevel, ItemSource, WorkItem};
 
 /// Extract work items from an artifact's markdown body.
 /// Supports: FR table rows from PRD, Phase checklist items from RFC.
@@ -16,6 +16,72 @@ pub fn extract_work_items(body: &str) -> Vec<WorkItem> {
     items.extend(extract_phase_items(body));
 
     items
+}
+
+/// Collect hints about artifact quality issues affecting estimates.
+pub fn collect_hints(body: &str, extracted_count: usize, kind: &str) -> Vec<EstimateHint> {
+    let mut hints = Vec::new();
+
+    // Detect template placeholder FRs that were filtered out
+    let total_fr_rows = count_fr_rows(body);
+    let template_count = total_fr_rows.saturating_sub(extracted_count);
+    if template_count > 0 {
+        hints.push(EstimateHint {
+            level: HintLevel::Warning,
+            message: format!(
+                "{} FR row(s) contain template placeholders (\"[Actor] can [capability]\") and were skipped",
+                template_count
+            ),
+            action: Some(format!(
+                "Fill in FR descriptions in the PRD with real requirements"
+            )),
+        });
+    }
+
+    // No items at all
+    if extracted_count == 0 {
+        let suggestion = match kind {
+            "prd" => "Add FR table: | FR-001 | Core | Must | User can ... | Journey 1 |",
+            "rfc" => "Add Phase checklist: - [ ] **1.1** Description",
+            _ => "Add FR table to PRD or Phase checklist to RFC",
+        };
+        hints.push(EstimateHint {
+            level: HintLevel::Warning,
+            message: "No estimable work items found".to_string(),
+            action: Some(suggestion.to_string()),
+        });
+    }
+
+    // Low item count
+    if extracted_count > 0 && extracted_count <= 2 {
+        hints.push(EstimateHint {
+            level: HintLevel::Info,
+            message: format!("Only {} item(s) — estimate may be incomplete", extracted_count),
+            action: Some("Consider breaking down into more granular FR/Phase items".to_string()),
+        });
+    }
+
+    // Confidence boost suggestions
+    let has_fr = body.contains("| FR-");
+    let has_phases = body.contains("- [ ] **") || body.contains("- [x] **");
+    if has_fr && !has_phases {
+        hints.push(EstimateHint {
+            level: HintLevel::Suggestion,
+            message: "Create an RFC with Implementation Phases for +25% confidence".to_string(),
+            action: Some("forgeplan new rfc \"<title>\"".to_string()),
+        });
+    }
+
+    hints
+}
+
+/// Count total FR table rows (including template placeholders).
+fn count_fr_rows(body: &str) -> usize {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(
+        r"(?m)^\|\s*FR-\d+\s*\|"
+    ).expect("valid regex"));
+    re.find_iter(body).count()
 }
 
 /// Extract FR rows from a markdown table in PRD.

--- a/crates/forgeplan-core/src/estimate/extractor.rs
+++ b/crates/forgeplan-core/src/estimate/extractor.rs
@@ -27,26 +27,47 @@ fn extract_fr_table(body: &str) -> Vec<WorkItem> {
     ).expect("valid regex"));
 
     re.captures_iter(body)
-        .map(|cap| WorkItem {
-            id: cap[1].to_string(),
-            description: cap[4].trim().to_string(),
-            category: cap[2].trim().to_string(),
-            priority: cap[3].trim().to_string(),
-            source: ItemSource::Fr,
+        .filter_map(|cap| {
+            let desc = cap[4].trim().to_string();
+            // Skip template placeholders — unfilled FR are noise
+            if is_template_placeholder(&desc) {
+                return None;
+            }
+            Some(WorkItem {
+                id: cap[1].to_string(),
+                description: desc,
+                category: cap[2].trim().to_string(),
+                priority: cap[3].trim().to_string(),
+                source: ItemSource::Fr,
+            })
         })
         .collect()
 }
 
+/// Detect template placeholder descriptions that were never filled in.
+fn is_template_placeholder(desc: &str) -> bool {
+    let d = desc.trim();
+    d == "[Actor] can [capability]"
+        || d.starts_with("{")
+        || d.starts_with("[Actor]")
+        || d == "..."
+        || d == "TBD"
+        || d.is_empty()
+}
+
 /// Extract Phase checklist items from RFC.
-/// Expected format: - [ ] **1.1** Description here
-///                  - [x] **2.3** Already done
+/// Supports multiple formats:
+///   - [ ] **1.1** Description        (standard forgeplan format)
+///   - [ ] Step 1: Description         (simple checklist)
+///   - [ ] Description                 (plain checklist, auto-numbered)
 fn extract_phase_items(body: &str) -> Vec<WorkItem> {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| Regex::new(
+    // Format 1: - [ ] **1.1** Description (standard)
+    static RE_STANDARD: OnceLock<Regex> = OnceLock::new();
+    let re_standard = RE_STANDARD.get_or_init(|| Regex::new(
         r"(?m)^- \[[ x]\] \*\*(\d+\.\d+)\*\*\s+(.+)$"
     ).expect("valid regex"));
 
-    re.captures_iter(body)
+    let mut items: Vec<WorkItem> = re_standard.captures_iter(body)
         .map(|cap| WorkItem {
             id: format!("P{}", cap[1].to_string()),
             description: cap[2].trim().to_string(),
@@ -54,7 +75,36 @@ fn extract_phase_items(body: &str) -> Vec<WorkItem> {
             priority: "Must".to_string(),
             source: ItemSource::Phase,
         })
-        .collect()
+        .collect();
+
+    // If standard format found items, return them
+    if !items.is_empty() {
+        return items;
+    }
+
+    // Format 2: - [ ] Description (plain checklist, under ## Implementation / ## Phase headers)
+    static RE_PLAIN: OnceLock<Regex> = OnceLock::new();
+    let re_plain = RE_PLAIN.get_or_init(|| Regex::new(
+        r"(?m)^- \[[ x]\]\s+(.+)$"
+    ).expect("valid regex"));
+
+    let mut counter = 0u32;
+    for cap in re_plain.captures_iter(body) {
+        let desc = cap[1].trim().to_string();
+        if is_template_placeholder(&desc) {
+            continue;
+        }
+        counter += 1;
+        items.push(WorkItem {
+            id: format!("P0.{}", counter),
+            description: desc,
+            category: "Implementation".to_string(),
+            priority: "Must".to_string(),
+            source: ItemSource::Phase,
+        });
+    }
+
+    items
 }
 
 #[cfg(test)]
@@ -127,5 +177,54 @@ mod tests {
         let body = "# Just a title\n\nSome regular text without FR or Phase items.";
         let items = extract_work_items(body);
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn template_fr_rows_are_filtered_out() {
+        let body = r#"
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | [Actor] can [capability] | Journey 1 |
+| FR-002 | Core | Must | User can search artifacts by keyword | Journey 1 |
+| FR-003 | UX | Should | [Actor] can [capability] | Journey 2 |
+"#;
+        let items = extract_fr_table(body);
+        assert_eq!(items.len(), 1, "Only filled FR should be extracted");
+        assert_eq!(items[0].id, "FR-002");
+        assert!(items[0].description.contains("search"));
+    }
+
+    #[test]
+    fn plain_checklist_fallback() {
+        let body = r#"
+## Implementation Phases
+
+### Phase 1: Core
+- [ ] Set up project structure
+- [x] Define data model
+- [ ] Implement CRUD operations
+
+### Phase 2: Polish
+- [ ] Add error handling
+"#;
+        let items = extract_phase_items(body);
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0].id, "P0.1");
+        assert!(items[0].description.contains("project structure"));
+        assert_eq!(items[2].id, "P0.3");
+        assert!(items[2].description.contains("CRUD"));
+    }
+
+    #[test]
+    fn standard_format_takes_priority_over_plain() {
+        let body = r#"
+- [ ] **1.1** Create types.rs
+- [ ] **1.2** Create parser.rs
+- [ ] Some plain checklist item
+"#;
+        let items = extract_phase_items(body);
+        // Standard format found — plain items ignored
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "P1.1");
     }
 }

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -194,10 +194,13 @@ fn infer_task_type(item: &WorkItem) -> TaskType {
 
     let infra_keywords = ["deploy", "k8s", "docker", "ci/cd", "pipeline", "infrastructure",
         "kubernetes", "helm", "terraform", "vault", "registry", "runner", "namespace"];
-    let design_keywords = ["design", "ux", "ui", "layout", "wireframe", "prototype", "mockup"];
-    let coordination_keywords = ["meeting", "review", "discuss", "plan", "coordinate", "align"];
+    let design_keywords = ["wireframe", "prototype", "mockup", "figma", "sketch",
+        "visual design", "user interface design", "responsive layout"];
+    let coordination_keywords = ["meeting", "discuss", "coordinate", "align", "stakeholder",
+        "handoff", "onboard", "workshop"];
     let coding_keywords = ["implement", "create", "add", "build", "write", "develop", "parse",
-        "extract", "calculate", "score", "validate", "convert", "format"];
+        "extract", "calculate", "score", "validate", "convert", "format", "configure",
+        "customize", "specify", "run", "show", "display", "list", "update", "delete"];
 
     let infra_hits = infra_keywords.iter().filter(|kw| desc.contains(*kw)).count();
     let design_hits = design_keywords.iter().filter(|kw| desc.contains(*kw)).count();
@@ -265,9 +268,24 @@ mod tests {
 
     #[test]
     fn design_task_detected() {
-        let item = work_item("FR-005", "Design UI layout for dashboard", "Should");
+        let item = work_item("FR-005", "Create wireframe prototype for dashboard mockup", "Should");
         let scored = score_single(&item);
         assert_eq!(scored.task_type, TaskType::DesignCoding);
+    }
+
+    #[test]
+    fn customize_is_coding_not_design() {
+        // "customize" was incorrectly classified as design in old keyword list
+        let item = work_item("FR-006", "User can customize Level 1 prompt template", "Should");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::PureCoding);
+    }
+
+    #[test]
+    fn show_capabilities_is_coding() {
+        let item = work_item("FR-007", "System can show routing capabilities", "Should");
+        let scored = score_single(&item);
+        assert_eq!(scored.task_type, TaskType::PureCoding);
     }
 
     #[test]

--- a/crates/forgeplan-core/src/estimate/scorer.rs
+++ b/crates/forgeplan-core/src/estimate/scorer.rs
@@ -1,9 +1,130 @@
+use crate::config::LlmConfig;
+use crate::llm::LlmClient;
+
 use super::types::{Complexity, ScoredItem, TaskType, WorkItem};
 
 /// Score work items with rule-based heuristics.
 /// Assigns Fibonacci complexity and task type based on description keywords.
 pub fn score_items(items: &[WorkItem]) -> Vec<ScoredItem> {
     items.iter().map(|item| score_single(item)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// LLM-based scoring (L1 opt-in)
+// ---------------------------------------------------------------------------
+
+/// System prompt for the LLM scorer.
+const LLM_SCORER_SYSTEM: &str = "\
+You are a senior engineering estimator. For each work item you receive, assign:
+1. A Fibonacci complexity score: 1 (trivial), 2 (simple), 3 (medium), 5 (complex), 8 (hard), 13 (epic).
+2. A task type: pure_coding, coding_infra, design_coding, pure_infra, coordination.
+
+Respond ONLY with one line per item in exactly this format (no extra text):
+ID|COMPLEXITY|TASK_TYPE
+
+Example:
+FR-001|3|pure_coding
+FR-002|8|coding_infra
+";
+
+/// Build the user prompt listing all items for the LLM.
+fn build_llm_prompt(items: &[WorkItem]) -> String {
+    let mut prompt = String::from("Score the following work items:\n\n");
+    for item in items {
+        prompt.push_str(&format!(
+            "- {} [{}] (priority: {}): {}\n",
+            item.id, item.category, item.priority, item.description
+        ));
+    }
+    prompt
+}
+
+/// Parse a single LLM response line like "FR-001|3|pure_coding" into (id, Complexity, TaskType).
+/// Returns None if the line cannot be parsed.
+pub fn parse_llm_line(line: &str) -> Option<(String, Complexity, TaskType)> {
+    let parts: Vec<&str> = line.split('|').map(|s| s.trim()).collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let id = parts[0].to_string();
+    let complexity = parts[1].parse::<u32>().ok().and_then(Complexity::from_value)?;
+    let task_type = parse_task_type(parts[2])?;
+    Some((id, complexity, task_type))
+}
+
+/// Parse a task type string from the LLM response.
+fn parse_task_type(s: &str) -> Option<TaskType> {
+    match s.to_lowercase().replace('-', "_").as_str() {
+        "pure_coding" | "purecoding" | "coding" => Some(TaskType::PureCoding),
+        "coding_infra" | "codinginfra" => Some(TaskType::CodingInfra),
+        "design_coding" | "designcoding" => Some(TaskType::DesignCoding),
+        "pure_infra" | "pureinfra" | "infra" => Some(TaskType::PureInfra),
+        "coordination" | "coord" => Some(TaskType::Coordination),
+        _ => None,
+    }
+}
+
+/// Parse the full LLM response into a map of id -> (Complexity, TaskType).
+fn parse_llm_response(
+    response: &str,
+    items: &[WorkItem],
+) -> Vec<ScoredItem> {
+    use std::collections::HashMap;
+
+    // Build a lookup from parsed LLM lines
+    let mut llm_map: HashMap<String, (Complexity, TaskType)> = HashMap::new();
+    for line in response.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((id, complexity, task_type)) = parse_llm_line(line) {
+            llm_map.insert(id, (complexity, task_type));
+        }
+    }
+
+    // For each work item, use LLM result if available, else fall back to rule-based
+    items
+        .iter()
+        .map(|item| {
+            if let Some((complexity, task_type)) = llm_map.get(&item.id) {
+                ScoredItem {
+                    id: item.id.clone(),
+                    description: item.description.clone(),
+                    complexity: *complexity,
+                    task_type: *task_type,
+                }
+            } else {
+                // Fallback to rule-based for items the LLM missed
+                score_single(item)
+            }
+        })
+        .collect()
+}
+
+/// Score work items using an LLM (L1).
+/// Falls back to rule-based scoring if the LLM call fails.
+pub async fn score_items_with_llm(
+    items: &[WorkItem],
+    llm_config: &LlmConfig,
+) -> Vec<ScoredItem> {
+    if items.is_empty() {
+        return Vec::new();
+    }
+
+    let client = LlmClient::new(llm_config.clone());
+    let prompt = build_llm_prompt(items);
+
+    match client.generate(&prompt, Some(LLM_SCORER_SYSTEM)).await {
+        Ok(response) => {
+            let scored = parse_llm_response(&response, items);
+            scored
+        }
+        Err(_) => {
+            // LLM failed — graceful fallback to rule-based
+            score_items(items)
+        }
+    }
 }
 
 fn score_single(item: &WorkItem) -> ScoredItem {
@@ -164,5 +285,92 @@ mod tests {
     fn empty_items() {
         let scored = score_items(&[]);
         assert!(scored.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // LLM scorer tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn parse_llm_line_valid() {
+        let result = parse_llm_line("FR-001|3|pure_coding");
+        assert!(result.is_some());
+        let (id, complexity, task_type) = result.unwrap();
+        assert_eq!(id, "FR-001");
+        assert_eq!(complexity, Complexity::Medium);
+        assert_eq!(task_type, TaskType::PureCoding);
+    }
+
+    #[test]
+    fn parse_llm_line_all_task_types() {
+        assert_eq!(parse_llm_line("A|1|pure_coding").unwrap().2, TaskType::PureCoding);
+        assert_eq!(parse_llm_line("B|2|coding_infra").unwrap().2, TaskType::CodingInfra);
+        assert_eq!(parse_llm_line("C|3|design_coding").unwrap().2, TaskType::DesignCoding);
+        assert_eq!(parse_llm_line("D|5|pure_infra").unwrap().2, TaskType::PureInfra);
+        assert_eq!(parse_llm_line("E|8|coordination").unwrap().2, TaskType::Coordination);
+    }
+
+    #[test]
+    fn parse_llm_line_invalid_complexity() {
+        assert!(parse_llm_line("FR-001|4|pure_coding").is_none()); // 4 is not Fibonacci
+    }
+
+    #[test]
+    fn parse_llm_line_invalid_task_type() {
+        assert!(parse_llm_line("FR-001|3|unknown_type").is_none());
+    }
+
+    #[test]
+    fn parse_llm_line_wrong_format() {
+        assert!(parse_llm_line("just some text").is_none());
+        assert!(parse_llm_line("FR-001|3").is_none()); // missing task type
+        assert!(parse_llm_line("").is_none());
+    }
+
+    #[test]
+    fn parse_llm_response_with_fallback() {
+        // Simulate an LLM response where only FR-001 is scored; FR-002 is missing
+        let items = vec![
+            work_item("FR-001", "Implement auth system with security encryption", "Must"),
+            work_item("FR-002", "Add button", "Could"),
+        ];
+        let llm_response = "FR-001|8|coding_infra\n";
+
+        let scored = parse_llm_response(llm_response, &items);
+        assert_eq!(scored.len(), 2);
+
+        // FR-001 should use LLM values
+        assert_eq!(scored[0].id, "FR-001");
+        assert_eq!(scored[0].complexity, Complexity::Hard);
+        assert_eq!(scored[0].task_type, TaskType::CodingInfra);
+
+        // FR-002 should fall back to rule-based
+        assert_eq!(scored[1].id, "FR-002");
+        // Rule-based would assign low complexity for "Add button"
+        assert!(scored[1].complexity.value() <= 3);
+    }
+
+    #[test]
+    fn parse_llm_response_all_garbage_falls_back() {
+        let items = vec![
+            work_item("FR-001", "Build search engine with validation pipeline", "Must"),
+        ];
+        let llm_response = "This is not valid output at all\nNeither is this";
+
+        let scored = parse_llm_response(llm_response, &items);
+        assert_eq!(scored.len(), 1);
+        // Should fall back to rule-based scoring
+        assert_eq!(scored[0].id, "FR-001");
+        assert!(scored[0].complexity.value() >= 1);
+    }
+
+    #[test]
+    fn parse_llm_line_with_whitespace() {
+        let result = parse_llm_line("  FR-001 | 5 | pure_coding  ");
+        assert!(result.is_some());
+        let (id, complexity, task_type) = result.unwrap();
+        assert_eq!(id, "FR-001");
+        assert_eq!(complexity, Complexity::Complex);
+        assert_eq!(task_type, TaskType::PureCoding);
     }
 }

--- a/crates/forgeplan-core/src/estimate/types.rs
+++ b/crates/forgeplan-core/src/estimate/types.rs
@@ -207,6 +207,28 @@ pub struct EstimateResult {
     pub total_score: f64,
     pub confidence: f64,
     pub confidence_reasons: Vec<String>,
+    /// Actionable hints — warnings, suggestions, methodology nudges.
+    /// Shown in CLI output and included in JSON for AI agents.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hints: Vec<EstimateHint>,
+}
+
+/// A hint/warning/suggestion attached to an estimate.
+#[derive(Debug, Clone, Serialize)]
+pub struct EstimateHint {
+    pub level: HintLevel,
+    pub message: String,
+    /// Suggested next action (forgeplan command or description)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HintLevel {
+    Warning,
+    Info,
+    Suggestion,
 }
 
 /// Per-domain grade mapping for a user.

--- a/crates/forgeplan-core/src/git/mod.rs
+++ b/crates/forgeplan-core/src/git/mod.rs
@@ -1,0 +1,130 @@
+//! Git integration — detect changed .forgeplan/ files from git operations.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Files changed in .forgeplan/ between two git refs.
+#[derive(Debug, Clone)]
+pub struct GitChangedFile {
+    /// Relative path from repo root (e.g., ".forgeplan/prds/PRD-001-auth.md")
+    pub path: String,
+    /// Git change status: A (added), M (modified), D (deleted)
+    pub status: char,
+}
+
+/// Get the current HEAD commit hash (short, 7 chars).
+pub fn head_commit_hash(repo_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Get the merge base (common ancestor) between HEAD and a ref.
+pub fn merge_base(repo_root: &Path, ref_name: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["merge-base", "HEAD", ref_name])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Detect .forgeplan/ files changed between two git refs (or since last N commits).
+/// Returns list of changed files with their status.
+pub fn changed_artifact_files(
+    repo_root: &Path,
+    since_ref: &str,
+) -> anyhow::Result<Vec<GitChangedFile>> {
+    let output = Command::new("git")
+        .args([
+            "diff",
+            "--name-status",
+            since_ref,
+            "HEAD",
+            "--",
+            ".forgeplan/",
+        ])
+        .current_dir(repo_root)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git diff failed: {}", stderr);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut files = Vec::new();
+
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        if parts.len() == 2 {
+            let status = parts[0].chars().next().unwrap_or('M');
+            let path = parts[1].to_string();
+            // Only .md files in artifact dirs
+            if path.ends_with(".md") {
+                files.push(GitChangedFile { path, status });
+            }
+        }
+    }
+
+    Ok(files)
+}
+
+/// Get the ORIG_HEAD ref (set after git pull/merge/rebase).
+/// Returns None if ORIG_HEAD doesn't exist (no recent merge).
+pub fn orig_head(repo_root: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "ORIG_HEAD"])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn head_commit_hash_returns_7_chars() {
+        // Run in current repo which is a git repo
+        let hash = head_commit_hash(Path::new("."));
+        assert!(hash.is_some(), "should find HEAD in git repo");
+        let h = hash.unwrap();
+        assert!(h.len() >= 7 && h.len() <= 12, "short hash should be 7-12 chars, got {}", h.len());
+    }
+
+    #[test]
+    fn head_commit_hash_returns_none_for_non_repo() {
+        let tmp = TempDir::new().unwrap();
+        let hash = head_commit_hash(tmp.path());
+        assert!(hash.is_none());
+    }
+
+    #[test]
+    fn changed_artifact_files_no_diff() {
+        // HEAD..HEAD = no changes
+        let files = changed_artifact_files(Path::new("."), "HEAD");
+        assert!(files.is_ok());
+        assert!(files.unwrap().is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/git/mod.rs
+++ b/crates/forgeplan-core/src/git/mod.rs
@@ -58,7 +58,8 @@ pub fn changed_artifact_files(
             ".forgeplan/",
         ])
         .current_dir(repo_root)
-        .output()?;
+        .output()
+        .map_err(|e| anyhow::anyhow!("Failed to run git (is git installed?): {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/forgeplan-core/src/hints.rs
+++ b/crates/forgeplan-core/src/hints.rs
@@ -203,6 +203,55 @@ pub fn search_hints(query: &str, result_count: usize) -> Vec<Hint> {
     hints
 }
 
+/// Hints for `forgeplan activate` when activation fails.
+pub fn activate_hints(
+    validation_passed: bool,
+    has_evidence: bool,
+    kind: &crate::artifact::types::ArtifactKind,
+) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    if !validation_passed {
+        hints.push(
+            Hint::warning("Validation gate failed — fix MUST errors before activating")
+                .with_action("forgeplan validate <id>")
+        );
+    }
+
+    if !has_evidence && matches!(kind,
+        crate::artifact::types::ArtifactKind::Prd
+        | crate::artifact::types::ArtifactKind::Rfc
+        | crate::artifact::types::ArtifactKind::Adr
+    ) {
+        hints.push(
+            Hint::suggestion("Link evidence before activating for non-zero R_eff")
+                .with_action("forgeplan new evidence \"<verification>\" && forgeplan link EVID-XXX <id> --relation informs")
+        );
+    }
+
+    hints
+}
+
+/// Hints for `forgeplan blocked` — suggest how to unblock.
+pub fn blocked_hints(blocked_by: &[(String, String)]) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    let draft_blockers: Vec<_> = blocked_by.iter()
+        .filter(|(_, status)| status == "draft")
+        .collect();
+
+    if !draft_blockers.is_empty() {
+        for (id, _) in &draft_blockers {
+            hints.push(
+                Hint::suggestion(format!("Activate draft dependency {}", id))
+                    .with_action(format!("forgeplan review {} && forgeplan activate {}", id, id))
+            );
+        }
+    }
+
+    hints
+}
+
 fn kind_to_str(kind: &crate::artifact::types::ArtifactKind) -> &'static str {
     use crate::artifact::types::ArtifactKind;
     match kind {
@@ -274,6 +323,32 @@ mod tests {
         let hints = search_hints("nonexistent", 0);
         assert_eq!(hints.len(), 3);
         assert!(hints[0].message.contains("No results"));
+    }
+
+    #[test]
+    fn activate_hints_no_evidence_prd() {
+        use crate::artifact::types::ArtifactKind;
+        let hints = activate_hints(true, false, &ArtifactKind::Prd);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].message.contains("evidence"));
+    }
+
+    #[test]
+    fn activate_hints_all_good() {
+        use crate::artifact::types::ArtifactKind;
+        let hints = activate_hints(true, true, &ArtifactKind::Prd);
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn blocked_hints_draft_dependency() {
+        let blockers = vec![
+            ("ADR-002".to_string(), "draft".to_string()),
+            ("RFC-001".to_string(), "active".to_string()),
+        ];
+        let hints = blocked_hints(&blockers);
+        assert_eq!(hints.len(), 1); // only draft blocker gets a hint
+        assert!(hints[0].message.contains("ADR-002"));
     }
 
     #[test]

--- a/crates/forgeplan-core/src/hints.rs
+++ b/crates/forgeplan-core/src/hints.rs
@@ -103,16 +103,24 @@ pub fn score_hints(
 }
 
 /// Hints for `forgeplan get` output.
+/// Accepts typed enums for kind and depth for compile-time safety.
 pub fn get_hints(
     status: &str,
-    kind: &str,
+    kind: &crate::artifact::types::ArtifactKind,
     has_links: bool,
-    depth: &str,
+    depth: &crate::artifact::types::Mode,
 ) -> Vec<Hint> {
     let mut hints = Vec::new();
+    let kind_str = kind_to_str(kind);
+    let depth_str = match depth {
+        crate::artifact::types::Mode::Tactical => "tactical",
+        crate::artifact::types::Mode::Standard => "standard",
+        crate::artifact::types::Mode::Deep => "deep",
+        crate::artifact::types::Mode::Note => "note",
+    };
 
     if status == "draft" {
-        let next = match kind {
+        let next = match kind_str {
             "prd" => "Fill MUST sections (Problem, Goals, FR, Target Users), then: forgeplan validate",
             "rfc" => "Fill Summary, Motivation, Options, Implementation Phases, then: forgeplan validate",
             "adr" => "Fill Context, Decision, Consequences, then: forgeplan validate",
@@ -122,14 +130,14 @@ pub fn get_hints(
         hints.push(Hint::suggestion(format!("Status is draft — next: {}", next)));
     }
 
-    if !has_links && status != "deprecated" && kind != "memory" {
+    if !has_links && status != "deprecated" && kind_str != "memory" {
         hints.push(
             Hint::info("No links — artifact is an orphan")
-                .with_action(format!("forgeplan link <this-id> <parent-id> --relation refines"))
+                .with_action("forgeplan link <this-id> <parent-id> --relation refines")
         );
     }
 
-    if depth == "standard" && (kind == "prd") && !has_links {
+    if depth_str == "standard" && kind_str == "prd" && !has_links {
         hints.push(
             Hint::suggestion("Standard PRD should have linked RFC")
                 .with_action("forgeplan new rfc \"<title>\" && forgeplan link RFC-XXX <this-id> --relation based_on")
@@ -144,18 +152,19 @@ pub fn review_hints(
     has_evidence: bool,
     is_stub: bool,
     has_must_errors: bool,
-    kind: &str,
+    kind: &crate::artifact::types::ArtifactKind,
 ) -> Vec<Hint> {
     let mut hints = Vec::new();
 
     if is_stub {
+        let action = match kind_to_str(kind) {
+            "prd" => "Fill: Problem, Goals, Non-Goals, Target Users, FR",
+            "rfc" => "Fill: Summary, Motivation, Goals, Options, Implementation Phases",
+            _ => "Fill all required sections",
+        };
         hints.push(
             Hint::warning("Artifact is a stub — MUST sections not filled")
-                .with_action(match kind {
-                    "prd" => "Fill: Problem, Goals, Non-Goals, Target Users, FR",
-                    "rfc" => "Fill: Summary, Motivation, Goals, Options, Implementation Phases",
-                    _ => "Fill all required sections",
-                })
+                .with_action(action)
         );
     }
 
@@ -194,6 +203,23 @@ pub fn search_hints(query: &str, result_count: usize) -> Vec<Hint> {
     hints
 }
 
+fn kind_to_str(kind: &crate::artifact::types::ArtifactKind) -> &'static str {
+    use crate::artifact::types::ArtifactKind;
+    match kind {
+        ArtifactKind::Prd => "prd",
+        ArtifactKind::Epic => "epic",
+        ArtifactKind::Spec => "spec",
+        ArtifactKind::Rfc => "rfc",
+        ArtifactKind::Adr => "adr",
+        ArtifactKind::Note => "note",
+        ArtifactKind::ProblemCard => "problem",
+        ArtifactKind::SolutionPortfolio => "solution",
+        ArtifactKind::EvidencePack => "evidence",
+        ArtifactKind::RefreshReport => "refresh",
+        ArtifactKind::Memory => "memory",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,21 +248,24 @@ mod tests {
 
     #[test]
     fn get_hints_draft_prd() {
-        let hints = get_hints("draft", "prd", false, "standard");
-        assert!(hints.len() >= 2); // draft + orphan + maybe RFC suggestion
+        use crate::artifact::types::{ArtifactKind, Mode};
+        let hints = get_hints("draft", &ArtifactKind::Prd, false, &Mode::Standard);
+        assert!(hints.len() >= 2);
         assert!(hints[0].message.contains("draft"));
     }
 
     #[test]
     fn get_hints_active_with_links() {
-        let hints = get_hints("active", "prd", true, "standard");
+        use crate::artifact::types::{ArtifactKind, Mode};
+        let hints = get_hints("active", &ArtifactKind::Prd, true, &Mode::Standard);
         assert!(hints.is_empty());
     }
 
     #[test]
     fn review_hints_stub() {
-        let hints = review_hints(false, true, false, "prd");
-        assert!(hints.len() >= 2); // stub + no evidence
+        use crate::artifact::types::ArtifactKind;
+        let hints = review_hints(false, true, false, &ArtifactKind::Prd);
+        assert!(hints.len() >= 2);
         assert!(hints[0].message.contains("stub"));
     }
 

--- a/crates/forgeplan-core/src/hints.rs
+++ b/crates/forgeplan-core/src/hints.rs
@@ -1,0 +1,261 @@
+//! Shared hints infrastructure — actionable suggestions across all commands.
+//!
+//! Hints are warnings, info messages, and suggestions that help users
+//! understand what's missing, what to do next, and how to improve quality.
+//! They appear in CLI output and are included in JSON for AI agents.
+
+use serde::Serialize;
+
+/// A hint attached to any command output.
+#[derive(Debug, Clone, Serialize)]
+pub struct Hint {
+    pub level: HintLevel,
+    pub message: String,
+    /// Suggested next action (forgeplan command or description)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HintLevel {
+    Warning,
+    Info,
+    Suggestion,
+}
+
+impl Hint {
+    pub fn warning(message: impl Into<String>) -> Self {
+        Self { level: HintLevel::Warning, message: message.into(), action: None }
+    }
+
+    pub fn info(message: impl Into<String>) -> Self {
+        Self { level: HintLevel::Info, message: message.into(), action: None }
+    }
+
+    pub fn suggestion(message: impl Into<String>) -> Self {
+        Self { level: HintLevel::Suggestion, message: message.into(), action: None }
+    }
+
+    pub fn with_action(mut self, action: impl Into<String>) -> Self {
+        self.action = Some(action.into());
+        self
+    }
+}
+
+/// Format hints for terminal output.
+pub fn format_hints(hints: &[Hint]) -> String {
+    if hints.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n");
+    for hint in hints {
+        let prefix = match hint.level {
+            HintLevel::Warning => "!",
+            HintLevel::Info => "i",
+            HintLevel::Suggestion => "*",
+        };
+        out.push_str(&format!("  {} {}\n", prefix, hint.message));
+        if let Some(ref action) = hint.action {
+            out.push_str(&format!("    -> {}\n", action));
+        }
+    }
+    out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain-specific hint collectors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Hints for `forgeplan score` output.
+pub fn score_hints(
+    r_eff: f64,
+    has_evidence: bool,
+    evidence_cl0_count: usize,
+) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    if !has_evidence {
+        hints.push(
+            Hint::warning("No evidence linked — R_eff will be 0.0")
+                .with_action("forgeplan new evidence \"<what you verified>\" && forgeplan link EVID-XXX <artifact> --relation informs")
+        );
+    }
+
+    if evidence_cl0_count > 0 {
+        hints.push(
+            Hint::warning(format!(
+                "{} evidence(s) have CL0 — check that body contains 'congruence_level: 3' (not template placeholder)",
+                evidence_cl0_count
+            ))
+            .with_action("Edit evidence body: add '## Structured Fields' with verdict/congruence_level/evidence_type")
+        );
+    }
+
+    if r_eff > 0.0 && r_eff < 0.5 {
+        hints.push(
+            Hint::info("R_eff below 0.5 — decision is weakly supported")
+                .with_action("Add more evidence or improve congruence level (CL3 = same context)")
+        );
+    }
+
+    hints
+}
+
+/// Hints for `forgeplan get` output.
+pub fn get_hints(
+    status: &str,
+    kind: &str,
+    has_links: bool,
+    depth: &str,
+) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    if status == "draft" {
+        let next = match kind {
+            "prd" => "Fill MUST sections (Problem, Goals, FR, Target Users), then: forgeplan validate",
+            "rfc" => "Fill Summary, Motivation, Options, Implementation Phases, then: forgeplan validate",
+            "adr" => "Fill Context, Decision, Consequences, then: forgeplan validate",
+            "evidence" => "Fill Structured Fields (verdict, congruence_level, evidence_type), then: forgeplan activate",
+            _ => "Fill required sections, then: forgeplan validate",
+        };
+        hints.push(Hint::suggestion(format!("Status is draft — next: {}", next)));
+    }
+
+    if !has_links && status != "deprecated" && kind != "memory" {
+        hints.push(
+            Hint::info("No links — artifact is an orphan")
+                .with_action(format!("forgeplan link <this-id> <parent-id> --relation refines"))
+        );
+    }
+
+    if depth == "standard" && (kind == "prd") && !has_links {
+        hints.push(
+            Hint::suggestion("Standard PRD should have linked RFC")
+                .with_action("forgeplan new rfc \"<title>\" && forgeplan link RFC-XXX <this-id> --relation based_on")
+        );
+    }
+
+    hints
+}
+
+/// Hints for `forgeplan review` output.
+pub fn review_hints(
+    has_evidence: bool,
+    is_stub: bool,
+    has_must_errors: bool,
+    kind: &str,
+) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    if is_stub {
+        hints.push(
+            Hint::warning("Artifact is a stub — MUST sections not filled")
+                .with_action(match kind {
+                    "prd" => "Fill: Problem, Goals, Non-Goals, Target Users, FR",
+                    "rfc" => "Fill: Summary, Motivation, Goals, Options, Implementation Phases",
+                    _ => "Fill all required sections",
+                })
+        );
+    }
+
+    if has_must_errors {
+        hints.push(
+            Hint::warning("Validation has MUST errors — fix before activating")
+                .with_action("forgeplan validate <id> to see specific errors")
+        );
+    }
+
+    if !has_evidence {
+        hints.push(
+            Hint::info("No evidence linked — consider adding evidence before activation")
+                .with_action("forgeplan new evidence \"<verification>\" && forgeplan link EVID-XXX <id> --relation informs")
+        );
+    }
+
+    hints
+}
+
+/// Hints for `forgeplan search` when no results found.
+pub fn search_hints(query: &str, result_count: usize) -> Vec<Hint> {
+    let mut hints = Vec::new();
+
+    if result_count == 0 {
+        hints.push(Hint::info(format!("No results for \"{}\"", query)));
+        hints.push(
+            Hint::suggestion("Try broader keywords or check spelling")
+                .with_action("forgeplan search \"<shorter query>\"")
+        );
+        hints.push(
+            Hint::suggestion("Search by kind: forgeplan list --type prd")
+        );
+    }
+
+    hints
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_hints_no_evidence() {
+        let hints = score_hints(0.0, false, 0);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].message.contains("No evidence"));
+        assert!(hints[0].action.is_some());
+    }
+
+    #[test]
+    fn score_hints_cl0() {
+        let hints = score_hints(0.7, true, 2);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].message.contains("CL0"));
+    }
+
+    #[test]
+    fn score_hints_low_reff() {
+        let hints = score_hints(0.3, true, 0);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].message.contains("below 0.5"));
+    }
+
+    #[test]
+    fn get_hints_draft_prd() {
+        let hints = get_hints("draft", "prd", false, "standard");
+        assert!(hints.len() >= 2); // draft + orphan + maybe RFC suggestion
+        assert!(hints[0].message.contains("draft"));
+    }
+
+    #[test]
+    fn get_hints_active_with_links() {
+        let hints = get_hints("active", "prd", true, "standard");
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn review_hints_stub() {
+        let hints = review_hints(false, true, false, "prd");
+        assert!(hints.len() >= 2); // stub + no evidence
+        assert!(hints[0].message.contains("stub"));
+    }
+
+    #[test]
+    fn search_hints_empty() {
+        let hints = search_hints("nonexistent", 0);
+        assert_eq!(hints.len(), 3);
+        assert!(hints[0].message.contains("No results"));
+    }
+
+    #[test]
+    fn format_hints_output() {
+        let hints = vec![
+            Hint::warning("Problem").with_action("Fix it"),
+            Hint::suggestion("Try this"),
+        ];
+        let output = format_hints(&hints);
+        assert!(output.contains("! Problem"));
+        assert!(output.contains("-> Fix it"));
+        assert!(output.contains("* Try this"));
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod lifecycle;
 pub mod llm;
 pub mod error;
 pub mod gaps;
+pub mod git;
 pub mod graph;
 pub mod link;
 pub mod progress;

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod embed;
 pub mod estimate;
 pub mod fpf;
 pub mod health;
+pub mod hints;
 pub mod journal;
 pub mod lifecycle;
 pub mod llm;

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -24,6 +24,42 @@ pub async fn render_projection(
     body: &str,
     links: &[(String, String)],
 ) -> anyhow::Result<PathBuf> {
+    render_projection_inner(workspace, id, kind, title, status, depth, author, parent_epic, valid_until, body, links, false).await
+}
+
+/// Like render_projection, but `force_body = true` uses the passed body
+/// instead of reading from file. Used by `update --body` to ensure the
+/// CLI-provided body takes precedence over the file on disk.
+pub async fn render_projection_with_body(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    status: &str,
+    depth: &str,
+    author: Option<&str>,
+    parent_epic: Option<&str>,
+    valid_until: Option<&str>,
+    body: &str,
+    links: &[(String, String)],
+) -> anyhow::Result<PathBuf> {
+    render_projection_inner(workspace, id, kind, title, status, depth, author, parent_epic, valid_until, body, links, true).await
+}
+
+async fn render_projection_inner(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    status: &str,
+    depth: &str,
+    author: Option<&str>,
+    parent_epic: Option<&str>,
+    valid_until: Option<&str>,
+    body: &str,
+    links: &[(String, String)],
+    force_body: bool,
+) -> anyhow::Result<PathBuf> {
     let artifact_kind = kind.parse::<ArtifactKind>().unwrap_or(ArtifactKind::Note);
     let dir = workspace.join(artifact_kind.dir_name());
     tokio::fs::create_dir_all(&dir).await?;
@@ -32,16 +68,16 @@ pub async fn render_projection(
     let filename = format!("{}-{}.md", id, slug);
     let filepath = dir.join(&filename);
 
-    // Files-first (RFC-004): ALWAYS preserve file body if file exists and has content.
+    // Files-first (RFC-004): preserve file body if file exists and has content.
     // Only frontmatter is updated from LanceDB. Body comes from the file on disk.
-    // This prevents data loss when `forgeplan link` or `forgeplan update` re-renders the projection.
-    let effective_body = if filepath.exists() {
+    // Exception: force_body=true (from `update --body`) uses the passed body.
+    let effective_body = if force_body {
+        body.to_string()
+    } else if filepath.exists() {
         match tokio::fs::read_to_string(&filepath).await {
             Ok(file_content) => {
                 if let Ok((_fm, file_body)) = frontmatter::parse_frontmatter(&file_content) {
                     if !file_body.trim().is_empty() {
-                        // File has content — always use it, regardless of whether it
-                        // matches LanceDB. The file is the source of truth for body.
                         file_body.to_string()
                     } else {
                         body.to_string()
@@ -430,5 +466,29 @@ mod tests {
 
         let result = read_file_body_if_newer(&ws, "PRD-001", "prd", "Test", body).await;
         assert!(result.is_none(), "should return None when body matches");
+    }
+
+    #[tokio::test]
+    async fn render_projection_with_body_overrides_file() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        // Step 1: create projection with template body
+        let template_body = "## Template\n\n{placeholder}";
+        render_projection(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, template_body, &[],
+        ).await.unwrap();
+
+        // Step 2: render_projection_with_body should override file content
+        let new_body = "## Problem\n\nNew body from CLI update.";
+        let path = render_projection_with_body(
+            &ws, "PRD-001", "prd", "Test", "draft", "standard",
+            None, None, None, new_body, &[],
+        ).await.unwrap();
+
+        let result = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(result.contains("New body from CLI update"), "force_body must override file");
+        assert!(!result.contains("{placeholder}"), "old file body must not survive");
     }
 }

--- a/crates/forgeplan-core/src/scoring/evidence.rs
+++ b/crates/forgeplan-core/src/scoring/evidence.rs
@@ -49,10 +49,18 @@ pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
 }
 
 /// Extract a simple "key: value" from body text.
+///
+/// Skips markdown table rows (lines starting with `|`) and HTML comments
+/// to avoid matching template placeholder values like `| CL | 0 / 1 / 2 / 3 |`.
+/// Only matches standalone `key: value` lines (structured fields).
 pub fn extract_field(body: &str, key: &str) -> Option<String> {
     let prefix = format!("{key}:");
     for line in body.lines() {
         let trimmed = line.trim();
+        // Skip markdown table rows and HTML comments — these are template placeholders
+        if trimmed.starts_with('|') || trimmed.starts_with("<!--") {
+            continue;
+        }
         if let Some(rest) = trimmed.strip_prefix(&prefix) {
             let val = rest.trim();
             if !val.is_empty() {
@@ -79,5 +87,74 @@ mod tests {
     fn extract_field_with_whitespace() {
         let body = "  verdict:   Weakens  \n";
         assert_eq!(extract_field(body, "verdict"), Some("Weakens".into()));
+    }
+
+    #[test]
+    fn extract_field_ignores_table_rows() {
+        let body = "| Type | measurement / test / benchmark / audit |\n| Verdict | supports / weakens / refutes |\n| CL | 0 / 1 / 2 / 3 |\n";
+        // Table rows should NOT match any field
+        assert_eq!(extract_field(body, "type"), None);
+        assert_eq!(extract_field(body, "verdict"), None);
+        assert_eq!(extract_field(body, "congruence_level"), None);
+    }
+
+    #[test]
+    fn extract_field_ignores_html_comments() {
+        let body = "<!-- congruence_level: 0 | 1 | 2 | 3 -->\ncongruence_level: 3\n";
+        assert_eq!(extract_field(body, "congruence_level"), Some("3".into()));
+    }
+
+    #[test]
+    fn extract_field_structured_field_wins_over_template_placeholders() {
+        // Simulates body with template table AND user-added structured fields
+        let body = r#"| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Type | measurement / test / benchmark / audit |
+| Verdict | supports / weakens / refutes |
+| CL | 0 / 1 / 2 / 3 |
+
+## Structured Fields
+
+evidence_type: test
+verdict: supports
+congruence_level: 3
+"#;
+        assert_eq!(extract_field(body, "verdict"), Some("supports".into()));
+        assert_eq!(extract_field(body, "congruence_level"), Some("3".into()));
+        assert_eq!(extract_field(body, "evidence_type"), Some("test".into()));
+    }
+
+    #[test]
+    fn parse_evidence_with_template_placeholders_returns_cl3() {
+        // Body has both template table placeholders AND structured fields
+        let body = r#"| Type | measurement / test / benchmark / audit |
+| Verdict | supports / weakens / refutes |
+| CL | 0 / 1 / 2 / 3 |
+
+## Structured Fields
+
+evidence_type: test
+verdict: supports
+congruence_level: 3
+"#;
+        let record = ArtifactRecord {
+            id: "EVID-001".into(),
+            kind: "evidence".into(),
+            status: "draft".into(),
+            title: "Test evidence".into(),
+            body: body.into(),
+            depth: "tactical".into(),
+            author: None,
+            parent_epic: None,
+            r_eff_score: 0.0,
+            valid_until: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+        let item = parse_evidence_from_record(&record);
+        assert_eq!(item.congruence_level, 3, "Should be CL3, not CL0");
+        assert!(matches!(item.verdict, Verdict::Supports));
+        assert!(matches!(item.evidence_type, EvidenceType::Test));
     }
 }

--- a/templates/evidence/_TEMPLATE.md
+++ b/templates/evidence/_TEMPLATE.md
@@ -5,10 +5,20 @@
 | Status | Draft |
 | Created | YYYY-MM-DD |
 | Valid Until | YYYY-MM-DD |
-| Type | measurement / test / benchmark / audit |
-| Verdict | supports / weakens / refutes |
-| CL | 0 / 1 / 2 / 3 |
 | Target | ADR-{NNN} (решение которое подтверждаем/опровергаем) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
 
 ## Measurement
 
@@ -24,11 +34,13 @@
 
 ## Congruence Level Justification
 
-{Почему выбран именно этот CL:
-- CL3: тот же контекст, внутренний тест (penalty 0.0)
-- CL2: похожий контекст, related project (penalty 0.1)
-- CL1: другой контекст, внешняя документация (penalty 0.4)
-- CL0: противоположный контекст (penalty 0.9)}
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+{Обоснование выбранного Congruence Level}
 
 ## Related Artifacts
 


### PR DESCRIPTION
## Release v0.12.0

### New Features
- **Estimate Engine** — `forgeplan estimate <id>` with multi-grade scoring, LLM scorer, config
- **Hints System** — 9 commands with contextual warnings, suggestions, methodology nudges
- **MemoryDriver** — `forgeplan remember/recall` commands
- **Smart domain inference** — frontmatter → keywords → LLM (3-level)
- `--depth` update, `--complexity` override, `--llm-score`, `--my-grade` flags
- `.env` support via dotenvy for API keys

### Bug Fixes
- `forgeplan link` no longer resets body to template (PR #75)
- Evidence parser ignores template placeholders (CL0 → CL3)
- 17 MUST pipeline gaps → 0 MUST
- Domain inference skips frontmatter, scans content
- Template FR filtering, keyword TaskType improvements
- Search hints on all 3 zero-result paths

### Stats
- 63 estimate tests, 11 hints tests, 500+ total
- 41MB release binary
- 40 CLI commands smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)