### PR TITLE
[Sprint 13.1.6] Audit followup — fix all Sprint 13.1.5 findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,6 +423,33 @@ git checkout -b feat/my-feature
 ```
 **НЕ создавать ветки из stale dev.** Всегда `git pull` первым.
 
+#### КРИТИЧНО: Dependent sprint branch base verification
+
+**Урок из Sprint 13.1.5 (2026-04-07):** если новый sprint зависит от кода другого sprint'а (ещё не merged), ОБЯЗАТЕЛЬНО проверить что base branch содержит нужные коммиты ПЕРЕД стартом. Иначе teammates упрутся в "код не существует" и придётся rebase + re-spawn.
+
+**Проверка перед стартом dependent sprint'а:**
+```bash
+# Убедиться что нужный PR/commit уже в base branch
+git log release/v0.17.0 --oneline | grep "PRD-043\|feat(integrity)"
+# Если нет — либо ждать merge, либо branched FROM dependent feature branch, либо rebase после merge
+```
+
+**Правильная цепочка:**
+```
+PR-A (foundation) → merge → release/v0.17.0 ← base для dependent PR-B
+```
+
+**Неправильная цепочка (то что было в Sprint 13.1.5):**
+```
+release/v0.17.0 (без PRD-043) ← base для hardening sprint, который фиксит PRD-043 код
+   ↓
+   hardening branch не содержит check_stub — fixers корректно отказались работать
+```
+
+**Починка:** `git rebase release/v0.17.0` ПОСЛЕ merge зависимости, resolve конфликтов, re-spawn заблокированных fixers.
+
+**Positive observation:** teammates правильно сообщили "BLOCKER — target code не существует" вместо false-green отчётов. Это показывает что strict file ownership + "run cargo test before reporting done" работают — teammates не делают фейковую работу.
+
 #### Lifecycle ветки:
 ```
 1. git checkout dev && git pull origin dev        # обязательно pull!

--- a/crates/forgeplan-cli/src/commands/import_cmd.rs
+++ b/crates/forgeplan-cli/src/commands/import_cmd.rs
@@ -5,6 +5,10 @@ use forgeplan_core::validation::rules::check_stub_detailed;
 use crate::commands::common;
 
 /// Build a minimal Frontmatter BTreeMap from record fields for stub checking.
