### PR TITLE
fix(dist): Homebrew tap org AiDogfood → ForgePlan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
-          repository: "AiDogfood/homebrew-tap"
+          repository: "ForgePlan/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,7 +13,7 @@ installers = ["shell", "homebrew"]
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 # Homebrew tap repository
-tap = "AiDogfood/homebrew-tap"
+tap = "ForgePlan/homebrew-tap"
 # Publish jobs
 publish-jobs = ["homebrew"]
 # Binary aliases


### PR DESCRIPTION
## Summary

Wrong org name in Homebrew tap config. `AiDogfood/homebrew-tap` → `ForgePlan/homebrew-tap`.

## Refs
PRD-023

🤖 Generated with [Claude Code](https://claude.com/claude-code)