### PR TITLE
Session audit fixes — promote warning, NaN guard

### DIFF
--- a/crates/forgeplan-cli/src/commands/calibrate_estimate.rs
+++ b/crates/forgeplan-cli/src/commands/calibrate_estimate.rs
@@ -9,8 +9,8 @@ use crate::commands::estimate::load_estimate_config;
 
 /// Compare estimated hours with actual hours to calibrate estimation accuracy.
 pub async fn run(artifact_id: &str, actual_hours: f64, grade: Option<&str>) -> Result<()> {
-    if actual_hours <= 0.0 {
-        anyhow::bail!("Actual hours must be positive");
+    if !actual_hours.is_finite() || actual_hours <= 0.0 {
+        anyhow::bail!("Actual hours must be a positive finite number (got: {})", actual_hours);
     }
 
     let store = common::store().await?;

--- a/crates/forgeplan-cli/src/commands/promote.rs
+++ b/crates/forgeplan-cli/src/commands/promote.rs
@@ -88,7 +88,9 @@ pub async fn run(memory_id: &str, kind: &str) -> Result<()> {
     let mem_filename = format!("{}-{}.md", record.id, mem_slug);
     let mem_filepath = workspace.join(ArtifactKind::Memory.dir_name()).join(&mem_filename);
     if mem_filepath.exists() {
-        tokio::fs::remove_file(&mem_filepath).await.ok();
+        if let Err(e) = tokio::fs::remove_file(&mem_filepath).await {
+            eprintln!("  Warning: could not remove memory file {}: {}", mem_filepath.display(), e);
+        }
     }
 
     println!(


### PR DESCRIPTION
## Summary
- promote.rs: `.ok()` → warning on file deletion failure (consensus: logic+security+arch)
- calibrate_estimate.rs: reject NaN/Infinity in --actual-hours (consensus: logic+security)
- PROB-017 + PROB-015 deprecated (resolved problems)

🤖 Generated with [Claude Code](https://claude.com/claude-code)