### PR TITLE
fix(ci): add protoc for lance-encoding build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,10 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot


### PR DESCRIPTION
## Summary

Cherry-pick of protoc fix from dev. All release builds fail without protobuf compiler.
Adds `arduino/setup-protoc@v3` to install step.

## Refs
PRD-023

🤖 Generated with [Claude Code](https://claude.com/claude-code)