### PR TITLE
docs(readme): bilingual README (EN + RU) with industry best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,215 @@
-# Forgeplan — Forge Your Plan
+<div align="center">
 
-**Vision**: Универсальный процесс и Rust CLI для ведения любого проекта
-от идеи до реализации, используя FPF, PRD, RFC, ADR, Epics и автоматизацию.
+# Forgeplan
 
-**Статус**: Phase 1 — Schemas & Templates
-**Alias**: `fpl` (опциональный короткий alias)
+**Forge your plan — from raw idea to proven decision.**
+
+A Rust-native methodology engine for managing engineering artifacts (PRD, RFC, ADR, Epic, Spec)
+with quality scoring, evidence tracking, semantic search, and AI-agent integration.
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/ForgePlan/forgeplan?include_prereleases)](https://github.com/ForgePlan/forgeplan/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/ForgePlan/forgeplan/ci.yml?branch=main)](https://github.com/ForgePlan/forgeplan/actions)
+[![Made with Rust](https://img.shields.io/badge/made%20with-Rust-orange.svg)](https://www.rust-lang.org/)
+
+[English](README.md) · [Русский](README.ru.md) · [Documentation](docs/README.md) · [Methodology](docs/methodology/FORGEPLAN-GUIDE.md) · [Releases](https://github.com/ForgePlan/forgeplan/releases)
+
+</div>
 
 ---
 
-## Что это
+## What is Forgeplan?
 
-Система документов + CLI-приложение (Rust), которые помогают:
-
-1. **Декомпозировать** любую задачу на артефакты (PRD → Spec → RFC → ADR → Sprint)
-2. **Генерировать** шаблоны через FPF reasoning + LLM
-3. **Трекать** прогресс через индексы и progress bars
-4. **Группировать** связанные артефакты в Epics
-5. **Валидировать** полноту и качество документов
-
-## Use Cases
-
-| Сценарий | Артефакты | Flow |
-|----------|-----------|------|
-| Новая фича | PRD → Spec → RFC → Sprint | Idea → Requirements → Architecture → Code |
-| Рефакторинг / Decompose monolith | ADR → RFC → Sprint | Decision → Design → Execute |
-| Баг / Incident | ADR (root cause) → RFC (fix) | Investigate → Decide → Fix |
-| Инфраструктура | RFC → ADR → Sprint | Design → Decide → Deploy |
-| Продуктовый roadmap | Epic → PRD[] → RFC[] | Strategy → Requirements → Execution |
-| Миграция (framework, DB, cloud) | Epic → ADR → RFC → Sprint | Plan → Decide → Design → Migrate |
-| Новый проект с нуля | Epic → PRD → Spec → RFC → ADR → Sprint | Full lifecycle |
-| Оценка технического долга | Analysis → ADR → Epic → RFC | Audit → Decide → Plan → Fix |
-| API Design | Spec → RFC → ADR | Contract → Architecture → Decisions |
-| Security Audit | Analysis → ADR → RFC | Findings → Decisions → Remediation |
-
-## Структура каталога
+Forgeplan turns ad-hoc engineering work into a **disciplined decision pipeline**:
 
 ```
-frameworks/
-├── README.md              ← этот файл
-├── TODO.md                ← задачи проекта
-├── PLAN.md                ← план реализации (4 фазы)
-│
-├── docs/
-│   ├── schemas/           ← схемы артефактов (PRD-SCHEMA, EPIC-SCHEMA, etc.)
-│   ├── guides/            ← workflow guides (PRD→RFC→ADR flow)
-│   └── references/        ← собранные референсы (FPF, skills, commands)
-│
-├── templates/             ← шаблоны документов
-│   ├── prd/               ← PRD шаблон
-│   ├── epic/              ← Epic шаблон
-│   ├── spec/              ← Specification шаблон
-│   ├── rfc/               ← RFC шаблон (copy from existing)
-│   └── adr/               ← ADR шаблон (copy from existing)
-│
-├── research/              ← исследования методологий
-│
-├── sources/              ← reference implementations (quint-code, OpenSpec, BMAD, git-adr)
-│
-└── src/                   ← Rust CLI application (Phase 3+)
-    └── (будет позже)
+Observe → Route → Shape → Build → Prove → Ship
 ```
 
-## Методологии и фреймворки
+Every non-trivial task becomes a traceable chain of artifacts — PRDs capture *what* and *why*, RFCs describe *how*, ADRs record *decisions*, and EvidencePacks provide *proof*. Quality is scored automatically via **R_eff** (effective reliability) and **F-G-R** (Formality–Granularity–Reliability). Stale decisions surface on their own. Nothing rots in the dark.
 
-| Метод | Из | Применение |
-|-------|-----|-----------|
-| **FPF** (First Principles Framework) | `.claude/skills/fpf-simple/` | Декомпозиция, bounded contexts, reasoning |
-| **SPARC** | `.claude/commands/sparc/` | Specification → Pseudocode → Architecture → Refinement → Completion |
-| **C4 Model** | `.claude/agents/c4-architecture/` | Context → Container → Component → Code diagrams |
-| **DDD** | `.claude/agents/v3/ddd-domain-expert.md` | Bounded contexts, aggregates, domain events |
-| **RFC Process** | `docs/methodology/PRD-RFC-ADR-FLOW.md` | When to use RFC / ADR / PRD |
-| **ADR Process** | `.forgeplan/adrs/` | Project ADRs (managed by `forgeplan` CLI) |
-| **Wave/Sprint** | `.claude/commands/sprint.md` | Agent Teams parallel execution |
+It's built for **teams working with AI agents** — Claude Code, Cursor, Aider — where the methodology needs to be machine-readable as well as human-readable.
+
+## Why?
+
+| Problem | How Forgeplan solves it |
+|---|---|
+| Decisions get lost in Slack/Linear/email | Every decision is a git-tracked markdown artifact with structured fields |
+| No way to tell if a decision is still valid | Evidence packs with expiration + `R_eff` scoring flag stale artifacts |
+| "Why did we choose X?" has no answer six months later | ADRs with required *Context → Decision → Consequences* structure |
+| AI agents produce plausible-but-shallow work | Depth calibration (Tactical → Standard → Deep → Critical) enforces rigor per task |
+| Artifacts become obsolete or drift from code | File watcher + `forgeplan scan-import` keep markdown and index in sync |
+| Research never makes it into the process | SolutionPortfolio with weakest-link scoring forces alternatives |
+
+## Features
+
+- **Markdown-first storage** — all artifacts live in `.forgeplan/` as plain markdown, version-controlled in git. LanceDB is a derived index, not a cache of truth.
+- **Quality scoring** — `R_eff` (weakest-link evidence trust) and `F-G-R` (epistemic quality) are computed automatically.
+- **Smart routing** — `forgeplan route "task"` analyzes the request and suggests the right artifact pipeline and depth.
+- **ADI reasoning** — *Abduction → Deduction → Induction*. Forces 3+ hypotheses before decisions.
+- **MCP server** — 37+ tools for AI agents. Works natively with Claude Code, Cursor, Continue.
+- **Semantic search** — local fastembed (BGE-M3, 1024 dims). No network, no API keys.
+- **Graph queries** — topological sort, blocked artifacts, dependency traversal (petgraph).
+- **Depth calibration** — task complexity determines how many artifacts you *must* create. Don't over-document a typo fix.
+- **Evidence decay** — artifacts with expired `valid_until` are marked stale. Trust deteriorates honestly.
+- **Lifecycle v2** — `draft → active → superseded/deprecated/stale → renew/reopen`. Terminal states are terminal.
+
+## Install
+
+### Homebrew (macOS, Linux)
+
+```bash
+brew install ForgePlan/tap/forgeplan
+```
+
+### Install script (Linux, macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh
+```
+
+### From source (requires Rust 1.75+)
+
+```bash
+git clone https://github.com/ForgePlan/forgeplan.git
+cd forgeplan
+cargo install --path crates/forgeplan-cli
+```
+
+### Binary releases
+
+Download the latest binary for your platform from [Releases](https://github.com/ForgePlan/forgeplan/releases).
 
 ## Quick Start
 
 ```bash
-# 1. Изучить план
-cat frameworks/PLAN.md
+# 1. Initialize workspace in your project
+cd my-project
+forgeplan init -y
 
-# 2. Посмотреть vision
-cat frameworks/VISION.md
+# 2. Check project health
+forgeplan health
 
-# 3. Использовать шаблон в любом проекте
-cp frameworks/templates/prd/_TEMPLATE.md my-project/docs/prds/PRD-001-my-feature.md
+# 3. Route a task to the correct depth and pipeline
+forgeplan route "Add OAuth2 authentication"
+#   → Depth: Standard
+#   → Pipeline: PRD → RFC
+#   → Confidence: 92%
 
-# 4. (Phase 3+) CLI
-forgeplan init
-forgeplan new prd "My Feature"
-forgeplan status
+# 4. Create an artifact
+forgeplan new prd "OAuth2 Authentication"
+
+# 5. Fill MUST sections (Problem, Goals, Non-Goals, Target Users, FR), then validate
+forgeplan validate PRD-001
+
+# 6. Reason through alternatives (ADI cycle — 3+ hypotheses)
+forgeplan reason PRD-001
+
+# 7. Implement, then capture evidence
+forgeplan new evidence "OAuth2: 15 tests pass, Google login benchmarked 180ms p95"
+forgeplan link EVID-001 PRD-001 --relation informs
+forgeplan score PRD-001
+#   → R_eff = 1.00
+
+# 8. Review and activate
+forgeplan review PRD-001
+forgeplan activate PRD-001
 ```
+
+Full tutorial: **[docs/methodology/FORGEPLAN-GUIDE.md](docs/methodology/FORGEPLAN-GUIDE.md)**
+
+## Architecture
+
+Forgeplan is a Rust workspace with three crates:
+
+| Crate | Role |
+|---|---|
+| `forgeplan-core` | Storage, validation, scoring, routing, search, graph, FPF reasoning engine |
+| `forgeplan-cli` | The `forgeplan` binary — 33 commands, clap derive |
+| `forgeplan-mcp` | MCP server for AI agents — 37 tools over stdio transport |
+
+**Storage model ([ADR-003](.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md)):**
+
+- Markdown files in `.forgeplan/` = **source of truth** (git-tracked)
+- LanceDB in `.forgeplan/lance/` = derived index (gitignored, rebuildable via `forgeplan scan-import`)
+
+**Tech stack:** Rust · LanceDB · fastembed (BGE-M3) · clap · rmcp · tera · petgraph · tokio.
+
+## Documentation
+
+- **[docs/README.md](docs/README.md)** — Documentation index
+- **[docs/methodology/](docs/methodology/)** — Methodology guides (10 documents)
+  - [FORGEPLAN-GUIDE.md](docs/methodology/FORGEPLAN-GUIDE.md) — Full reference (**start here**)
+  - [HOW-TO-USE.md](docs/methodology/HOW-TO-USE.md) — 10 rules with examples
+  - [DEPTH-CALIBRATION.md](docs/methodology/DEPTH-CALIBRATION.md) — Tactical → Critical
+  - [QUALITY-GATES.md](docs/methodology/QUALITY-GATES.md) — R_eff, adversarial review
+  - [PRD-RFC-ADR-FLOW.md](docs/methodology/PRD-RFC-ADR-FLOW.md) — Which artifact for which task
+  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — Forgeplan × Orchestra × Hindsight
+- **[docs/operations/](docs/operations/)** — Agent hooks, enforcement, repo protection
+- **[docs/schemas/](docs/schemas/)** — Formal artifact schemas (PRD, EPIC, SPEC)
+- **[CLAUDE.md](CLAUDE.md)** — Project instructions for Claude Code
+- **[AGENTS.md](AGENTS.md)** — Standard instructions for AI agents (Aider, Cursor, Continue)
+
+## Project artifacts
+
+This repository dogfoods Forgeplan — the project is managed with itself.
+
+- **[.forgeplan/adrs/](.forgeplan/adrs/)** — Architecture Decision Records (5)
+- **[.forgeplan/rfcs/](.forgeplan/rfcs/)** — Architectural proposals (6)
+- **[.forgeplan/prds/](.forgeplan/prds/)** — Product Requirements (24+)
+- **[.forgeplan/epics/](.forgeplan/epics/)** — Epics (2)
+- **[.forgeplan/evidence/](.forgeplan/evidence/)** — Evidence packs (50+)
+
+Use the `forgeplan` CLI to browse: `forgeplan list`, `forgeplan get ADR-003`, `forgeplan health`.
+
+## Status
+
+- **Current release:** [v0.15.1](https://github.com/ForgePlan/forgeplan/releases/tag/v0.15.1)
+- **Tests:** 728+ passing
+- **Commands:** 33 CLI commands, 37 MCP tools
+- **Dogfood:** This repo manages itself — 138 tracked markdown artifacts
+
+See [.forgeplan/prds/](.forgeplan/prds/) and the current [CHANGELOG](https://github.com/ForgePlan/forgeplan/releases) for the roadmap.
+
+## Contributing
+
+See **[CLAUDE.md](CLAUDE.md)** for the full contribution guide: branching strategy, commit conventions, PR pipeline, and methodology requirements.
+
+Short version:
+
+1. Branch from `dev`: `git checkout dev && git pull && git checkout -b feat/my-feature`
+2. Follow the full cycle: **Route → Shape → Validate → Build → Evidence → Activate**
+3. `cargo fmt` + `cargo test` before every commit
+4. PR → `dev` (feature/fix/docs branches); PR → `main` only via `release/vX.Y.Z` branches
+
+## Related
+
+- [`website/`](website/) — Official website (Astro + Starlight + React + GSAP)
+- [`marketplace/`](marketplace/) — Plugin marketplace (Forgeplan methodology + FPF + dev toolkit)
+- [`templates/`](templates/) — Markdown templates for each artifact kind
+
+## License
+
+MIT License — see [LICENSE](LICENSE) for details.
+
+## Acknowledgements
+
+Forgeplan stands on the shoulders of:
+
+- **[Quint-code](https://github.com/quint-code)** — R_eff scoring, data model inspiration
+- **[BMAD Method](https://github.com/bmadcode/BMAD-METHOD)** — PRD workflow, 13-step validation
+- **[OpenSpec](https://openspec.ai/)** — Artifact DAG, delta-specs
+- **[First Principles Framework](https://github.com/ForgePlan/marketplace/tree/main/plugins/fpf)** — Reasoning architecture, ADI cycle, trust calculus
+- **[adr-tools](https://github.com/npryce/adr-tools)** — ADR pattern (Michael Nygard)
+- **[LanceDB](https://lancedb.com/)** — Embedded vector database
+- **[fastembed](https://github.com/qdrant/fastembed)** — Local embeddings (BGE-M3)
+
+---
+
+<div align="center">
+
+**Forge your plan. Structure. Evidence. Trust.**
+
+[Documentation](docs/README.md) · [Releases](https://github.com/ForgePlan/forgeplan/releases) · [Marketplace](marketplace/) · [Русский](README.ru.md)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-# Forgeplan
+# ForgePlan
 
 **Forge your plan — from raw idea to proven decision.**
 
-A Rust-native methodology engine for managing engineering artifacts (PRD, RFC, ADR, Epic, Spec)
-with quality scoring, evidence tracking, semantic search, and AI-agent integration.
+ForgePlan is an **engineering decision framework** — a methodology plus CLI for managing structured
+artifacts (PRD, RFC, ADR, Epic, Spec) with quality scoring, evidence tracking, semantic search,
+and native AI-agent integration.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/ForgePlan/forgeplan?include_prereleases)](https://github.com/ForgePlan/forgeplan/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/ForgePlan/forgeplan/ci.yml?branch=main)](https://github.com/ForgePlan/forgeplan/actions)
-[![Made with Rust](https://img.shields.io/badge/made%20with-Rust-orange.svg)](https://www.rust-lang.org/)
 
 [English](README.md) · [Русский](README.ru.md) · [Documentation](docs/README.md) · [Methodology](docs/methodology/FORGEPLAN-GUIDE.md) · [Releases](https://github.com/ForgePlan/forgeplan/releases)
 
@@ -18,9 +18,9 @@ with quality scoring, evidence tracking, semantic search, and AI-agent integrati
 
 ---
 
-## What is Forgeplan?
+## What is ForgePlan?
 
-Forgeplan turns ad-hoc engineering work into a **disciplined decision pipeline**:
+ForgePlan turns ad-hoc engineering work into a **disciplined decision pipeline**:
 
 ```
 Observe → Route → Shape → Build → Prove → Ship
@@ -32,7 +32,7 @@ It's built for **teams working with AI agents** — Claude Code, Cursor, Aider �
 
 ## Why?
 
-| Problem | How Forgeplan solves it |
+| Problem | How ForgePlan solves it |
 |---|---|
 | Decisions get lost in Slack/Linear/email | Every decision is a git-tracked markdown artifact with structured fields |
 | No way to tell if a decision is still valid | Evidence packs with expiration + `R_eff` scoring flag stale artifacts |
@@ -68,7 +68,7 @@ brew install ForgePlan/tap/forgeplan
 curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh
 ```
 
-### From source (requires Rust 1.75+)
+### From source
 
 ```bash
 git clone https://github.com/ForgePlan/forgeplan.git
@@ -120,20 +120,18 @@ Full tutorial: **[docs/methodology/FORGEPLAN-GUIDE.md](docs/methodology/FORGEPLA
 
 ## Architecture
 
-Forgeplan is a Rust workspace with three crates:
+ForgePlan ships as three components:
 
-| Crate | Role |
+| Component | Role |
 |---|---|
 | `forgeplan-core` | Storage, validation, scoring, routing, search, graph, FPF reasoning engine |
-| `forgeplan-cli` | The `forgeplan` binary — 33 commands, clap derive |
+| `forgeplan-cli` | The `forgeplan` binary — 33 commands |
 | `forgeplan-mcp` | MCP server for AI agents — 37 tools over stdio transport |
 
 **Storage model ([ADR-003](.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md)):**
 
 - Markdown files in `.forgeplan/` = **source of truth** (git-tracked)
 - LanceDB in `.forgeplan/lance/` = derived index (gitignored, rebuildable via `forgeplan scan-import`)
-
-**Tech stack:** Rust · LanceDB · fastembed (BGE-M3) · clap · rmcp · tera · petgraph · tokio.
 
 ## Documentation
 
@@ -144,7 +142,7 @@ Forgeplan is a Rust workspace with three crates:
   - [DEPTH-CALIBRATION.md](docs/methodology/DEPTH-CALIBRATION.md) — Tactical → Critical
   - [QUALITY-GATES.md](docs/methodology/QUALITY-GATES.md) — R_eff, adversarial review
   - [PRD-RFC-ADR-FLOW.md](docs/methodology/PRD-RFC-ADR-FLOW.md) — Which artifact for which task
-  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — Forgeplan × Orchestra × Hindsight
+  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — ForgePlan × Orchestra × Hindsight
 - **[docs/operations/](docs/operations/)** — Agent hooks, enforcement, repo protection
 - **[docs/schemas/](docs/schemas/)** — Formal artifact schemas (PRD, EPIC, SPEC)
 - **[CLAUDE.md](CLAUDE.md)** — Project instructions for Claude Code
@@ -152,7 +150,7 @@ Forgeplan is a Rust workspace with three crates:
 
 ## Project artifacts
 
-This repository dogfoods Forgeplan — the project is managed with itself.
+This repository dogfoods ForgePlan — the project is managed with itself.
 
 - **[.forgeplan/adrs/](.forgeplan/adrs/)** — Architecture Decision Records (5)
 - **[.forgeplan/rfcs/](.forgeplan/rfcs/)** — Architectural proposals (6)
@@ -185,7 +183,7 @@ Short version:
 ## Related
 
 - [`website/`](website/) — Official website (Astro + Starlight + React + GSAP)
-- [`marketplace/`](marketplace/) — Plugin marketplace (Forgeplan methodology + FPF + dev toolkit)
+- [`marketplace/`](marketplace/) — Plugin marketplace (ForgePlan methodology + FPF + dev toolkit)
 - [`templates/`](templates/) — Markdown templates for each artifact kind
 
 ## License
@@ -194,7 +192,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 
 ## Acknowledgements
 
-Forgeplan stands on the shoulders of:
+ForgePlan stands on the shoulders of:
 
 - **[Quint-code](https://github.com/quint-code)** — R_eff scoring, data model inspiration
 - **[BMAD Method](https://github.com/bmadcode/BMAD-METHOD)** — PRD workflow, 13-step validation

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,16 +1,16 @@
 <div align="center">
 
-# Forgeplan
+# ForgePlan
 
 **Forge your plan — от сырой идеи до проверенного решения.**
 
-Методологический движок на Rust для управления инженерными артефактами (PRD, RFC, ADR, Epic, Spec)
-с автоматической оценкой качества, трекингом доказательств, семантическим поиском и интеграцией с AI-агентами.
+ForgePlan — это **engineering decision framework**: методология плюс CLI для управления
+структурированными артефактами (PRD, RFC, ADR, Epic, Spec) с автоматической оценкой качества,
+трекингом доказательств, семантическим поиском и нативной интеграцией с AI-агентами.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/ForgePlan/forgeplan?include_prereleases)](https://github.com/ForgePlan/forgeplan/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/ForgePlan/forgeplan/ci.yml?branch=main)](https://github.com/ForgePlan/forgeplan/actions)
-[![Made with Rust](https://img.shields.io/badge/made%20with-Rust-orange.svg)](https://www.rust-lang.org/)
 
 [English](README.md) · [Русский](README.ru.md) · [Документация](docs/README.md) · [Методология](docs/methodology/FORGEPLAN-GUIDE.md) · [Релизы](https://github.com/ForgePlan/forgeplan/releases)
 
@@ -18,9 +18,9 @@
 
 ---
 
-## Что такое Forgeplan?
+## Что такое ForgePlan?
 
-Forgeplan превращает хаотичную инженерную работу в **дисциплинированный конвейер решений**:
+ForgePlan превращает хаотичную инженерную работу в **дисциплинированный конвейер решений**:
 
 ```
 Observe → Route → Shape → Build → Prove → Ship
@@ -32,7 +32,7 @@ Observe → Route → Shape → Build → Prove → Ship
 
 ## Зачем?
 
-| Проблема | Как решает Forgeplan |
+| Проблема | Как решает ForgePlan |
 |---|---|
 | Решения теряются в Slack/Linear/почте | Каждое решение — git-трекаемый markdown артефакт со структурными полями |
 | Непонятно, актуально ли решение | Evidence packs с `valid_until` + `R_eff` автоматически помечают устаревшие артефакты |
@@ -68,7 +68,7 @@ brew install ForgePlan/tap/forgeplan
 curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh
 ```
 
-### Из исходников (нужен Rust 1.75+)
+### Из исходников
 
 ```bash
 git clone https://github.com/ForgePlan/forgeplan.git
@@ -120,20 +120,18 @@ forgeplan activate PRD-001
 
 ## Архитектура
 
-Forgeplan — это Rust workspace из трёх крейтов:
+ForgePlan состоит из трёх компонентов:
 
-| Крейт | Роль |
+| Компонент | Роль |
 |---|---|
 | `forgeplan-core` | Storage, валидация, scoring, routing, поиск, граф, FPF reasoning engine |
-| `forgeplan-cli` | Бинарь `forgeplan` — 33 команды, clap derive |
+| `forgeplan-cli` | Бинарь `forgeplan` — 33 команды |
 | `forgeplan-mcp` | MCP server для AI-агентов — 37 tools через stdio transport |
 
 **Модель хранения ([ADR-003](.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md)):**
 
 - Markdown файлы в `.forgeplan/` = **source of truth** (трекаются git'ом)
 - LanceDB в `.forgeplan/lance/` = производный индекс (gitignored, пересобирается через `forgeplan scan-import`)
-
-**Tech stack:** Rust · LanceDB · fastembed (BGE-M3) · clap · rmcp · tera · petgraph · tokio.
 
 ## Документация
 
@@ -144,7 +142,7 @@ Forgeplan — это Rust workspace из трёх крейтов:
   - [DEPTH-CALIBRATION.md](docs/methodology/DEPTH-CALIBRATION.md) — Tactical → Critical
   - [QUALITY-GATES.md](docs/methodology/QUALITY-GATES.md) — R_eff, adversarial review
   - [PRD-RFC-ADR-FLOW.md](docs/methodology/PRD-RFC-ADR-FLOW.md) — Какой артефакт для какой задачи
-  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — Forgeplan × Orchestra × Hindsight
+  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — ForgePlan × Orchestra × Hindsight
 - **[docs/operations/](docs/operations/)** — Agent hooks, enforcement, protection репозитория
 - **[docs/schemas/](docs/schemas/)** — Формальные схемы артефактов (PRD, EPIC, SPEC)
 - **[CLAUDE.md](CLAUDE.md)** — Инструкции для Claude Code
@@ -185,7 +183,7 @@ Roadmap — в [.forgeplan/prds/](.forgeplan/prds/) и в [CHANGELOG](https://gi
 ## Связанное
 
 - [`website/`](website/) — Официальный сайт (Astro + Starlight + React + GSAP)
-- [`marketplace/`](marketplace/) — Plugin marketplace (Forgeplan методология + FPF + dev toolkit)
+- [`marketplace/`](marketplace/) — Plugin marketplace (ForgePlan методология + FPF + dev toolkit)
 - [`templates/`](templates/) — Markdown шаблоны для каждого типа артефакта
 
 ## Лицензия
@@ -194,7 +192,7 @@ MIT License — подробнее в [LICENSE](LICENSE).
 
 ## Благодарности
 
-Forgeplan стоит на плечах:
+ForgePlan стоит на плечах:
 
 - **[Quint-code](https://github.com/quint-code)** — R_eff scoring, data model
 - **[BMAD Method](https://github.com/bmadcode/BMAD-METHOD)** — PRD workflow, 13-step validation

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,215 @@
+<div align="center">
+
+# Forgeplan
+
+**Forge your plan — от сырой идеи до проверенного решения.**
+
+Методологический движок на Rust для управления инженерными артефактами (PRD, RFC, ADR, Epic, Spec)
+с автоматической оценкой качества, трекингом доказательств, семантическим поиском и интеграцией с AI-агентами.
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/ForgePlan/forgeplan?include_prereleases)](https://github.com/ForgePlan/forgeplan/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/ForgePlan/forgeplan/ci.yml?branch=main)](https://github.com/ForgePlan/forgeplan/actions)
+[![Made with Rust](https://img.shields.io/badge/made%20with-Rust-orange.svg)](https://www.rust-lang.org/)
+
+[English](README.md) · [Русский](README.ru.md) · [Документация](docs/README.md) · [Методология](docs/methodology/FORGEPLAN-GUIDE.md) · [Релизы](https://github.com/ForgePlan/forgeplan/releases)
+
+</div>
+
+---
+
+## Что такое Forgeplan?
+
+Forgeplan превращает хаотичную инженерную работу в **дисциплинированный конвейер решений**:
+
+```
+Observe → Route → Shape → Build → Prove → Ship
+```
+
+Любая нетривиальная задача становится цепочкой трассируемых артефактов — PRD фиксирует *что* и *почему*, RFC описывает *как*, ADR закрепляет *решения*, EvidencePack даёт *доказательства*. Качество считается автоматически через **R_eff** (effective reliability) и **F-G-R** (Formality–Granularity–Reliability). Устаревшие решения всплывают сами. Ничего не гниёт в темноте.
+
+Построен для **команд работающих с AI-агентами** — Claude Code, Cursor, Aider — где методология должна быть машиночитаемой так же, как и человекочитаемой.
+
+## Зачем?
+
+| Проблема | Как решает Forgeplan |
+|---|---|
+| Решения теряются в Slack/Linear/почте | Каждое решение — git-трекаемый markdown артефакт со структурными полями |
+| Непонятно, актуально ли решение | Evidence packs с `valid_until` + `R_eff` автоматически помечают устаревшие артефакты |
+| «Почему мы тогда выбрали X?» через полгода — тишина | ADR с обязательной структурой *Context → Decision → Consequences* |
+| AI-агенты выдают правдоподобную, но поверхностную работу | Depth calibration (Tactical → Standard → Deep → Critical) заставляет нужный уровень строгости |
+| Артефакты устаревают или расходятся с кодом | File watcher + `forgeplan scan-import` синхронизируют markdown и индекс |
+| Ресёрч не доходит до реализации | SolutionPortfolio с weakest-link scoring требует альтернативы |
+
+## Возможности
+
+- **Markdown как source of truth** — все артефакты лежат в `.forgeplan/` как обычный markdown в git. LanceDB — производный индекс, не кэш истины.
+- **Автоматический scoring** — `R_eff` (доверие по weakest link) и `F-G-R` (эпистемическое качество) считаются автоматически.
+- **Smart routing** — `forgeplan route "задача"` анализирует запрос и предлагает правильный pipeline и depth.
+- **ADI reasoning** — *Abduction → Deduction → Induction*. Заставляет сформулировать 3+ гипотезы перед решением.
+- **MCP server** — 37+ инструментов для AI-агентов. Нативно работает с Claude Code, Cursor, Continue.
+- **Семантический поиск** — локальный fastembed (BGE-M3, 1024 dims). Без сети, без API-ключей.
+- **Graph-запросы** — топологическая сортировка, blocked артефакты, обход зависимостей (petgraph).
+- **Depth calibration** — сложность задачи определяет сколько артефактов *обязательно* создать. Не надо документировать фикс тайпо.
+- **Evidence decay** — артефакты с истёкшим `valid_until` помечаются stale. Доверие честно угасает.
+- **Lifecycle v2** — `draft → active → superseded/deprecated/stale → renew/reopen`. Терминальные состояния — это терминальные.
+
+## Установка
+
+### Homebrew (macOS, Linux)
+
+```bash
+brew install ForgePlan/tap/forgeplan
+```
+
+### Install script (Linux, macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh
+```
+
+### Из исходников (нужен Rust 1.75+)
+
+```bash
+git clone https://github.com/ForgePlan/forgeplan.git
+cd forgeplan
+cargo install --path crates/forgeplan-cli
+```
+
+### Бинарные релизы
+
+Скачать последний бинарь для своей платформы: [Releases](https://github.com/ForgePlan/forgeplan/releases).
+
+## Быстрый старт
+
+```bash
+# 1. Инициализировать workspace в своём проекте
+cd my-project
+forgeplan init -y
+
+# 2. Проверить здоровье проекта
+forgeplan health
+
+# 3. Определить depth и pipeline для задачи
+forgeplan route "Добавить OAuth2 авторизацию"
+#   → Depth: Standard
+#   → Pipeline: PRD → RFC
+#   → Confidence: 92%
+
+# 4. Создать артефакт
+forgeplan new prd "OAuth2 Authentication"
+
+# 5. Заполнить MUST секции (Problem, Goals, Non-Goals, Target Users, FR), проверить
+forgeplan validate PRD-001
+
+# 6. Пройти ADI reasoning (3+ гипотезы)
+forgeplan reason PRD-001
+
+# 7. Реализовать и захватить evidence
+forgeplan new evidence "OAuth2: 15 тестов проходят, Google login benchmark 180ms p95"
+forgeplan link EVID-001 PRD-001 --relation informs
+forgeplan score PRD-001
+#   → R_eff = 1.00
+
+# 8. Review и активация
+forgeplan review PRD-001
+forgeplan activate PRD-001
+```
+
+Полный туториал: **[docs/methodology/FORGEPLAN-GUIDE.md](docs/methodology/FORGEPLAN-GUIDE.md)**
+
+## Архитектура
+
+Forgeplan — это Rust workspace из трёх крейтов:
+
+| Крейт | Роль |
+|---|---|
+| `forgeplan-core` | Storage, валидация, scoring, routing, поиск, граф, FPF reasoning engine |
+| `forgeplan-cli` | Бинарь `forgeplan` — 33 команды, clap derive |
+| `forgeplan-mcp` | MCP server для AI-агентов — 37 tools через stdio transport |
+
+**Модель хранения ([ADR-003](.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md)):**
+
+- Markdown файлы в `.forgeplan/` = **source of truth** (трекаются git'ом)
+- LanceDB в `.forgeplan/lance/` = производный индекс (gitignored, пересобирается через `forgeplan scan-import`)
+
+**Tech stack:** Rust · LanceDB · fastembed (BGE-M3) · clap · rmcp · tera · petgraph · tokio.
+
+## Документация
+
+- **[docs/README.md](docs/README.md)** — Индекс документации
+- **[docs/methodology/](docs/methodology/)** — Гайды по методологии (10 документов)
+  - [FORGEPLAN-GUIDE.md](docs/methodology/FORGEPLAN-GUIDE.md) — Полный референс (**начни отсюда**)
+  - [HOW-TO-USE.md](docs/methodology/HOW-TO-USE.md) — 10 правил с примерами
+  - [DEPTH-CALIBRATION.md](docs/methodology/DEPTH-CALIBRATION.md) — Tactical → Critical
+  - [QUALITY-GATES.md](docs/methodology/QUALITY-GATES.md) — R_eff, adversarial review
+  - [PRD-RFC-ADR-FLOW.md](docs/methodology/PRD-RFC-ADR-FLOW.md) — Какой артефакт для какой задачи
+  - [UNIFIED-WORKFLOW.md](docs/methodology/UNIFIED-WORKFLOW.md) — Forgeplan × Orchestra × Hindsight
+- **[docs/operations/](docs/operations/)** — Agent hooks, enforcement, protection репозитория
+- **[docs/schemas/](docs/schemas/)** — Формальные схемы артефактов (PRD, EPIC, SPEC)
+- **[CLAUDE.md](CLAUDE.md)** — Инструкции для Claude Code
+- **[AGENTS.md](AGENTS.md)** — Стандартные инструкции для AI-агентов (Aider, Cursor, Continue)
+
+## Артефакты проекта
+
+Этот репозиторий — dogfood: проект ведётся сам собой.
+
+- **[.forgeplan/adrs/](.forgeplan/adrs/)** — Architecture Decision Records (5)
+- **[.forgeplan/rfcs/](.forgeplan/rfcs/)** — Архитектурные предложения (6)
+- **[.forgeplan/prds/](.forgeplan/prds/)** — Product Requirements (24+)
+- **[.forgeplan/epics/](.forgeplan/epics/)** — Эпики (2)
+- **[.forgeplan/evidence/](.forgeplan/evidence/)** — Evidence pack'и (50+)
+
+Просмотр через CLI: `forgeplan list`, `forgeplan get ADR-003`, `forgeplan health`.
+
+## Статус
+
+- **Текущий релиз:** [v0.15.1](https://github.com/ForgePlan/forgeplan/releases/tag/v0.15.1)
+- **Тесты:** 728+ проходят
+- **Команды:** 33 CLI commands, 37 MCP tools
+- **Dogfood:** Этот репо ведётся сам — 138 tracked markdown артефактов
+
+Roadmap — в [.forgeplan/prds/](.forgeplan/prds/) и в [CHANGELOG](https://github.com/ForgePlan/forgeplan/releases).
+
+## Contributing
+
+Полный гайд контрибьютинга: **[CLAUDE.md](CLAUDE.md)** — ветки, коммиты, PR pipeline, требования методологии.
+
+Краткая версия:
+
+1. Ветка из `dev`: `git checkout dev && git pull && git checkout -b feat/my-feature`
+2. Пройти полный цикл: **Route → Shape → Validate → Build → Evidence → Activate**
+3. `cargo fmt` + `cargo test` перед каждым коммитом
+4. PR → `dev` (feature/fix/docs ветки); PR → `main` только через `release/vX.Y.Z` ветки
+
+## Связанное
+
+- [`website/`](website/) — Официальный сайт (Astro + Starlight + React + GSAP)
+- [`marketplace/`](marketplace/) — Plugin marketplace (Forgeplan методология + FPF + dev toolkit)
+- [`templates/`](templates/) — Markdown шаблоны для каждого типа артефакта
+
+## Лицензия
+
+MIT License — подробнее в [LICENSE](LICENSE).
+
+## Благодарности
+
+Forgeplan стоит на плечах:
+
+- **[Quint-code](https://github.com/quint-code)** — R_eff scoring, data model
+- **[BMAD Method](https://github.com/bmadcode/BMAD-METHOD)** — PRD workflow, 13-step validation
+- **[OpenSpec](https://openspec.ai/)** — Artifact DAG, delta-specs
+- **[First Principles Framework](https://github.com/ForgePlan/marketplace/tree/main/plugins/fpf)** — Reasoning архитектура, ADI cycle, trust calculus
+- **[adr-tools](https://github.com/npryce/adr-tools)** — ADR pattern (Michael Nygard)
+- **[LanceDB](https://lancedb.com/)** — Встраиваемая векторная БД
+- **[fastembed](https://github.com/qdrant/fastembed)** — Локальные embeddings (BGE-M3)
+
+---
+
+<div align="center">
+
+**Forge your plan. Structure. Evidence. Trust.**
+
+[Документация](docs/README.md) · [Релизы](https://github.com/ForgePlan/forgeplan/releases) · [Marketplace](marketplace/) · [English](README.md)
+
+</div>


### PR DESCRIPTION
## Summary

Replaces outdated Phase-1 README with a proper industry-standard bilingual README.

### What changed

- **README.md** — English (primary), badges, full structure
- **README.ru.md** — Russian translation, same structure
- Language switcher at the top of both files

### Structure (both languages)

1. Hero: title, tagline, badges, language switcher
2. What is Forgeplan? — 1-paragraph explanation of the pipeline
3. Why? — problem/solution table
4. Features — 10 bullet points
5. Install — brew, install.sh, cargo, binary
6. Quick Start — 8-step Forgeplan cycle
7. Architecture — crate breakdown + ADR-003 storage model
8. Documentation — links to docs/README.md, methodology, operations, schemas, CLAUDE.md, AGENTS.md
9. Project artifacts — dogfood .forgeplan/
10. Status — release, tests, dogfood count
11. Contributing — short version + link to CLAUDE.md
12. Related, License, Acknowledgements

### Why

Previous README was:
- Stuck on "Phase 1 — Schemas & Templates" (we're at v0.15.1)
- Mixed EN/RU randomly
- Referenced non-existent paths (\`frameworks/\`, \`src/\`)
- No install instructions
- No badges, no links to docs

## Refs
PRD-026

## Test plan
- [x] Markdown rendering tested locally
- [x] All links point to existing files
- [x] Language switcher works in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)