### PR TITLE
fix(dist): allow-dirty CI for patched action versions

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,3 +18,5 @@ tap = "AiDogfood/homebrew-tap"
 publish-jobs = ["homebrew"]
 # Binary aliases
 bin-aliases = { "forgeplan" = ["fpl"] }
+# Allow dirty CI files (we patched action versions v6→v4)
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary

Cherry-pick of fix from dev. cargo-dist v0.31.0 generates non-existent action versions (@v6/@v7). We patched to @v4, which requires `allow-dirty = ["ci"]` to skip dist's file content check during release.

Fixes: v0.13.0 release workflow failure.

## Refs

PRD-023

🤖 Generated with [Claude Code](https://claude.com/claude-code)