### PR TITLE
[Sprint 7] Audit fixes — LICENSE, CI, release, metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,18 @@ on:
   pull_request:
     branches: [dev, main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
   check:
-    name: Check & Lint
+    name: Check, Lint & Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,20 +25,25 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
 
       - name: cargo check
         run: cargo check --workspace --all-targets
 
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets
 
   test:
     name: Tests
     runs-on: ubuntu-latest
+    needs: check
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 permissions:
   contents: write
@@ -24,7 +24,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13  # Intel runner for native x86_64 build
 
     steps:
       - name: Checkout

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ForgePlan Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -13,8 +13,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core" }
-forgeplan-mcp = { path = "../forgeplan-mcp" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.12.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.12.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -2,7 +2,11 @@
 name = "forgeplan-mcp"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "MCP server for Forgeplan — expose artifact tools via Model Context Protocol"
+keywords = ["mcp", "model-context-protocol", "project-management", "artifacts"]
+categories = ["development-tools"]
 
 [[bin]]
 name = "forgeplan-mcp"
@@ -13,7 +17,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.12.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@
 # Supports: Linux x86_64, macOS arm64, macOS x86_64.
 # Requires: curl or wget.
 #
+# Security note: piping to sh executes unverified remote code.
+# For verified install, use: cargo install forgeplan-cli
+# Or download manually from https://github.com/ForgePlan/forgeplan/releases
+#
 # Exit codes:
 #   0 — success
 #   1 — unsupported OS or architecture


### PR DESCRIPTION
## Summary
4-agent audit fixes for Sprint 7 distribution:
- LICENSE file (MIT) — required for crates.io
- CI: cargo fmt, permissions, timeouts, needs chain
- Release: semver tag pattern, macos-13 for x86
- MCP metadata: license, repository, keywords
- install.sh: pipe-to-sh security warning
- Path deps versioned for crates.io

## Test plan
- [x] 731 tests pass, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)