### PR TITLE
Release v0.14.0 — crate renamed to forgeplan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,10 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
-          repository: "AiDogfood/homebrew-tap"
+          repository: "ForgePlan/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,8 +2251,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "forgeplan-cli"
-version = "0.13.0"
+name = "forgeplan"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.13.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.13.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.14.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.14.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "forgeplan-cli"
+name = "forgeplan"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.13.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.14.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -13,7 +13,7 @@ installers = ["shell", "homebrew"]
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 
 # Homebrew tap repository
-tap = "AiDogfood/homebrew-tap"
+tap = "ForgePlan/homebrew-tap"
 # Publish jobs
 publish-jobs = ["homebrew"]
 # Binary aliases

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,3 +18,5 @@ tap = "AiDogfood/homebrew-tap"
 publish-jobs = ["homebrew"]
 # Binary aliases
 bin-aliases = { "forgeplan" = ["fpl"] }
+# Allow dirty CI files (we patched action versions v6→v4)
+allow-dirty = ["ci"]


### PR DESCRIPTION
## Summary

- Crate renamed `forgeplan-cli` → `forgeplan`
- Now: `brew install forgeplan`, `cargo install forgeplan`
- Archives: `forgeplan-*.tar.xz` (clean naming)
- Version bump 0.13.0 → 0.14.0

## Test plan
- [x] `cargo test` — 753 pass
- [x] `dist plan` — shows `forgeplan 0.14.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)