### PR TITLE
[Sprint 13.1.7] Fix IntegrityConfig wiring + health version field

### DIFF
--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -12,6 +12,10 @@ pub async fn open_store() -> anyhow::Result<(PathBuf, LanceStore)> {
     let cwd = std::env::current_dir()?;
     let ws = workspace::find_workspace(&cwd)
         .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    // Load + validate config on every command that opens the store.
+    // This ensures IntegrityConfig::validate() runs for all code paths
+    // (new, score, list, etc. — not just commands that explicitly load config).
+    let _config = workspace::load_config(&ws)?;
     let store = LanceStore::open(&ws).await?;
     Ok((ws, store))
 }

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::fpf::core::config::FpfConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct Config {
     pub version: u32,
     pub project_name: String,

--- a/crates/forgeplan-core/tests/workspace_test.rs
+++ b/crates/forgeplan-core/tests/workspace_test.rs
@@ -32,6 +32,70 @@ fn find_workspace_walks_up() {
 }
 
 #[test]
+fn load_config_rejects_bad_integrity_threshold() {
+    // Bug 1 regression: IntegrityConfig::validate() must run on every load_config call.
+    let dir = tempdir().unwrap();
+    let ws = workspace::init_workspace(dir.path(), "test").unwrap();
+    // Overwrite config.yaml with bad integrity values.
+    std::fs::write(
+        ws.join("config.yaml"),
+        "integrity:\n  duplicate_threshold: 5.0\n",
+    )
+    .unwrap();
+    let result = workspace::load_config(&ws);
+    assert!(result.is_err(), "expected validation error, got Ok");
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.contains("duplicate_threshold"),
+        "error should mention duplicate_threshold: {msg}"
+    );
+}
+
+#[test]
+fn load_config_rejects_zero_body_limit() {
+    // Bug 1 regression: zero body limit must be rejected.
+    let dir = tempdir().unwrap();
+    let ws = workspace::init_workspace(dir.path(), "test").unwrap();
+    std::fs::write(
+        ws.join("config.yaml"),
+        "integrity:\n  mcp_max_body_len: 0\n",
+    )
+    .unwrap();
+    let result = workspace::load_config(&ws);
+    assert!(result.is_err());
+}
+
+#[test]
+fn load_config_accepts_partial_config_without_version() {
+    // Bug 2 regression: partial config.yaml without top-level `version` must parse.
+    // All Config top-level fields have serde defaults, so missing fields fall back.
+    let dir = tempdir().unwrap();
+    let fp = dir.path().join(".forgeplan");
+    std::fs::create_dir_all(&fp).unwrap();
+    std::fs::write(
+        fp.join("config.yaml"),
+        "integrity:\n  duplicate_threshold: 0.7\n",
+    )
+    .unwrap();
+    let config = workspace::load_config(&fp).expect("partial config should parse");
+    // Missing `version` falls back to default.
+    assert_eq!(config.version, 1);
+    assert!((config.integrity.duplicate_threshold - 0.7).abs() < f64::EPSILON);
+}
+
+#[test]
+fn load_config_accepts_empty_config() {
+    // Bug 2 regression: empty config.yaml must parse using defaults.
+    let dir = tempdir().unwrap();
+    let fp = dir.path().join(".forgeplan");
+    std::fs::create_dir_all(&fp).unwrap();
+    std::fs::write(fp.join("config.yaml"), "").unwrap();
+    let config = workspace::load_config(&fp).expect("empty config should parse");
+    assert_eq!(config.version, 1);
+    assert_eq!(config.default_depth, "standard");
+}
+
+#[test]
 fn load_config_roundtrip() {
     let dir = tempdir().unwrap();
     let ws = workspace::init_workspace(dir.path(), "my-project").unwrap();


### PR DESCRIPTION
## Summary

Two real runtime bugs discovered via E2E manual verification after Sprint 13.1.6.

## Bugs fixed

### Bug 1: IntegrityConfig::validate() not called by CLI commands
- **Symptom:** bad config values silently accepted by \`list\`, \`new\`, \`score\`
- **Root cause:** CLI commands went through \`open_store()\` which skipped config loading
- **Fix:** \`open_store()\` now calls \`workspace::load_config()\` before opening store

### Bug 2: health command required \`version\` field
- **Symptom:** \`forgeplan health\` crashed with \"missing field \`version\`\" on minimal config
- **Root cause:** \`Config\` struct required version via serde
- **Fix:** \`#[serde(default)]\` on Config — all top-level fields fall back to defaults

## E2E manual verification

\`\`\`
$ forgeplan list  # bad config
Error: Invalid integrity config: duplicate_threshold must be in [0.0, 1.0], got 5  ✓

$ forgeplan health  # partial config
Project: | Artifacts: 0 | ... (no version error)  ✓
\`\`\`

## Tests

- **903 pass** (up from 899)
- 4 new regression tests
- cargo fmt --check: clean
- cargo check: 0 warnings

## Key insight

Unit tests passed but production code path was broken. "Tested but not wired" is real. Always verify with manual E2E on built binary.

Refs: PRD-043, Sprint 13.1.6 audit followup

🤖 Generated with [Claude Code](https://claude.com/claude-code)