### PR TITLE
fix(dist): rename crate forgeplan-cli → forgeplan

### DIFF
--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "forgeplan-cli"
+name = "forgeplan"
 version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Crate name `forgeplan-cli` → `forgeplan`
- Now: `brew install forgeplan`, `cargo install forgeplan`
- Archives: `forgeplan-*.tar.xz` (clean, no `-cli` suffix)
- Binary was already named `forgeplan` via `[[bin]]`

## Refs
PRD-023

## Test plan
- [x] `cargo test` — 753 pass
- [x] `cargo fmt -- --check` — 0 diffs
- [x] `cargo check` — 0 warnings
- [x] `dist plan` — shows `forgeplan 0.13.0` (not forgeplan-cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)