### PR TITLE
[Sprint 13.0] Security hotfix — bump vite (Dependabot #4-6)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -7239,9 +7239,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## Summary

- Bumps vite 7.3.1 → 7.3.2 (vendored via website/)
- Closes 3 of 4 Dependabot alerts (2 HIGH + 1 MED)
- lru #3 LOW deferred (transitive via tantivy, upstream fix needed)

## CVEs fixed

| # | Severity | Title |
|---|----------|-------|
| #6 | HIGH | Vite arbitrary file read via WebSocket |
| #4 | HIGH | Vite server.fs.deny bypass with queries |
| #5 | MED | Vite path traversal in optimized deps .map handling |

## Verification

- [x] npm audit: 0 vulnerabilities
- [x] cargo test --workspace: 841 passed, 0 failed
- [x] cargo fmt --check: clean
- [x] cargo check --workspace: clean
- [x] Vulnerable range \`<= 7.3.1\` → no longer matches (7.3.2 installed)

## Deferred

- **#3 LOW lru** — transitive: forgeplan-core → lancedb → lance → tantivy → lru@0.12.5
  Requires upstream tantivy bump. Tracked in roadmap-v0.17.md.

## Sprint context

This is **Sprint 13.0** of v0.17.0 release per EPIC-003.
Branch: \`feat/sprint-13.0-security\` → \`release/v0.17.0\` (NOT dev).

After merge: continue to Sprint 13.1 (PRD-043 Methodology Integrity FOUNDATION).

Refs: EPIC-003, Dependabot #4, #5, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)