### PR TITLE
fix(deps): replace serde_yml → serde_yaml (Dependabot #1 #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
  "notify-debouncer-mini",
  "predicates",
  "serde_json",
- "serde_yml",
+ "serde_yaml",
  "tempfile",
  "tokio",
 ]
@@ -2292,7 +2292,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3880,16 +3880,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -5787,18 +5777,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6706,6 +6694,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ description = "Forge your plan — structured artifacts with quality scoring"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yml = "0.0.12"
+serde_yaml = "0.9"
 thiserror = "2"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true
 tokio.workspace = true
-serde_yml.workspace = true
+serde_yaml.workspace = true
 serde_json.workspace = true
 cliclack = "0.5.2"
 console = "0.16.3"

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
-serde_yml.workspace = true
+serde_yaml.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/src/artifact/frontmatter.rs
+++ b/crates/forgeplan-core/src/artifact/frontmatter.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 /// Parsed frontmatter as key-value pairs (flexible, not tied to Meta struct).
-pub type Frontmatter = BTreeMap<String, serde_yml::Value>;
+pub type Frontmatter = BTreeMap<String, serde_yaml::Value>;
 
 /// Parse YAML frontmatter from markdown content.
 /// Returns `(frontmatter, body)` where body is everything after the closing `---`.
@@ -19,7 +19,7 @@ pub fn parse_frontmatter(content: &str) -> anyhow::Result<(Frontmatter, String)>
     if yaml_str.len() > 65536 {
         anyhow::bail!("Frontmatter too large ({} bytes, max 64KB)", yaml_str.len());
     }
