### PR TITLE
[Sprint 7] Homebrew formula + crates.io auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,34 @@ jobs:
             --generate-notes \
             artifacts/forgeplan-* \
             artifacts/checksums-sha256.txt
+
+  publish:
+    name: Publish to crates.io
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish forgeplan-core
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p forgeplan-core --no-verify
+
+      - name: Publish forgeplan-mcp
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          sleep 30
+          cargo publish -p forgeplan-mcp --no-verify
+
+      - name: Publish forgeplan-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          sleep 30
+          cargo publish -p forgeplan-cli --no-verify

--- a/Formula/forgeplan.rb
+++ b/Formula/forgeplan.rb
@@ -1,0 +1,33 @@
+class Forgeplan < Formula
+  desc "Forge your plan — structured artifacts with quality scoring"
+  homepage "https://github.com/ForgePlan/forgeplan"
+  license "MIT"
+  version "1.0.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/ForgePlan/forgeplan/releases/download/v#{version}/forgeplan-aarch64-apple-darwin"
+      sha256 "PLACEHOLDER_SHA256_ARM64"
+    end
+    on_intel do
+      url "https://github.com/ForgePlan/forgeplan/releases/download/v#{version}/forgeplan-x86_64-apple-darwin"
+      sha256 "PLACEHOLDER_SHA256_X86_64"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/ForgePlan/forgeplan/releases/download/v#{version}/forgeplan-x86_64-unknown-linux-gnu"
+      sha256 "PLACEHOLDER_SHA256_LINUX"
+    end
+  end
+
+  def install
+    binary_name = stable.url.split("/").last
+    bin.install binary_name => "forgeplan"
+  end
+
+  test do
+    assert_match "forgeplan #{version}", shell_output("#{bin}/forgeplan --version")
+  end
+end


### PR DESCRIPTION
## Summary
- `Formula/forgeplan.rb` — brew tap for macOS (arm64 + x86_64) + Linux
- `release.yml` — auto-publish to crates.io on tag push (core → mcp → cli)
- SHA256 placeholders in formula — filled after first release

## Test plan
- [x] `cargo check` — 0 warnings
- [x] `cargo package -p forgeplan-core --list` — 92 files, clean
- [x] Homebrew formula syntax valid (Ruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)