### PR TITLE
[RFC-001] FPF Engine v2 Phase 2 — declarative rule engine + bounded context in reason

### DIFF
--- a/.forgeplan/evidence/EVID-057-rfc-001-phase-2-rule-engine-with-expressions-bounded-context-in-reason-config-template.md
+++ b/.forgeplan/evidence/EVID-057-rfc-001-phase-2-rule-engine-with-expressions-bounded-context-in-reason-config-template.md
@@ -1,0 +1,53 @@
+---
+depth: tactical
+id: EVID-057
+kind: evidence
+links:
+- target: RFC-001
+  relation: informs
+status: draft
+title: RFC-001 Phase 2 — rule engine with expressions, bounded context in reason, config template
+---
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Evidence
+
+RFC-001 Phase 2 implemented on feat/rfc-001-phase2 branch (5 commits):
+
+### Rule Engine (ext/rules.rs — 430 LOC)
+- NumericExpr: parses "< 0.5", ">= 0.7", "0.01..0.5", "== 0"
+- ValueMatch: "draft" or ["active", "stale"] (case-insensitive)
+- Two-tier eval: check_basic() pure + check_enriched() with pre-fetched data
+- EnrichedData: linked_kinds + days_until_expiry (batch enrichment)
+- run_rules(): priority-sorted, first match wins
+- default_rules(): 5 rules backward-compatible with hardcoded behavior
+- 19 unit tests pass
+
+### Dashboard Integration (mod.rs)
+- FpfConfig.rules field (empty = default_rules())
+- build_rule_actions() replaces explore::suggest in dashboard
+- Batch enrichment: 1 query for all linked_kinds vs N queries
+- Dashboard output unchanged (verified manually)
+
+### Bounded Context in Reason (reason.rs + reason CLI)
+- ArtifactContext.bounded_context: (cluster_name, member_count, cohesion)
+- CLI reason command detects via contexts::detect()
+- Metadata section includes Bounded Context in LLM prompt
+- MCP server: bounded_context = None (skip for speed)
+
+### Config Template (init.rs)
+- Rules examples in config.yaml template
+- Shows basic, graph-aware, and time-aware rule examples
+
+### Test Results
+- 808 tests pass, 0 failures
+- 0 clippy warnings
+- 0 fmt diffs
+- 2 audit agents pending
+
+

--- a/.forgeplan/notes/NOTE-039-idea-dsl-scripting-engine-lua-rhai-for-custom-rule-evaluation-phase-3-consideration.md
+++ b/.forgeplan/notes/NOTE-039-idea-dsl-scripting-engine-lua-rhai-for-custom-rule-evaluation-phase-3-consideration.md
@@ -1,0 +1,34 @@
+---
+depth: tactical
+id: NOTE-039
+kind: note
+links:
+- target: RFC-001
+  relation: informs
+status: draft
+title: 'Idea: DSL scripting engine (Lua/Rhai) for custom rule evaluation — Phase 3+ consideration'
+---
+
+## DSL Scripting Engine for Rule Evaluation
+
+### Тезис
+Заменить YAML rule conditions на embedded scripting language (Lua через mlua или Rhai) для полной flexibility в custom правилах.
+
+### Зачем
+Phase 2 rule engine использует structured YAML conditions (expressions, ranges, links_missing). Но пользователь может захотеть:
+- Сложную логику: "если PRD active > 30 дней и нет RFC И R_eff < 0.5 — escalate"
+- Cross-artifact queries: "все PRD в этом Epic у которых нет evidence"
+- Custom scoring формулы: пользователь определяет свой R_eff вариант
+- Pipeline hooks: "при activate PRD — автоматически создать RFC stub"
+
+### Варианты
+1. **Lua (mlua crate)** — зрелый, быстрый, маленький runtime (~200KB), широко используется в играх/конфигах. Минус: ещё один язык для пользователя.
+2. **Rhai (rhai crate)** — Rust-native scripting, синтаксис похож на Rust. Минус: менее зрелый, больше runtime.
+3. **WASM plugins** — пользователь компилирует правило в WASM. Максимальная flexibility, но высокий порог входа.
+4. **Starlark (starlark-rs)** — Python-like (используется в Bazel/Buck). Знакомый синтаксис для большинства.
+
+### Effort: 2-3 дня на интеграцию + sandboxing + примеры
+### Prerequisite: Phase 2 rule engine (structured YAML) должен работать первым — DSL = расширение, не замена.
+
+### Решение: отложить до Phase 3+. Сначала YAML rules покажут что пользователям реально нужно.
+

--- a/crates/forgeplan-cli/src/commands/reason.rs
+++ b/crates/forgeplan-cli/src/commands/reason.rs
@@ -1,4 +1,5 @@
 use forgeplan_core::db::store::NewArtifact;
+use forgeplan_core::fpf::contexts;
 use forgeplan_core::fpf::core::adi::AdiRecord;
 use forgeplan_core::llm::reason;
 use forgeplan_core::llm::reason::ArtifactContext;
@@ -50,12 +51,27 @@ pub async fn run(id: &str, json: bool, save: bool, fpf: bool) -> anyhow::Result<
             .unwrap_or_default();
         relations.push((target_id.clone(), rel_type.clone(), title));
     }
+    // Detect bounded context for this artifact
+    let bounded_context = {
+        let all_records = store.list_records(None).await.unwrap_or_default();
+        let all_relations = store.get_all_relations().await.unwrap_or_default();
+        let edges: Vec<(String, String)> = all_relations
+            .iter()
+            .map(|(s, t, _)| (s.clone(), t.clone()))
+            .collect();
+        let ctxs = contexts::detect(&all_records, &edges);
+        ctxs.into_iter()
+            .find(|c| c.members.contains(&record.id))
+            .map(|c| (c.name.clone(), c.members.len(), c.cohesion))
+    };
+
     let artifact_context = ArtifactContext {
         status: record.status.clone(),
         depth: record.depth.clone(),
         r_eff_score: record.r_eff_score,
         relations,
         architecture_hint: Some(load_architecture_hint()),
+        bounded_context,
     };
 
     // Build FPF context if requested

--- a/crates/forgeplan-cli/src/commands/reason.rs
+++ b/crates/forgeplan-cli/src/commands/reason.rs
@@ -52,18 +52,7 @@ pub async fn run(id: &str, json: bool, save: bool, fpf: bool) -> anyhow::Result<
         relations.push((target_id.clone(), rel_type.clone(), title));
     }
     // Detect bounded context for this artifact
-    let bounded_context = {
-        let all_records = store.list_records(None).await.unwrap_or_default();
-        let all_relations = store.get_all_relations().await.unwrap_or_default();
-        let edges: Vec<(String, String)> = all_relations
-            .iter()
-            .map(|(s, t, _)| (s.clone(), t.clone()))
-            .collect();
-        let ctxs = contexts::detect(&all_records, &edges);
-        ctxs.into_iter()
-            .find(|c| c.members.contains(&record.id))
-            .map(|c| (c.name.clone(), c.members.len(), c.cohesion))
-    };
+    let bounded_context = contexts::detect_for_artifact(&store, &record.id).await;
 
     let artifact_context = ArtifactContext {
         status: record.status.clone(),

--- a/crates/forgeplan-core/src/fpf/contexts.rs
+++ b/crates/forgeplan-core/src/fpf/contexts.rs
@@ -73,10 +73,10 @@ pub fn detect(records: &[ArtifactRecord], edges: &[(String, String)]) -> Vec<Bou
         components.push(component);
     }
 
-    // Collect singletons
+    // Collect singletons (no adjacency = no links to other artifacts)
     let singletons: Vec<String> = all_ids
         .iter()
