### PR TITLE
Sprint 6+7 final audit fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,16 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          sleep 30
-          cargo publish -p forgeplan-mcp --no-verify
+          for i in 1 2 3; do
+            sleep 60
+            cargo publish -p forgeplan-mcp --no-verify && break || echo "Retry $i..."
+          done
 
       - name: Publish forgeplan-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          sleep 30
-          cargo publish -p forgeplan-cli --no-verify
+          for i in 1 2 3; do
+            sleep 60
+            cargo publish -p forgeplan-cli --no-verify && break || echo "Retry $i..."
+          done

--- a/Formula/forgeplan.rb
+++ b/Formula/forgeplan.rb
@@ -4,6 +4,11 @@ class Forgeplan < Formula
   license "MIT"
   version "1.0.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   on_macos do
     on_arm do
       url "https://github.com/ForgePlan/forgeplan/releases/download/v#{version}/forgeplan-aarch64-apple-darwin"

--- a/crates/forgeplan-cli/src/commands/calibrate_estimate.rs
+++ b/crates/forgeplan-cli/src/commands/calibrate_estimate.rs
@@ -106,8 +106,10 @@ pub async fn run(artifact_id: &str, actual_hours: f64, grade: Option<&str>) -> R
         println!("  {} Slightly optimistic ({:.0}% accuracy). Acceptable range.", style("i").dim(), accuracy_pct);
     } else if ratio < 0.5 {
         println!("  {} Finished {:.1}x faster. Estimates may be too conservative.", style("*").green(), 1.0 / ratio);
+    } else if ratio < 0.7 {
+        println!("  {} Finished faster than expected ({:.0}% of estimate). Estimates may be conservative.", style("i").dim(), ratio * 100.0);
     } else {
-        println!("  {} Good calibration — within 10-30% of actual.", style("*").green());
+        println!("  {} Good calibration — within 30% of actual.", style("*").green());
     }
     println!();
 

--- a/crates/forgeplan-cli/src/commands/promote.rs
+++ b/crates/forgeplan-cli/src/commands/promote.rs
@@ -85,7 +85,7 @@ pub async fn run(memory_id: &str, kind: &str) -> Result<()> {
 
     // Remove memory markdown file
     let mem_slug = slugify(&record.title);
-    let mem_filename = format!("{}-{}.md", record.id, mem_slug);
+    let mem_filename = format!("{}-{}.md", memory_id, mem_slug);
     let mem_filepath = workspace.join(ArtifactKind::Memory.dir_name()).join(&mem_filename);
     if mem_filepath.exists() {
         if let Err(e) = tokio::fs::remove_file(&mem_filepath).await {


### PR DESCRIPTION
## Fixes
- calibrate_estimate: 0.5-0.7 ratio advisory band (was "good calibration")
- promote: memory_id for file path (was record.id — potential orphan)
- release.yml: 60s sleep + retry for crates.io indexing (was 30s, no retry)
- Formula: livecheck for Homebrew auto-version detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)