### PR TITLE
[Sprint 13.6] PRD-041 FPF Rules CLI + MCP tools

### DIFF
--- a/.forgeplan/evidence/EVID-063-sprint-13-6-prd-041-fpf-rules-cli-mcp-1075-tests-pass-12-12-e2e-ready-to-merge.md
+++ b/.forgeplan/evidence/EVID-063-sprint-13-6-prd-041-fpf-rules-cli-mcp-1075-tests-pass-12-12-e2e-ready-to-merge.md
@@ -1,0 +1,171 @@
+---
+depth: tactical
+id: EVID-063
+kind: evidence
+links:
+- target: PRD-041
+  relation: informs
+status: draft
+title: Sprint 13.6 PRD-041 FPF Rules CLI + MCP — 1075 tests pass, 12/12 E2E, READY TO MERGE
+---
+
+# EVID-063: Sprint 13.6 PRD-041 Implementation Evidence
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Summary
+
+Sprint 13.6 implemented PRD-041 in full: 4 FRs (CLI `fpf rules`, CLI `fpf check`, MCP `forgeplan_fpf_rules`, MCP `forgeplan_fpf_check`) shipped on branch `feat/sprint-13.6-prd-041-fpf-rules` over `release/v0.17.0`. Multi-agent team execution with full /forge-cycle discipline: 2 parallel implementers, 1 tester, 4 parallel auditors, 1 fixer, 1 re-auditor + manual UX polish by team-lead.
+
+## Commits (6)
+
+| Commit | Scope | LOC |
+|---|---|---|
+| `7056e14` | core helpers: RuleSource, active_rules, RuleCheckResult, check_artifact_against_rules | +218 |
+| `ff6babc` | MCP forgeplan_fpf_rules + forgeplan_fpf_check tools | +181 |
+| `e819596` | CLI run_rules (tree/flat/json) + run_check (styled/verbose/json) + enum wiring | +436 |
+| `24369aa` | unit + CLI integration + E2E regression tests | +392 |
+| `76d5e7a` | audit fixes: dedupe enrichment, canonical JSON, Option refactor, Condition::summarize in core, param bounds, test strengthening | +541/-366 |
+| `77b0c12` | manual UX polish: pluralization, link_count== → =, error dedup via exit(1), condition_summary in CLI JSON | +8/-5 |
+
+## FR mapping
+
+### FR-001 — `forgeplan fpf rules [--flat] [--json]`
+Action-grouped tree by default (EXPLORE/INVESTIGATE/EXPLOIT), `--flat` = priority-linear table, `--json` = dump with condition + condition_summary per rule.
+- Impl: `crates/forgeplan-cli/src/commands/fpf.rs::run_rules()`
+- Tests: cli_fpf_rules_shows_default_source, cli_fpf_rules_json_valid, cli_fpf_rules_flat_has_priorities + 8 unit tests for summarize_condition/style_action/truncate
+
+### FR-002 — `forgeplan fpf check <id> [--verbose] [--json]`
+Styled: header + `★ winning` + action + message + "N other rule(s) did not match." Verbose adds unmatched list. JSON emits canonical `{artifact_id, kind, status, matched, unmatched, winning, summary}`. Missing id: clean `✗ not found → hint`, exit 1.
+- Impl: `crates/forgeplan-cli/src/commands/fpf.rs::run_check()`
+- Tests: cli_fpf_check_missing_artifact_errors, cli_fpf_check_existing_artifact, cli_fpf_check_verbose_shows_unmatched, cli_fpf_check_json_has_required_fields
+
+### FR-003 — MCP `forgeplan_fpf_rules`
+4 optional params: action (≤64), name (≤128), summary (bool), source (≤16). Default full dump with condition tree + condition_summary.
+- Impl: `crates/forgeplan-mcp/src/server.rs::forgeplan_fpf_rules()`
+- Tests: fpf_param_validation_tests (length bounds) + core active_rules tests
+
+### FR-004 — MCP `forgeplan_fpf_check`
+Single required param `id` (≤128). Canonical JSON shape (identical to CLI --json).
+- Impl: `crates/forgeplan-mcp/src/server.rs::forgeplan_fpf_check()`
+- Tests: param validation + core check_artifact_against_rules tests (None on missing, custom config, priority order, Serialize, summary_line)
+
+## Core API
+
+- `RuleSource` — Config | Default, `#[serde(rename_all="snake_case")]`
+- `active_rules(fpf_config) -> (Vec<Rule>, RuleSource)`
+- `RuleCheckResult` — Serialize derived, `#[serde(rename)]` for canonical kind/status
+- `MatchedRule { name, priority, action, message }` — Serialize
+- `RuleCheckResult::summary_line() -> String` — "N matched, N unmatched, winning: name"
+- `check_artifact_against_rules(store, id, config) -> Result<Option<RuleCheckResult>>` — None on missing, Err only on real errors
+- `Condition::summarize() -> String` + `CONDITION_SUMMARY_MAX: usize = 120` in `fpf/ext/rules.rs` — used by both CLI and MCP
+- Internal: `build_lookup_maps` + `enrich_one` — shared O(N+R) helper between `build_rule_actions` and `check_artifact_against_rules`
+
+## Audit cycle
+
+### Round 1: 4 parallel auditors
+| Auditor | Crit | High | Med | Low |
+|---|---|---|---|---|
+| Rust | 0 | 0 | 2 | 5 |
+| Security | 0 | 0 | 3 | 6 |
+| Architecture | 0 | 2 | 4 | 4 |
+| Tests | 0 | 1-cluster + 4 sub | 7 | 5 |
+
+**HIGH findings:**
+- Arch H1: enrich_record_for_rules duplicated build_rule_actions logic + lost O(N+R) optimization → O(N·R) regression
+- Arch H2: RuleCheckResult/MatchedRule without Serialize; CLI and MCP JSON already drifted (artifact_kind vs kind, summary in MCP only)
+- Tests T-H1: MCP tools zero handler test coverage
+- Tests sub: weak tautological assertions in 2 CLI integration tests, missing verbose/Config-source coverage
+
+### Round 2: fixer (commit 76d5e7a) applied 7 fixes
+1. Dedupe enrichment — shared `build_lookup_maps` + `enrich_one`, both paths O(N+R)
+2. Canonical JSON — derive Serialize + rename, summary_line() method, retire hand-rolled JSON
+3. Condition::summarize() moved to core, MCP now emits condition_summary alongside nested condition
+4. MCP param length bounds + 4 unit tests
+5. Result<Option<RuleCheckResult>> — kills brittle string-match, removes Lance internals leak in CLI errors
+6. MCP handler harness DEFERRED (no tests/ dir infra; handlers 15 LOC thin wrappers; core well-tested; param validation at unit level)
+7. Test strengthening — concrete assertions, new verbose test, 6 new core prd041_tests
+
+### Round 3: re-auditor verification
+- 6 HIGH verified PASS against actual code
+- 1 PARTIAL (MCP harness) confirmed as intentional deferral
+- 0 new issues introduced
+- Quality gates green
+- **Verdict: READY TO MERGE**
+
+### Round 4: manual UX polish (commit 77b0c12)
+Team-lead ran 7 commands on release binary. 4 cosmetic fixes:
+1. "1 rules" → "1 rule" pluralization
+2. `link_count==0` → `link_count=0` (format_numeric Eq variant)
+3. Error dedup: `std::process::exit(1)` after ui::error_hint instead of bubbling anyhow
+4. CLI fpf rules --json missing condition_summary → added for MCP parity
+
+## Test results
+
+- **Total: 1075 tests pass, 0 failed**, 1 ignored (baseline ~1060 + 15 net)
+- New tests by location:
+  - `forgeplan-core/src/fpf/mod.rs::prd041_tests`: 12 tests
+  - `forgeplan-core/src/fpf/ext/rules.rs::tests`: 5 tests for Condition::summarize (migrated + extended)
+  - `forgeplan-cli/src/commands/fpf.rs`: 8 unit tests
+  - `forgeplan-cli/tests/fpf_rules_check.rs`: 6 integration tests (assert_cmd)
+  - `forgeplan-mcp/src/server.rs::fpf_param_validation_tests`: 4 tests
+- `cargo fmt --check`: clean
+- `cargo check --workspace`: 0 warnings, 0 errors
+- `cargo build --release`: 1m 56s, 42MB binary
+- E2E regression `tests/e2e/sprint-13.6-regression.sh`: exit 0, 12/12 checks pass (Sprint 13.1 dup guard → 13.2 search → 13.3 tags → 13.4 discover → 13.5 score → 13.6 fpf rules/check)
+
+## UX verification (manual on release binary)
+
+| Command | Quality | Key finding |
+|---|---|---|
+| `fpf rules` (tree) | ★★★★★ | Action-grouped box-drawing, correct pluralization, condition summaries |
+| `fpf rules --flat` | ★★★★★ | Aligned ASCII table |
+| `fpf rules --json` | ★★★★★ | Canonical shape + condition_summary parity with MCP |
+| `fpf check <id>` styled | ★★★★★ | ★ winning + action + message + summary |
+| `fpf check --verbose` | ★★★★★ | Unmatched rules section |
+| `fpf check --json` | ★★★★★ | Canonical kind/status/summary |
+| `fpf check NOT-EXIST` | ★★★★★ | ✗ clean error + hint + exit 1, no duplication |
+
+## Deferred to backlog
+
+- **Arch M1**: move PRD-041 code from `fpf/mod.rs` to `fpf/ext/rules.rs` for organization
+- **Arch M3 / Sec M1**: O(N) workspace scan per check_artifact_against_rules call — doc warning added; actual batching/caching deferred until MCP does batch-check
+- **Arch M4**: `RuleQuery` helper type if third surface appears (TUI, web)
+- **Tests T-H1 residual**: full MCP handler integration harness (`crates/forgeplan-mcp/tests/`) — needs design decision on handler visibility
+- **Tests Medium**: unicode boundary truncate, priority tie-break, MCP filter combos
+- **Rust nits**: cosmetic items from audit
+
+## Integration with prior Sprint 13.x
+
+- Sprint 13.2 BM25 search: regression verified
+- Sprint 13.3 tags: regression verified
+- Sprint 13.4 discover: regression verified
+- Sprint 13.5 score with CI: regression verified
+- Sprint 12 FPF Rule Engine: this sprint is the missing surface — was hidden before, now introspectable via 4 entry points
+
+## Team execution pattern (for future sprints)
+
+Hybrid team-up pattern worked well:
+- team-lead (main) spawned agents (subagents can't use Agent tool)
+- 2 parallel implementers (CLI + MCP, independent files) → both done
+- 1 tester picked up unblocked W3
+- 4 parallel auditors (Rust/Sec/Arch/Tests) read-only
+- 1 sequential fixer (touches multiple crates — no file-conflict risk at cost of serial)
+- 1 re-auditor verified
+- team-lead did manual UX polish directly (faster for cosmetic)
+- Total wall time: ~30 min parallel phase + ~25 min serial fix + ~10 min polish = ~65 min
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PRD-041 | informs (this evidence supports FR-001..FR-004) |
+| EPIC-003 | informs (Sprint 13 v0.17.0 series) |
+| RFC-001 | informs (Phase 3 — rules surface) |
+| EVID-062 | predecessor (Sprint 13.5) |
+| PRD-040 | context (Sprint 13.5) |
+| PRD-042 | blocked-until-now (Sprint 13.7 needs 13.6 merged — shared fpf.rs + server.rs files) |

--- a/.forgeplan/prds/PRD-041-fpf-rules-cli-list-check-mcp-tools-rfc-001-phase-3.md
+++ b/.forgeplan/prds/PRD-041-fpf-rules-cli-list-check-mcp-tools-rfc-001-phase-3.md
@@ -5,7 +5,7 @@ kind: prd
 links:
 - target: EPIC-003
   relation: refines
-status: draft
+status: active
 title: FPF Rules — CLI list/check + MCP tools (RFC-001 Phase 3)
 ---
 
@@ -26,13 +26,34 @@ parent_epic: EPIC-003
 ## Progress
 
 ```
-FR-001  ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  forgeplan fpf rules
-FR-002  ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  forgeplan fpf check
-FR-003  ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  MCP fpf_rules tool
-FR-004  ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  MCP fpf_check tool
+FR-001  ████████████████████████  1/1  forgeplan fpf rules    ✓ Sprint 13.6
+FR-002  ████████████████████████  1/1  forgeplan fpf check    ✓ Sprint 13.6
+FR-003  ████████████████████████  1/1  MCP fpf_rules tool     ✓ Sprint 13.6
+FR-004  ████████████████████████  1/1  MCP fpf_check tool     ✓ Sprint 13.6
 ─────────────────────────────────────────────────
-TOTAL                              0/4  ( 0%)
+TOTAL                              4/4  (100%) — COMPLETE
 ```
+
+## Implementation map (FR → file:line → test)
+
+| FR | Surface | Implementation | Tests |
+|---|---|---|---|
+| FR-001 | `forgeplan fpf rules [--flat] [--json]` | `crates/forgeplan-cli/src/commands/fpf.rs::run_rules()` + `crates/forgeplan-cli/src/main.rs::FpfCommands::Rules` | `cli_fpf_rules_shows_default_source`, `cli_fpf_rules_json_valid`, `cli_fpf_rules_flat_has_priorities` (tests/fpf_rules_check.rs) + `summarize_condition` unit tests |
+| FR-002 | `forgeplan fpf check <id> [--verbose] [--json]` | `crates/forgeplan-cli/src/commands/fpf.rs::run_check()` + `crates/forgeplan-cli/src/main.rs::FpfCommands::Check` | `cli_fpf_check_missing_artifact_errors`, `cli_fpf_check_existing_artifact`, `cli_fpf_check_verbose_shows_unmatched`, `cli_fpf_check_json_has_required_fields` |
+| FR-003 | MCP `forgeplan_fpf_rules` (params: action/name/summary/source) | `crates/forgeplan-mcp/src/server.rs::forgeplan_fpf_rules()` | `fpf_param_validation_tests` (rules bounds) + core `active_rules` tests in `forgeplan-core/src/fpf/mod.rs::prd041_tests` |
+| FR-004 | MCP `forgeplan_fpf_check` (param: id) | `crates/forgeplan-mcp/src/server.rs::forgeplan_fpf_check()` | `fpf_param_validation_tests` (id bound) + core `check_artifact_against_rules` tests (missing id, custom config, canonical serialize, summary_line variants) |
+
+### Core API (shared by CLI + MCP)
+- `forgeplan_core::fpf::RuleSource` — Config | Default
+- `forgeplan_core::fpf::active_rules(fpf_config) -> (Vec<Rule>, RuleSource)`
+- `forgeplan_core::fpf::RuleCheckResult { artifact_id, artifact_kind, artifact_status, matched, unmatched, winning }` + `Serialize` (canonical JSON: `kind`/`status`) + `summary_line()` method
+- `forgeplan_core::fpf::check_artifact_against_rules(store, id, config) -> Result<Option<RuleCheckResult>>`
+- `forgeplan_core::fpf::ext::rules::Condition::summarize()` — human-readable one-liner for rules surface
+- Private helpers: `build_lookup_maps`, `enrich_one` (shared between `build_rule_actions` and `check_artifact_against_rules`, O(N+R))
+
+**Sprint 13.6 delivered:** All 4 FRs implemented, audited (0 CRITICAL, 0 HIGH remaining after fixes), re-audited READY TO MERGE. 1075 tests pass, E2E regression 12/12 pass on release binary.
+
+See EVID-063 for full evidence.
 
 ---
 
@@ -180,4 +201,5 @@ CLI/MCP просто читают `FpfConfig.rules` и вызывают `run_rul
 | RFC-001 | parent (FPF Engine) | active |
 | EVID-057 | source evidence (Sprint 12 rule engine) | active |
 | sources/RuVector | inspiration (filter expressions) | external |
+
 

--- a/crates/forgeplan-cli/src/commands/fpf.rs
+++ b/crates/forgeplan-cli/src/commands/fpf.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use console::style;
 use forgeplan_core::db::store::{FpfChunk, LanceStore};
 use forgeplan_core::fpf;
-use forgeplan_core::fpf::ext::rules::{Condition, NumericExpr, Rule, ValueMatch};
+use forgeplan_core::fpf::ext::rules::Rule;
 use forgeplan_core::fpf::knowledge;
 use forgeplan_core::workspace;
 
@@ -246,71 +246,6 @@ pub async fn run_list() -> anyhow::Result<()> {
 // PRD-041 FR-001: `forgeplan fpf rules`
 // ──────────────────────────────────────────────────────────────────
 
-/// Render a single `Condition` as a human-readable "k=v AND k>0.5" string.
-///
-/// Condition is a flat implicit-AND struct; every Some(...) field becomes one
-/// "key op value" clause joined with " AND ". Truncates to 120 chars with "…".
-pub(crate) fn summarize_condition(cond: &Condition) -> String {
-    if cond.is_empty() {
-        return "(always matches)".to_string();
-    }
-
-    let mut parts: Vec<String> = Vec::new();
-
-    if let Some(v) = &cond.kind {
-        parts.push(format!("kind={}", format_value_match(v)));
-    }
-    if let Some(v) = &cond.status {
-        parts.push(format!("status={}", format_value_match(v)));
-    }
-    if let Some(v) = &cond.depth {
-        parts.push(format!("depth={}", format_value_match(v)));
-    }
-    if let Some(n) = &cond.r_eff {
-        parts.push(format!("r_eff{}", format_numeric(n)));
-    }
-    if let Some(n) = &cond.overall {
-        parts.push(format!("overall{}", format_numeric(n)));
-    }
-    if let Some(n) = &cond.link_count {
-        parts.push(format!("link_count{}", format_numeric(n)));
-    }
-    if let Some(b) = cond.is_stale {
-        parts.push(format!("is_stale={b}"));
-    }
-    if let Some(links) = &cond.links_missing {
-        parts.push(format!("links_missing={}", links.join(",")));
-    }
-    if let Some(n) = &cond.days_until_expiry {
-        parts.push(format!("days_until_expiry{}", format_numeric(n)));
-    }
-
-    let mut joined = parts.join(" AND ");
-    if joined.chars().count() > 120 {
-        joined = joined.chars().take(119).collect::<String>();
-        joined.push('…');
-    }
-    joined
-}
-
-fn format_value_match(v: &ValueMatch) -> String {
-    match v {
-        ValueMatch::Single(s) => s.clone(),
-        ValueMatch::Multiple(list) => format!("[{}]", list.join("|")),
-    }
-}
-
-fn format_numeric(n: &NumericExpr) -> String {
-    match n {
-        NumericExpr::Lt(v) => format!("<{v}"),
-        NumericExpr::Le(v) => format!("<={v}"),
-        NumericExpr::Gt(v) => format!(">{v}"),
-        NumericExpr::Ge(v) => format!(">={v}"),
-        NumericExpr::Eq(v) => format!("=={v}"),
-        NumericExpr::Range(lo, hi) => format!("={lo}..{hi}"),
-    }
-}
-
 fn style_action(action: &str) -> String {
     match action {
         "EXPLORE" => style(action).cyan().bold().to_string(),
@@ -379,7 +314,7 @@ pub async fn run_rules(flat: bool, json: bool) -> anyhow::Result<()> {
                 r.priority,
                 truncate(&r.name, 28),
                 style_action(&action),
-                summarize_condition(&r.condition),
+                r.condition.summarize(),
             );
         }
         println!();
@@ -435,7 +370,7 @@ pub async fn run_rules(flat: bool, json: bool) -> anyhow::Result<()> {
                 "  {}{}     {}",
                 vbar,
                 rule_vbar,
-                style(summarize_condition(&rule.condition)).dim()
+                style(rule.condition.summarize()).dim()
             );
             if let Some(msg) = &rule.message {
                 println!("  {}{}     {}", vbar, rule_vbar, style(msg).italic().dim());
@@ -469,36 +404,32 @@ pub async fn run_check(id: &str, verbose: bool, json: bool) -> anyhow::Result<()
     let fpf_config = config.fpf.as_ref();
 
     let result = match fpf::check_artifact_against_rules(&store, id, fpf_config).await {
-        Ok(r) => r,
-        Err(e) => {
+        Ok(Some(r)) => r,
+        Ok(None) => {
             ui::error_hint(
-                &format!("Artifact '{id}' not found: {e}"),
+                &format!("Artifact '{id}' not found"),
                 "forgeplan list --kind prd",
             );
             return Err(anyhow::anyhow!("artifact not found"));
         }
+        Err(_) => {
+            ui::error_hint(
+                &format!("Failed to check artifact '{id}'"),
+                "forgeplan health",
+            );
+            return Err(anyhow::anyhow!("check failed"));
+        }
     };
 
     if json {
-        let out = serde_json::json!({
-            "artifact_id": result.artifact_id,
-            "artifact_kind": result.artifact_kind,
-            "artifact_status": result.artifact_status,
-            "matched": result.matched.iter().map(|m| serde_json::json!({
-                "name": m.name,
-                "priority": m.priority,
-                "action": m.action,
-                "message": m.message,
-            })).collect::<Vec<_>>(),
-            "unmatched": result.unmatched,
-            "winning": result.winning.as_ref().map(|m| serde_json::json!({
-                "name": m.name,
-                "priority": m.priority,
-                "action": m.action,
-                "message": m.message,
-            })),
-        });
-        println!("{}", serde_json::to_string_pretty(&out)?);
+        let mut val = serde_json::to_value(&result)?;
+        if let Some(obj) = val.as_object_mut() {
+            obj.insert(
+                "summary".to_string(),
+                serde_json::Value::String(result.summary_line()),
+            );
+        }
+        println!("{}", serde_json::to_string_pretty(&val)?);
         return Ok(());
     }
 
@@ -558,49 +489,7 @@ pub async fn run_check(id: &str, verbose: bool, json: bool) -> anyhow::Result<()
 mod tests {
     use super::*;
     use forgeplan_core::fpf::core::model::ActionType;
-    use forgeplan_core::fpf::ext::rules::{Condition, NumericExpr, Rule, ValueMatch};
-
-    #[test]
-    fn summarize_empty_condition() {
-        let c = Condition::default();
-        assert_eq!(summarize_condition(&c), "(always matches)");
-    }
-
-    #[test]
-    fn summarize_flat_condition_joined_with_and() {
-        let c = Condition {
-            kind: Some(ValueMatch::Single("prd".into())),
-            status: Some(ValueMatch::Single("active".into())),
-            r_eff: Some(NumericExpr::Lt(0.5)),
-            ..Default::default()
-        };
-        let s = summarize_condition(&c);
-        assert!(s.contains("kind=prd"));
-        assert!(s.contains("status=active"));
-        assert!(s.contains("r_eff<0.5"));
-        assert!(s.contains(" AND "));
-    }
-
-    #[test]
-    fn summarize_multi_value_match() {
-        let c = Condition {
-            status: Some(ValueMatch::Multiple(vec!["draft".into(), "stale".into()])),
-            ..Default::default()
-        };
-        assert_eq!(summarize_condition(&c), "status=[draft|stale]");
-    }
-
-    #[test]
-    fn summarize_truncates_long_output() {
-        let links: Vec<String> = (0..60).map(|i| format!("link{i}")).collect();
-        let c = Condition {
-            links_missing: Some(links),
-            ..Default::default()
-        };
-        let s = summarize_condition(&c);
-        assert!(s.chars().count() <= 120);
-        assert!(s.ends_with('…'));
-    }
+    use forgeplan_core::fpf::ext::rules::{Condition, Rule};
 
     #[test]
     fn style_action_returns_nonempty_for_known_actions() {
@@ -620,20 +509,6 @@ mod tests {
         let t = truncate("abcdefghijklmn", 5);
         assert_eq!(t.chars().count(), 5);
         assert!(t.ends_with('…'));
-    }
-
-    #[test]
-    fn summarize_uses_all_numeric_operators() {
-        let c = Condition {
-            r_eff: Some(NumericExpr::Ge(0.7)),
-            overall: Some(NumericExpr::Range(0.1, 0.5)),
-            link_count: Some(NumericExpr::Eq(0.0)),
-            ..Default::default()
-        };
-        let s = summarize_condition(&c);
-        assert!(s.contains("r_eff>=0.7"));
-        assert!(s.contains("overall=0.1..0.5"));
-        assert!(s.contains("link_count==0"));
     }
 
     // Smoke: a Rule with ActionType serializes via Display as expected

--- a/crates/forgeplan-cli/src/commands/fpf.rs
+++ b/crates/forgeplan-cli/src/commands/fpf.rs
@@ -278,6 +278,7 @@ pub async fn run_rules(flat: bool, json: bool) -> anyhow::Result<()> {
                     "priority": r.priority,
                     "action": r.action.to_string(),
                     "condition": serde_json::to_value(&r.condition).unwrap_or(serde_json::Value::Null),
+                    "condition_summary": r.condition.summarize(),
                     "message": r.message,
                 })
             })
@@ -348,11 +349,13 @@ pub async fn run_rules(flat: bool, json: bool) -> anyhow::Result<()> {
         let branch = if is_last_group { "└─" } else { "├─" };
         let vbar = if is_last_group { "   " } else { "│  " };
         println!();
+        let plural = if in_group.len() == 1 { "rule" } else { "rules" };
         println!(
-            "  {} {} ({} rules) — {}",
+            "  {} {} ({} {}) — {}",
             branch,
             style_action(action),
             in_group.len(),
+            plural,
             style(descr).dim()
         );
         let last_idx = in_group.len().saturating_sub(1);
@@ -410,14 +413,14 @@ pub async fn run_check(id: &str, verbose: bool, json: bool) -> anyhow::Result<()
                 &format!("Artifact '{id}' not found"),
                 "forgeplan list --kind prd",
             );
-            return Err(anyhow::anyhow!("artifact not found"));
+            std::process::exit(1);
         }
         Err(_) => {
             ui::error_hint(
                 &format!("Failed to check artifact '{id}'"),
                 "forgeplan health",
             );
-            return Err(anyhow::anyhow!("check failed"));
+            std::process::exit(1);
         }
     };
 

--- a/crates/forgeplan-cli/src/commands/fpf.rs
+++ b/crates/forgeplan-cli/src/commands/fpf.rs
@@ -1,10 +1,14 @@
 use std::env;
 use std::path::PathBuf;
 
+use console::style;
 use forgeplan_core::db::store::{FpfChunk, LanceStore};
 use forgeplan_core::fpf;
+use forgeplan_core::fpf::ext::rules::{Condition, NumericExpr, Rule, ValueMatch};
 use forgeplan_core::fpf::knowledge;
 use forgeplan_core::workspace;
+
+use crate::ui;
 
 /// FPF Dashboard (original command, now `forgeplan fpf dashboard`)
 pub async fn run_dashboard() -> anyhow::Result<()> {
@@ -236,4 +240,412 @@ pub async fn run_list() -> anyhow::Result<()> {
     println!();
     println!("  {} sections total", sections.len());
     Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────
+// PRD-041 FR-001: `forgeplan fpf rules`
+// ──────────────────────────────────────────────────────────────────
+
+/// Render a single `Condition` as a human-readable "k=v AND k>0.5" string.
+///
+/// Condition is a flat implicit-AND struct; every Some(...) field becomes one
+/// "key op value" clause joined with " AND ". Truncates to 120 chars with "…".
+pub(crate) fn summarize_condition(cond: &Condition) -> String {
+    if cond.is_empty() {
+        return "(always matches)".to_string();
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+
+    if let Some(v) = &cond.kind {
+        parts.push(format!("kind={}", format_value_match(v)));
+    }
+    if let Some(v) = &cond.status {
+        parts.push(format!("status={}", format_value_match(v)));
+    }
+    if let Some(v) = &cond.depth {
+        parts.push(format!("depth={}", format_value_match(v)));
+    }
+    if let Some(n) = &cond.r_eff {
+        parts.push(format!("r_eff{}", format_numeric(n)));
+    }
+    if let Some(n) = &cond.overall {
+        parts.push(format!("overall{}", format_numeric(n)));
+    }
+    if let Some(n) = &cond.link_count {
+        parts.push(format!("link_count{}", format_numeric(n)));
+    }
+    if let Some(b) = cond.is_stale {
+        parts.push(format!("is_stale={b}"));
+    }
+    if let Some(links) = &cond.links_missing {
+        parts.push(format!("links_missing={}", links.join(",")));
+    }
+    if let Some(n) = &cond.days_until_expiry {
+        parts.push(format!("days_until_expiry{}", format_numeric(n)));
+    }
+
+    let mut joined = parts.join(" AND ");
+    if joined.chars().count() > 120 {
+        joined = joined.chars().take(119).collect::<String>();
+        joined.push('…');
+    }
+    joined
+}
+
+fn format_value_match(v: &ValueMatch) -> String {
+    match v {
+        ValueMatch::Single(s) => s.clone(),
+        ValueMatch::Multiple(list) => format!("[{}]", list.join("|")),
+    }
+}
+
+fn format_numeric(n: &NumericExpr) -> String {
+    match n {
+        NumericExpr::Lt(v) => format!("<{v}"),
+        NumericExpr::Le(v) => format!("<={v}"),
+        NumericExpr::Gt(v) => format!(">{v}"),
+        NumericExpr::Ge(v) => format!(">={v}"),
+        NumericExpr::Eq(v) => format!("=={v}"),
+        NumericExpr::Range(lo, hi) => format!("={lo}..{hi}"),
+    }
+}
+
+fn style_action(action: &str) -> String {
+    match action {
+        "EXPLORE" => style(action).cyan().bold().to_string(),
+        "INVESTIGATE" => style(action).yellow().bold().to_string(),
+        "EXPLOIT" => style(action).green().bold().to_string(),
+        _ => action.to_string(),
+    }
+}
+
+/// `forgeplan fpf rules [--flat] [--json]`
+pub async fn run_rules(flat: bool, json: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let config = workspace::load_config(&ws).map_err(|e| anyhow::anyhow!("Config error: {e}"))?;
+    let fpf_config = config.fpf.as_ref();
+
+    let (rules, source) = fpf::active_rules(fpf_config);
+    let source_label = match source {
+        fpf::RuleSource::Config => "Config",
+        fpf::RuleSource::Default => "Default",
+    };
+
+    if json {
+        let dump: Vec<serde_json::Value> = rules
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name": r.name,
+                    "priority": r.priority,
+                    "action": r.action.to_string(),
+                    "condition": serde_json::to_value(&r.condition).unwrap_or(serde_json::Value::Null),
+                    "message": r.message,
+                })
+            })
+            .collect();
+        let out = serde_json::json!({
+            "source": source_label,
+            "count": rules.len(),
+            "rules": dump,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    let mut sorted: Vec<&Rule> = rules.iter().collect();
+    sorted.sort_by_key(|r| r.priority);
+
+    if flat {
+        ui::header(
+            "FPF Rules",
+            &format!("{} active (source: {source_label})", sorted.len()),
+        );
+        println!(
+            "  {:<4}  {:<28}  {:<13}  {}",
+            style("prio").bold(),
+            style("name").bold(),
+            style("action").bold(),
+            style("condition").bold()
+        );
+        println!("  {}", style("-".repeat(90)).dim());
+        for r in &sorted {
+            let action = r.action.to_string();
+            println!(
+                "  [{}]   {:<28}  {:<13}  {}",
+                r.priority,
+                truncate(&r.name, 28),
+                style_action(&action),
+                summarize_condition(&r.condition),
+            );
+        }
+        println!();
+        return Ok(());
+    }
+
+    // Tree view — group by action
+    ui::header(
+        "FPF Rules",
+        &format!("{} active (source: {source_label})", sorted.len()),
+    );
+    println!(
+        "  {}",
+        style("Evaluation order: priority ascending — first match wins").dim()
+    );
+
+    let groups: [(&str, &str, bool); 3] = [
+        ("EXPLORE", "когда исследовать варианты", false),
+        ("INVESTIGATE", "когда собрать больше данных", false),
+        ("EXPLOIT", "когда действовать решительно", true),
+    ];
+
+    for (action, descr, is_last_group) in groups {
+        let in_group: Vec<&&Rule> = sorted
+            .iter()
+            .filter(|r| r.action.to_string() == action)
+            .collect();
+        if in_group.is_empty() {
+            continue;
+        }
+        let branch = if is_last_group { "└─" } else { "├─" };
+        let vbar = if is_last_group { "   " } else { "│  " };
+        println!();
+        println!(
+            "  {} {} ({} rules) — {}",
+            branch,
+            style_action(action),
+            in_group.len(),
+            style(descr).dim()
+        );
+        let last_idx = in_group.len().saturating_sub(1);
+        for (i, rule) in in_group.iter().enumerate() {
+            let rule_branch = if i == last_idx { "└─" } else { "├─" };
+            let rule_vbar = if i == last_idx { "   " } else { "│  " };
+            println!(
+                "  {}{} [{}] {}",
+                vbar,
+                rule_branch,
+                rule.priority,
+                style(&rule.name).bold()
+            );
+            println!(
+                "  {}{}     {}",
+                vbar,
+                rule_vbar,
+                style(summarize_condition(&rule.condition)).dim()
+            );
+            if let Some(msg) = &rule.message {
+                println!("  {}{}     {}", vbar, rule_vbar, style(msg).italic().dim());
+            }
+        }
+    }
+    println!();
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let t: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{t}…")
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────
+// PRD-041 FR-002: `forgeplan fpf check <id>`
+// ──────────────────────────────────────────────────────────────────
+
+/// `forgeplan fpf check <id> [--verbose] [--json]`
+pub async fn run_check(id: &str, verbose: bool, json: bool) -> anyhow::Result<()> {
+    let cwd = env::current_dir()?;
+    let ws = workspace::find_workspace(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("No .forgeplan/ found. Run `forgeplan init` first."))?;
+    let store = LanceStore::open(&ws).await?;
+    let config = workspace::load_config(&ws).map_err(|e| anyhow::anyhow!("Config error: {e}"))?;
+    let fpf_config = config.fpf.as_ref();
+
+    let result = match fpf::check_artifact_against_rules(&store, id, fpf_config).await {
+        Ok(r) => r,
+        Err(e) => {
+            ui::error_hint(
+                &format!("Artifact '{id}' not found: {e}"),
+                "forgeplan list --kind prd",
+            );
+            return Err(anyhow::anyhow!("artifact not found"));
+        }
+    };
+
+    if json {
+        let out = serde_json::json!({
+            "artifact_id": result.artifact_id,
+            "artifact_kind": result.artifact_kind,
+            "artifact_status": result.artifact_status,
+            "matched": result.matched.iter().map(|m| serde_json::json!({
+                "name": m.name,
+                "priority": m.priority,
+                "action": m.action,
+                "message": m.message,
+            })).collect::<Vec<_>>(),
+            "unmatched": result.unmatched,
+            "winning": result.winning.as_ref().map(|m| serde_json::json!({
+                "name": m.name,
+                "priority": m.priority,
+                "action": m.action,
+                "message": m.message,
+            })),
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    ui::header(
+        &result.artifact_id,
+        &format!("[{}, {}]", result.artifact_kind, result.artifact_status),
+    );
+
+    if let Some(win) = &result.winning {
+        ui::section("Winning rule");
+        println!(
+            "  {} {} (priority {}) → {}",
+            style("★").yellow().bold(),
+            style(&win.name).bold(),
+            win.priority,
+            style_action(&win.action),
+        );
+        println!("    {}", style(&win.message).dim());
+
+        if result.matched.len() > 1 {
+            ui::section("Other matched rules");
+            for m in result.matched.iter().skip(1) {
+                println!(
+                    "  - {} (priority {}) → {}",
+                    m.name,
+                    m.priority,
+                    style_action(&m.action)
+                );
+            }
+        }
+    } else {
+        ui::section("Result");
+        println!("  No rules matched this artifact.");
+    }
+
+    if verbose && !result.unmatched.is_empty() {
+        ui::section("Unmatched rules");
+        for name in &result.unmatched {
+            println!("  - {name}");
+        }
+    } else if !result.unmatched.is_empty() {
+        println!();
+        println!(
+            "  {}",
+            style(format!(
+                "{} other rule(s) did not match.",
+                result.unmatched.len()
+            ))
+            .dim()
+        );
+    }
+    println!();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use forgeplan_core::fpf::core::model::ActionType;
+    use forgeplan_core::fpf::ext::rules::{Condition, NumericExpr, Rule, ValueMatch};
+
+    #[test]
+    fn summarize_empty_condition() {
+        let c = Condition::default();
+        assert_eq!(summarize_condition(&c), "(always matches)");
+    }
+
+    #[test]
+    fn summarize_flat_condition_joined_with_and() {
+        let c = Condition {
+            kind: Some(ValueMatch::Single("prd".into())),
+            status: Some(ValueMatch::Single("active".into())),
+            r_eff: Some(NumericExpr::Lt(0.5)),
+            ..Default::default()
+        };
+        let s = summarize_condition(&c);
+        assert!(s.contains("kind=prd"));
+        assert!(s.contains("status=active"));
+        assert!(s.contains("r_eff<0.5"));
+        assert!(s.contains(" AND "));
+    }
+
+    #[test]
+    fn summarize_multi_value_match() {
+        let c = Condition {
+            status: Some(ValueMatch::Multiple(vec!["draft".into(), "stale".into()])),
+            ..Default::default()
+        };
+        assert_eq!(summarize_condition(&c), "status=[draft|stale]");
+    }
+
+    #[test]
+    fn summarize_truncates_long_output() {
+        let links: Vec<String> = (0..60).map(|i| format!("link{i}")).collect();
+        let c = Condition {
+            links_missing: Some(links),
+            ..Default::default()
+        };
+        let s = summarize_condition(&c);
+        assert!(s.chars().count() <= 120);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn style_action_returns_nonempty_for_known_actions() {
+        assert!(!style_action("EXPLORE").is_empty());
+        assert!(!style_action("INVESTIGATE").is_empty());
+        assert!(!style_action("EXPLOIT").is_empty());
+        assert!(!style_action("UNKNOWN").is_empty());
+    }
+
+    #[test]
+    fn truncate_short_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_appends_ellipsis() {
+        let t = truncate("abcdefghijklmn", 5);
+        assert_eq!(t.chars().count(), 5);
+        assert!(t.ends_with('…'));
+    }
+
+    #[test]
+    fn summarize_uses_all_numeric_operators() {
+        let c = Condition {
+            r_eff: Some(NumericExpr::Ge(0.7)),
+            overall: Some(NumericExpr::Range(0.1, 0.5)),
+            link_count: Some(NumericExpr::Eq(0.0)),
+            ..Default::default()
+        };
+        let s = summarize_condition(&c);
+        assert!(s.contains("r_eff>=0.7"));
+        assert!(s.contains("overall=0.1..0.5"));
+        assert!(s.contains("link_count==0"));
+    }
+
+    // Smoke: a Rule with ActionType serializes via Display as expected
+    #[test]
+    fn rule_action_display_matches_expected() {
+        let r = Rule {
+            name: "t".into(),
+            priority: 1,
+            condition: Condition::default(),
+            action: ActionType::Explore,
+            message: None,
+        };
+        assert_eq!(r.action.to_string(), "EXPLORE");
+    }
 }

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -585,6 +585,26 @@ enum FpfCommands {
     List,
     /// Show FPF knowledge base status — source, ingested count, staleness
     Status,
+    /// List active FPF rules grouped by action (EXPLORE/INVESTIGATE/EXPLOIT)
+    Rules {
+        /// Flat priority-linear table instead of action-grouped tree
+        #[arg(long)]
+        flat: bool,
+        /// Output full rule dump as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Check which FPF rules match a given artifact
+    Check {
+        /// Artifact ID (e.g. PRD-041)
+        id: String,
+        /// Show unmatched rule names too
+        #[arg(long)]
+        verbose: bool,
+        /// Output full RuleCheckResult as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -780,6 +800,10 @@ async fn main() -> anyhow::Result<()> {
             FpfCommands::Section { id, summary } => commands::fpf::run_section(&id, summary).await,
             FpfCommands::List => commands::fpf::run_list().await,
             FpfCommands::Status => commands::fpf::run_status().await,
+            FpfCommands::Rules { flat, json } => commands::fpf::run_rules(flat, json).await,
+            FpfCommands::Check { id, verbose, json } => {
+                commands::fpf::run_check(&id, verbose, json).await
+            }
         },
         Commands::Gaps => commands::gaps::run().await,
         Commands::Fgr { id, json } => commands::fgr::run(id.as_deref(), json).await,

--- a/crates/forgeplan-cli/tests/fpf_rules_check.rs
+++ b/crates/forgeplan-cli/tests/fpf_rules_check.rs
@@ -64,12 +64,26 @@ fn cli_fpf_rules_flat_has_priorities() {
     let tmp = TempDir::new().unwrap();
     init_ws(&tmp);
 
-    forgeplan()
+    let output = forgeplan()
         .args(["fpf", "rules", "--flat"])
         .current_dir(tmp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("["));
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    // Flat mode must emit at least one concrete priority marker like [1] or [10].
+    let has_digit_bracket = (0..=20).any(|n| s.contains(&format!("[{n}]")));
+    assert!(
+        has_digit_bracket,
+        "flat output should contain [<digit>] priority marker"
+    );
+    // And no tree box-drawing chars.
+    assert!(
+        !s.contains("├─") && !s.contains("└─"),
+        "flat output must not contain tree branches"
+    );
 }
 
 #[test]
@@ -95,7 +109,21 @@ fn cli_fpf_check_existing_artifact() {
         .current_dir(tmp.path())
         .assert()
         .success()
-        .stdout(predicate::str::contains("PRD-001"));
+        .stdout(predicate::str::contains("Winning rule").or(predicate::str::contains("No rules")));
+}
+
+#[test]
+fn cli_fpf_check_verbose_shows_unmatched() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+    make_prd(&tmp);
+
+    forgeplan()
+        .args(["fpf", "check", "PRD-001", "--verbose"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unmatched"));
 }
 
 #[test]
@@ -116,13 +144,15 @@ fn cli_fpf_check_json_has_required_fields() {
     let j: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
     for key in [
         "artifact_id",
-        "artifact_kind",
-        "artifact_status",
+        "kind",
+        "status",
         "matched",
         "unmatched",
+        "summary",
     ] {
         assert!(j.get(key).is_some(), "missing key: {key}");
     }
     assert!(j["matched"].is_array());
     assert!(j["unmatched"].is_array());
+    assert!(j["summary"].is_string());
 }

--- a/crates/forgeplan-cli/tests/fpf_rules_check.rs
+++ b/crates/forgeplan-cli/tests/fpf_rules_check.rs
@@ -1,0 +1,128 @@
+//! PRD-041 Sprint 13.6: integration tests for `forgeplan fpf rules` and `forgeplan fpf check`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn forgeplan() -> Command {
+    Command::cargo_bin("forgeplan").unwrap()
+}
+
+fn init_ws(tmp: &TempDir) {
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+fn make_prd(tmp: &TempDir) {
+    forgeplan()
+        .args(["new", "prd", "Test PRD"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn cli_fpf_rules_shows_default_source() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+
+    forgeplan()
+        .args(["fpf", "rules"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Default"))
+        .stdout(predicate::str::contains("blind-spot"));
+}
+
+#[test]
+fn cli_fpf_rules_json_valid() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+
+    let output = forgeplan()
+        .args(["fpf", "rules", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let j: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+    assert!(j.get("rules").is_some(), "has rules key");
+    assert!(j["rules"].as_array().unwrap().len() > 0, "rules non-empty");
+    assert!(j.get("source").is_some());
+    assert!(j.get("count").is_some());
+}
+
+#[test]
+fn cli_fpf_rules_flat_has_priorities() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+
+    forgeplan()
+        .args(["fpf", "rules", "--flat"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("["));
+}
+
+#[test]
+fn cli_fpf_check_missing_artifact_errors() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+
+    forgeplan()
+        .args(["fpf", "check", "NOPE-999"])
+        .current_dir(tmp.path())
+        .assert()
+        .failure();
+}
+
+#[test]
+fn cli_fpf_check_existing_artifact() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+    make_prd(&tmp);
+
+    forgeplan()
+        .args(["fpf", "check", "PRD-001"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("PRD-001"));
+}
+
+#[test]
+fn cli_fpf_check_json_has_required_fields() {
+    let tmp = TempDir::new().unwrap();
+    init_ws(&tmp);
+    make_prd(&tmp);
+
+    let output = forgeplan()
+        .args(["fpf", "check", "PRD-001", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let j: serde_json::Value = serde_json::from_str(&s).expect("valid JSON");
+    for key in [
+        "artifact_id",
+        "artifact_kind",
+        "artifact_status",
+        "matched",
+        "unmatched",
+    ] {
+        assert!(j.get(key).is_some(), "missing key: {key}");
+    }
+    assert!(j["matched"].is_array());
+    assert!(j["unmatched"].is_array());
+}

--- a/crates/forgeplan-core/src/fpf/ext/rules.rs
+++ b/crates/forgeplan-core/src/fpf/ext/rules.rs
@@ -131,7 +131,7 @@ fn format_numeric(n: &NumericExpr) -> String {
         NumericExpr::Le(v) => format!("<={v}"),
         NumericExpr::Gt(v) => format!(">{v}"),
         NumericExpr::Ge(v) => format!(">={v}"),
-        NumericExpr::Eq(v) => format!("=={v}"),
+        NumericExpr::Eq(v) => format!("={v}"),
         NumericExpr::Range(lo, hi) => format!("={lo}..{hi}"),
     }
 }
@@ -568,7 +568,7 @@ mod tests {
         let s = c.summarize();
         assert!(s.contains("r_eff>=0.7"));
         assert!(s.contains("overall=0.1..0.5"));
-        assert!(s.contains("link_count==0"));
+        assert!(s.contains("link_count=0"));
     }
 
     fn make_data(id: &str, status: &str, r_eff: f64, link_count: usize) -> ArtifactData {

--- a/crates/forgeplan-core/src/fpf/ext/rules.rs
+++ b/crates/forgeplan-core/src/fpf/ext/rules.rs
@@ -47,6 +47,9 @@ pub struct Condition {
     pub days_until_expiry: Option<NumericExpr>,
 }
 
+/// Max length of a human-readable condition summary (chars).
+pub const CONDITION_SUMMARY_MAX: usize = 120;
+
 impl Condition {
     /// Returns true if this condition requires enrichment data (Tier 2).
     pub fn needs_enrichment(&self) -> bool {
@@ -64,6 +67,72 @@ impl Condition {
             && self.is_stale.is_none()
             && self.links_missing.is_none()
             && self.days_until_expiry.is_none()
+    }
+
+    /// Render as "kind=prd AND status=active AND r_eff<0.5" (≤ `CONDITION_SUMMARY_MAX` chars).
+    /// Empty conditions return "(always matches)".
+    pub fn summarize(&self) -> String {
+        if self.is_empty() {
+            return "(always matches)".to_string();
+        }
+
+        let mut parts: Vec<String> = Vec::new();
+
+        if let Some(v) = &self.kind {
+            parts.push(format!("kind={}", format_value_match(v)));
+        }
+        if let Some(v) = &self.status {
+            parts.push(format!("status={}", format_value_match(v)));
+        }
+        if let Some(v) = &self.depth {
+            parts.push(format!("depth={}", format_value_match(v)));
+        }
+        if let Some(n) = &self.r_eff {
+            parts.push(format!("r_eff{}", format_numeric(n)));
+        }
+        if let Some(n) = &self.overall {
+            parts.push(format!("overall{}", format_numeric(n)));
+        }
+        if let Some(n) = &self.link_count {
+            parts.push(format!("link_count{}", format_numeric(n)));
+        }
+        if let Some(b) = self.is_stale {
+            parts.push(format!("is_stale={b}"));
+        }
+        if let Some(links) = &self.links_missing {
+            parts.push(format!("links_missing={}", links.join(",")));
+        }
+        if let Some(n) = &self.days_until_expiry {
+            parts.push(format!("days_until_expiry{}", format_numeric(n)));
+        }
+
+        let mut joined = parts.join(" AND ");
+        if joined.chars().count() > CONDITION_SUMMARY_MAX {
+            joined = joined
+                .chars()
+                .take(CONDITION_SUMMARY_MAX - 1)
+                .collect::<String>();
+            joined.push('…');
+        }
+        joined
+    }
+}
+
+fn format_value_match(v: &ValueMatch) -> String {
+    match v {
+        ValueMatch::Single(s) => s.clone(),
+        ValueMatch::Multiple(list) => format!("[{}]", list.join("|")),
+    }
+}
+
+fn format_numeric(n: &NumericExpr) -> String {
+    match n {
+        NumericExpr::Lt(v) => format!("<{v}"),
+        NumericExpr::Le(v) => format!("<={v}"),
+        NumericExpr::Gt(v) => format!(">{v}"),
+        NumericExpr::Ge(v) => format!(">={v}"),
+        NumericExpr::Eq(v) => format!("=={v}"),
+        NumericExpr::Range(lo, hi) => format!("={lo}..{hi}"),
     }
 }
 
@@ -445,6 +514,62 @@ pub fn default_rules() -> Vec<Rule> {
 mod tests {
     use super::*;
     use crate::fpf::core::trust::TrustScore;
+
+    #[test]
+    fn summarize_empty_condition() {
+        let c = Condition::default();
+        assert_eq!(c.summarize(), "(always matches)");
+    }
+
+    #[test]
+    fn summarize_flat_condition_joined_with_and() {
+        let c = Condition {
+            kind: Some(ValueMatch::Single("prd".into())),
+            status: Some(ValueMatch::Single("active".into())),
+            r_eff: Some(NumericExpr::Lt(0.5)),
+            ..Default::default()
+        };
+        let s = c.summarize();
+        assert!(s.contains("kind=prd"));
+        assert!(s.contains("status=active"));
+        assert!(s.contains("r_eff<0.5"));
+        assert!(s.contains(" AND "));
+    }
+
+    #[test]
+    fn summarize_multi_value_match() {
+        let c = Condition {
+            status: Some(ValueMatch::Multiple(vec!["draft".into(), "stale".into()])),
+            ..Default::default()
+        };
+        assert_eq!(c.summarize(), "status=[draft|stale]");
+    }
+
+    #[test]
+    fn summarize_truncates_long_output() {
+        let links: Vec<String> = (0..60).map(|i| format!("link{i}")).collect();
+        let c = Condition {
+            links_missing: Some(links),
+            ..Default::default()
+        };
+        let s = c.summarize();
+        assert!(s.chars().count() <= CONDITION_SUMMARY_MAX);
+        assert!(s.ends_with('…'));
+    }
+
+    #[test]
+    fn summarize_uses_all_numeric_operators() {
+        let c = Condition {
+            r_eff: Some(NumericExpr::Ge(0.7)),
+            overall: Some(NumericExpr::Range(0.1, 0.5)),
+            link_count: Some(NumericExpr::Eq(0.0)),
+            ..Default::default()
+        };
+        let s = c.summarize();
+        assert!(s.contains("r_eff>=0.7"));
+        assert!(s.contains("overall=0.1..0.5"));
+        assert!(s.contains("link_count==0"));
+    }
 
     fn make_data(id: &str, status: &str, r_eff: f64, link_count: usize) -> ArtifactData {
         let trust = TrustScore {

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -9,7 +9,9 @@ pub mod explore;
 pub mod ext;
 pub mod knowledge;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
 
 use crate::artifact::types::{ArtifactKind, Mode};
 use crate::db::store::LanceStore;
@@ -211,38 +213,12 @@ fn build_rule_actions(
     config: &FpfConfig,
 ) -> Vec<Action> {
     // Pre-build lookup maps for O(1) access (audit fix: O(N²) → O(N+R))
-    let kind_map: std::collections::HashMap<&str, &str> = records
-        .iter()
-        .map(|r| (r.id.as_str(), r.kind.as_str()))
-        .collect();
+    let (kind_map, linked_kinds_map, link_count_map) = build_lookup_maps(records, relations);
 
     let fgr_map: std::collections::HashMap<&str, &fgr::FgrScore> = fgr_scores
         .iter()
         .map(|s| (s.artifact_id.as_str(), s))
         .collect();
-
-    // Build linked_kinds and link_count per artifact from relations
-    let mut linked_kinds_map: std::collections::HashMap<&str, Vec<String>> =
-        std::collections::HashMap::new();
-    let mut link_count_map: std::collections::HashMap<&str, usize> =
-        std::collections::HashMap::new();
-
-    for (src, tgt, _) in relations {
-        *link_count_map.entry(src.as_str()).or_default() += 1;
-        *link_count_map.entry(tgt.as_str()).or_default() += 1;
-        if let Some(&kind) = kind_map.get(tgt.as_str()) {
-            linked_kinds_map
-                .entry(src.as_str())
-                .or_default()
-                .push(kind.to_string());
-        }
-        if let Some(&kind) = kind_map.get(src.as_str()) {
-            linked_kinds_map
-                .entry(tgt.as_str())
-                .or_default()
-                .push(kind.to_string());
-        }
-    }
 
     // Pre-sort rules by priority (audit fix: sort once, not per-artifact)
     let mut sorted_rules: Vec<&rules::Rule> = active_rules.iter().collect();
@@ -258,62 +234,27 @@ fn build_rule_actions(
             continue;
         }
 
-        let link_count = link_count_map.get(record.id.as_str()).copied().unwrap_or(0);
-
-        let is_stale = record
-            .valid_until
-            .as_ref()
-            .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
-            .is_some_and(|dt| now > dt);
-
-        let fgr_score = fgr_map.get(record.id.as_str()).copied();
-        let formality = fgr_score.map(|s| s.formality).unwrap_or(0.0);
-        let granularity = fgr_score.map(|s| s.granularity).unwrap_or(0.0);
-
-        // Use stored r_eff directly — don't recompute from fake evidence (avoids circular scoring)
-        let reliability =
-            TrustScore::compute_reliability(record.r_eff_score, link_count, is_stale, config);
-        let overall = (formality * granularity * reliability).cbrt();
-
-        let trust = TrustScore {
-            r_eff: record.r_eff_score,
-            formality,
-            granularity,
-            reliability,
-            overall,
-            weakest_link: None,
+        // Resolve FGR or fall back to a zero score — enrich_one expects a real ref.
+        let zero_fgr = fgr::FgrScore {
+            artifact_id: record.id.clone(),
+            formality: 0.0,
+            granularity: 0.0,
+            reliability: 0.0,
         };
-
-        let data = ArtifactData {
-            id: record.id.clone(),
-            status: record.status.clone(),
-            kind: record.kind.clone(),
-            depth: record.depth.clone(),
-            evidence: vec![], // not needed — r_eff used directly from store
-            formality,
-            granularity,
-            link_count,
-            is_stale,
-            trust,
-        };
-
-        let linked_kinds = linked_kinds_map
+        let fgr_score = fgr_map
             .get(record.id.as_str())
-            .cloned()
-            .unwrap_or_default();
+            .copied()
+            .unwrap_or(&zero_fgr);
 
-        // days_until_expiry: negative = already expired (documented behavior)
-        let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
-            chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
-                .ok()
-                .map(|dt| (dt - now).num_days())
-        });
-
-        let enriched = rules::EnrichedData {
-            base: data,
-            linked_kinds,
-            days_until_expiry,
-        };
+        let enriched = enrich_one(
+            record,
+            &kind_map,
+            &linked_kinds_map,
+            &link_count_map,
+            fgr_score,
+            now,
+            config,
+        );
 
         // Use pre-sorted rules directly (no sort inside run_rules needed)
         for rule in &sorted_rules {
@@ -347,7 +288,8 @@ fn build_rule_actions(
 // ──────────────────────────────────────────────────────────────────
 
 /// Active rules source — whether they come from config.yaml or defaults.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RuleSource {
     /// User-defined in .forgeplan/config.yaml under `fpf.rules`
     Config,
@@ -367,10 +309,12 @@ pub fn active_rules(fpf_config: Option<&FpfConfig>) -> (Vec<rules::Rule>, RuleSo
 }
 
 /// Result of checking a single artifact against the rule engine.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuleCheckResult {
     pub artifact_id: String,
+    #[serde(rename = "kind")]
     pub artifact_kind: String,
+    #[serde(rename = "status")]
     pub artifact_status: String,
     /// All rules that matched (priority-sorted ascending = highest priority first).
     pub matched: Vec<MatchedRule>,
@@ -380,8 +324,23 @@ pub struct RuleCheckResult {
     pub winning: Option<MatchedRule>,
 }
 
+impl RuleCheckResult {
+    /// One-line human summary: "N matched, N unmatched, winning: <name-or-none>".
+    pub fn summary_line(&self) -> String {
+        format!(
+            "{} matched, {} unmatched, winning: {}",
+            self.matched.len(),
+            self.unmatched.len(),
+            self.winning
+                .as_ref()
+                .map(|m| m.name.as_str())
+                .unwrap_or("none"),
+        )
+    }
+}
+
 /// A matched rule with its action and message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MatchedRule {
     pub name: String,
     pub priority: u8,
@@ -391,26 +350,43 @@ pub struct MatchedRule {
 
 /// Check a single artifact against all active rules.
 ///
-/// Returns ALL matching rules (not just first) — used by `forgeplan fpf check`
-/// for full introspection. Also returns the "winning" rule (first in priority
-/// order) which matches the runtime behavior of `run_rules()`.
+/// Returns `Ok(None)` if the artifact does not exist, `Ok(Some(result))`
+/// with all matched/unmatched/winning rules for introspection, or `Err`
+/// on I/O / store errors.
+///
+/// NOTE: scans the full workspace (list_records + get_all_relations) to
+/// build enrichment maps — O(N) in artifact count. For large workspaces
+/// consider batching multiple check calls via `build_rule_actions`.
 pub async fn check_artifact_against_rules(
     store: &LanceStore,
     artifact_id: &str,
     fpf_config: Option<&FpfConfig>,
-) -> anyhow::Result<RuleCheckResult> {
-    let record = store
-        .get_record(artifact_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Artifact not found: {artifact_id}"))?;
+) -> anyhow::Result<Option<RuleCheckResult>> {
+    let record = match store.get_record(artifact_id).await? {
+        Some(r) => r,
+        None => return Ok(None),
+    };
 
     let all_relations = store.get_all_relations().await?;
     let records = store.list_records(None).await?;
 
-    // Reuse the existing enrichment logic from build_rule_actions.
+    // Build shared lookup maps once (same as build_rule_actions).
+    let (kind_map, linked_kinds_map, link_count_map) = build_lookup_maps(&records, &all_relations);
+
     let fgr_score = compute_fgr_for_record(&record, &all_relations, fpf_config);
-    let enriched =
-        enrich_record_for_rules(&record, &records, &all_relations, &fgr_score, fpf_config);
+    let cfg_default = FpfConfig::default();
+    let cfg = fpf_config.unwrap_or(&cfg_default);
+    let now = chrono::Utc::now().naive_utc();
+
+    let enriched = enrich_one(
+        &record,
+        &kind_map,
+        &linked_kinds_map,
+        &link_count_map,
+        &fgr_score,
+        now,
+        cfg,
+    );
 
     let (active, _source) = active_rules(fpf_config);
     let mut sorted: Vec<&rules::Rule> = active.iter().collect();
@@ -442,14 +418,117 @@ pub async fn check_artifact_against_rules(
 
     let winning = matched.first().cloned();
 
-    Ok(RuleCheckResult {
+    Ok(Some(RuleCheckResult {
         artifact_id: artifact_id.to_string(),
         artifact_kind: record.kind,
         artifact_status: record.status,
         matched,
         unmatched,
         winning,
-    })
+    }))
+}
+
+/// Build the three enrichment lookup maps shared by `build_rule_actions`
+/// and `check_artifact_against_rules`. O(N + R).
+#[allow(clippy::type_complexity)]
+fn build_lookup_maps<'a>(
+    records: &'a [crate::db::store::ArtifactRecord],
+    relations: &'a [(String, String, String)],
+) -> (
+    HashMap<&'a str, &'a str>,
+    HashMap<String, Vec<String>>,
+    HashMap<String, usize>,
+) {
+    let kind_map: HashMap<&str, &str> = records
+        .iter()
+        .map(|r| (r.id.as_str(), r.kind.as_str()))
+        .collect();
+
+    let mut linked_kinds_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut link_count_map: HashMap<String, usize> = HashMap::new();
+
+    for (src, tgt, _) in relations {
+        *link_count_map.entry(src.clone()).or_default() += 1;
+        *link_count_map.entry(tgt.clone()).or_default() += 1;
+        if let Some(&kind) = kind_map.get(tgt.as_str()) {
+            linked_kinds_map
+                .entry(src.clone())
+                .or_default()
+                .push(kind.to_string());
+        }
+        if let Some(&kind) = kind_map.get(src.as_str()) {
+            linked_kinds_map
+                .entry(tgt.clone())
+                .or_default()
+                .push(kind.to_string());
+        }
+    }
+
+    (kind_map, linked_kinds_map, link_count_map)
+}
+
+/// Build EnrichedData for ONE record using pre-built lookup maps.
+/// Single source of truth for enrichment — used by both bulk and single-record paths.
+#[allow(clippy::too_many_arguments)]
+fn enrich_one(
+    record: &crate::db::store::ArtifactRecord,
+    _kind_map: &HashMap<&str, &str>,
+    linked_kinds_map: &HashMap<String, Vec<String>>,
+    link_count_map: &HashMap<String, usize>,
+    fgr_score: &fgr::FgrScore,
+    now: chrono::NaiveDateTime,
+    config: &FpfConfig,
+) -> rules::EnrichedData {
+    let link_count = link_count_map.get(&record.id).copied().unwrap_or(0);
+
+    let is_stale = record
+        .valid_until
+        .as_ref()
+        .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
+        .is_some_and(|dt| now > dt);
+
+    let reliability =
+        TrustScore::compute_reliability(record.r_eff_score, link_count, is_stale, config);
+    let overall = (fgr_score.formality * fgr_score.granularity * reliability).cbrt();
+
+    let trust = TrustScore {
+        r_eff: record.r_eff_score,
+        formality: fgr_score.formality,
+        granularity: fgr_score.granularity,
+        reliability,
+        overall,
+        weakest_link: None,
+    };
+
+    let base = ArtifactData {
+        id: record.id.clone(),
+        status: record.status.clone(),
+        kind: record.kind.clone(),
+        depth: record.depth.clone(),
+        evidence: vec![],
+        formality: fgr_score.formality,
+        granularity: fgr_score.granularity,
+        link_count,
+        is_stale,
+        trust,
+    };
+
+    let linked_kinds = linked_kinds_map
+        .get(&record.id)
+        .cloned()
+        .unwrap_or_default();
+
+    let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
+        chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
+            .ok()
+            .map(|dt| (dt - now).num_days())
+    });
+
+    rules::EnrichedData {
+        base,
+        linked_kinds,
+        days_until_expiry,
+    }
 }
 
 /// Compute FGR score for a single record (helper for rule enrichment).
@@ -484,81 +563,7 @@ fn compute_fgr_for_record(
     )
 }
 
-/// Build EnrichedData for a single record (helper extracted from `build_rule_actions`).
-fn enrich_record_for_rules(
-    record: &crate::db::store::ArtifactRecord,
-    all_records: &[crate::db::store::ArtifactRecord],
-    all_relations: &[(String, String, String)],
-    fgr_score: &fgr::FgrScore,
-    fpf_config: Option<&FpfConfig>,
-) -> rules::EnrichedData {
-    let kind_map: std::collections::HashMap<&str, &str> = all_records
-        .iter()
-        .map(|r| (r.id.as_str(), r.kind.as_str()))
-        .collect();
-
-    let mut linked_kinds = Vec::new();
-    let mut link_count = 0usize;
-    for (src, tgt, _) in all_relations {
-        if src == &record.id {
-            link_count += 1;
-            if let Some(&kind) = kind_map.get(tgt.as_str()) {
-                linked_kinds.push(kind.to_string());
-            }
-        } else if tgt == &record.id {
-            link_count += 1;
-            if let Some(&kind) = kind_map.get(src.as_str()) {
-                linked_kinds.push(kind.to_string());
-            }
-        }
-    }
-
-    let now = chrono::Utc::now().naive_utc();
-    let is_stale = record
-        .valid_until
-        .as_ref()
-        .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
-        .is_some_and(|dt| now > dt);
-
-    let cfg = fpf_config.cloned().unwrap_or_default();
-    let reliability =
-        TrustScore::compute_reliability(record.r_eff_score, link_count, is_stale, &cfg);
-    let overall = (fgr_score.formality * fgr_score.granularity * reliability).cbrt();
-
-    let trust = TrustScore {
-        r_eff: record.r_eff_score,
-        formality: fgr_score.formality,
-        granularity: fgr_score.granularity,
-        reliability,
-        overall,
-        weakest_link: None,
-    };
-
-    let base = ArtifactData {
-        id: record.id.clone(),
-        status: record.status.clone(),
-        kind: record.kind.clone(),
-        depth: record.depth.clone(),
-        evidence: vec![],
-        formality: fgr_score.formality,
-        granularity: fgr_score.granularity,
-        link_count,
-        is_stale,
-        trust,
-    };
-
-    let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
-        chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
-            .ok()
-            .map(|dt| (dt - now).num_days())
-    });
-
-    rules::EnrichedData {
-        base,
-        linked_kinds,
-        days_until_expiry,
-    }
-}
+// `enrich_record_for_rules` replaced by shared `enrich_one` + `build_lookup_maps`.
 
 // ──────────────────────────────────────────────────────────────────
 // PRD-041 tests: active_rules + check_artifact_against_rules
@@ -618,17 +623,13 @@ mod prd041_tests {
     }
 
     #[tokio::test]
-    async fn check_returns_error_for_missing_id() {
+    async fn check_returns_none_for_missing_id() {
         let tmp = TempDir::new().unwrap();
         let store = make_store(&tmp).await;
-        let err = check_artifact_against_rules(&store, "DOES-NOT-EXIST", None)
+        let res = check_artifact_against_rules(&store, "DOES-NOT-EXIST", None)
             .await
-            .unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not found") || msg.contains("Artifact not found"),
-            "expected not-found error, got: {msg}"
-        );
+            .unwrap();
+        assert!(res.is_none(), "missing artifact must return Ok(None)");
     }
 
     async fn seed_draft_prd(store: &LanceStore, id: &str) {
@@ -656,7 +657,8 @@ mod prd041_tests {
         let (default_rules, _) = active_rules(None);
         let result = check_artifact_against_rules(&store, "PRD-001", None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("PRD-001 exists");
 
         assert_eq!(
             result.matched.len() + result.unmatched.len(),
@@ -676,7 +678,8 @@ mod prd041_tests {
 
         let result = check_artifact_against_rules(&store, "PRD-001", None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("PRD-001 exists");
 
         if let Some(winning) = &result.winning {
             let first = result.matched.first().expect("matched non-empty");
@@ -690,6 +693,120 @@ mod prd041_tests {
         }
     }
 
+    #[test]
+    fn active_rules_with_custom_config_returns_config_source() {
+        let mut cfg = FpfConfig::default();
+        let custom = custom_rule("custom-only", 5);
+        cfg.rules = vec![custom.clone()];
+        let (rules, source) = active_rules(Some(&cfg));
+        assert_eq!(source, RuleSource::Config);
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].name, "custom-only");
+    }
+
+    #[tokio::test]
+    async fn check_uses_custom_config_rules() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        seed_draft_prd(&store, "PRD-001").await;
+
+        let mut cfg = FpfConfig::default();
+        cfg.rules = vec![custom_rule("only-rule", 1)];
+
+        let result = check_artifact_against_rules(&store, "PRD-001", Some(&cfg))
+            .await
+            .unwrap()
+            .expect("PRD-001 exists");
+
+        assert_eq!(result.matched.len(), 1);
+        assert_eq!(result.matched[0].name, "only-rule");
+        let win = result.winning.expect("winning rule");
+        assert_eq!(win.name, "only-rule");
+    }
+
+    #[tokio::test]
+    async fn check_returns_empty_when_all_unmatched() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        seed_draft_prd(&store, "PRD-001").await;
+
+        // Custom rule that requires status="active" — won't match a draft.
+        let mut cfg = FpfConfig::default();
+        cfg.rules = vec![Rule {
+            name: "needs-active".to_string(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("active".into())),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority: 1,
+            message: None,
+        }];
+
+        let result = check_artifact_against_rules(&store, "PRD-001", Some(&cfg))
+            .await
+            .unwrap()
+            .expect("PRD-001 exists");
+
+        assert!(result.matched.is_empty());
+        assert!(result.winning.is_none());
+        assert_eq!(result.unmatched.len(), 1);
+    }
+
+    #[test]
+    fn rule_check_result_summary_line_with_winning() {
+        let r = RuleCheckResult {
+            artifact_id: "PRD-001".into(),
+            artifact_kind: "prd".into(),
+            artifact_status: "draft".into(),
+            matched: vec![MatchedRule {
+                name: "rule-a".into(),
+                priority: 1,
+                action: "EXPLORE".into(),
+                message: "x".into(),
+            }],
+            unmatched: vec!["rule-b".into(), "rule-c".into()],
+            winning: Some(MatchedRule {
+                name: "rule-a".into(),
+                priority: 1,
+                action: "EXPLORE".into(),
+                message: "x".into(),
+            }),
+        };
+        assert_eq!(r.summary_line(), "1 matched, 2 unmatched, winning: rule-a");
+    }
+
+    #[test]
+    fn rule_check_result_summary_line_no_match() {
+        let r = RuleCheckResult {
+            artifact_id: "PRD-001".into(),
+            artifact_kind: "prd".into(),
+            artifact_status: "draft".into(),
+            matched: vec![],
+            unmatched: vec!["a".into()],
+            winning: None,
+        };
+        assert_eq!(r.summary_line(), "0 matched, 1 unmatched, winning: none");
+    }
+
+    #[test]
+    fn rule_check_result_serializes_canonical_kind_status() {
+        let r = RuleCheckResult {
+            artifact_id: "PRD-001".into(),
+            artifact_kind: "prd".into(),
+            artifact_status: "draft".into(),
+            matched: vec![],
+            unmatched: vec![],
+            winning: None,
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["artifact_id"], "PRD-001");
+        assert_eq!(v["kind"], "prd");
+        assert_eq!(v["status"], "draft");
+        assert!(v.get("artifact_kind").is_none());
+        assert!(v.get("artifact_status").is_none());
+    }
+
     #[tokio::test]
     async fn check_finds_winning_rule_in_priority_order() {
         // Draft PRD with r_eff = 0.0 should match `blind-spot` (priority 1).
@@ -699,7 +816,8 @@ mod prd041_tests {
 
         let result = check_artifact_against_rules(&store, "PRD-001", None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("PRD-001 exists");
 
         let winning = result.winning.expect("should have winning rule");
         assert_eq!(winning.name, "blind-spot");

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -341,3 +341,221 @@ fn build_rule_actions(
     actions.sort_by_key(|a| a.priority);
     actions
 }
+
+// ──────────────────────────────────────────────────────────────────
+// PRD-041 FR-001..004: FPF Rules surface (CLI + MCP)
+// ──────────────────────────────────────────────────────────────────
+
+/// Active rules source — whether they come from config.yaml or defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleSource {
+    /// User-defined in .forgeplan/config.yaml under `fpf.rules`
+    Config,
+    /// Built-in defaults from `ext::rules::default_rules()`
+    Default,
+}
+
+/// Return the active rules plus their source.
+///
+/// If the workspace config has a non-empty `fpf.rules`, those are returned
+/// with `RuleSource::Config`. Otherwise, built-in defaults with `RuleSource::Default`.
+pub fn active_rules(fpf_config: Option<&FpfConfig>) -> (Vec<rules::Rule>, RuleSource) {
+    match fpf_config {
+        Some(cfg) if !cfg.rules.is_empty() => (cfg.rules.clone(), RuleSource::Config),
+        _ => (rules::default_rules(), RuleSource::Default),
+    }
+}
+
+/// Result of checking a single artifact against the rule engine.
+#[derive(Debug, Clone)]
+pub struct RuleCheckResult {
+    pub artifact_id: String,
+    pub artifact_kind: String,
+    pub artifact_status: String,
+    /// All rules that matched (priority-sorted ascending = highest priority first).
+    pub matched: Vec<MatchedRule>,
+    /// Rules that did not match (for full introspection).
+    pub unmatched: Vec<String>,
+    /// Winning rule (first match in priority order), if any. Mirrors `run_rules()`.
+    pub winning: Option<MatchedRule>,
+}
+
+/// A matched rule with its action and message.
+#[derive(Debug, Clone)]
+pub struct MatchedRule {
+    pub name: String,
+    pub priority: u8,
+    pub action: String,
+    pub message: String,
+}
+
+/// Check a single artifact against all active rules.
+///
+/// Returns ALL matching rules (not just first) — used by `forgeplan fpf check`
+/// for full introspection. Also returns the "winning" rule (first in priority
+/// order) which matches the runtime behavior of `run_rules()`.
+pub async fn check_artifact_against_rules(
+    store: &LanceStore,
+    artifact_id: &str,
+    fpf_config: Option<&FpfConfig>,
+) -> anyhow::Result<RuleCheckResult> {
+    let record = store
+        .get_record(artifact_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Artifact not found: {artifact_id}"))?;
+
+    let all_relations = store.get_all_relations().await?;
+    let records = store.list_records(None).await?;
+
+    // Reuse the existing enrichment logic from build_rule_actions.
+    let fgr_score = compute_fgr_for_record(&record, &all_relations, fpf_config);
+    let enriched =
+        enrich_record_for_rules(&record, &records, &all_relations, &fgr_score, fpf_config);
+
+    let (active, _source) = active_rules(fpf_config);
+    let mut sorted: Vec<&rules::Rule> = active.iter().collect();
+    sorted.sort_by_key(|r| r.priority);
+
+    let mut matched = Vec::new();
+    let mut unmatched = Vec::new();
+
+    for rule in &sorted {
+        let hit = if rule.condition.needs_enrichment() {
+            rules::check_enriched(rule, &enriched)
+        } else {
+            rules::check_basic(rule, &enriched.base)
+        };
+        if hit {
+            matched.push(MatchedRule {
+                name: rule.name.clone(),
+                priority: rule.priority,
+                action: rule.action.to_string(),
+                message: rule
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| format!("Matched rule '{}'", rule.name)),
+            });
+        } else {
+            unmatched.push(rule.name.clone());
+        }
+    }
+
+    let winning = matched.first().cloned();
+
+    Ok(RuleCheckResult {
+        artifact_id: artifact_id.to_string(),
+        artifact_kind: record.kind,
+        artifact_status: record.status,
+        matched,
+        unmatched,
+        winning,
+    })
+}
+
+/// Compute FGR score for a single record (helper for rule enrichment).
+fn compute_fgr_for_record(
+    record: &crate::db::store::ArtifactRecord,
+    all_relations: &[(String, String, String)],
+    fpf_config: Option<&FpfConfig>,
+) -> fgr::FgrScore {
+    let kind = record.kind.parse().unwrap_or(ArtifactKind::Note);
+    let depth = record.depth.parse().unwrap_or(Mode::Standard);
+    let fm = record.frontmatter_map();
+    let link_count = all_relations
+        .iter()
+        .filter(|(src, tgt, _)| src == &record.id || tgt == &record.id)
+        .count();
+    let is_stale = record
+        .valid_until
+        .as_ref()
+        .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
+        .is_some_and(|dt| chrono::Utc::now().naive_utc() > dt);
+
+    fgr::compute(
+        &record.id,
+        &record.body,
+        &fm,
+        &kind,
+        &depth,
+        record.r_eff_score,
+        link_count,
+        is_stale,
+        fpf_config.map(|c| &c.weights),
+    )
+}
+
+/// Build EnrichedData for a single record (helper extracted from `build_rule_actions`).
+fn enrich_record_for_rules(
+    record: &crate::db::store::ArtifactRecord,
+    all_records: &[crate::db::store::ArtifactRecord],
+    all_relations: &[(String, String, String)],
+    fgr_score: &fgr::FgrScore,
+    fpf_config: Option<&FpfConfig>,
+) -> rules::EnrichedData {
+    let kind_map: std::collections::HashMap<&str, &str> = all_records
+        .iter()
+        .map(|r| (r.id.as_str(), r.kind.as_str()))
+        .collect();
+
+    let mut linked_kinds = Vec::new();
+    let mut link_count = 0usize;
+    for (src, tgt, _) in all_relations {
+        if src == &record.id {
+            link_count += 1;
+            if let Some(&kind) = kind_map.get(tgt.as_str()) {
+                linked_kinds.push(kind.to_string());
+            }
+        } else if tgt == &record.id {
+            link_count += 1;
+            if let Some(&kind) = kind_map.get(src.as_str()) {
+                linked_kinds.push(kind.to_string());
+            }
+        }
+    }
+
+    let now = chrono::Utc::now().naive_utc();
+    let is_stale = record
+        .valid_until
+        .as_ref()
+        .and_then(|v| chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S").ok())
+        .is_some_and(|dt| now > dt);
+
+    let cfg = fpf_config.cloned().unwrap_or_default();
+    let reliability =
+        TrustScore::compute_reliability(record.r_eff_score, link_count, is_stale, &cfg);
+    let overall = (fgr_score.formality * fgr_score.granularity * reliability).cbrt();
+
+    let trust = TrustScore {
+        r_eff: record.r_eff_score,
+        formality: fgr_score.formality,
+        granularity: fgr_score.granularity,
+        reliability,
+        overall,
+        weakest_link: None,
+    };
+
+    let base = ArtifactData {
+        id: record.id.clone(),
+        status: record.status.clone(),
+        kind: record.kind.clone(),
+        depth: record.depth.clone(),
+        evidence: vec![],
+        formality: fgr_score.formality,
+        granularity: fgr_score.granularity,
+        link_count,
+        is_stale,
+        trust,
+    };
+
+    let days_until_expiry = record.valid_until.as_ref().and_then(|v| {
+        chrono::NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S")
+            .ok()
+            .map(|dt| (dt - now).num_days())
+    });
+
+    rules::EnrichedData {
+        base,
+        linked_kinds,
+        days_until_expiry,
+    }
+}

--- a/crates/forgeplan-core/src/fpf/mod.rs
+++ b/crates/forgeplan-core/src/fpf/mod.rs
@@ -559,3 +559,151 @@ fn enrich_record_for_rules(
         days_until_expiry,
     }
 }
+
+// ──────────────────────────────────────────────────────────────────
+// PRD-041 tests: active_rules + check_artifact_against_rules
+// ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod prd041_tests {
+    use super::*;
+    use crate::db::store::{LanceStore, NewArtifact};
+    use crate::fpf::core::model::ActionType;
+    use crate::fpf::ext::rules::{Condition, Rule, ValueMatch};
+    use tempfile::TempDir;
+
+    async fn make_store(tmp: &TempDir) -> LanceStore {
+        let ws = tmp.path().join(".forgeplan");
+        LanceStore::init(&ws).await.unwrap()
+    }
+
+    fn custom_rule(name: &str, priority: u8) -> Rule {
+        Rule {
+            name: name.to_string(),
+            condition: Condition {
+                status: Some(ValueMatch::Single("draft".into())),
+                ..Default::default()
+            },
+            action: ActionType::Explore,
+            priority,
+            message: Some(format!("custom rule {name}")),
+        }
+    }
+
+    #[test]
+    fn active_rules_returns_default_when_config_none() {
+        let (rules, source) = active_rules(None);
+        assert_eq!(source, RuleSource::Default);
+        assert!(!rules.is_empty(), "default rules must be non-empty");
+    }
+
+    #[test]
+    fn active_rules_returns_default_when_empty() {
+        let cfg = FpfConfig::default();
+        assert!(cfg.rules.is_empty());
+        let (rules, source) = active_rules(Some(&cfg));
+        assert_eq!(source, RuleSource::Default);
+        assert!(!rules.is_empty());
+    }
+
+    #[test]
+    fn active_rules_returns_config_when_non_empty() {
+        let mut cfg = FpfConfig::default();
+        cfg.rules = vec![custom_rule("a", 10), custom_rule("b", 20)];
+        let (rules, source) = active_rules(Some(&cfg));
+        assert_eq!(source, RuleSource::Config);
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].name, "a");
+        assert_eq!(rules[1].name, "b");
+    }
+
+    #[tokio::test]
+    async fn check_returns_error_for_missing_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        let err = check_artifact_against_rules(&store, "DOES-NOT-EXIST", None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not found") || msg.contains("Artifact not found"),
+            "expected not-found error, got: {msg}"
+        );
+    }
+
+    async fn seed_draft_prd(store: &LanceStore, id: &str) {
+        let a = NewArtifact {
+            id: id.to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Test PRD".to_string(),
+            body: "## Problem\nx\n".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&a).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_returns_all_matched_plus_unmatched_equals_total() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        seed_draft_prd(&store, "PRD-001").await;
+
+        let (default_rules, _) = active_rules(None);
+        let result = check_artifact_against_rules(&store, "PRD-001", None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.matched.len() + result.unmatched.len(),
+            default_rules.len(),
+            "matched + unmatched must account for every rule"
+        );
+        assert_eq!(result.artifact_id, "PRD-001");
+        assert_eq!(result.artifact_kind, "prd");
+        assert_eq!(result.artifact_status, "draft");
+    }
+
+    #[tokio::test]
+    async fn check_winning_is_first_of_matched() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        seed_draft_prd(&store, "PRD-001").await;
+
+        let result = check_artifact_against_rules(&store, "PRD-001", None)
+            .await
+            .unwrap();
+
+        if let Some(winning) = &result.winning {
+            let first = result.matched.first().expect("matched non-empty");
+            assert_eq!(winning.name, first.name);
+            // priority-sorted ascending — winning priority <= any other matched
+            for m in result.matched.iter().skip(1) {
+                assert!(winning.priority <= m.priority);
+            }
+        } else {
+            assert!(result.matched.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn check_finds_winning_rule_in_priority_order() {
+        // Draft PRD with r_eff = 0.0 should match `blind-spot` (priority 1).
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        seed_draft_prd(&store, "PRD-001").await;
+
+        let result = check_artifact_against_rules(&store, "PRD-001", None)
+            .await
+            .unwrap();
+
+        let winning = result.winning.expect("should have winning rule");
+        assert_eq!(winning.name, "blind-spot");
+        assert_eq!(winning.priority, 1);
+        assert_eq!(winning.action, "EXPLORE");
+    }
+}

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -2477,6 +2477,17 @@ impl ForgeplanServer {
 
         let ws_config = self.load_workspace_config().await;
         let fpf_cfg = ws_config.as_ref().and_then(|c| c.fpf.as_ref());
+        // FIX 4: validate param lengths before doing any work.
+        if p.action.as_deref().map(|s| s.len()).unwrap_or(0) > 64 {
+            return Ok(err_result("action filter too long (max 64)"));
+        }
+        if p.name.as_deref().map(|s| s.len()).unwrap_or(0) > 128 {
+            return Ok(err_result("name filter too long (max 128)"));
+        }
+        if p.source.as_deref().map(|s| s.len()).unwrap_or(0) > 16 {
+            return Ok(err_result("source filter too long (max 16)"));
+        }
+
         let (rules, source) = fpf::active_rules(fpf_cfg);
 
         let source_str = match source {
@@ -2538,6 +2549,7 @@ impl ForgeplanServer {
                         "action": r.action.to_string(),
                         "condition": serde_json::to_value(&r.condition)
                             .unwrap_or(serde_json::Value::Null),
+                        "condition_summary": r.condition.summarize(),
                         "message": r.message,
                     })
                 }
@@ -2565,62 +2577,35 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // FIX 4: param length bound.
+        if p.id.len() > 128 {
+            return Ok(err_result("artifact id too long (max 128)"));
+        }
+
         let ws_config = self.load_workspace_config().await;
         let fpf_cfg = ws_config.as_ref().and_then(|c| c.fpf.as_ref());
 
         let result = match fpf::check_artifact_against_rules(&store, &p.id, fpf_cfg).await {
-            Ok(r) => r,
-            Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("Artifact not found") {
-                    return Ok(err_result(&format!("Artifact not found: {}", p.id)));
-                }
-                return Ok(err_result(&format!("Failed to check artifact: {msg}")));
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                return Ok(err_result(&format!("Artifact not found: {}", p.id)));
+            }
+            Err(_) => {
+                return Ok(err_result(&format!("Failed to check artifact: {}", p.id)));
             }
         };
 
-        let matched_json: Vec<serde_json::Value> = result
-            .matched
-            .iter()
-            .map(|m| {
-                serde_json::json!({
-                    "name": m.name,
-                    "priority": m.priority,
-                    "action": m.action,
-                    "message": m.message,
-                })
-            })
-            .collect();
-
-        let winning_json = result.winning.as_ref().map(|m| {
-            serde_json::json!({
-                "name": m.name,
-                "priority": m.priority,
-                "action": m.action,
-                "message": m.message,
-            })
-        });
-
-        let summary = format!(
-            "{} matched, {} unmatched, winning: {}",
-            result.matched.len(),
-            result.unmatched.len(),
-            result
-                .winning
-                .as_ref()
-                .map(|m| m.name.as_str())
-                .unwrap_or("none"),
-        );
-
-        Ok(json_result(&serde_json::json!({
-            "artifact_id": result.artifact_id,
-            "kind": result.artifact_kind,
-            "status": result.artifact_status,
-            "winning": winning_json,
-            "matched": matched_json,
-            "unmatched": result.unmatched,
-            "summary": summary,
-        })))
+        // Canonical JSON — serialize the core struct (kind/status already renamed
+        // via serde) and splice the summary line.
+        let summary = result.summary_line();
+        let mut val = match serde_json::to_value(&result) {
+            Ok(v) => v,
+            Err(e) => return Ok(err_result(&format!("serialize failed: {e}"))),
+        };
+        if let Some(obj) = val.as_object_mut() {
+            obj.insert("summary".to_string(), serde_json::Value::String(summary));
+        }
+        Ok(json_result(&val))
     }
 
     #[tool(
@@ -3266,5 +3251,47 @@ mod search_params_tests {
     #[test]
     fn test_default_search_limit() {
         assert_eq!(default_search_limit(), 20);
+    }
+}
+
+#[cfg(test)]
+mod fpf_param_validation_tests {
+    use super::*;
+
+    /// Helper: build FpfRulesParams from JSON.
+    fn rules_params(json: &str) -> FpfRulesParams {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn rules_params_accepts_short_filters() {
+        let p = rules_params(r#"{"action": "EXPLORE", "name": "blind-spot", "source": "config"}"#);
+        assert_eq!(p.action.as_deref(), Some("EXPLORE"));
+        assert_eq!(p.name.as_deref(), Some("blind-spot"));
+        assert_eq!(p.source.as_deref(), Some("config"));
+        // Bounds we enforce in handler
+        assert!(p.action.as_deref().unwrap().len() <= 64);
+        assert!(p.name.as_deref().unwrap().len() <= 128);
+        assert!(p.source.as_deref().unwrap().len() <= 16);
+    }
+
+    #[test]
+    fn rules_params_action_too_long_detected() {
+        let long = "X".repeat(65);
+        let p = rules_params(&format!(r#"{{"action": "{long}"}}"#));
+        assert!(p.action.as_deref().unwrap().len() > 64);
+    }
+
+    #[test]
+    fn check_params_id_too_long_detected() {
+        let id = "A".repeat(200);
+        let p: FpfCheckParams = serde_json::from_str(&format!(r#"{{"id": "{id}"}}"#)).unwrap();
+        assert!(p.id.len() > 128);
+    }
+
+    #[test]
+    fn check_params_normal_id_within_bounds() {
+        let p: FpfCheckParams = serde_json::from_str(r#"{"id": "PRD-001"}"#).unwrap();
+        assert!(p.id.len() <= 128);
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -376,6 +376,30 @@ struct FpfSectionParams {
     id: String,
 }
 
+// ── FPF Rules params (PRD-041 FR-003, FR-004) ────────────────
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct FpfRulesParams {
+    /// Filter by action: "EXPLORE", "INVESTIGATE", or "EXPLOIT". Omit for all.
+    #[serde(default)]
+    action: Option<String>,
+    /// Fetch single rule by name. Returns 1 rule or error if not found.
+    #[serde(default)]
+    name: Option<String>,
+    /// If true, return only {name, priority, action} without condition details.
+    #[serde(default)]
+    summary: Option<bool>,
+    /// Filter by source: "config" or "default". For debugging workspace state.
+    #[serde(default)]
+    source: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+struct FpfCheckParams {
+    /// Artifact ID to check (e.g. "PRD-041")
+    id: String,
+}
+
 // ── Discover params (PRD-035 FR-004..006) ────────────────────
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -2440,6 +2464,163 @@ impl ForgeplanServer {
                 .collect(),
             total: sections.len(),
         }))
+    }
+
+    #[tool(
+        description = "List active FPF rules from the workspace. By default returns all rules with full condition trees and messages. Parameters allow filtering: `action` (EXPLORE/INVESTIGATE/EXPLOIT) to show only rules for that action category; `name` to fetch a single rule by name; `summary: true` to return only name/priority/action without condition details (useful for quick overviews); `source` (config/default) for debugging which rule source is active. If workspace has user-defined rules in .forgeplan/config.yaml under fpf.rules, those take precedence; otherwise built-in defaults are returned."
+    )]
+    async fn forgeplan_fpf_rules(
+        &self,
+        Parameters(p): Parameters<FpfRulesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        use forgeplan_core::fpf;
+
+        let ws_config = self.load_workspace_config().await;
+        let fpf_cfg = ws_config.as_ref().and_then(|c| c.fpf.as_ref());
+        let (rules, source) = fpf::active_rules(fpf_cfg);
+
+        let source_str = match source {
+            fpf::RuleSource::Config => "config",
+            fpf::RuleSource::Default => "default",
+        };
+
+        // Filter by source if requested.
+        let mut filtered: Vec<&fpf::ext::rules::Rule> = if let Some(src) = p.source.as_deref() {
+            if !src.eq_ignore_ascii_case(source_str) {
+                Vec::new()
+            } else {
+                rules.iter().collect()
+            }
+        } else {
+            rules.iter().collect()
+        };
+
+        // Filter by name (exact match).
+        if let Some(name) = p.name.as_deref() {
+            let found: Vec<&fpf::ext::rules::Rule> = filtered
+                .iter()
+                .copied()
+                .filter(|r| r.name == name)
+                .collect();
+            if found.is_empty() {
+                let available: Vec<String> = rules.iter().map(|r| r.name.clone()).collect();
+                return Ok(json_result(&serde_json::json!({
+                    "error": "rule not found",
+                    "name": name,
+                    "available": available,
+                })));
+            }
+            filtered = found;
+        }
+
+        // Filter by action (case-insensitive).
+        if let Some(action) = p.action.as_deref() {
+            filtered.retain(|r| r.action.to_string().eq_ignore_ascii_case(action));
+        }
+
+        // Sort by priority ascending (highest-priority first at runtime).
+        filtered.sort_by_key(|r| r.priority);
+
+        let summary_only = p.summary.unwrap_or(false);
+        let rules_json: Vec<serde_json::Value> = filtered
+            .iter()
+            .map(|r| {
+                if summary_only {
+                    serde_json::json!({
+                        "name": r.name,
+                        "priority": r.priority,
+                        "action": r.action.to_string(),
+                    })
+                } else {
+                    serde_json::json!({
+                        "name": r.name,
+                        "priority": r.priority,
+                        "action": r.action.to_string(),
+                        "condition": serde_json::to_value(&r.condition)
+                            .unwrap_or(serde_json::Value::Null),
+                        "message": r.message,
+                    })
+                }
+            })
+            .collect();
+
+        Ok(json_result(&serde_json::json!({
+            "source": source_str,
+            "count": rules_json.len(),
+            "rules": rules_json,
+        })))
+    }
+
+    #[tool(
+        description = "Check which FPF rules match a given artifact, showing all matched rules, the winning rule (first in priority order, same as runtime), and rules that did not match. Use this to understand FPF engine behavior for a specific artifact before acting on it."
+    )]
+    async fn forgeplan_fpf_check(
+        &self,
+        Parameters(p): Parameters<FpfCheckParams>,
+    ) -> Result<CallToolResult, McpError> {
+        use forgeplan_core::fpf;
+
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let ws_config = self.load_workspace_config().await;
+        let fpf_cfg = ws_config.as_ref().and_then(|c| c.fpf.as_ref());
+
+        let result = match fpf::check_artifact_against_rules(&store, &p.id, fpf_cfg).await {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("Artifact not found") {
+                    return Ok(err_result(&format!("Artifact not found: {}", p.id)));
+                }
+                return Ok(err_result(&format!("Failed to check artifact: {msg}")));
+            }
+        };
+
+        let matched_json: Vec<serde_json::Value> = result
+            .matched
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "name": m.name,
+                    "priority": m.priority,
+                    "action": m.action,
+                    "message": m.message,
+                })
+            })
+            .collect();
+
+        let winning_json = result.winning.as_ref().map(|m| {
+            serde_json::json!({
+                "name": m.name,
+                "priority": m.priority,
+                "action": m.action,
+                "message": m.message,
+            })
+        });
+
+        let summary = format!(
+            "{} matched, {} unmatched, winning: {}",
+            result.matched.len(),
+            result.unmatched.len(),
+            result
+                .winning
+                .as_ref()
+                .map(|m| m.name.as_str())
+                .unwrap_or("none"),
+        );
+
+        Ok(json_result(&serde_json::json!({
+            "artifact_id": result.artifact_id,
+            "kind": result.artifact_kind,
+            "status": result.artifact_status,
+            "winning": winning_json,
+            "matched": matched_json,
+            "unmatched": result.unmatched,
+            "summary": summary,
+        })))
     }
 
     #[tool(

--- a/tests/e2e/sprint-13.6-regression.sh
+++ b/tests/e2e/sprint-13.6-regression.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Sprint 13.6 — PRD-041 FPF Rules surface — regression smoke for prior sprints + new commands.
+# Runs against the release binary at $REPO/target/release/forgeplan.
+#
+# Note: pipefail is intentionally OFF — `grep -q` may close the pipe early, causing
+# upstream forgeplan to receive SIGPIPE (exit 141), which would erroneously fail
+# the whole pipeline. We capture output to variables and grep separately.
+set -eu
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN="${REPO}/target/release/forgeplan"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "✗ Release binary not found at $BIN — run 'cargo build --release' first"
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+cd "$WORK"
+echo "Working dir: $WORK"
+echo
+
+assert_contains() {
+  local label="$1" haystack="$2" needle_re="$3"
+  if printf '%s' "$haystack" | grep -qE "$needle_re"; then
+    echo "✓ $label"
+  else
+    echo "✗ $label FAILED"
+    echo "    expected to match: $needle_re"
+    echo "    output (first 200 chars): ${haystack:0:200}"
+    exit 1
+  fi
+}
+
+"$BIN" init -y >/dev/null
+echo "✓ init"
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.1 — duplicate guard
+# ─────────────────────────────────────────────────────────────
+"$BIN" new prd "Regression Test 13.6" >/dev/null
+"$BIN" new prd "Regression Test 13.6" >/dev/null 2>&1 || true
+COUNT=$(ls .forgeplan/prds/ | wc -l | tr -d ' ')
+if [[ "$COUNT" == "1" ]]; then
+  echo "✓ 13.1 duplicate guard (only PRD-001 exists)"
+else
+  echo "✗ 13.1 duplicate guard FAILED (expected 1 PRD, got $COUNT)"
+  exit 1
+fi
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.2 — smart search
+# ─────────────────────────────────────────────────────────────
+OUT="$("$BIN" search "regression" --no-expand 2>&1)"
+assert_contains "13.2 smart search" "$OUT" "PRD-001"
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.3 — tags
+# ─────────────────────────────────────────────────────────────
+"$BIN" tag PRD-001 source=code >/dev/null
+OUT="$("$BIN" list --tag source=code 2>&1)"
+assert_contains "13.3 tags (key=value filter)" "$OUT" "PRD-001"
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.4 — discover subcommand present
+# ─────────────────────────────────────────────────────────────
+OUT="$("$BIN" discover --help 2>&1 || true)"
+assert_contains "13.4 discover subcommand present" "$OUT" "discover|Usage"
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.5 — score with evidence
+# ─────────────────────────────────────────────────────────────
+"$BIN" new evidence "Test Evidence" --allow-duplicate >/dev/null
+"$BIN" link EVID-001 PRD-001 --relation informs >/dev/null 2>&1 || true
+OUT="$("$BIN" score PRD-001 2>&1)"
+assert_contains "13.5 score with evidence" "$OUT" "R_eff|Confidence|Quality"
+
+# ─────────────────────────────────────────────────────────────
+# Sprint 13.6 — NEW: forgeplan fpf rules / check
+# ─────────────────────────────────────────────────────────────
+OUT="$("$BIN" fpf rules 2>&1)"
+assert_contains "13.6 fpf rules tree" "$OUT" "EXPLORE|INVESTIGATE|EXPLOIT"
+
+OUT="$("$BIN" fpf rules --flat 2>&1)"
+assert_contains "13.6 fpf rules --flat" "$OUT" "\["
+
+OUT="$("$BIN" fpf rules --json 2>&1)"
+if printf '%s' "$OUT" | python3 -c "import sys,json; j=json.load(sys.stdin); assert j['count']>0 and isinstance(j['rules'],list) and len(j['rules'])>0"; then
+  echo "✓ 13.6 fpf rules --json (count>0, rules array)"
+else
+  echo "✗ 13.6 fpf rules --json FAILED"
+  echo "$OUT" | head -20
+  exit 1
+fi
+
+OUT="$("$BIN" fpf check PRD-001 2>&1)"
+assert_contains "13.6 fpf check styled" "$OUT" "PRD-001"
+
+OUT="$("$BIN" fpf check PRD-001 --json 2>&1)"
+if printf '%s' "$OUT" | python3 -c "import sys,json; j=json.load(sys.stdin); assert 'matched' in j and 'unmatched' in j and 'artifact_id' in j"; then
+  echo "✓ 13.6 fpf check --json (artifact_id, matched, unmatched)"
+else
+  echo "✗ 13.6 fpf check --json FAILED"
+  echo "$OUT" | head -20
+  exit 1
+fi
+
+if "$BIN" fpf check NOPE-999 >/dev/null 2>&1; then
+  echo "✗ 13.6 fpf check missing artifact should fail but succeeded"
+  exit 1
+else
+  echo "✓ 13.6 fpf check missing artifact errors (non-zero exit)"
+fi
+
+echo
+echo "=== ALL REGRESSION + NEW CHECKS PASSED ==="


### PR DESCRIPTION
## Summary
Sprint 13.6 ships PRD-041 FPF Rules surface (RFC-001 Phase 3) — rule engine from Sprint 12 is now introspectable via 4 entry points:

- **FR-001** `forgeplan fpf rules [--flat] [--json]` — action-grouped tree (EXPLORE/INVESTIGATE/EXPLOIT) by default, flat table, or JSON
- **FR-002** `forgeplan fpf check <id> [--verbose] [--json]` — check which rules match a specific artifact, `★` winning highlighted
- **FR-003** MCP `forgeplan_fpf_rules` — 4 optional params (action/name/summary/source), default full dump with condition + condition_summary
- **FR-004** MCP `forgeplan_fpf_check` — canonical JSON shape identical to CLI `--json`

## Audit cycle (full /forge-cycle)

- 4 parallel auditors (Rust/Security/Architecture/Tests) → 0C / 2H / 13M / 20L
- fixer applied 7 fixes in one commit (76d5e7a): dedupe enrichment (H1), canonical JSON Serialize (H2), Condition::summarize() moved to core (M2), Option refactor killing error string-match (M3+M2), MCP param length bounds (Sec M2), test strengthening (Tests H gaps)
- re-auditor verified all HIGH findings resolved against actual code → **READY TO MERGE**
- team-lead manual UX polish (77b0c12): pluralization, `link_count==` → `=`, error dedup via `exit(1)`, `condition_summary` in CLI JSON for MCP parity

## Commits (7)
- `7056e14` core helpers (RuleSource, active_rules, RuleCheckResult, check_artifact_against_rules)
- `ff6babc` MCP tools (forgeplan_fpf_rules + forgeplan_fpf_check)
- `e819596` CLI commands (run_rules + run_check + enum wiring)
- `24369aa` unit + CLI integration + E2E regression tests
- `76d5e7a` audit fixes (dedupe + canonical JSON + Option + param bounds + test strengthening)
- `77b0c12` UX polish (pluralization + link_count + exit + condition_summary)
- `f64f515` closeout (EVID-063 + PRD-041 activate)

## Test plan
- [x] `cargo fmt -- --check` clean
- [x] `cargo check --workspace` 0 warnings, 0 errors
- [x] `cargo test --workspace` — 1075 passed, 0 failed, 1 ignored (+15 net new)
- [x] `cargo build --release` — 1m 56s, 42MB binary
- [x] `tests/e2e/sprint-13.6-regression.sh` — exit 0, 12/12 checks (regression on 13.1 dup guard, 13.2 search, 13.3 tags, 13.4 discover, 13.5 score + 13.6 new)
- [x] Manual UX verification on release binary: 7 commands × ★★★★★ output quality

## Quality

- **R_eff(PRD-041) = 1.00**, F-G-R overall **0.85 (A)**
- EVID-063 linked with `verdict: supports`, `congruence_level: 3`, `evidence_type: test`
- PRD-041 status: draft → active

## Deferred to backlog

- Arch M1: move PRD-041 core code to `fpf/ext/rules.rs` (organizational)
- Arch M3 / Sec M1: O(N) workspace scan — doc warning added; batching deferred
- Arch M4: RuleQuery helper type if third surface appears
- Tests T-H1 residual: full MCP handler integration harness (param validation at unit level as interim)
- Tests Medium: unicode truncate, priority tie-break, MCP filter combos

## Refs
- PRD-041 (active, R_eff=1.00)
- EPIC-003 v0.17.0
- RFC-001 Phase 3
- EVID-063 (Sprint 13.6 implementation evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)