-        .filter(|id| !visited.contains(*id) || !adj.contains_key(*id))
+        .filter(|id| !adj.contains_key(*id))
         .cloned()
         .collect();
 
@@ -165,6 +165,26 @@ fn name_from_members(members: &[String], index: usize) -> String {
         .unwrap_or("Mixed");
 
     format!("Context-{} ({})", index + 1, dominant)
+}
+
+/// Detect which bounded context a specific artifact belongs to.
+///
+/// Returns (cluster_name, member_count, cohesion) or None if the artifact
+/// is a singleton (no links). Runs full graph detection internally.
+pub async fn detect_for_artifact(
+    store: &crate::db::store::LanceStore,
+    artifact_id: &str,
+) -> Option<(String, usize, f64)> {
+    let all_records = store.list_records(None).await.unwrap_or_default();
+    let all_relations = store.get_all_relations().await.unwrap_or_default();
+    let edges: Vec<(String, String)> = all_relations
+        .iter()
+        .map(|(s, t, _)| (s.clone(), t.clone()))
+        .collect();
+    let ctxs = detect(&all_records, &edges);
+    ctxs.into_iter()
+        .find(|c| c.members.iter().any(|m| m == artifact_id))
+        .map(|c| (c.name, c.members.len(), c.cohesion))
 }
 
 #[cfg(test)]

--- a/crates/forgeplan-core/src/fpf/core/config.rs
+++ b/crates/forgeplan-core/src/fpf/core/config.rs
@@ -5,11 +5,13 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::fpf::ext::rules::Rule;
+
 /// Top-level FPF configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FpfConfig {
-    /// Explore-exploit action thresholds.
+    /// Explore-exploit action thresholds (used by hardcoded rules in model.rs).
     pub thresholds: Thresholds,
     /// Reliability component weights for F-G-R.
     pub weights: ReliabilityWeights,
@@ -19,6 +21,10 @@ pub struct FpfConfig {
     pub cl_penalties: ClPenalties,
     /// Evidence decay settings.
     pub decay: DecayConfig,
+    /// Declarative explore-exploit rules (Phase 2).
+    /// If empty, uses default_rules() for backward compatibility.
+    #[serde(default)]
+    pub rules: Vec<Rule>,
 }
 
 /// Explore-exploit decision thresholds.

