### PR TITLE
[PRD-022] Estimate audit v2 — 6 fixes + 6 regression tests

### DIFF
--- a/crates/forgeplan-cli/src/commands/estimate.rs
+++ b/crates/forgeplan-cli/src/commands/estimate.rs
@@ -88,12 +88,15 @@ pub async fn run(
     let phase_items: Vec<_> = work_items.iter().filter(|w| w.source == ItemSource::Phase).collect();
 
     // Check linked Spec and Evidence for confidence boost
-    let relations = store.get_relations(&record.id).await.unwrap_or_default();
+    // Outgoing: this artifact → target (e.g., PRD → SPEC)
+    let outgoing = store.get_relations(&record.id).await.unwrap_or_default();
+    // Incoming: source → this artifact (e.g., EVID → PRD)
     let incoming = store.get_incoming_relations(&record.id).await.unwrap_or_default();
-    let all_rels: Vec<_> = relations.iter().chain(incoming.iter()).collect();
 
-    let has_spec = all_rels.iter().any(|(target, _)| target.to_uppercase().starts_with("SPEC-"));
-    let has_evidence = all_rels.iter().any(|(target, _)| target.to_uppercase().starts_with("EVID-"));
+    let has_spec = outgoing.iter().any(|(target, _)| target.to_uppercase().starts_with("SPEC-"))
+        || incoming.iter().any(|(source, _)| source.to_uppercase().starts_with("SPEC-"));
+    let has_evidence = outgoing.iter().any(|(target, _)| target.to_uppercase().starts_with("EVID-"))
+        || incoming.iter().any(|(source, _)| source.to_uppercase().starts_with("EVID-"));
 
     let (conf, conf_reasons) = confidence::score_confidence(
         !fr_items.is_empty(),
@@ -280,10 +283,21 @@ fn infer_domain(title: &str, body: &str) -> String {
 }
 
 /// Extract `domain:` value from YAML frontmatter in body.
+/// Only searches within a `---` delimited frontmatter block to avoid matching body text.
 fn extract_frontmatter_domain(body: &str) -> Option<String> {
+    let mut in_frontmatter = false;
     for line in body.lines().take(30) {
         let trimmed = line.trim();
-        if trimmed.starts_with("domain:") {
+        if trimmed == "---" {
+            if !in_frontmatter {
+                in_frontmatter = true;
+                continue;
+            } else {
+                // End of frontmatter
+                break;
+            }
+        }
+        if in_frontmatter && trimmed.starts_with("domain:") {
             let value = trimmed[7..].trim().trim_matches('"').trim();
             if !value.is_empty() {
                 return Some(value.to_string());

--- a/crates/forgeplan-core/src/estimate/calculator.rs
+++ b/crates/forgeplan-core/src/estimate/calculator.rs
@@ -51,7 +51,9 @@ fn calculate_item(scored: &ScoredItem, config: &EstimateConfig) -> EstimateItem 
             .unwrap_or(grade.default_multiplier());
 
         let effective_hours = if *grade == Grade::Ai {
-            // AI gets task-type-specific multiplier on top of grade multiplier
+            // AI uses task-type-specific multiplier (not grade_multiplier) because
+            // AI effort depends on task nature (coding vs infra), not experience level.
+            // The `ai` key in grade_multipliers is intentionally unused here.
             let task_mult = config
                 .ai_task_multipliers
                 .get(&scored.task_type)
@@ -190,7 +192,6 @@ mod tests {
         assert_eq!(result.confidence_reasons.len(), 2);
     }
 
-    #[test]
     #[test]
     fn missing_grade_in_config_uses_default() {
         let mut config = default_config();

--- a/crates/forgeplan-core/src/estimate/confidence.rs
+++ b/crates/forgeplan-core/src/estimate/confidence.rs
@@ -77,11 +77,29 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn has_fr_but_zero_count_is_negative() {
         let (score, reasons) = score_confidence(true, 0, false, 0, false, false);
         assert!((score - 0.10).abs() < 0.01); // baseline only, has_fr=true but count=0 → no bonus
         assert!(reasons.iter().any(|r| r.contains("no FR")));
+    }
+
+    #[test]
+    fn has_rfc_phases_but_zero_count_no_bonus() {
+        let (score, reasons) = score_confidence(false, 0, true, 0, false, false);
+        assert!((score - 0.10).abs() < 0.01); // baseline only, phase_count=0 → no +25%
+        assert!(reasons.iter().any(|r| r.contains("no RFC")));
+    }
+
+    #[test]
+    fn spec_only() {
+        let (score, _) = score_confidence(false, 0, false, 0, true, false);
+        assert!((score - 0.25).abs() < 0.01); // 0.15 + 0.10 baseline
+    }
+
+    #[test]
+    fn evidence_only() {
+        let (score, _) = score_confidence(false, 0, false, 0, false, true);
+        assert!((score - 0.30).abs() < 0.01); // 0.20 + 0.10 baseline
     }
 
     #[test]

--- a/crates/forgeplan-core/src/estimate/extractor.rs
+++ b/crates/forgeplan-core/src/estimate/extractor.rs
@@ -38,8 +38,8 @@ pub fn collect_hints(body: &str, extracted_count: usize, kind: &str) -> Vec<Esti
         });
     }
 
-    // No items at all
-    if extracted_count == 0 {
+    // No items at all — but only if there weren't template placeholders (which have their own hint)
+    if extracted_count == 0 && template_count == 0 {
         let suggestion = match kind {
             "prd" => "Add FR table: | FR-001 | Core | Must | User can ... | Journey 1 |",
             "rfc" => "Add Phase checklist: - [ ] **1.1** Description",
@@ -89,7 +89,7 @@ fn count_fr_rows(body: &str) -> usize {
 fn extract_fr_table(body: &str) -> Vec<WorkItem> {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(
-        r"(?m)^\|\s*(FR-\d+)\s*\|\s*(\w[\w\s]*?)\s*\|\s*(Must|Should|Could|Won't)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|"
+        r"(?m)^\|\s*(FR-\d+)\s*\|\s*([\w\-][\w\s\-]*?)\s*\|\s*(Must|Should|Could|Won't)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|"
     ).expect("valid regex"));
 
     re.captures_iter(body)
@@ -279,6 +279,65 @@ mod tests {
         assert!(items[0].description.contains("project structure"));
         assert_eq!(items[2].id, "P0.3");
         assert!(items[2].description.contains("CRUD"));
+    }
+
+    #[test]
+    fn collect_hints_no_items_no_templates() {
+        let body = "# Just a title\n\nSome text.";
+        let hints = collect_hints(body, 0, "prd");
+        // Should get "no estimable items" hint but NOT template warning
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].message.contains("No estimable"));
+        assert!(hints[0].action.as_ref().unwrap().contains("FR table"));
+    }
+
+    #[test]
+    fn collect_hints_all_templates_no_double_hint() {
+        let body = r#"
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | [Actor] can [capability] | Journey 1 |
+| FR-002 | Core | Must | [Actor] can [capability] | Journey 2 |
+"#;
+        let hints = collect_hints(body, 0, "prd");
+        // Should get template warning + RFC suggestion, but NOT "no items found" (F3 fix)
+        assert!(hints.iter().any(|h| h.message.contains("template placeholders")));
+        assert!(!hints.iter().any(|h| h.message.contains("No estimable")),
+            "Should NOT show 'no items' when templates exist — user already has FR table");
+    }
+
+    #[test]
+    fn collect_hints_low_item_count() {
+        let body = r#"
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | User can do X | Journey 1 |
+"#;
+        let hints = collect_hints(body, 1, "prd");
+        // Should get low count info + RFC suggestion
+        assert!(hints.iter().any(|h| h.message.contains("Only 1 item")));
+        assert!(hints.iter().any(|h| h.message.contains("RFC")));
+    }
+
+    #[test]
+    fn collect_hints_rfc_kind_suggestion() {
+        let body = "# No FR or phases";
+        let hints = collect_hints(body, 0, "rfc");
+        assert!(hints[0].action.as_ref().unwrap().contains("Phase checklist"));
+    }
+
+    #[test]
+    fn fr_regex_accepts_hyphenated_category() {
+        let body = r#"
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Non-Core | Must | User can do X | Journey 1 |
+| FR-002 | API-Design | Should | System can do Y | Journey 2 |
+"#;
+        let items = extract_fr_table(body);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].category, "Non-Core");
+        assert_eq!(items[1].category, "API-Design");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **F1 CRITICAL**: `has_spec`/`has_evidence` didn't distinguish incoming/outgoing relations — false confidence boost. Fixed with separate directional checks.
- **F3 IMPORTANT**: Double hint when all FR rows are template placeholders ("placeholders" + "no items"). Guard: only show "no items" when `template_count == 0`.
- **F4 IMPORTANT**: FR regex dropped hyphenated categories (Non-Core, API-Design). Regex relaxed to accept hyphens.
- **F5 IMPORTANT**: Duplicate `#[test]` attributes — compiler warnings. Removed duplicates.
- **F6 MINOR**: `extract_frontmatter_domain` matched `domain:` in body text, not just YAML frontmatter. Added `---` delimiter check.
- **F2 DOC**: AI grade_multiplier intentionally unused — clarified in comment.

6 new tests: collect_hints (4 branches), hyphenated category, confidence edge cases.

## Refs

- PRD-022, RFC-005, ADR-004
- EVID-036 (updated: CL3, verdict: supports)
- Audit: 2 agents (code-reviewer + test-coverage explorer)

## Test plan

- [x] `cargo test` — 636 pass, 0 fail
- [x] `cargo check` — 0 warnings, 0 errors
- [x] `forgeplan estimate PRD-022` — works
- [x] `forgeplan estimate PRD-022 --complexity "FR-001=5"` — override works
- [x] Verified no duplication with previous audit fixes (edc8acc, 143c0e0)
- [x] Verified no conflicts with PR #80, #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)