### PR TITLE
fix(dist): allow-dirty CI for patched action versions

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,3 +18,5 @@ tap = "AiDogfood/homebrew-tap"
 publish-jobs = ["homebrew"]
 # Binary aliases
 bin-aliases = { "forgeplan" = ["fpl"] }
+# Allow dirty CI files (we patched action versions v6→v4)
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary

- cargo-dist v0.31.0 generates non-existent action versions (@v6/@v7)
- We patched to @v4, making CI file "dirty" from dist's perspective
- `allow-dirty = ["ci"]` tells dist to skip file content check during release
- Fixes GH Actions release workflow failure on v0.13.0 tag push

## Refs

PRD-023

## Test plan

- [x] `cargo test` — 753 pass
- [x] `cargo fmt -- --check` — 0 diffs
- [x] `cargo check` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)