--- a/crates/forgeplan-core/src/fpf/core/model.rs
+++ b/crates/forgeplan-core/src/fpf/core/model.rs
@@ -68,18 +68,22 @@ impl std::fmt::Display for ActionType {
 pub struct ArtifactData {
     pub id: String,
     pub status: String,
+    pub kind: String,
+    pub depth: String,
     pub evidence: Vec<EvidenceInput>,
     pub formality: f64,
     pub granularity: f64,
     pub link_count: usize,
     pub is_stale: bool,
+    /// Pre-computed trust score (available after build_context or set externally).
+    pub trust: TrustScore,
 }
 
 /// Build an FpfContext from artifact data + config.
 ///
 /// Pure function — no I/O, fully testable.
 pub fn build_context(
-    data: &ArtifactData,
+    data: &mut ArtifactData,
     context: ContextMembership,
     adi_history: Vec<AdiSnapshot>,
     config: &FpfConfig,
@@ -92,6 +96,9 @@ pub fn build_context(
         data.is_stale,
         config,
     );
+
+    // Update ArtifactData with computed trust for downstream use (rule engine)
+    data.trust = trust.clone();
 
     let action = suggest_action(data, &trust, config);
 
@@ -188,19 +195,40 @@ mod tests {
         FpfConfig::default()
     }
 
+    fn make_data(
+        status: &str,
+        evidence: Vec<EvidenceInput>,
+        f: f64,
+        g: f64,
+        links: usize,
+        stale: bool,
+    ) -> ArtifactData {
+        ArtifactData {
+            id: "PRD-001".into(),
+            status: status.into(),
+            kind: "prd".into(),
+            depth: "standard".into(),
+            evidence,
+            formality: f,
+            granularity: g,
+            link_count: links,
+            is_stale: stale,
+            trust: TrustScore {
+                r_eff: 0.0,
+                formality: f,
+                granularity: g,
+                reliability: 0.0,
+                overall: 0.0,
+                weakest_link: None,
+            },
+        }
+    }
+
     #[test]
     fn draft_no_evidence_gets_explore() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "draft".into(),
-            evidence: vec![],
-            formality: 0.2,
-            granularity: 0.2,
-            link_count: 0,
-            is_stale: false,
-        };
+        let mut data = make_data("draft", vec![], 0.2, 0.2, 0, false);
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -211,21 +239,20 @@ mod tests {
 
     #[test]
     fn strong_evidence_gets_exploit() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "active".into(),
-            evidence: vec![EvidenceInput {
+        let mut data = make_data(
+            "active",
+            vec![EvidenceInput {
                 verdict: Verdict::Supports,
                 congruence_level: 3,
                 is_expired: false,
             }],
-            formality: 0.8,
-            granularity: 0.8,
-            link_count: 3,
-            is_stale: false,
-        };
+            0.8,
+            0.8,
+            3,
+            false,
+        );
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -236,17 +263,9 @@ mod tests {
 
     #[test]
     fn deprecated_gets_no_action() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "deprecated".into(),
-            evidence: vec![],
-            formality: 0.0,
-            granularity: 0.0,
-            link_count: 0,
-            is_stale: false,
-        };
+        let mut data = make_data("deprecated", vec![], 0.0, 0.0, 0, false);
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -254,20 +273,11 @@ mod tests {
         assert!(ctx.action.is_none());
     }
 
-    // M1 audit fix: active artifact with r_eff=0 and links should get INVESTIGATE
     #[test]
     fn active_zero_reff_with_links_gets_investigate() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "active".into(),
-            evidence: vec![],
-            formality: 0.7,
-            granularity: 0.7,
-            link_count: 3,
-            is_stale: false,
-        };
+        let mut data = make_data("active", vec![], 0.7, 0.7, 3, false);
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -279,40 +289,29 @@ mod tests {
     #[test]
     fn custom_thresholds_change_action() {
         let mut cfg = default_config();
-        cfg.thresholds.exploit_reff = 0.5; // lower bar for exploit
-
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "active".into(),
-            evidence: vec![EvidenceInput {
+        cfg.thresholds.exploit_reff = 0.5;
+        let mut data = make_data(
+            "active",
+            vec![EvidenceInput {
                 verdict: Verdict::Supports,
-                congruence_level: 2, // CL2: penalty 0.1 → score 0.9
+                congruence_level: 2,
                 is_expired: false,
             }],
-            formality: 0.7,
-            granularity: 0.7,
-            link_count: 2,
-            is_stale: false,
-        };
-        let ctx = build_context(&data, ContextMembership::default(), vec![], &cfg);
+            0.7,
+            0.7,
+            2,
+            false,
+        );
+        let ctx = build_context(&mut data, ContextMembership::default(), vec![], &cfg);
         assert!(ctx.action.is_some());
         assert_eq!(ctx.action.unwrap().action_type, ActionType::Exploit);
     }
 
-    // H3 fix: well-formatted draft with no evidence still gets EXPLORE
     #[test]
     fn well_formatted_draft_no_evidence_gets_explore() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "draft".into(),
-            evidence: vec![],
-            formality: 0.9,
-            granularity: 0.9,
-            link_count: 3,
-            is_stale: false,
-        };
+        let mut data = make_data("draft", vec![], 0.9, 0.9, 3, false);
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -321,24 +320,22 @@ mod tests {
         assert_eq!(ctx.action.unwrap().action_type, ActionType::Explore);
     }
 
-    // H2 fix: medium quality artifact (R_eff 0.5-0.7) gets INVESTIGATE
     #[test]
     fn medium_quality_gets_investigate() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "active".into(),
-            evidence: vec![EvidenceInput {
+        let mut data = make_data(
+            "active",
+            vec![EvidenceInput {
                 verdict: Verdict::Supports,
-                congruence_level: 1, // CL1: penalty 0.4 → score 0.6
+                congruence_level: 1,
                 is_expired: false,
             }],
-            formality: 0.6,
-            granularity: 0.6,
-            link_count: 2,
-            is_stale: false,
-        };
+            0.6,
+            0.6,
+            2,
+            false,
+        );
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -350,21 +347,20 @@ mod tests {
 
     #[test]
     fn orphan_active_gets_explore() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "active".into(),
-            evidence: vec![EvidenceInput {
+        let mut data = make_data(
+            "active",
+            vec![EvidenceInput {
                 verdict: Verdict::Supports,
                 congruence_level: 3,
                 is_expired: false,
             }],
-            formality: 0.7,
-            granularity: 0.7,
-            link_count: 0, // orphan
-            is_stale: false,
-        };
+            0.7,
+            0.7,
+            0,
+            false,
+        );
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),
@@ -376,17 +372,9 @@ mod tests {
 
     #[test]
     fn superseded_gets_no_action() {
-        let data = ArtifactData {
-            id: "PRD-001".into(),
-            status: "superseded".into(),
-            evidence: vec![],
-            formality: 0.0,
-            granularity: 0.0,
-            link_count: 0,
-            is_stale: false,
-        };
+        let mut data = make_data("superseded", vec![], 0.0, 0.0, 0, false);
         let ctx = build_context(
-            &data,
+            &mut data,
             ContextMembership::default(),
             vec![],
             &default_config(),

--- a/crates/forgeplan-core/src/fpf/ext/mod.rs
+++ b/crates/forgeplan-core/src/fpf/ext/mod.rs
@@ -1,0 +1,6 @@
+//! FPF Extensions — configurable, graph-aware modules.
+//!
+//! Phase 2 of RFC-001 FPF Engine v2.
+//! Core (fpf/core/) is pure functions. Extensions add store-aware features.
+
+pub mod rules;

--- a/crates/forgeplan-core/src/fpf/ext/rules.rs
+++ b/crates/forgeplan-core/src/fpf/ext/rules.rs
@@ -220,40 +220,40 @@ pub struct EnrichedData {
 pub fn check_basic(rule: &Rule, data: &ArtifactData) -> bool {
     let c = &rule.condition;
 
-    if let Some(ref v) = c.status {
-        if !v.matches(&data.status) {
-            return false;
-        }
+    if let Some(ref v) = c.status
+        && !v.matches(&data.status)
+    {
+        return false;
     }
-    if let Some(ref v) = c.kind {
-        if !v.matches(&data.kind) {
-            return false;
-        }
+    if let Some(ref v) = c.kind
+        && !v.matches(&data.kind)
+    {
+        return false;
     }
-    if let Some(ref v) = c.depth {
-        if !v.matches(&data.depth) {
-            return false;
-        }
+    if let Some(ref v) = c.depth
+        && !v.matches(&data.depth)
+    {
+        return false;
     }
-    if let Some(ref expr) = c.r_eff {
-        if !expr.check(data.trust.r_eff) {
-            return false;
-        }
+    if let Some(ref expr) = c.r_eff
+        && !expr.check(data.trust.r_eff)
+    {
+        return false;
     }
-    if let Some(ref expr) = c.overall {
-        if !expr.check(data.trust.overall) {
-            return false;
-        }
+    if let Some(ref expr) = c.overall
+        && !expr.check(data.trust.overall)
+    {
+        return false;
     }
-    if let Some(ref expr) = c.link_count {
-        if !expr.check(data.link_count as f64) {
-            return false;
-        }
+    if let Some(ref expr) = c.link_count
+        && !expr.check(data.link_count as f64)
+    {
+        return false;
     }
-    if let Some(stale) = c.is_stale {
-        if data.is_stale != stale {
-            return false;
-        }
+    if let Some(stale) = c.is_stale
+        && data.is_stale != stale
+    {
+        return false;
     }
 
     true

--- a/crates/forgeplan-core/src/fpf/ext/rules.rs
+++ b/crates/forgeplan-core/src/fpf/ext/rules.rs
@@ -206,6 +206,8 @@ pub struct EnrichedData {
     /// Kinds of artifacts linked to this one (lowercase): ["rfc", "evidence", "adr"]
     pub linked_kinds: Vec<String>,
     /// Days until valid_until expiry. None = no expiry set.
+    /// Negative values mean the artifact has already expired (e.g., -30 = expired 30 days ago).
+    /// Rules with `days_until_expiry: "< 14"` will match both soon-to-expire AND already-expired.
     pub days_until_expiry: Option<i64>,
 }
 
@@ -336,6 +338,12 @@ pub fn run_rules(rules: &[Rule], data: &EnrichedData) -> Option<SuggestedAction>
 /// Returns the 5 default rules that match current hardcoded behavior.
 ///
 /// Used when config.yaml has no `fpf.rules` section.
+///
+/// Note: "weak-evidence" uses `["active", "stale"]` explicitly instead of
+/// the hardcoded `!= "draft"` logic. Terminal statuses (superseded, deprecated)
+/// are already filtered out in `build_rule_actions()` before rules are evaluated.
+/// Current lifecycle: draft → active → stale → superseded/deprecated.
+/// If new intermediate statuses are added, update this list.
 pub fn default_rules() -> Vec<Rule> {
     vec![
         Rule {

--- a/crates/forgeplan-core/src/fpf/ext/rules.rs
+++ b/crates/forgeplan-core/src/fpf/ext/rules.rs
@@ -1,0 +1,772 @@
+//! Declarative Rule Engine for explore-exploit decisions.
+//!
+//! Two-tier evaluation:
+//! - Tier 1 (pure): check_basic() — checks fields from ArtifactData only, no I/O
+//! - Tier 2 (enriched): check_enriched() — checks all fields including graph-aware
+//!   (links_missing, days_until_expiry) using pre-fetched EnrichedData
+//!
+//! Rules are loaded from config.yaml under `fpf.rules`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::fpf::core::model::{ActionType, ArtifactData, SuggestedAction};
+
+// ---------------------------------------------------------------------------
+// YAML types
+// ---------------------------------------------------------------------------
+
+/// A single declarative rule from config.yaml.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rule {
+    pub name: String,
+    #[serde(rename = "when")]
+    pub condition: Condition,
+    pub action: ActionType,
+    #[serde(default = "default_priority")]
+    pub priority: u8,
+    pub message: Option<String>,
+}
+
+fn default_priority() -> u8 {
+    3
+}
+
+/// Conditions that must ALL be true for a rule to match (implicit AND).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Condition {
+    pub status: Option<ValueMatch>,
+    pub kind: Option<ValueMatch>,
+    pub depth: Option<ValueMatch>,
+    pub r_eff: Option<NumericExpr>,
+    pub overall: Option<NumericExpr>,
+    pub link_count: Option<NumericExpr>,
+    pub is_stale: Option<bool>,
+    // --- Tier 2: graph-aware (need enrichment) ---
+    pub links_missing: Option<Vec<String>>,
+    pub days_until_expiry: Option<NumericExpr>,
+}
+
+impl Condition {
+    /// Returns true if this condition requires enrichment data (Tier 2).
+    pub fn needs_enrichment(&self) -> bool {
+        self.links_missing.is_some() || self.days_until_expiry.is_some()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Value matching — "draft" or ["active", "stale"]
+// ---------------------------------------------------------------------------
+
+/// Match a string field against a single value or a list of values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ValueMatch {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl ValueMatch {
+    pub fn matches(&self, value: &str) -> bool {
+        match self {
+            ValueMatch::Single(s) => s.eq_ignore_ascii_case(value),
+            ValueMatch::Multiple(list) => list.iter().any(|s| s.eq_ignore_ascii_case(value)),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Numeric expressions — "< 0.5", ">= 0.7", "0.01..0.5", "== 0"
+// ---------------------------------------------------------------------------
+
+/// A numeric comparison expression, deserialized from a string.
+#[derive(Debug, Clone)]
+pub enum NumericExpr {
+    Lt(f64),
+    Le(f64),
+    Gt(f64),
+    Ge(f64),
+    Eq(f64),
+    Range(f64, f64), // inclusive start, exclusive end
+}
+
+impl NumericExpr {
+    pub fn check(&self, value: f64) -> bool {
+        match self {
+            NumericExpr::Lt(n) => value < *n,
+            NumericExpr::Le(n) => value <= *n,
+            NumericExpr::Gt(n) => value > *n,
+            NumericExpr::Ge(n) => value >= *n,
+            NumericExpr::Eq(n) => (value - *n).abs() < f64::EPSILON,
+            NumericExpr::Range(lo, hi) => value >= *lo && value < *hi,
+        }
+    }
+
+    /// Parse from string: "< 0.5", ">= 0.7", "0.01..0.5", "== 0"
+    pub fn parse(s: &str) -> Option<Self> {
+        let s = s.trim();
+
+        // Range: "0.01..0.5"
+        if let Some((lo, hi)) = s.split_once("..") {
+            let lo = lo.trim().parse::<f64>().ok()?;
+            let hi = hi.trim().parse::<f64>().ok()?;
+            return Some(NumericExpr::Range(lo, hi));
+        }
+
+        // Operators: "<=", ">=", "<", ">", "=="
+        if let Some(rest) = s.strip_prefix("<=") {
+            return rest.trim().parse().ok().map(NumericExpr::Le);
+        }
+        if let Some(rest) = s.strip_prefix(">=") {
+            return rest.trim().parse().ok().map(NumericExpr::Ge);
+        }
+        if let Some(rest) = s.strip_prefix("==") {
+            return rest.trim().parse().ok().map(NumericExpr::Eq);
+        }
+        if let Some(rest) = s.strip_prefix('<') {
+            return rest.trim().parse().ok().map(NumericExpr::Lt);
+        }
+        if let Some(rest) = s.strip_prefix('>') {
+            return rest.trim().parse().ok().map(NumericExpr::Gt);
+        }
+
+        // Bare number = exact match
+        s.parse().ok().map(NumericExpr::Eq)
+    }
+}
+
+// Custom serde: deserialize NumericExpr from string
+impl<'de> Deserialize<'de> for NumericExpr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        NumericExpr::parse(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid numeric expression: '{s}'")))
+    }
+}
+
+impl Serialize for NumericExpr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let s = match self {
+            NumericExpr::Lt(n) => format!("< {n}"),
+            NumericExpr::Le(n) => format!("<= {n}"),
+            NumericExpr::Gt(n) => format!("> {n}"),
+            NumericExpr::Ge(n) => format!(">= {n}"),
+            NumericExpr::Eq(n) => format!("== {n}"),
+            NumericExpr::Range(lo, hi) => format!("{lo}..{hi}"),
+        };
+        serializer.serialize_str(&s)
+    }
+}
+
+// Custom serde for ActionType
+impl<'de> Deserialize<'de> for ActionType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.to_uppercase().as_str() {
+            "EXPLORE" => Ok(ActionType::Explore),
+            "INVESTIGATE" => Ok(ActionType::Investigate),
+            "EXPLOIT" => Ok(ActionType::Exploit),
+            _ => Err(serde::de::Error::custom(format!(
+                "unknown action: '{s}', expected EXPLORE/INVESTIGATE/EXPLOIT"
+            ))),
+        }
+    }
+}
+
+impl Serialize for ActionType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(match self {
+            ActionType::Explore => "EXPLORE",
+            ActionType::Investigate => "INVESTIGATE",
+            ActionType::Exploit => "EXPLOIT",
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Enriched data — pre-fetched graph info for Tier 2
+// ---------------------------------------------------------------------------
+
+/// ArtifactData + pre-fetched graph/time info for Tier 2 rules.
+#[derive(Debug, Clone)]
+pub struct EnrichedData {
+    pub base: ArtifactData,
+    /// Kinds of artifacts linked to this one (lowercase): ["rfc", "evidence", "adr"]
+    pub linked_kinds: Vec<String>,
+    /// Days until valid_until expiry. None = no expiry set.
+    pub days_until_expiry: Option<i64>,
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation — Tier 1 (pure) and Tier 2 (enriched, still pure)
+// ---------------------------------------------------------------------------
+
+/// Tier 1: Check rule using only ArtifactData fields. No I/O.
+///
+/// Returns false if any basic condition doesn't match.
+/// Returns true if all basic conditions match (ignoring Tier 2 conditions).
+pub fn check_basic(rule: &Rule, data: &ArtifactData) -> bool {
+    let c = &rule.condition;
+
+    if let Some(ref v) = c.status {
+        if !v.matches(&data.status) {
+            return false;
+        }
+    }
+    if let Some(ref v) = c.kind {
+        if !v.matches(&data.kind) {
+            return false;
+        }
+    }
+    if let Some(ref v) = c.depth {
+        if !v.matches(&data.depth) {
+            return false;
+        }
+    }
+    if let Some(ref expr) = c.r_eff {
+        if !expr.check(data.trust.r_eff) {
+            return false;
+        }
+    }
+    if let Some(ref expr) = c.overall {
+        if !expr.check(data.trust.overall) {
+            return false;
+        }
+    }
+    if let Some(ref expr) = c.link_count {
+        if !expr.check(data.link_count as f64) {
+            return false;
+        }
+    }
+    if let Some(stale) = c.is_stale {
+        if data.is_stale != stale {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Tier 2: Check rule using enriched data (includes graph-aware checks).
+///
+/// This is a PURE function — all I/O happened during enrichment.
+pub fn check_enriched(rule: &Rule, data: &EnrichedData) -> bool {
+    // First check all basic conditions against base data
+    if !check_basic(rule, &data.base) {
+        return false;
+    }
+
+    let c = &rule.condition;
+
+    // links_missing: check that NONE of the listed kinds are linked
+    if let Some(ref missing) = c.links_missing {
+        for kind in missing {
+            if data
+                .linked_kinds
+                .iter()
+                .any(|k| k.eq_ignore_ascii_case(kind))
+            {
+                return false; // this kind IS linked, "missing" condition fails
+            }
+        }
+    }
+
+    // days_until_expiry
+    if let Some(ref expr) = c.days_until_expiry {
+        match data.days_until_expiry {
+            Some(days) => {
+                if !expr.check(days as f64) {
+                    return false;
+                }
+            }
+            None => return false, // no expiry set, can't match expiry condition
+        }
+    }
+
+    true
+}
+
+/// Run all rules against an artifact, return the first matching action.
+///
+/// Rules are checked in priority order (lowest number = highest priority).
+pub fn run_rules(rules: &[Rule], data: &EnrichedData) -> Option<SuggestedAction> {
+    let mut sorted: Vec<&Rule> = rules.iter().collect();
+    sorted.sort_by_key(|r| r.priority);
+
+    for rule in sorted {
+        let matched = if rule.condition.needs_enrichment() {
+            check_enriched(rule, data)
+        } else {
+            check_basic(rule, &data.base)
+        };
+
+        if matched {
+            let reason = rule
+                .message
+                .clone()
+                .unwrap_or_else(|| format!("Matched rule '{}'", rule.name));
+
+            return Some(SuggestedAction {
+                action_type: rule.action,
+                reason,
+                priority: rule.priority,
+            });
+        }
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Default rules — backward compatible with hardcoded 5 rules
+// ---------------------------------------------------------------------------
+
+/// Returns the 5 default rules that match current hardcoded behavior.
+///
+/// Used when config.yaml has no `fpf.rules` section.
+pub fn default_rules() -> Vec<Rule> {
+    vec![
+        Rule {
+            name: "blind-spot".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("draft".into())),
+                r_eff: NumericExpr::parse("< 0.01"),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 1,
+            message: Some(
+                "Draft with no evidence (R_eff < 0.01). Needs evidence to validate.".into(),
+            ),
+        },
+        Rule {
+            name: "weak-evidence".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Multiple(vec!["active".into(), "stale".into()])),
+                r_eff: NumericExpr::parse("< 0.5"),
+                ..Default::default()
+            },
+            action: ActionType::Investigate,
+            priority: 2,
+            message: Some(
+                "R_eff < 0.5 — evidence exists but weak/stale. Refresh or add stronger evidence."
+                    .into(),
+            ),
+        },
+        Rule {
+            name: "orphan-active".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("active".into())),
+                link_count: NumericExpr::parse("== 0"),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 3,
+            message: Some(
+                "Active but no links to other artifacts. Connect it to the graph.".into(),
+            ),
+        },
+        Rule {
+            name: "medium-quality".into(),
+            condition: Condition {
+                r_eff: NumericExpr::parse("0.5..0.7"),
+                ..Default::default()
+            },
+            action: ActionType::Investigate,
+            priority: 4,
+            message: Some(
+                "R_eff 0.5-0.7 — evidence moderate. Add stronger evidence to unlock EXPLOIT."
+                    .into(),
+            ),
+        },
+        Rule {
+            name: "ready-to-build".into(),
+            condition: Condition {
+                r_eff: NumericExpr::parse(">= 0.7"),
+                overall: NumericExpr::parse(">= 0.6"),
+                ..Default::default()
+            },
+            action: ActionType::Exploit,
+            priority: 5,
+            message: Some("Strong evidence + quality. Ready to build on.".into()),
+        },
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fpf::core::trust::TrustScore;
+
+    fn make_data(id: &str, status: &str, r_eff: f64, link_count: usize) -> ArtifactData {
+        let trust = TrustScore {
+            r_eff,
+            formality: 0.5,
+            granularity: 0.5,
+            reliability: 0.5,
+            overall: 0.5,
+            weakest_link: None,
+        };
+        ArtifactData {
+            id: id.into(),
+            status: status.into(),
+            kind: "prd".into(),
+            depth: "standard".into(),
+            evidence: vec![],
+            formality: 0.5,
+            granularity: 0.5,
+            link_count,
+            is_stale: false,
+            trust,
+        }
+    }
+
+    fn enrich(data: ArtifactData) -> EnrichedData {
+        EnrichedData {
+            base: data,
+            linked_kinds: vec![],
+            days_until_expiry: None,
+        }
+    }
+
+    // --- NumericExpr tests ---
+
+    #[test]
+    fn parse_lt() {
+        let expr = NumericExpr::parse("< 0.5").unwrap();
+        assert!(expr.check(0.3));
+        assert!(!expr.check(0.5));
+        assert!(!expr.check(0.7));
+    }
+
+    #[test]
+    fn parse_ge() {
+        let expr = NumericExpr::parse(">= 0.7").unwrap();
+        assert!(expr.check(0.7));
+        assert!(expr.check(0.9));
+        assert!(!expr.check(0.69));
+    }
+
+    #[test]
+    fn parse_range() {
+        let expr = NumericExpr::parse("0.01..0.5").unwrap();
+        assert!(expr.check(0.01));
+        assert!(expr.check(0.3));
+        assert!(!expr.check(0.5)); // exclusive end
+        assert!(!expr.check(0.0));
+    }
+
+    #[test]
+    fn parse_eq() {
+        let expr = NumericExpr::parse("== 0").unwrap();
+        assert!(expr.check(0.0));
+        assert!(!expr.check(0.1));
+    }
+
+    #[test]
+    fn parse_bare_number() {
+        let expr = NumericExpr::parse("0.5").unwrap();
+        assert!(expr.check(0.5));
+        assert!(!expr.check(0.6));
+    }
+
+    // --- ValueMatch tests ---
+
+    #[test]
+    fn value_match_single() {
+        let v = ValueMatch::Single("draft".into());
+        assert!(v.matches("draft"));
+        assert!(v.matches("Draft")); // case-insensitive
+        assert!(!v.matches("active"));
+    }
+
+    #[test]
+    fn value_match_multiple() {
+        let v = ValueMatch::Multiple(vec!["active".into(), "stale".into()]);
+        assert!(v.matches("active"));
+        assert!(v.matches("stale"));
+        assert!(!v.matches("draft"));
+    }
+
+    // --- Tier 1 tests ---
+
+    #[test]
+    fn basic_status_match() {
+        let rule = Rule {
+            name: "test".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("draft".into())),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 1,
+            message: None,
+        };
+        assert!(check_basic(&rule, &make_data("X", "draft", 0.0, 0)));
+        assert!(!check_basic(&rule, &make_data("X", "active", 0.0, 0)));
+    }
+
+    #[test]
+    fn basic_reff_expr() {
+        let rule = Rule {
+            name: "test".into(),
+            condition: Condition {
+                r_eff: NumericExpr::parse("< 0.5"),
+                ..Default::default()
+            },
+            action: ActionType::Investigate,
+            priority: 2,
+            message: None,
+        };
+        assert!(check_basic(&rule, &make_data("X", "active", 0.3, 1)));
+        assert!(!check_basic(&rule, &make_data("X", "active", 0.7, 1)));
+    }
+
+    #[test]
+    fn basic_combined_conditions() {
+        let rule = Rule {
+            name: "test".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("draft".into())),
+                r_eff: NumericExpr::parse("< 0.01"),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 1,
+            message: None,
+        };
+        assert!(check_basic(&rule, &make_data("X", "draft", 0.0, 0)));
+        assert!(!check_basic(&rule, &make_data("X", "draft", 0.5, 0)));
+        assert!(!check_basic(&rule, &make_data("X", "active", 0.0, 0)));
+    }
+
+    // --- Tier 2 tests ---
+
+    #[test]
+    fn enriched_links_missing() {
+        let rule = Rule {
+            name: "prd-needs-rfc".into(),
+            condition: Condition {
+                kind: Some(ValueMatch::Single("prd".into())),
+                status: Some(ValueMatch::Single("active".into())),
+                links_missing: Some(vec!["rfc".into()]),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 2,
+            message: None,
+        };
+
+        // No RFC linked -> rule matches
+        let data_no_rfc = EnrichedData {
+            base: make_data("PRD-018", "active", 0.8, 2),
+            linked_kinds: vec!["evidence".into(), "epic".into()],
+            days_until_expiry: None,
+        };
+        assert!(check_enriched(&rule, &data_no_rfc));
+
+        // RFC IS linked -> rule doesn't match
+        let data_with_rfc = EnrichedData {
+            base: make_data("PRD-018", "active", 0.8, 3),
+            linked_kinds: vec!["rfc".into(), "evidence".into()],
+            days_until_expiry: None,
+        };
+        assert!(!check_enriched(&rule, &data_with_rfc));
+    }
+
+    #[test]
+    fn enriched_days_until_expiry() {
+        let rule = Rule {
+            name: "expiring".into(),
+            condition: Condition {
+                kind: Some(ValueMatch::Single("evidence".into())),
+                days_until_expiry: NumericExpr::parse("< 14"),
+                ..Default::default()
+            },
+            action: ActionType::Investigate,
+            priority: 3,
+            message: None,
+        };
+
+        // Expires in 7 days -> matches
+        let mut data = make_data("EVID-001", "active", 0.8, 1);
+        data.kind = "evidence".into();
+        let enriched = EnrichedData {
+            base: data.clone(),
+            linked_kinds: vec![],
+            days_until_expiry: Some(7),
+        };
+        assert!(check_enriched(&rule, &enriched));
+
+        // Expires in 30 days -> doesn't match
+        let enriched_far = EnrichedData {
+            base: data.clone(),
+            linked_kinds: vec![],
+            days_until_expiry: Some(30),
+        };
+        assert!(!check_enriched(&rule, &enriched_far));
+
+        // No expiry -> doesn't match
+        let enriched_none = EnrichedData {
+            base: data,
+            linked_kinds: vec![],
+            days_until_expiry: None,
+        };
+        assert!(!check_enriched(&rule, &enriched_none));
+    }
+
+    // --- run_rules() tests ---
+
+    #[test]
+    fn run_rules_picks_highest_priority() {
+        let rules = vec![
+            Rule {
+                name: "low-priority".into(),
+                condition: Condition {
+                    status: Some(ValueMatch::Single("draft".into())),
+                    ..Default::default()
+                },
+                action: ActionType::Investigate,
+                priority: 5,
+                message: None,
+            },
+            Rule {
+                name: "high-priority".into(),
+                condition: Condition {
+                    status: Some(ValueMatch::Single("draft".into())),
+                    r_eff: NumericExpr::parse("< 0.01"),
+                    ..Default::default()
+                },
+                action: ActionType::Explore,
+                priority: 1,
+                message: Some("Urgent!".into()),
+            },
+        ];
+
+        let data = enrich(make_data("X", "draft", 0.0, 0));
+        let action = run_rules(&rules, &data).unwrap();
+        assert_eq!(action.action_type, ActionType::Explore);
+        assert_eq!(action.priority, 1);
+        assert_eq!(action.reason, "Urgent!");
+    }
+
+    #[test]
+    fn run_rules_no_match_returns_none() {
+        let rules = vec![Rule {
+            name: "only-draft".into(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("draft".into())),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 1,
+            message: None,
+        }];
+
+        let data = enrich(make_data("X", "active", 0.8, 3));
+        assert!(run_rules(&rules, &data).is_none());
+    }
+
+    // --- Default rules backward compat ---
+
+    #[test]
+    fn default_rules_match_hardcoded_behavior() {
+        let rules = default_rules();
+
+        // Draft + no evidence -> EXPLORE (rule "blind-spot")
+        let draft_no_ev = enrich(make_data("P-1", "draft", 0.0, 0));
+        let action = run_rules(&rules, &draft_no_ev).unwrap();
+        assert_eq!(action.action_type, ActionType::Explore);
+        assert_eq!(action.priority, 1);
+
+        // Active + weak evidence -> INVESTIGATE (rule "weak-evidence")
+        let active_weak = enrich(make_data("P-2", "active", 0.3, 2));
+        let action = run_rules(&rules, &active_weak).unwrap();
+        assert_eq!(action.action_type, ActionType::Investigate);
+
+        // Active + orphan -> EXPLORE (rule "orphan-active")
+        let mut orphan_data = make_data("P-3", "active", 0.8, 0);
+        orphan_data.trust.overall = 0.8;
+        let orphan = enrich(orphan_data);
+        let action = run_rules(&rules, &orphan).unwrap();
+        assert_eq!(action.action_type, ActionType::Explore);
+        assert_eq!(action.priority, 3);
+
+        // Strong evidence + quality -> EXPLOIT
+        let mut strong_data = make_data("P-4", "active", 0.8, 3);
+        strong_data.trust.overall = 0.7;
+        let strong = enrich(strong_data);
+        let action = run_rules(&rules, &strong).unwrap();
+        assert_eq!(action.action_type, ActionType::Exploit);
+    }
+
+    // --- YAML deserialization ---
+
+    #[test]
+    fn rule_deserializes_from_yaml() {
+        let yaml = r#"
+name: "blind-spot"
+when:
+  status: "draft"
+  r_eff: "< 0.01"
+action: EXPLORE
+priority: 1
+message: "Draft with no evidence"
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(rule.name, "blind-spot");
+        assert_eq!(rule.action, ActionType::Explore);
+        assert_eq!(rule.priority, 1);
+        assert!(rule.condition.status.is_some());
+        assert!(rule.condition.r_eff.is_some());
+    }
+
+    #[test]
+    fn rule_with_list_status_deserializes() {
+        let yaml = r#"
+name: "weak-evidence"
+when:
+  status: ["active", "stale"]
+  r_eff: "0.01..0.5"
+action: INVESTIGATE
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).unwrap();
+        if let Some(ValueMatch::Multiple(list)) = &rule.condition.status {
+            assert_eq!(list.len(), 2);
+        } else {
+            panic!("Expected Multiple");
+        }
+    }
+
+    #[test]
+    fn rule_with_links_missing_deserializes() {
+        let yaml = r#"
+name: "prd-needs-rfc"
+when:
+  kind: "prd"
+  status: "active"
+  links_missing: ["rfc"]
+action: EXPLORE
+priority: 2
+"#;
+        let rule: Rule = serde_yaml::from_str(yaml).unwrap();
+        assert!(rule.condition.needs_enrichment());
+        assert_eq!(rule.condition.links_missing, Some(vec!["rfc".to_string()]));
+    }
+}

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -14,10 +14,13 @@ use std::collections::BTreeMap;
 use crate::artifact::types::{ArtifactKind, Mode};
 use crate::db::store::LanceStore;
 use crate::fpf::core::config::FpfConfig;
+use crate::fpf::core::model::ArtifactData;
+use crate::fpf::core::trust::{EvidenceInput, TrustScore, Verdict};
 use crate::scoring::fgr;
 
 use contexts::BoundedContext;
 use explore::Action;
+use ext::rules;
 
 /// Full FPF dashboard data.
 #[derive(Debug)]
@@ -145,8 +148,15 @@ pub async fn dashboard(
         fgr_scores.push(score);
     }
 
-    // Explore-Exploit Actions
-    let actions = explore::suggest(&records, &fgr_scores, &all_relations, None);
+    // Explore-Exploit Actions — use rule engine if rules configured, else legacy
+    let cfg = fpf_config.cloned().unwrap_or_default();
+    let active_rules = if cfg.rules.is_empty() {
+        rules::default_rules()
+    } else {
+        cfg.rules.clone()
+    };
+
+    let actions = build_rule_actions(&records, &fgr_scores, &all_relations, &active_rules, &cfg);
 
     // Pipeline Status — compute aggregate across all PRDs
     let active_count = records.iter().filter(|r| r.status == "active").count();
@@ -165,4 +175,128 @@ pub async fn dashboard(
         pipeline_status,
         artifact_count: records.len(),
     })
+}
+
+/// Build explore-exploit actions using the rule engine.
+///
+/// Converts ArtifactRecords → EnrichedData (batch enrichment) → runs rules.
+/// Returns legacy Action structs for dashboard compatibility.
+fn build_rule_actions(
+    records: &[crate::db::store::ArtifactRecord],
+    fgr_scores: &[fgr::FgrScore],
+    relations: &[(String, String, String)],
+    active_rules: &[rules::Rule],
+    config: &FpfConfig,
+) -> Vec<Action> {
+    let mut actions = Vec::new();
+
+    for record in records {
+        // Skip terminal statuses
+        if record.status == "superseded" || record.status == "deprecated" {
+            continue;
+        }
+
+        let link_count = relations
+            .iter()
+            .filter(|(src, tgt, _)| src == &record.id || tgt == &record.id)
+            .count();
+
+        let is_stale = record
+            .valid_until
+            .as_ref()
+            .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
+            .is_some_and(|dt| chrono::Utc::now().naive_utc() > dt);
+
+        let fgr_score = fgr_scores.iter().find(|s| s.artifact_id == record.id);
+
+        // Parse evidence from body for trust computation
+        let evidence = parse_evidence_from_record(record);
+
+        let trust = TrustScore::compute(
+            &evidence,
+            fgr_score.map(|s| s.formality).unwrap_or(0.0),
+            fgr_score.map(|s| s.granularity).unwrap_or(0.0),
+            link_count,
+            is_stale,
+            config,
+        );
+
+        let data = ArtifactData {
+            id: record.id.clone(),
+            status: record.status.clone(),
+            kind: record.kind.clone(),
+            depth: record.depth.clone(),
+            evidence,
+            formality: fgr_score.map(|s| s.formality).unwrap_or(0.0),
+            granularity: fgr_score.map(|s| s.granularity).unwrap_or(0.0),
+            link_count,
+            is_stale,
+            trust,
+        };
+
+        // Batch enrichment: collect linked kinds for this artifact
+        let linked_kinds: Vec<String> = relations
+            .iter()
+            .filter_map(|(src, tgt, _rel)| {
+                if src == &record.id {
+                    // Find the kind of the target
+                    records
+                        .iter()
+                        .find(|r| r.id == *tgt)
+                        .map(|r| r.kind.clone())
+                } else if tgt == &record.id {
+                    records
+                        .iter()
+                        .find(|r| r.id == *src)
+                        .map(|r| r.kind.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
+            chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
+                .ok()
+                .map(|dt| (dt - chrono::Utc::now().naive_utc()).num_days())
+        });
+
+        let enriched = rules::EnrichedData {
+            base: data,
+            linked_kinds,
+            days_until_expiry,
+        };
+
+        if let Some(suggested) = rules::run_rules(active_rules, &enriched) {
+            actions.push(Action {
+                artifact_id: record.id.clone(),
+                action_type: suggested.action_type.to_string(),
+                reason: suggested.reason,
+                priority: suggested.priority,
+            });
+        }
+    }
+
+    actions.sort_by_key(|a| a.priority);
+    actions
+}
+
+/// Parse evidence inputs from a record (simplified: uses r_eff_score).
+fn parse_evidence_from_record(record: &crate::db::store::ArtifactRecord) -> Vec<EvidenceInput> {
+    if record.r_eff_score > 0.0 {
+        // Approximate: if r_eff > 0, there's at least one supporting evidence
+        vec![EvidenceInput {
+            verdict: Verdict::Supports,
+            congruence_level: if record.r_eff_score >= 0.9 {
+                3
+            } else if record.r_eff_score >= 0.5 {
+                2
+            } else {
+                1
+            },
+            is_expired: false,
+        }]
+    } else {
+        vec![]
+    }
 }

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -6,6 +6,7 @@
 pub mod contexts;
 pub mod core;
 pub mod explore;
+pub mod ext;
 pub mod knowledge;
 
 use std::collections::BTreeMap;

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -188,6 +188,44 @@ fn build_rule_actions(
     active_rules: &[rules::Rule],
     config: &FpfConfig,
 ) -> Vec<Action> {
+    // Pre-build lookup maps for O(1) access (audit fix: O(N²) → O(N+R))
+    let kind_map: std::collections::HashMap<&str, &str> = records
+        .iter()
+        .map(|r| (r.id.as_str(), r.kind.as_str()))
+        .collect();
+
+    let fgr_map: std::collections::HashMap<&str, &fgr::FgrScore> = fgr_scores
+        .iter()
+        .map(|s| (s.artifact_id.as_str(), s))
+        .collect();
+
+    // Build linked_kinds and link_count per artifact from relations
+    let mut linked_kinds_map: std::collections::HashMap<&str, Vec<String>> =
+        std::collections::HashMap::new();
+    let mut link_count_map: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+
+    for (src, tgt, _) in relations {
+        *link_count_map.entry(src.as_str()).or_default() += 1;
+        *link_count_map.entry(tgt.as_str()).or_default() += 1;
+        if let Some(&kind) = kind_map.get(tgt.as_str()) {
+            linked_kinds_map
+                .entry(src.as_str())
+                .or_default()
+                .push(kind.to_string());
+        }
+        if let Some(&kind) = kind_map.get(src.as_str()) {
+            linked_kinds_map
+                .entry(tgt.as_str())
+                .or_default()
+                .push(kind.to_string());
+        }
+    }
+
+    // Pre-sort rules by priority (audit fix: sort once, not per-artifact)
+    let mut sorted_rules: Vec<&rules::Rule> = active_rules.iter().collect();
+    sorted_rules.sort_by_key(|r| r.priority);
+
     let mut actions = Vec::new();
 
     for record in records {
@@ -196,10 +234,7 @@ fn build_rule_actions(
             continue;
         }
 
-        let link_count = relations
-            .iter()
-            .filter(|(src, tgt, _)| src == &record.id || tgt == &record.id)
-            .count();
+        let link_count = link_count_map.get(record.id.as_str()).copied().unwrap_or(0);
 
         let is_stale = record
             .valid_until
@@ -207,9 +242,7 @@ fn build_rule_actions(
             .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
             .is_some_and(|dt| chrono::Utc::now().naive_utc() > dt);
 
-        let fgr_score = fgr_scores.iter().find(|s| s.artifact_id == record.id);
-
-        // Parse evidence from body for trust computation
+        let fgr_score = fgr_map.get(record.id.as_str()).copied();
         let evidence = parse_evidence_from_record(record);
 
         let trust = TrustScore::compute(
@@ -234,27 +267,12 @@ fn build_rule_actions(
             trust,
         };
 
-        // Batch enrichment: collect linked kinds for this artifact
-        let linked_kinds: Vec<String> = relations
-            .iter()
-            .filter_map(|(src, tgt, _rel)| {
-                if src == &record.id {
-                    // Find the kind of the target
-                    records
-                        .iter()
-                        .find(|r| r.id == *tgt)
-                        .map(|r| r.kind.clone())
-                } else if tgt == &record.id {
-                    records
-                        .iter()
-                        .find(|r| r.id == *src)
-                        .map(|r| r.kind.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let linked_kinds = linked_kinds_map
+            .get(record.id.as_str())
+            .cloned()
+            .unwrap_or_default();
 
+        // days_until_expiry: negative = already expired (documented behavior)
         let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
             chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
                 .ok()
@@ -267,13 +285,26 @@ fn build_rule_actions(
             days_until_expiry,
         };
 
-        if let Some(suggested) = rules::run_rules(active_rules, &enriched) {
-            actions.push(Action {
-                artifact_id: record.id.clone(),
-                action_type: suggested.action_type.to_string(),
-                reason: suggested.reason,
-                priority: suggested.priority,
-            });
+        // Use pre-sorted rules directly (no sort inside run_rules needed)
+        for rule in &sorted_rules {
+            let matched = if rule.condition.needs_enrichment() {
+                rules::check_enriched(rule, &enriched)
+            } else {
+                rules::check_basic(rule, &enriched.base)
+            };
+            if matched {
+                let reason = rule
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| format!("Matched rule '{}'", rule.name));
+                actions.push(Action {
+                    artifact_id: record.id.clone(),
+                    action_type: rule.action.to_string(),
+                    reason,
+                    priority: rule.priority,
+                });
+                break;
+            }
         }
     }
 

--- a/crates/forgeplan-core/src/llm/reason.rs
+++ b/crates/forgeplan-core/src/llm/reason.rs
@@ -363,6 +363,23 @@ mod tests {
     }
 
     #[test]
+    fn build_metadata_section_with_bounded_context() {
+        let ctx = ArtifactContext {
+            status: "active".to_string(),
+            depth: "standard".to_string(),
+            r_eff_score: 0.5,
+            relations: vec![],
+            architecture_hint: None,
+            bounded_context: Some(("Context-1 (PRD)".to_string(), 5, 0.8)),
+        };
+        let section = build_metadata_section(&ctx);
+        assert!(section.contains("### Bounded Context"));
+        assert!(section.contains("**Cluster**: Context-1 (PRD)"));
+        assert!(section.contains("**Members**: 5 artifacts"));
+        assert!(section.contains("**Cohesion**: 80%"));
+    }
+
+    #[test]
     fn parse_adi_output_valid_json() {
         let json = r#"{"hypotheses":[{"id":"H1","description":"test","assumptions":[],"confidence":"High — good reason"}],"deductions":[],"evidence_needed":[],"recommendation":"do H1","confidence":"High — justified"}"#;
         let output = parse_adi_output(json);

--- a/crates/forgeplan-core/src/llm/reason.rs
+++ b/crates/forgeplan-core/src/llm/reason.rs
@@ -206,6 +206,8 @@ pub struct ArtifactContext {
     pub relations: Vec<(String, String, String)>,
     /// Brief project architecture summary
     pub architecture_hint: Option<String>,
+    /// Bounded context info: (cluster_name, member_count, cohesion)
+    pub bounded_context: Option<(String, usize, f64)>,
 }
 
 /// Build the metadata section for the ADI user prompt.
@@ -224,6 +226,13 @@ pub fn build_metadata_section(ctx: &ArtifactContext) -> String {
                 section.push_str(&format!("- {} — \"{}\" ({})\n", target, title, rel_type));
             }
         }
+    }
+
+    if let Some((name, members, cohesion)) = &ctx.bounded_context {
+        section.push_str(&format!(
+            "\n### Bounded Context\n\n- **Cluster**: {}\n- **Members**: {} artifacts\n- **Cohesion**: {:.0}%\n",
+            name, members, cohesion * 100.0
+        ));
     }
 
     if let Some(hint) = &ctx.architecture_hint {
@@ -301,6 +310,7 @@ mod tests {
                 ),
             ],
             architecture_hint: Some("Rust CLI with LanceDB".to_string()),
+            bounded_context: None,
         };
         let section = build_metadata_section(&ctx);
         assert!(section.contains("**Status**: active"));
@@ -322,6 +332,7 @@ mod tests {
             r_eff_score: 0.0,
             relations: vec![("PRD-001".to_string(), "informs".to_string(), String::new())],
             architecture_hint: None,
+            bounded_context: None,
         };
         let section = build_metadata_section(&ctx);
         assert!(section.contains("PRD-001 (informs)"));
@@ -336,6 +347,7 @@ mod tests {
             r_eff_score: 0.0,
             relations: vec![],
             architecture_hint: None,
+            bounded_context: None,
         };
         let section = build_metadata_section(&ctx);
         assert!(section.contains("**Status**: draft"));

--- a/crates/forgeplan-core/src/workspace/init.rs
+++ b/crates/forgeplan-core/src/workspace/init.rs
@@ -162,5 +162,10 @@ pub fn load_config(workspace: &Path) -> anyhow::Result<Config> {
     let config_path = workspace.join("config.yaml");
     let content = fs::read_to_string(&config_path)?;
     let config: Config = serde_yaml::from_str(&content)?;
+    // Validate FPF config if present (catches NaN/Infinity/negative from YAML)
+    if let Some(ref fpf) = config.fpf {
+        fpf.validate()
+            .map_err(|e| anyhow::anyhow!("Invalid fpf config: {e}"))?;
+    }
     Ok(config)
 }

--- a/crates/forgeplan-core/src/workspace/init.rs
+++ b/crates/forgeplan-core/src/workspace/init.rs
@@ -80,6 +80,29 @@ const CONFIG_TEMPLATES: &str = r#"
 #     kb_sections_limit: 5     # max FPF KB sections injected into prompt
 #     temperature_cap: 0.3     # max temperature for ADI reasoning
 #     auto_save: true          # auto-save ADI results
+#   # Custom explore-exploit rules (override defaults):
+#   # rules:
+#   #   - name: "blind-spot"
+#   #     when:
+#   #       status: "draft"
+#   #       r_eff: "< 0.01"
+#   #     action: EXPLORE
+#   #     priority: 1
+#   #     message: "Draft with no evidence"
+#   #   - name: "prd-needs-rfc"
+#   #     when:
+#   #       kind: "prd"
+#   #       status: "active"
+#   #       links_missing: ["rfc"]     # graph-aware: checks linked artifact kinds
+#   #     action: EXPLORE
+#   #     priority: 2
+#   #     message: "Active PRD without linked RFC"
+#   #   - name: "expiring-evidence"
+#   #     when:
+#   #       kind: "evidence"
+#   #       days_until_expiry: "< 14"  # time-aware: days until valid_until
+#   #     action: INVESTIGATE
+#   #     priority: 3
 "#;
 
 /// All artifact subdirectories created inside `.forgeplan/`.

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1770,6 +1770,7 @@ impl ForgeplanServer {
             r_eff_score: record.r_eff_score,
             relations,
             architecture_hint: None, // MCP callers are AI agents — they already know the architecture
+            bounded_context: None,   // MCP: skip bounded context detection for speed
         };
 
         let (analysis, _adi_output) = forgeplan_core::llm::reason::reason(

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1770,7 +1770,8 @@ impl ForgeplanServer {
             r_eff_score: record.r_eff_score,
             relations,
             architecture_hint: None, // MCP callers are AI agents — they already know the architecture
-            bounded_context: None,   // MCP: skip bounded context detection for speed
+            bounded_context: forgeplan_core::fpf::contexts::detect_for_artifact(&store, &record.id)
+                .await,
         };
 
         let (analysis, _adi_output) = forgeplan_core::llm::reason::reason(


### PR DESCRIPTION
## Summary

- **Rule engine** (`ext/rules.rs`, 430 LOC, 19 tests): declarative YAML rules with expressions (`"< 0.5"`, `"0.01..0.5"`, `["active", "stale"]`), graph-aware conditions (`links_missing: ["rfc"]`), time-aware conditions (`days_until_expiry: "< 14"`)
- **Two-tier eval**: Tier 1 pure (check_basic) + Tier 2 enriched (check_enriched with pre-fetched data)
- **Dashboard integration**: rule engine replaces explore::suggest, batch HashMap enrichment O(N+R)
- **Bounded context in reason**: LLM prompt includes cluster membership, cohesion, member count
- **Config template**: rules examples (basic, graph-aware, time-aware) in `forgeplan init`
- **FpfConfig.rules**: empty = default 5 rules, custom = user YAML rules

## Audit Results

2 agents, findings fixed:
- CRITICAL: `FpfConfig.validate()` now called in `load_config()` — catches NaN/Infinity
- HIGH: O(N²) → O(N+R) via HashMap lookups in `build_rule_actions`
- HIGH: rules pre-sorted once (not per-artifact)
- MEDIUM: `days_until_expiry` negative values documented
- MEDIUM: `default_rules()` narrowing documented

## Test Plan

- [x] 808 tests pass (19 new for rule engine)
- [x] 0 clippy warnings
- [x] 0 fmt diffs
- [x] Dashboard output unchanged (manual verification)
- [x] `forgeplan reason --save --fpf` verified with NOTE-040
- [x] EVID-057 linked, R_eff = 1.00
- [ ] KB semantic search deferred (keyword search works, vector requires embed feature)

## Refs

RFC-001 Phase 2, EVID-057, NOTE-039 (DSL idea), NOTE-040 (ADI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)