+///
+/// Note: import_cmd reads raw JSON (not `ArtifactRecord`), so we cannot reuse
+/// `ArtifactRecord::frontmatter_map()` here. For the canonical builder, see
+/// `forgeplan_core::db::store::ArtifactRecord::frontmatter_map`.
 fn build_frontmatter(id: &str, kind: &str, status: &str, title: &str) -> Frontmatter {
     let mut fm = Frontmatter::new();
     fm.insert("id".to_string(), serde_yaml::Value::String(id.to_string()));

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -3001,3 +3001,38 @@ fn e2e_empty_route_rejected() {
         .failure()
         .stderr(predicate::str::contains("empty"));
 }
+
+// -----------------------------------------------------------------------
+// Sprint 13.1.6: --force is a visible alias for --allow-duplicate
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_new_accepts_force_alias() {
+    let tmp = TempDir::new().unwrap();
+
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    forgeplan()
+        .args(["new", "prd", "Test Title"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    forgeplan()
+        .args(["new", "prd", "Test Title", "--force"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    forgeplan()
+        .args(["list", "--type", "prd"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PRD-001"))
+        .stdout(predicate::str::contains("PRD-002"));
+}

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -70,6 +70,45 @@ fn default_mcp_max_body_len() -> usize {
     1_048_576
 }
 
+impl IntegrityConfig {
+    /// Validate field ranges. Called from `workspace::load_config` after YAML parse.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if !(0.0..=1.0).contains(&self.duplicate_threshold) || self.duplicate_threshold.is_nan() {
+            anyhow::bail!(
+                "integrity.duplicate_threshold must be in [0.0, 1.0], got {}",
+                self.duplicate_threshold
+            );
+        }
+        if self.stub_marker_threshold < 1 {
+            anyhow::bail!(
+                "integrity.stub_marker_threshold must be >= 1, got {}",
+                self.stub_marker_threshold
+            );
+        }
+        if !(16..=4096).contains(&self.mcp_max_title_len) {
+            anyhow::bail!(
+                "integrity.mcp_max_title_len must be in [16, 4096], got {}",
+                self.mcp_max_title_len
+            );
+        }
+        const MAX_BODY: usize = 100 * 1024 * 1024;
+        if !(1024..=MAX_BODY).contains(&self.mcp_max_body_len) {
+            anyhow::bail!(
+                "integrity.mcp_max_body_len must be in [1024, {}], got {}",
+                MAX_BODY,
+                self.mcp_max_body_len
+            );
+        }
+        if !(1..=10_000).contains(&self.duplicate_pairs_limit) {
+            anyhow::bail!(
+                "integrity.duplicate_pairs_limit must be in [1, 10000], got {}",
+                self.duplicate_pairs_limit
+            );
+        }
+        Ok(())
+    }
+}
+
 impl Default for IntegrityConfig {
     fn default() -> Self {
         Self {
@@ -418,6 +457,47 @@ mod integrity_tests {
         let bad_title = "x".repeat(cfg.mcp_max_title_len + 1);
         assert!(ok_title.len() <= cfg.mcp_max_title_len);
         assert!(bad_title.len() > cfg.mcp_max_title_len);
+    }
+
+    #[test]
+    fn test_integrity_config_validate_accepts_defaults() {
+        let cfg = IntegrityConfig::default();
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn test_integrity_config_validate_rejects_out_of_range_threshold() {
+        let mut cfg = IntegrityConfig::default();
+        cfg.duplicate_threshold = 1.5;
+        assert!(cfg.validate().is_err());
+        cfg.duplicate_threshold = -0.5;
+        assert!(cfg.validate().is_err());
+        cfg.duplicate_threshold = f64::NAN;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_integrity_config_validate_rejects_zero_body_limit() {
+        let mut cfg = IntegrityConfig::default();
+        cfg.mcp_max_body_len = 0;
+        assert!(cfg.validate().is_err());
+        cfg.mcp_max_body_len = 1023;
+        assert!(cfg.validate().is_err());
+        cfg.mcp_max_body_len = 200 * 1024 * 1024;
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_integrity_config_validate_rejects_bad_title_and_pairs() {
+        let mut cfg = IntegrityConfig::default();
+        cfg.mcp_max_title_len = 8;
+        assert!(cfg.validate().is_err());
+        let mut cfg = IntegrityConfig::default();
+        cfg.duplicate_pairs_limit = 0;
+        assert!(cfg.validate().is_err());
+        let mut cfg = IntegrityConfig::default();
+        cfg.stub_marker_threshold = 0;
+        assert!(cfg.validate().is_err());
     }
 
     #[test]

--- a/crates/forgeplan-core/src/duplicate/mod.rs
+++ b/crates/forgeplan-core/src/duplicate/mod.rs
@@ -77,6 +77,34 @@ mod tests {
     }
 
     #[test]
+    fn test_jaccard_boundary_at_threshold_70_percent() {
+        // Construct two titles whose Jaccard similarity equals exactly 0.7.
+        // A tokens: {alpha, beta, gamma, delta, epsilon, zeta, eta}  (7 tokens, all len >= 3)
+        // B tokens: A ∪ {theta, iota, kappa}  (10 tokens)
+        // Intersection = 7, union = 10, Jaccard = 7/10 = 0.7
+        let a = "alpha beta gamma delta epsilon zeta eta";
+        let b = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+        let s = title_similarity(a, b);
+        assert!(
+            (s - 0.7).abs() < 1e-9,
+            "expected exact 0.7 boundary, got {s}"
+        );
+
+        // At threshold (0.7) — `>=` comparison MUST flag as duplicate.
+        assert!(s >= DUPLICATE_SIMILARITY_THRESHOLD);
+
+        // Just-below boundary (0.69) MUST NOT clear the threshold.
+        let below: f64 = 0.69;
+        assert!(below < DUPLICATE_SIMILARITY_THRESHOLD);
+        assert!(!(below >= DUPLICATE_SIMILARITY_THRESHOLD));
+
+        // Just-above boundary (0.71) MUST clear the threshold.
+        let above: f64 = 0.71;
+        assert!(above > DUPLICATE_SIMILARITY_THRESHOLD);
+        assert!(above >= DUPLICATE_SIMILARITY_THRESHOLD);
+    }
+
+    #[test]
     fn threshold_constant_is_reasonable() {
         // Sanity: two-of-three tokens overlap should clear threshold
         let s = title_similarity("FPF Knowledge Base", "FPF Knowledge System");

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -149,12 +149,7 @@ pub fn find_active_stubs(records: &[ArtifactRecord]) -> Vec<ActiveStub> {
         if matches!(r.kind.as_str(), "evidence" | "memory" | "note") {
             continue;
         }
-        let mut fm = Frontmatter::new();
-        fm.insert("id".into(), serde_yaml::Value::String(r.id.clone()));
-        fm.insert("status".into(), serde_yaml::Value::String(r.status.clone()));
-        fm.insert("title".into(), serde_yaml::Value::String(r.title.clone()));
-        fm.insert("kind".into(), serde_yaml::Value::String(r.kind.clone()));
-        fm.insert("depth".into(), serde_yaml::Value::String(r.depth.clone()));
+        let fm = r.frontmatter_map();
 
         if let Some(report) = validation::rules::check_stub_detailed(&r.body, &fm) {
             stubs.push(ActiveStub {

--- a/crates/forgeplan-core/src/lifecycle/mod.rs
+++ b/crates/forgeplan-core/src/lifecycle/mod.rs
@@ -78,10 +78,8 @@ pub struct GatesReport {
     pub length_msg: Option<String>,
     pub evidence_ok: bool,
     pub evidence_msg: Option<String>,
-    /// Stub gate — reserved for `validation::rules::check_stub` (added by
-    /// rust-fixer in a sibling change). Currently mirrors `length_ok` as a
-    /// conservative proxy; refactoring review/activate to a single helper
-    /// means the stub gate only needs to be wired in one place.
+    /// True when stub-content check passes. Calls `validation::rules::check_stub`
+    /// which detects unfilled template bodies via marker counting.
     pub stub_ok: bool,
     pub stub_msg: Option<String>,
 }
@@ -288,19 +286,30 @@ pub async fn activate(
         anyhow::bail!("{msg}");
     }
 
-    // Must pass validation before activation (unless --force)
-    let review_result = review(store, artifact_id).await?;
-    if !review_result.can_activate && !force {
+    // Must pass validation before activation (unless --force).
+    // Call the validator directly instead of going through review() —
+    // review() would re-run collect_activation_gates, duplicating work (M-5 fix).
+    let kind = record.kind.parse()?;
+    let depth = record
+        .depth
+        .parse()
+        .unwrap_or(crate::artifact::types::Mode::Standard);
+    let fm = record.frontmatter_map();
+    let validation_result = validation::validate(artifact_id, &record.body, &fm, &kind, &depth);
+    let must_findings: Vec<String> = validation_result
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::Must)
+        .map(|f| format!("{}: {}", f.rule_id, f.message))
+        .collect();
+
+    if !must_findings.is_empty() && !force {
         let mut msg = format!(
             "Validation failed ({} MUST error{}):",
-            review_result.must_findings.len(),
-            if review_result.must_findings.len() == 1 {
-                ""
-            } else {
-                "s"
-            }
+            must_findings.len(),
+            if must_findings.len() == 1 { "" } else { "s" }
         );
-        for finding in &review_result.must_findings {
+        for finding in &must_findings {
             msg.push_str(&format!("\n  - {finding}"));
         }
         msg.push_str("\n\nUse --force to override.");
@@ -313,8 +322,8 @@ pub async fn activate(
 
     Ok(ActivateResult {
         artifact_id: artifact_id.to_string(),
-        forced: force && !review_result.must_findings.is_empty(),
-        must_errors: review_result.must_findings,
+        forced: force && !must_findings.is_empty(),
+        must_errors: must_findings,
     })
 }
 

--- a/crates/forgeplan-core/src/workspace/init.rs
+++ b/crates/forgeplan-core/src/workspace/init.rs
@@ -175,5 +175,9 @@ pub fn load_config(workspace: &Path) -> anyhow::Result<Config> {
         fpf.validate()
             .map_err(|e| anyhow::anyhow!("Invalid fpf config: {e}"))?;
     }
+    config
+        .integrity
+        .validate()
+        .map_err(|e| anyhow::anyhow!("Invalid integrity config: {e}"))?;
     Ok(config)
 }


### PR DESCRIPTION
## Summary

Addresses **all 2 HIGH + 5 MEDIUM** findings from Sprint 13.1.5 multi-agent audit (4 independent auditors: Rust, Security, Architecture, Test Coverage).

## Fixes

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| H1 | HIGH | Jaccard 0.7 boundary test missing | ✅ |
| H2 | HIGH | --force alias untested | ✅ |
| M1 | MED | IntegrityConfig no range validation | ✅ |
| M2 | MED | Stale \`stub_ok\` doc comment | ✅ |
| M3 | MED | 3 duplicate Frontmatter builders | ✅ |
| M4 | MED | Double gates execution in activate() | ✅ |
| M5 | MED | forgeplan_new MCP body check | ⏳ DEFERRED (NewParams has no body field) |

## Test results

- **899 tests pass, 0 fail** (up from 893)
- cargo fmt --check: clean
- cargo check --workspace: 0 warnings
- 0 new dependencies

## Files changed (8)

\`\`\`
CLAUDE.md                                          (+27 — lesson learned)
crates/forgeplan-cli/src/commands/import_cmd.rs    (+4 — doc ref)
crates/forgeplan-cli/tests/cli_integration_test.rs (+35 — --force E2E)
crates/forgeplan-core/src/config/types.rs          (+80 — validate())
crates/forgeplan-core/src/duplicate/mod.rs         (+28 — Jaccard 0.7 test)
crates/forgeplan-core/src/health/mod.rs            (+7  — use frontmatter_map)
crates/forgeplan-core/src/lifecycle/mod.rs         (+41 — no double gates)
crates/forgeplan-core/src/workspace/init.rs        (+4  — wire validate())
\`\`\`

Total: +204 / -22 LOC

## Sprint methodology

- Branch: feat/sprint-13.1.6-audit-followup
- Direct Agent pattern (bypassed TeamCreate — previous team stuck, lesson for NOTE-043)
- 2 parallel fixers, no file conflicts
- ~15 minutes start to PR

## Next

Sprint 13.2 — PRD-039 Smart Search v2

Refs: PRD-043, EPIC-003, EVID-059, CLAUDE.md (new section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)