-    let fm: Frontmatter = serde_yml::from_str(yaml_str)?;
+    let fm: Frontmatter = serde_yaml::from_str(yaml_str)?;
     // Body starts after closing --- and newline
     let body_start = 3 + end + 4; // "---" + yaml + "\n---"
     let body = if body_start < content.len() {
@@ -32,6 +32,6 @@ pub fn parse_frontmatter(content: &str) -> anyhow::Result<(Frontmatter, String)>
 
 /// Render frontmatter + body back to a markdown string.
 pub fn render_frontmatter(fm: &Frontmatter, body: &str) -> anyhow::Result<String> {
-    let yaml = serde_yml::to_string(fm)?;
+    let yaml = serde_yaml::to_string(fm)?;
     Ok(format!("---\n{}---\n\n{}", yaml, body))
 }

--- a/crates/forgeplan-core/src/artifact/store.rs
+++ b/crates/forgeplan-core/src/artifact/store.rs
@@ -92,9 +92,9 @@ pub async fn list_artifacts(workspace: &Path) -> anyhow::Result<Vec<ArtifactSumm
 
 fn fm_string(fm: &Frontmatter, key: &str) -> Option<String> {
     fm.get(key).map(|v| match v {
-        serde_yml::Value::String(s) => s.clone(),
-        serde_yml::Value::Number(n) => format!("{:?}", n),
-        serde_yml::Value::Bool(b) => format!("{}", b),
+        serde_yaml::Value::String(s) => s.clone(),
+        serde_yaml::Value::Number(n) => format!("{:?}", n),
+        serde_yaml::Value::Bool(b) => format!("{}", b),
         _ => format!("{:?}", v),
     })
 }

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -117,8 +117,8 @@ impl ArtifactRecord {
     }
 
     /// Reconstruct YAML frontmatter fields as a BTreeMap for serialization.
-    pub fn frontmatter_map(&self) -> BTreeMap<String, serde_yml::Value> {
-        use serde_yml::Value;
+    pub fn frontmatter_map(&self) -> BTreeMap<String, serde_yaml::Value> {
+        use serde_yaml::Value;
 
         let mut map = BTreeMap::new();
         map.insert("id".to_string(), Value::String(self.id.clone()));
@@ -134,7 +134,7 @@ impl ArtifactRecord {
         }
         map.insert(
             "r_eff_score".to_string(),
-            Value::Number(serde_yml::Number::from(self.r_eff_score)),
+            Value::Number(serde_yaml::Number::from(self.r_eff_score)),
         );
         if let Some(ref vu) = self.valid_until {
             map.insert("valid_until".to_string(), Value::String(vu.clone()));
@@ -1832,19 +1832,19 @@ mod tests {
         let map = record.frontmatter_map();
         assert_eq!(
             map.get("id").unwrap(),
-            &serde_yml::Value::String("PRD-001".to_string())
+            &serde_yaml::Value::String("PRD-001".to_string())
         );
         assert_eq!(
             map.get("kind").unwrap(),
-            &serde_yml::Value::String("prd".to_string())
+            &serde_yaml::Value::String("prd".to_string())
         );
         assert_eq!(
             map.get("author").unwrap(),
-            &serde_yml::Value::String("alice".to_string())
+            &serde_yaml::Value::String("alice".to_string())
         );
         assert_eq!(
             map.get("valid_until").unwrap(),
-            &serde_yml::Value::String("2025-06-01".to_string())
+            &serde_yaml::Value::String("2025-06-01".to_string())
         );
         // parent_epic should not be present (None)
         assert!(!map.contains_key("parent_epic"));

--- a/crates/forgeplan-core/src/error.rs
+++ b/crates/forgeplan-core/src/error.rs
@@ -43,7 +43,7 @@ pub enum ForgeplanError {
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
-    Yaml(#[from] serde_yml::Error),
+    Yaml(#[from] serde_yaml::Error),
 }
 
 pub type Result<T> = std::result::Result<T, ForgeplanError>;

--- a/crates/forgeplan-core/src/graph/mod.rs
+++ b/crates/forgeplan-core/src/graph/mod.rs
@@ -46,7 +46,7 @@ pub async fn build_edges(workspace: &Path) -> anyhow::Result<Vec<Edge>> {
                 }
                 // Also check parent_epic / epic / prd fields
                 for field in &["epic", "prd", "parent_epic"] {
-                    if let Some(serde_yml::Value::String(parent)) = fm.get(*field)
+                    if let Some(serde_yaml::Value::String(parent)) = fm.get(*field)
                         && !parent.is_empty()
                     {
                         edges.push(Edge {

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -308,22 +308,25 @@ fn check_validation_passed(record: &ArtifactRecord) -> bool {
 
     // Build a minimal YAML frontmatter from the record fields
     let mut fm = Frontmatter::new();
-    fm.insert("id".into(), serde_yml::Value::String(record.id.clone()));
+    fm.insert("id".into(), serde_yaml::Value::String(record.id.clone()));
     fm.insert(
         "status".into(),
-        serde_yml::Value::String(record.status.clone()),
+        serde_yaml::Value::String(record.status.clone()),
     );
     fm.insert(
         "title".into(),
-        serde_yml::Value::String(record.title.clone()),
+        serde_yaml::Value::String(record.title.clone()),
     );
-    fm.insert("kind".into(), serde_yml::Value::String(record.kind.clone()));
+    fm.insert(
+        "kind".into(),
+        serde_yaml::Value::String(record.kind.clone()),
+    );
     fm.insert(
         "depth".into(),
-        serde_yml::Value::String(record.depth.clone()),
+        serde_yaml::Value::String(record.depth.clone()),
     );
     if let Some(ref author) = record.author {
-        fm.insert("author".into(), serde_yml::Value::String(author.clone()));
+        fm.insert("author".into(), serde_yaml::Value::String(author.clone()));
     }
 
     let result = validation::validate(&record.id, &record.body, &fm, &kind, &depth);

--- a/crates/forgeplan-core/src/link/mod.rs
+++ b/crates/forgeplan-core/src/link/mod.rs
@@ -14,15 +14,15 @@ pub async fn add_link(artifact_path: &Path, target_id: &str, relation: &str) -> 
     // Get or create links array
     let links = fm
         .entry("links".to_string())
-        .or_insert_with(|| serde_yml::Value::Sequence(Vec::new()));
+        .or_insert_with(|| serde_yaml::Value::Sequence(Vec::new()));
 
-    if let serde_yml::Value::Sequence(seq) = links {
+    if let serde_yaml::Value::Sequence(seq) = links {
         // Check for duplicates
         let already_exists = seq.iter().any(|entry| {
-            if let serde_yml::Value::Mapping(map) = entry {
-                let t = map.get(serde_yml::Value::String("target".into()));
-                let r = map.get(serde_yml::Value::String("relation".into()));
-                matches!((t, r), (Some(serde_yml::Value::String(t)), Some(serde_yml::Value::String(r)))
+            if let serde_yaml::Value::Mapping(map) = entry {
+                let t = map.get(serde_yaml::Value::String("target".into()));
+                let r = map.get(serde_yaml::Value::String("relation".into()));
+                matches!((t, r), (Some(serde_yaml::Value::String(t)), Some(serde_yaml::Value::String(r)))
                     if t.eq_ignore_ascii_case(&target_id) && r == relation)
             } else {
                 false
@@ -42,16 +42,16 @@ pub async fn add_link(artifact_path: &Path, target_id: &str, relation: &str) -> 
             .into());
         }
 
-        let mut entry = serde_yml::Mapping::new();
+        let mut entry = serde_yaml::Mapping::new();
         entry.insert(
-            serde_yml::Value::String("target".into()),
-            serde_yml::Value::String(target_id),
+            serde_yaml::Value::String("target".into()),
+            serde_yaml::Value::String(target_id),
         );
         entry.insert(
-            serde_yml::Value::String("relation".into()),
-            serde_yml::Value::String(relation.into()),
+            serde_yaml::Value::String("relation".into()),
+            serde_yaml::Value::String(relation.into()),
         );
-        seq.push(serde_yml::Value::Mapping(entry));
+        seq.push(serde_yaml::Value::Mapping(entry));
     } else {
         return Err(ForgeplanError::Frontmatter("'links' field is not a sequence".into()).into());
     }
@@ -65,15 +65,15 @@ pub async fn add_link(artifact_path: &Path, target_id: &str, relation: &str) -> 
 /// Returns Vec<(target_id, relation)>.
 pub fn list_links(fm: &Frontmatter) -> Vec<(String, String)> {
     let mut results = Vec::new();
-    if let Some(serde_yml::Value::Sequence(seq)) = fm.get("links") {
+    if let Some(serde_yaml::Value::Sequence(seq)) = fm.get("links") {
         for entry in seq {
-            if let serde_yml::Value::Mapping(map) = entry {
+            if let serde_yaml::Value::Mapping(map) = entry {
                 let target = map
-                    .get(serde_yml::Value::String("target".into()))
+                    .get(serde_yaml::Value::String("target".into()))
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 let relation = map
-                    .get(serde_yml::Value::String("relation".into()))
+                    .get(serde_yaml::Value::String("relation".into()))
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 if !target.is_empty() {
@@ -150,7 +150,7 @@ links:
   - target: RFC-002
     relation: based_on
 "#;
-        let fm: crate::artifact::frontmatter::Frontmatter = serde_yml::from_str(yaml).unwrap();
+        let fm: crate::artifact::frontmatter::Frontmatter = serde_yaml::from_str(yaml).unwrap();
         let links = list_links(&fm);
         assert_eq!(links.len(), 2);
         assert_eq!(links[0], ("PRD-001".to_string(), "informs".to_string()));
@@ -160,7 +160,7 @@ links:
     #[test]
     fn list_links_non_sequence_links_field() {
         let yaml = r#"links: "not-a-sequence""#;
-        let fm: crate::artifact::frontmatter::Frontmatter = serde_yml::from_str(yaml).unwrap();
+        let fm: crate::artifact::frontmatter::Frontmatter = serde_yaml::from_str(yaml).unwrap();
         // Non-sequence links field should return empty vec
         assert!(list_links(&fm).is_empty());
     }

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -207,63 +207,63 @@ fn render_markdown(
     links: &[(String, String)],
 ) -> anyhow::Result<String> {
     let mut fm = BTreeMap::new();
-    fm.insert("id".to_string(), serde_yml::Value::String(id.to_string()));
+    fm.insert("id".to_string(), serde_yaml::Value::String(id.to_string()));
     fm.insert(
         "title".to_string(),
-        serde_yml::Value::String(title.to_string()),
+        serde_yaml::Value::String(title.to_string()),
     );
     fm.insert(
         "kind".to_string(),
-        serde_yml::Value::String(kind.to_string()),
+        serde_yaml::Value::String(kind.to_string()),
     );
     fm.insert(
         "status".to_string(),
-        serde_yml::Value::String(status.to_string()),
+        serde_yaml::Value::String(status.to_string()),
     );
     fm.insert(
         "depth".to_string(),
-        serde_yml::Value::String(depth.to_string()),
+        serde_yaml::Value::String(depth.to_string()),
     );
 
     if let Some(a) = author {
         fm.insert(
             "author".to_string(),
-            serde_yml::Value::String(a.to_string()),
+            serde_yaml::Value::String(a.to_string()),
         );
     }
     if let Some(pe) = parent_epic {
         fm.insert(
             "parent_epic".to_string(),
-            serde_yml::Value::String(pe.to_string()),
+            serde_yaml::Value::String(pe.to_string()),
         );
     }
     if let Some(vu) = valid_until {
         fm.insert(
             "valid_until".to_string(),
-            serde_yml::Value::String(vu.to_string()),
+            serde_yaml::Value::String(vu.to_string()),
         );
     }
 
     if !links.is_empty() {
-        let links_seq: Vec<serde_yml::Value> = links
+        let links_seq: Vec<serde_yaml::Value> = links
             .iter()
             .map(|(target, relation)| {
-                let mut m = serde_yml::Mapping::new();
+                let mut m = serde_yaml::Mapping::new();
                 m.insert(
-                    serde_yml::Value::String("target".to_string()),
-                    serde_yml::Value::String(target.clone()),
+                    serde_yaml::Value::String("target".to_string()),
+                    serde_yaml::Value::String(target.clone()),
                 );
                 m.insert(
-                    serde_yml::Value::String("relation".to_string()),
-                    serde_yml::Value::String(relation.clone()),
+                    serde_yaml::Value::String("relation".to_string()),
+                    serde_yaml::Value::String(relation.clone()),
                 );
-                serde_yml::Value::Mapping(m)
+                serde_yaml::Value::Mapping(m)
             })
             .collect();
-        fm.insert("links".to_string(), serde_yml::Value::Sequence(links_seq));
+        fm.insert("links".to_string(), serde_yaml::Value::Sequence(links_seq));
     }
 
-    let yaml = serde_yml::to_string(&fm)?;
+    let yaml = serde_yaml::to_string(&fm)?;
     Ok(format!("---\n{}---\n\n{}\n", yaml, body))
 }
 

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -6,8 +6,8 @@ use std::sync::LazyLock;
 pub fn frontmatter_has(fm: &Frontmatter, key: &str) -> bool {
     fm.get(key)
         .map(|v| match v {
-            serde_yml::Value::Null => false,
-            serde_yml::Value::String(s) => !s.trim().is_empty(),
+            serde_yaml::Value::Null => false,
+            serde_yaml::Value::String(s) => !s.trim().is_empty(),
             _ => true,
         })
         .unwrap_or(false)

--- a/crates/forgeplan-core/src/validation/rules.rs
+++ b/crates/forgeplan-core/src/validation/rules.rs
@@ -569,7 +569,7 @@ fn check_prd_orphan_goals(body: &str, _fm: &Frontmatter) -> Option<String> {
 
 fn check_prd_domain_sections(body: &str, fm: &Frontmatter) -> Option<String> {
     let domain = match fm.get("domain") {
-        Some(serde_yml::Value::String(s)) if !s.trim().is_empty() => s.trim().to_string(),
+        Some(serde_yaml::Value::String(s)) if !s.trim().is_empty() => s.trim().to_string(),
         _ => return None, // No domain set — skip check
     };
 
@@ -599,7 +599,7 @@ fn check_prd_domain_sections(body: &str, fm: &Frontmatter) -> Option<String> {
 
 fn check_prd_project_type_sections(body: &str, fm: &Frontmatter) -> Option<String> {
     let project_type = match fm.get("project_type") {
-        Some(serde_yml::Value::String(s)) if !s.trim().is_empty() => s.trim().to_string(),
+        Some(serde_yaml::Value::String(s)) if !s.trim().is_empty() => s.trim().to_string(),
         _ => return None, // No project_type set — skip check
     };
 
@@ -1019,8 +1019,8 @@ mod tests {
 
     fn make_fm(id: &str, status: &str) -> Frontmatter {
         let mut fm = Frontmatter::new();
-        fm.insert("id".into(), serde_yml::Value::String(id.into()));
-        fm.insert("status".into(), serde_yml::Value::String(status.into()));
+        fm.insert("id".into(), serde_yaml::Value::String(id.into()));
+        fm.insert("status".into(), serde_yaml::Value::String(status.into()));
         fm
     }
 

--- a/crates/forgeplan-core/src/workspace/init.rs
+++ b/crates/forgeplan-core/src/workspace/init.rs
@@ -63,7 +63,7 @@ pub fn init_workspace(root: &Path, project_name: &str) -> anyhow::Result<PathBuf
         project_name: project_name.into(),
         ..Config::default()
     };
-    let mut yaml = serde_yml::to_string(&config)?;
+    let mut yaml = serde_yaml::to_string(&config)?;
     // Append commented estimate config template
     yaml.push_str(ESTIMATE_CONFIG_TEMPLATE);
     fs::write(fp_dir.join("config.yaml"), yaml)?;
@@ -88,6 +88,6 @@ pub fn find_workspace(start: &Path) -> Option<PathBuf> {
 pub fn load_config(workspace: &Path) -> anyhow::Result<Config> {
     let config_path = workspace.join("config.yaml");
     let content = fs::read_to_string(&config_path)?;
-    let config: Config = serde_yml::from_str(&content)?;
+    let config: Config = serde_yaml::from_str(&content)?;
     Ok(config)
 }

--- a/crates/forgeplan-core/tests/frontmatter_test.rs
+++ b/crates/forgeplan-core/tests/frontmatter_test.rs
@@ -6,7 +6,7 @@ fn parse_valid_frontmatter() {
     let (fm, body) = frontmatter::parse_frontmatter(content).unwrap();
     assert_eq!(
         fm.get("id").unwrap(),
-        &serde_yml::Value::String("PRD-001".into())
+        &serde_yaml::Value::String("PRD-001".into())
     );
     assert!(body.contains("# Body here"));
 }


### PR DESCRIPTION
## Summary
Resolves Dependabot alerts #1 (High) and #2 (Moderate).

- **serde_yml** (0.0.12, unsound) → **serde_yaml** (0.9, safe `unsafe-libyaml` backend)
- Drop-in replacement — identical API, 64 occurrences updated
- `libyml` removed from dependency tree entirely

## Test plan
- [x] cargo check: 0 errors
- [x] cargo test: 728 passed, 0 failed
- [x] cargo fmt --check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)