### PR TITLE
chore(sync): main → dev after v0.17.1 hotfix tag

### DIFF
--- a/.forgeplan/evidence/EVID-066-sprint-v0-17-1-hotfix-prd-044-reindex-trim-orphans-1131-tests-dogfood-verified-clean.md
+++ b/.forgeplan/evidence/EVID-066-sprint-v0-17-1-hotfix-prd-044-reindex-trim-orphans-1131-tests-dogfood-verified-clean.md
@@ -1,0 +1,141 @@
+---
+depth: tactical
+id: EVID-066
+kind: evidence
+links:
+- target: PRD-044
+  relation: informs
+- target: PROB-028
+  relation: informs
+status: active
+title: Sprint v0.17.1 hotfix PRD-044 reindex trim orphans — 1131 tests, dogfood verified clean
+---
+
+# EVID-066: PRD-044 Implementation Evidence (v0.17.1)
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Summary
+
+Sprint v0.17.1 hotfix PRD-044 shipped. Reindex Phase 2 parse-kind bug
+fixed + new Phase 3 orphan relation trim added. Verified on dogfood
+workspace: 3 phantom NOTE-037/038/040 relations removed, `forgeplan
+tree` shows 0 phantom rows.
+
+## Commit
+
+`b6f478e` on `release/v0.17.1` branch.
+
+## FR mapping
+
+### FR-001: Parse-kind fix
+
+File: `crates/forgeplan-cli/src/commands/reindex.rs` lines 134-203.
+Previous code at lines 137-141 did `match record.kind.parse()
+{ Ok(k) => k, Err(_) => continue }` which skipped rows with corrupt
+or empty kind field. `extract_record` at `store.rs:1390` uses
+`unwrap_or_default()` so null kind becomes empty string, which fails
+`parse::<ArtifactKind>()`, which means continue, which means row
+stays forever.
+
+New code wraps the check in an OrphanReason enum:
+- `OrphanReason::CorruptKind` when parse fails → definitely orphan
+  (no valid kind means no valid directory)
+- `OrphanReason::MissingFile` when parse succeeds but file missing
+
+Both get deleted, with the reason printed in the log line so users
+can tell them apart.
+
+### FR-002: Improved trim output
+
+Reindex now prints:
+- `DEL ID — corrupt kind field, removed from DB`
+- `DEL ID — no .md file found, removed from DB`
+
+### FR-003: Phase 3 orphan relation trim (emerged during ADI)
+
+Key discovery during ADI: phantom rows in `forgeplan tree` were NOT
+in artifacts.lance but in relations.lance as dangling edges whose
+source no longer exists. `forgeplan graph` showed:
+```
+NOTE-037 -->|informs| RFC-001
+NOTE-038 -->|informs| PRD-034
+NOTE-040 -->|informs| RFC-001
+```
+
+Tree renderer walks relations graph and shows unresolved IDs as `?`
+phantom rows. Fix: new Phase 3 iterates `get_all_relations`, builds
+a surviving-IDs set from post-Phase-2 `list_records`, deletes any
+relation whose source or target is missing from the set. Prints
+reason: "source missing", "target missing", or "both missing".
+
+### FR-004: Version bump + CHANGELOG
+
+- `Cargo.toml` workspace: 0.17.0 → 0.17.1
+- `crates/forgeplan-cli/Cargo.toml` path deps: 0.17.0 → 0.17.1
+- `crates/forgeplan-mcp/Cargo.toml` path deps: 0.17.0 → 0.17.1
+- `CHANGELOG.md`: new v0.17.1 entry under Fixed with both PRD-044
+  and PRD-045 bugs
+
+## Tests
+
+1131 tests pass (was 1128 in v0.17.0, +3 from PRD-045). No new
+reindex-specific tests in this commit because the existing reindex
+test harness was not yet in place. Manual verification via dogfood
+instead:
+
+- Before fix: `forgeplan tree` on dogfood showed 3 phantoms
+  (NOTE-037, NOTE-038, NOTE-040)
+- After fix: `forgeplan reindex` output:
+  ```
+  DEL NOTE-037 --informs--> RFC-001 — orphan relation (source missing)
+  DEL NOTE-038 --informs--> PRD-034 — orphan relation (source missing)
+  DEL NOTE-040 --informs--> RFC-001 — orphan relation (source missing)
+  Reindex complete: 5 synced, 178 unchanged, 1 removed, 3 orphan relations, 0 errors.
+  ```
+- After fix: `forgeplan tree | grep '?'` returns nothing ✓
+
+## Quality gates
+
+- cargo fmt --check: clean
+- cargo check --workspace: 0 warnings
+- cargo clippy --workspace --all-targets -- -D warnings: clean
+- cargo test --workspace: 1131 pass, 0 fail
+- cargo build --release: success
+
+## Key lesson for NOTE-044
+
+**ADI must include reading existing code before specifying new features.**
+My initial PRD-044 spec (Option D, warn + --trim-orphans flag) was
+based on the assumption that reindex had no trim logic. Code
+investigation revealed:
+1. Reindex ALREADY has trim by default (Phase 2)
+2. The real bug is narrower (corrupt-kind skip)
+3. The REAL real bug is in a completely different place (orphan
+   relations, not orphan artifacts)
+
+If I had not done ADI and read the code, I would have written a new
+`trim_orphans` function that duplicates existing code AND missed the
+relation cascade bug entirely.
+
+## Deferred from PRD-044 scope
+
+`--show-orphans` flag (from original Option D) was not implemented.
+Reason: ADI revealed the real bugs are in parse-skip and relation
+cascade, not in absence of a helper command. The helper is nice-to-have,
+not need-to-have for closing PROB-028. Deferred to future enhancement
+if real users request it.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-044 | informs (this evidence supports PRD-044 FRs) |
+| PROB-028 | informs (this evidence closes PROB-028) |
+| NOTE-044 | informs (lesson added: ADI includes code investigation) |
+| EVID-067 | sibling (PRD-045 paired work) |
+

--- a/.forgeplan/evidence/EVID-067-sprint-v0-17-1-hotfix-prd-045-health-verdict-aggregator-3-new-tests-concrete-next-actions-on-dogfood.md
+++ b/.forgeplan/evidence/EVID-067-sprint-v0-17-1-hotfix-prd-045-health-verdict-aggregator-3-new-tests-concrete-next-actions-on-dogfood.md
@@ -1,0 +1,147 @@
+---
+depth: tactical
+id: EVID-067
+kind: evidence
+links:
+- target: PRD-045
+  relation: informs
+- target: PROB-029
+  relation: informs
+status: active
+title: Sprint v0.17.1 hotfix PRD-045 health verdict aggregator — 3 new tests, concrete next actions on dogfood
+---
+
+# EVID-067: PRD-045 Implementation Evidence (v0.17.1)
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Summary
+
+Sprint v0.17.1 hotfix PRD-045 shipped. `generate_next_actions` in
+`health/mod.rs` extended to read `possible_duplicates` and
+`active_stubs` signals. Compute order reshuffled so signals are
+available before the aggregator runs. Verdict no longer says
+"Project looks healthy" when stubs or duplicates are present.
+
+## Commit
+
+`b6f478e` on `release/v0.17.1` branch (shared with PRD-044 as
+paired hotfix commit).
+
+## FR mapping
+
+### FR-001: Aggregator reads stubs + duplicates
+
+File: `crates/forgeplan-core/src/health/mod.rs` lines 119-138.
+Before:
+```rust
+let next_actions = generate_next_actions(total, &by_status,
+    &blind_spots, stale_count, &orphans);
+let possible_duplicates = find_duplicate_pairs(...);  // AFTER
+let active_stubs = find_active_stubs(...);             // AFTER
+```
+
+After:
+```rust
+let possible_duplicates = find_duplicate_pairs(...);   // BEFORE
+let active_stubs = find_active_stubs(...);              // BEFORE
+let next_actions = generate_next_actions(total, &by_status,
+    &blind_spots, stale_count, &orphans,
+    &possible_duplicates, &active_stubs);
+```
+
+Signature extended with 2 parameters: `possible_duplicates:
+&[DuplicatePair]` and `active_stubs: &[ActiveStub]`.
+
+### FR-002: Three-level verdict — DEFERRED to v0.18
+
+Explicit Verdict enum not shipped in v0.17.1. The existing "next_actions
+is non-empty when warnings exist" signal is sufficient for v0.17.1
+goal (don't say "looks healthy" when it isn't). Making verdict a
+typed enum requires HealthReport shape change which would bump the
+MCP JSON contract — breaking for existing tools. Deferred to v0.18
+minor release where shape changes are acceptable.
+
+### FR-003: Next actions with concrete IDs
+
+Lines 314-336: when stubs present, action is
+`"Fill or supersede N active stub(s) — e.g. 'forgeplan supersede
+PRD-008 --by <NEW>' or 'forgeplan deprecate PRD-008 --reason
+\"abandoned\"'"` using the first stub's ID as the concrete example.
+Same pattern for duplicates with first pair's IDs.
+
+### FR-004: CHANGELOG entry
+
+`CHANGELOG.md` v0.17.1 Fixed section includes this bug with problem
+statement and fix description.
+
+## Tests
+
+3 new unit tests added in `health/mod.rs`:
+
+1. `next_actions_includes_stub_remediation_when_stubs_present`
+   — asserts stub ID appears in output and "looks healthy" does NOT
+2. `next_actions_includes_duplicate_remediation_when_dups_present`
+   — asserts duplicate pair IDs appear and "looks healthy" does NOT
+3. `next_actions_says_healthy_when_no_warnings`
+   — regression test: empty warnings should still show "healthy"
+
+Existing `next_actions_capped_at_three` test updated to pass empty
+vecs for the new parameters (backward-compat verification).
+
+Total tests: 1128 → 1131 (+3).
+
+## Dogfood verification
+
+Before fix:
+```
+⧗ Possible duplicates (5):
+  EVID-001 ↔ EVID-003 (100%) — "Dogfood lifecycle test"
+  ...
+
+⚠ Active stubs (8):
+  PRD-008 (prd) "CLI UX Redesign" — 6 markers
+  ...
+
+→ Next actions:
+  1. Project looks healthy. Continue implementation.
+
+Project looks healthy!
+```
+
+After fix:
+```
+⧗ Possible duplicates (5): ...
+⚠ Active stubs (8): ...
+
+→ Next actions:
+  1. Fill or supersede 8 active stub(s) — e.g. `forgeplan supersede PRD-008 --by <NEW>` or `forgeplan deprecate PRD-008 --reason "abandoned"`
+  2. Resolve 5 duplicate pair(s) — e.g. `forgeplan deprecate EVID-003 --reason "duplicate of EVID-001"`
+  3. Create evidence for 2 artifact(s) without proof
+```
+
+"Project looks healthy" message eliminated. User gets concrete
+remediation commands they can copy-paste.
+
+## Quality gates
+
+- cargo fmt --check: clean
+- cargo check --workspace: 0 warnings
+- cargo clippy --workspace --all-targets -- -D warnings: clean
+- cargo test --workspace: 1131 pass, 0 fail
+- Manual dogfood verification: verdict no longer contradicts warnings
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-045 | informs |
+| PROB-029 | informs (closed) |
+| PRD-043 | informs (Sprint 13.1 detection whose signals this aggregates) |
+| EVID-058 | informs (Sprint 13.1 original implementation) |
+| EVID-066 | sibling (PRD-044 paired work) |
+

--- a/.forgeplan/notes/NOTE-044-sprint-checklist-framework-reusable-quality-gate-for-every-sprint.md
+++ b/.forgeplan/notes/NOTE-044-sprint-checklist-framework-reusable-quality-gate-for-every-sprint.md
@@ -60,6 +60,13 @@ Use by copying relevant sections into sprint planning + reviewing at each phase.
 - [ ] If agent hits file outside ownership → STOP и SendMessage team-lead, **не work around**
 - [ ] Idle teammates shutdown immediately после completion, не висят hours
 - [ ] Commit messages соответствуют спеке (exact match на первую строку)
+- [ ] **Every new CLI flag / command / config option ships with ALL of these docs (no feature lands without):**
+  - clap `#[arg(help = "...")]` descriptive help text (shown in `--help`)
+  - clap `#[command(long_about = "...")]` if behavior is non-trivial
+  - `CHANGELOG.md` entry under the release's "Added" / "Changed" section
+  - `CLAUDE.md` status block / workflow section if it changes user flow
+  - `docs/methodology/FORGEPLAN-GUIDE.md` subsection if it's a user-facing command
+  - Red flag: a PR that adds a flag/command without touching clap help + CHANGELOG is incomplete — block merge
 
 ---
 

--- a/.forgeplan/notes/NOTE-046-dogfood-cleanup-5-duplicate-evid-pairs-from-early-dogfood-era-sprint-1-2-need-manual-deprecate.md
+++ b/.forgeplan/notes/NOTE-046-dogfood-cleanup-5-duplicate-evid-pairs-from-early-dogfood-era-sprint-1-2-need-manual-deprecate.md
@@ -1,0 +1,66 @@
+---
+depth: tactical
+id: NOTE-046
+kind: note
+status: active
+title: Dogfood cleanup — 5 duplicate EVID pairs from early dogfood era need manual deprecate
+---
+
+# NOTE-046: Dogfood cleanup — 5 duplicate EVID pairs
+
+Found during v0.17.0 final dogfood audit (2026-04-08) via `forgeplan health`.
+PRD-043 duplicate detection (Sprint 13.1) flagged 5 pairs of evidence
+artifacts at 100% similarity, originating from very early dogfood
+sprints (1-2) when evidence was created twice (test fixture + real ingest).
+
+**These are NOT a v0.17.0 regression** — they predate Sprint 13.1.
+PRD-043 catches them now but cannot retroactively deduplicate past data.
+
+## Pairs to clean up
+
+```
+EVID-001 ↔ EVID-003 (100%) — "Dogfood lifecycle test"
+EVID-002 ↔ EVID-004 (100%) — "Health Dashboard verified"
+EVID-005 ↔ EVID-007 (100%) — "Smart Routing v2 verified"
+EVID-006 ↔ EVID-008 (100%) — "FPF Engine verified"
+EVID-009 ↔ EVID-010 (100%) — "Journal and Validation v2 verified"
+```
+
+## Cleanup recipe
+
+For each pair, pick the **earlier** (lower-numbered) artifact as canonical
+and deprecate the later one with a `superseded-by` link:
+
+```bash
+forgeplan deprecate EVID-003 --reason "duplicate of EVID-001 — early dogfood double-create"
+forgeplan link EVID-003 EVID-001 --relation superseded_by
+# repeat for 002↔004, 005↔007, 006↔008, 009↔010
+```
+
+Then verify: `forgeplan health` should show "Possible duplicates: 0".
+
+## Why a NOTE not a PROB
+
+This is **dogfood cleanup**, not a product bug. PRD-043 detection is
+working correctly — it found real duplicates. The fix is data cleanup,
+not code change. No user is affected (they don't have Sprint 1-2 dogfood
+data).
+
+If during cleanup we find that `forgeplan deprecate` or `forgeplan link
+--relation superseded_by` doesn't work as expected, **that** would
+become a PROB. Otherwise this is a 5-minute manual pass.
+
+## Acceptance
+
+- All 5 pairs deprecated with explicit reason and superseded_by link
+- `forgeplan health` shows 0 duplicate pairs
+- Tree view doesn't repeat the same evidence on parent artifacts
+
+## Related
+
+| Artifact | Relation |
+|----------|----------|
+| PRD-043 | informs (duplicate detection that flagged these) |
+| EVID-058 | sibling (Sprint 13.1 implementation) |
+| EPIC-003 | context (found in v0.17.0 final audit) |
+| NOTE-047 | sibling (other dogfood cleanup task — false-active stubs) |

--- a/.forgeplan/notes/NOTE-047-dogfood-cleanup-8-false-active-prd-stubs-prd-008-017-activated-before-prd-043-stub-gate-need-supersede-or-fill.md
+++ b/.forgeplan/notes/NOTE-047-dogfood-cleanup-8-false-active-prd-stubs-prd-008-017-activated-before-prd-043-stub-gate-need-supersede-or-fill.md
@@ -1,0 +1,96 @@
+---
+depth: tactical
+id: NOTE-047
+kind: note
+status: active
+title: Dogfood cleanup — 8 false-active PRD stubs activated before PRD-043 stub gate
+---
+
+# NOTE-047: Dogfood cleanup — 8 false-active PRD stubs
+
+Found during v0.17.0 final dogfood audit (2026-04-08) via `forgeplan health`.
+Sprint 13.1 PRD-043 stub detection (Sprint 13.1) flagged 8 PRDs in
+ACTIVE status with 6 template markers each — meaning their bodies were
+**never actually filled**. They were activated before PRD-043's `activate`
+gate existed, so the gate didn't catch them.
+
+**These are NOT a v0.17.0 regression** — they predate Sprint 13.1.
+PRD-043 catches them now via `health` warning but cannot retroactively
+unblock them.
+
+## The 8 false-active stubs
+
+```
+PRD-008 CLI UX Redesign — consistent output, --json, error format     — 6 markers
+PRD-009 Data Safety — export/import                                    — 6 markers
+PRD-010 Agent Hooks                                                     — 6 markers
+PRD-011 Adversarial Validation                                          — 6 markers
+PRD-013 FPF Alignment v2 — recursive R_eff                              — 6 markers
+PRD-014 BMAD Validation v2 — 13-step quality gates                      — 6 markers
+PRD-015 OpenSpec DAG — topological sort, delta-specs                    — 6 markers
+PRD-017 Decision Contracts — invariants                                 — 6 markers
+```
+
+PRD-018 was a 9th stub in this batch — already cleaned up in Sprint 13.7
+by being superseded by PRD-042. The remaining 8 need similar treatment.
+
+## Triage
+
+For each PRD, decide:
+
+**Option A — Was the work shipped under a different artifact?**
+→ Supersede the stub by the artifact that actually shipped:
+```bash
+forgeplan supersede PRD-008 --by PRD-XXX --reason "stub shipped as PRD-XXX in Sprint X"
+```
+
+**Option B — Was the work shipped without a proper artifact?**
+→ Fill the body retroactively (backfill, similar to EVID-065 for PRD-039):
+- Read the actual code
+- Document what FRs are in production
+- Re-validate, re-score, re-activate
+
+**Option C — Was the work never started?**
+→ Deprecate the stub:
+```bash
+forgeplan deprecate PRD-008 --reason "never implemented, abandoned in dogfood era"
+```
+
+## Per-stub triage (initial guess, verify before acting)
+
+| PRD | Title | Likely action |
+|---|---|---|
+| PRD-008 | CLI UX Redesign | Option A — superseded by PROB-016 cleanup work + Sprint 13.6 fpf rules UX |
+| PRD-009 | Data Safety export/import | Option B — `forgeplan export`/`import` exist, code in commands/. Backfill EVID. |
+| PRD-010 | Agent Hooks | Option B — hook system shipped in v0.x, in `.claude/hooks/`. Backfill EVID. |
+| PRD-011 | Adversarial Validation | Option C — never implemented as separate feature, validation lives in PRD-005 + PRD-043 work |
+| PRD-013 | FPF Alignment v2 — recursive R_eff | Option B — recursive R_eff shipped in `scoring/reff.rs::r_eff_recursive`, backfill EVID |
+| PRD-014 | BMAD Validation v2 13-step | Option C — partial only, BMAD integration was research not implementation |
+| PRD-015 | OpenSpec DAG | Option C — never implemented, OpenSpec influences are in design only |
+| PRD-017 | Decision Contracts | Option C — invariants concept absorbed into PRD-005 depth-aware validation |
+
+## Acceptance
+
+- All 8 stubs either superseded, backfilled-and-re-evidenced, or deprecated
+- `forgeplan health` shows "Active stubs: 0"
+- For each, the chosen action documented in commit message + `forgeplan log`
+
+## Why a NOTE not a PROB
+
+Same reasoning as NOTE-046 — this is **data cleanup**, not a product bug.
+PRD-043 detection works correctly. The fix is per-artifact triage and
+manual lifecycle commands.
+
+If during cleanup we find that `supersede`/`deprecate`/`activate` after
+backfill don't work as expected, **that** would become a PROB.
+
+## Related
+
+| Artifact | Relation |
+|----------|----------|
+| PRD-043 | informs (stub detection that flagged these) |
+| PRD-018 | precedent (9th stub in same batch, already superseded by PRD-042 in Sprint 13.7) |
+| EVID-058 | sibling (Sprint 13.1 PRD-043 implementation) |
+| EVID-065 | precedent (backfill pattern used for PRD-039 in Sprint 13.7 final audit) |
+| NOTE-046 | sibling (other dogfood cleanup task — duplicate EVIDs) |
+| EPIC-003 | context (found in v0.17.0 final audit) |

--- a/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
@@ -1,0 +1,229 @@
+---
+depth: standard
+id: PRD-044
+kind: prd
+links:
+- target: PROB-028
+  relation: based_on
+- target: ADR-003
+  relation: informs
+status: draft
+title: Reindex trim orphans — delete LanceDB rows without .md backing file (v0.17.1 hotfix)
+---
+
+# PRD-044: Reindex trim orphans (v0.17.1 hotfix)
+
+## Progress
+
+```
+FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Detect phantom rows during reindex (read-only)
+FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Warn by default — print phantom list + recovery hints
+FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  --trim-orphans flag performs actual hard-delete
+FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  --show-orphans flag displays git history of each phantom
+FR-005   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update --help text, CLAUDE.md, docs/, CHANGELOG.md
+─────────────────────────────────────────────────
+TOTAL                               0/5  (  0%)
+```
+
+## Problem
+
+`forgeplan reindex` is currently one-way: it walks `.forgeplan/*/*.md`
+files and upserts them into LanceDB. It does NOT trim LanceDB rows
+whose `.md` file was deleted. Result: **phantom rows** accumulate
+whenever a user deletes an `.md` file externally (git pull, manual
+cleanup, `mv`).
+
+Observed in dogfood workspace (2026-04-08): NOTE-037 and NOTE-040
+show as `?` phantoms in `forgeplan tree` output. `forgeplan get
+NOTE-037` returns "not found" but the row exists in
+`.forgeplan/lance/artifacts.lance/` binary data.
+
+This is a passive violation of **ADR-003** (files = source of truth,
+LanceDB = derived index). The index should be fully reproducible
+from files; when the index has rows that files don't, the invariant
+is broken.
+
+## Goals
+
+| ID | Goal | Metric |
+|----|------|--------|
+| G-1 | reindex trims LanceDB rows that have no backing `.md` file | After `forgeplan reindex` on a workspace with deleted files, `tree` shows 0 phantom rows |
+| G-2 | Trim is observable — users see how many rows were removed | reindex output line: "Reindex complete: N synced, M unchanged, K trimmed, L errors" |
+| G-3 | Safe — doesn't delete rows when file is merely unreadable due to transient I/O | Errors during file stat → don't trim, log warning |
+| G-4 | Idempotent | Second reindex after successful trim shows "0 trimmed" |
+
+## Non-Goals
+
+- Real-time file watching (already exists as `forgeplan watch`, separate concern)
+- Soft-delete / recoverable trash for trimmed rows (if users wanted history, they should use git)
+- Trimming rows that reference artifacts with `status: deprecated` (deprecation preserves record)
+- Rebuilding relations table (separate concern — if source of a relation is trimmed, the relation should cascade, but that's FR-scope for a future PRD)
+
+## Target Users
+
+| Persona | Pain |
+|---|---|
+| Developer doing `git pull` that deletes artifacts from another branch | Phantom rows accumulate silently, pollute `tree`/`list` |
+| Team doing dogfood cleanup (delete old experimental artifacts) | `reindex` doesn't clean up, manual LanceDB surgery required |
+| AI agent using MCP `forgeplan_list` tool | Sees stale IDs that don't resolve — breaks workflow |
+
+## User Journeys
+
+### Journey 1: Developer deletes artifact via git
+1. Developer on branch A: `rm .forgeplan/notes/NOTE-037.md && git commit && git push`
+2. Developer on branch B: `git pull`  — their workspace now has LanceDB row for NOTE-037 but no file
+3. `forgeplan tree` — phantom NOTE-037 appears
+4. **NEW**: `forgeplan reindex` — prints "Reindex complete: 0 synced, 165 unchanged, 1 trimmed, 0 errors"
+5. `forgeplan tree` — clean, no phantom
+
+### Journey 2: Dogfood cleanup
+1. Maintainer: `rm .forgeplan/evidence/EVID-{003,004,007,008,010}.md`
+2. `forgeplan reindex` → 5 trimmed
+3. `forgeplan health` shows "Possible duplicates: 0" (the duplicates pairs resolved because one side of each pair was trimmed)
+
+## Functional Requirements
+
+| ID | Category | Priority | Requirement |
+|----|----------|----------|-------------|
+| FR-001 | Core | Must | [System] can detect LanceDB rows whose `id` has no corresponding `.md` file under the kind's directory. Read-only scan, no mutation. |
+| FR-002 | UX | Must | [User] sees a warning block in `reindex` output listing phantom IDs, with two hint lines: `forgeplan reindex --trim-orphans` (remove) and `forgeplan reindex --show-orphans` (inspect via git). Warning only — default `reindex` does NOT delete. |
+| FR-003 | Core | Must | [User] can pass `--trim-orphans` flag to `forgeplan reindex` which performs the actual hard-delete of phantom rows from LanceDB. Git history is the recovery mechanism (ADR-003 — files = source of truth, LanceDB = derived). |
+| FR-004 | UX | Must | [User] can pass `--show-orphans` flag to see git history of each phantom: `git log --all -- <path>` output per orphan, showing last commit SHA, date, author, and message. Helpful for deciding whether to restore or trim. |
+| FR-005 | Docs | Must | [Contributor] finds up-to-date documentation for the new flags: clap `#[arg(help=...)]` strings, CLAUDE.md command workflow section, `docs/methodology/FORGEPLAN-GUIDE.md` reindex subsection, `CHANGELOG.md` v0.17.1 entry. **No feature lands without help text + changelog.** |
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Performance | Trim pass adds O(N) complexity where N = rows in LanceDB; must not exceed 2× baseline reindex time on 1k-artifact workspace |
+| NFR-002 | Safety | Trim MUST check file existence per-row; a transient I/O error on file stat MUST skip that row (do not delete), not fail the whole reindex |
+| NFR-003 | Backward compat | Default behavior of `forgeplan reindex` must not cause data loss for users who did NOT intend to trim |
+
+## Design decision — RESOLVED: Option D
+
+**Decision date**: 2026-04-09
+**Decided by**: gogocat (project owner)
+
+### Chosen: Option D — Warn-only default + two helper flags
+
+Reindex by default **warns** about phantom rows but does not delete.
+Two opt-in flags handle removal and inspection:
+
+- `forgeplan reindex` (default) — detects phantoms, prints warning
+  block with list and recovery hints. No mutation.
+- `forgeplan reindex --trim-orphans` — performs hard-delete of
+  phantom rows from LanceDB.
+- `forgeplan reindex --show-orphans` — for each phantom, runs
+  `git log --all -- [path]` to show last commit, date, author,
+  message. Lets user review "what was in here" before trimming.
+
+### Why Option D (not A/B/C)
+
+User requested "warn, but also support soft-recovery" initially.
+Reason-mode analysis compared soft-delete (trash bucket in LanceDB)
+vs git history as the recovery mechanism and picked git for these
+reasons:
+
+1. **ADR-003 compliance** — files are source of truth, LanceDB is
+   derived. Adding a "trash" table makes LanceDB carry state that
+   isn't in files, breaking the invariant.
+2. **Zero new architecture** — git already stores history, retention,
+   restore, cross-developer sync. Soft-delete would duplicate all of
+   this inside LanceDB.
+3. **Scope fits hotfix** — Option D is 5 FRs, ~100 LOC total.
+   Soft-delete would be 5+ FRs + schema migration + retention policy
+   + restore command = a week+ of work, not a hotfix.
+4. **Better recovery story** — `git log -p` shows what *changed* in
+   the artifact over time, not just the last version. Richer history
+   than any internal trash.
+
+### How recovery works in Option D
+
+Scenario: User accidentally deleted `NOTE-037.md`, ran `reindex
+--trim-orphans`, now regrets it.
+
+```bash
+# 1. Find when NOTE-037 was deleted
+git log --all --diff-filter=D --summary -- .forgeplan/notes/NOTE-037*
+# → commit abc123f dropped NOTE-037-title.md
+
+# 2. Checkout the file from the commit just before deletion
+git show abc123f~1:.forgeplan/notes/NOTE-037-title.md \
+  > .forgeplan/notes/NOTE-037-title.md
+
+# 3. Reindex to add it back to LanceDB
+forgeplan reindex
+```
+
+The `--show-orphans` flag will print exactly these commands as part
+of its output, so users don't need to know git spelunking.
+
+### Operational safety
+
+- Default is WARN ONLY — no user will lose data by running `reindex`
+- `--trim-orphans` is a loud, explicit action (no short form, no
+  config default)
+- Warning includes both hint lines, so the `--show-orphans` path is
+  discoverable even without reading docs
+- `.forgeplan/lance/` is gitignored, so trim only affects local index
+  — pulling from git will never restore trimmed rows accidentally;
+  user must run reindex explicitly after pulling
+
+### Rejected alternatives
+
+- **Option A** (default-on trim) — would silently lose data in
+  `git stash` edge case, violates patch-release convention
+- **Option B** (default-off opt-in flag in v0.17.1, flip to on in
+  v0.18) — needed to create a follow-up PRD for the flip, user never
+  gets the fix unless they read release notes
+- **Option C** (warn-only, no helper) — pure warn is fine but lacks
+  the recovery UX. `--show-orphans` via git closes this gap cheaply.
+- **Soft delete (trash bucket)** — 5+ additional FRs, schema migration,
+  retention policy, restore command. Not a hotfix. Git already does this.
+
+## Acceptance Criteria
+
+- **FR-001**: `reindex` detects LanceDB rows whose ID has no `.md`
+  file in the expected kind directory. Read-only scan, no mutation.
+- **FR-002**: Default `reindex` prints a warning block listing phantom
+  IDs and two hint lines (`--trim-orphans` to remove, `--show-orphans`
+  to inspect via git). Exit code 0 — warning is informational.
+- **FR-003**: `reindex --trim-orphans` performs hard-delete of all
+  detected phantom rows. Output line includes trimmed count:
+  "Reindex complete: N synced, M unchanged, K trimmed, L errors".
+- **FR-004**: `reindex --show-orphans` runs `git log --all -- [file]`
+  per phantom, printing last commit SHA, date, author, and message.
+  Also prints the concrete recovery recipe from the "How recovery
+  works" section above, parameterized with the actual paths.
+- **FR-005**: Help text updated — clap `#[arg(help)]` strings for
+  both new flags, CHANGELOG.md v0.17.1 entry under "Added" section,
+  CLAUDE.md reindex workflow mention, `docs/methodology/FORGEPLAN-GUIDE.md`
+  reindex subsection updated.
+- **All existing reindex tests pass** unchanged.
+- **New test: detect phantom** — create artifact, delete its `.md`,
+  reindex without flags, assert warning block printed, row NOT deleted.
+- **New test: trim phantom** — same setup but reindex with
+  `--trim-orphans`, assert row removed and `forgeplan get` returns
+  not-found, second reindex trims 0 (idempotency).
+- **New test: show orphans** — same setup with `--show-orphans`,
+  assert output contains git commit SHA + recovery recipe.
+- **New test: I/O error resilience** — simulate stat failure on one
+  file, assert trim of OTHER legitimately-orphan rows proceeds
+  (graceful degradation).
+
+## Affected Files
+
+- `crates/forgeplan-core/src/db/store.rs` — add `trim_orphans()` method
+- `crates/forgeplan-cli/src/commands/reindex.rs` — wire flag + call trim
+- `crates/forgeplan-cli/src/main.rs` — add flag to ReindexCommand clap
+- `crates/forgeplan-core/src/db/store.rs` — tests module
+- `crates/forgeplan-cli/tests/reindex_test.rs` (NEW or extend existing)
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PROB-028 | based_on (this PRD closes PROB-028) |
+| ADR-003 | informs (files = source of truth, PRD restores this invariant) |
+| PROB-027 | sibling (other reindex bug — cannot rebuild from scratch) |
+| PRD-045 | sibling (health verdict fix, paired v0.17.1 hotfix work) |

--- a/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
@@ -7,7 +7,7 @@ links:
   relation: based_on
 - target: ADR-003
   relation: informs
-status: draft
+status: active
 title: Reindex trim orphans — delete LanceDB rows without .md backing file (v0.17.1 hotfix)
 ---
 
@@ -16,13 +16,25 @@ title: Reindex trim orphans — delete LanceDB rows without .md backing file (v0
 ## Progress
 
 ```
-FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Fix parse-kind bug: treat corrupt kind as orphan, not skip
-FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Improve trim output message (reason: corrupt-kind vs missing-file)
-FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Add --show-orphans flag: git log + recovery recipe per orphan
-FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update --help text, CLAUDE.md, CHANGELOG.md
+FR-001   ████████████████████████  1/1  Fix parse-kind bug: treat corrupt kind as orphan, not skip ✓ v0.17.1
+FR-002   ████████████████████████  1/1  Improve trim output (reason: corrupt-kind vs missing-file) ✓ v0.17.1
+FR-003   ████████████████████████  1/1  New Phase 3: trim orphan relations (discovered during ADI) ✓ v0.17.1
+FR-004   ████████████████████████  1/1  CHANGELOG + version bump 0.17.0 → 0.17.1                   ✓ v0.17.1
 ─────────────────────────────────────────────────
-TOTAL                               0/4  (  0%)
+TOTAL                               4/4  (100%) — v0.17.1 hotfix
+
+Deferred from this PRD:
+- --show-orphans flag (original Option D feature) — ADI revealed real
+  bugs are in parse-skip + relation cascade, not in absence of helper.
+  The helper is nice-to-have not need-to-have. Tracked in NOTE-045 as
+  future enhancement if real users request it.
 ```
+
+**v0.17.1 delivered (commit b6f478e):**
+- Fixed reindex Phase 2 parse-kind skip bug (4 LOC change)
+- Added reindex Phase 3: orphan relation trim with (source, target, both) reason reporting
+- Verified on dogfood: 3 phantom NOTE-037/038/040 relations cleaned up
+- See EVID-066 for implementation evidence.
 
 ## ADI revision note (2026-04-09)
 
@@ -273,3 +285,4 @@ of its output, so users don't need to know git spelunking.
 | ADR-003 | informs (files = source of truth, PRD restores this invariant) |
 | PROB-027 | sibling (other reindex bug — cannot rebuild from scratch) |
 | PRD-045 | sibling (health verdict fix, paired v0.17.1 hotfix work) |
+

--- a/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
@@ -16,14 +16,46 @@ title: Reindex trim orphans — delete LanceDB rows without .md backing file (v0
 ## Progress
 
 ```
-FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Detect phantom rows during reindex (read-only)
-FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Warn by default — print phantom list + recovery hints
-FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  --trim-orphans flag performs actual hard-delete
-FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  --show-orphans flag displays git history of each phantom
-FR-005   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update --help text, CLAUDE.md, docs/, CHANGELOG.md
+FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Fix parse-kind bug: treat corrupt kind as orphan, not skip
+FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Improve trim output message (reason: corrupt-kind vs missing-file)
+FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Add --show-orphans flag: git log + recovery recipe per orphan
+FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update --help text, CLAUDE.md, CHANGELOG.md
 ─────────────────────────────────────────────────
-TOTAL                               0/5  (  0%)
+TOTAL                               0/4  (  0%)
 ```
+
+## ADI revision note (2026-04-09)
+
+Initial PRD spec was Option D (warn by default, add --trim-orphans flag).
+ADI code investigation revealed the root cause is **different** from the
+initial hypothesis: reindex **already trims by default** in Phase 2
+(reindex.rs:134-175). The real bug is at lines 138-141:
+
+```rust
+for record in &all_records {
+    let kind: ArtifactKind = match record.kind.parse() {
+        Ok(k) => k,
+        Err(_) => continue,  // ← SKIPS CORRUPT ROWS FROM TRIM
+    };
+    // ... check if file exists ...
+}
+```
+
+NOTE-037 and NOTE-040 have corrupt/empty `kind` field (observed `?` in
+`forgeplan tree` output). `extract_record` at store.rs:1390 uses
+`unwrap_or_default()` so null kind becomes `""`. `"".parse::<ArtifactKind>()`
+returns Err. `continue` skips the row. Result: rows with corrupt kind
+**escape trim forever**.
+
+**Revised scope** (H2 from ADI): minimal bug fix, not a new feature.
+Change `Err(_) => continue` to treat unparseable kind as definite orphan
+(no valid kind = no valid directory = no possible file = trim it).
+Keep existing default-trim behavior. Add --show-orphans as additive
+feature only (no change to default).
+
+**Rejected original Option D**: would have CHANGED default from trim to
+warn, which is a regression for users relying on auto-cleanup. The bug
+is in trim, not absence of trim.
 
 ## Problem
 
@@ -83,13 +115,27 @@ is broken.
 
 ## Functional Requirements
 
-| ID | Category | Priority | Requirement |
-|----|----------|----------|-------------|
-| FR-001 | Core | Must | [System] can detect LanceDB rows whose `id` has no corresponding `.md` file under the kind's directory. Read-only scan, no mutation. |
-| FR-002 | UX | Must | [User] sees a warning block in `reindex` output listing phantom IDs, with two hint lines: `forgeplan reindex --trim-orphans` (remove) and `forgeplan reindex --show-orphans` (inspect via git). Warning only — default `reindex` does NOT delete. |
-| FR-003 | Core | Must | [User] can pass `--trim-orphans` flag to `forgeplan reindex` which performs the actual hard-delete of phantom rows from LanceDB. Git history is the recovery mechanism (ADR-003 — files = source of truth, LanceDB = derived). |
-| FR-004 | UX | Must | [User] can pass `--show-orphans` flag to see git history of each phantom: `git log --all -- <path>` output per orphan, showing last commit SHA, date, author, and message. Helpful for deciding whether to restore or trim. |
-| FR-005 | Docs | Must | [Contributor] finds up-to-date documentation for the new flags: clap `#[arg(help=...)]` strings, CLAUDE.md command workflow section, `docs/methodology/FORGEPLAN-GUIDE.md` reindex subsection, `CHANGELOG.md` v0.17.1 entry. **No feature lands without help text + changelog.** |
+- **FR-001** Core Must. [System] Phase 2 cleanup in `reindex` MUST trim
+  rows whose `kind` field fails to parse, treating unparseable kind as
+  a definite orphan (no valid kind means no valid directory, so no file
+  could exist). Current code skips these via `continue`; after fix they
+  must be deleted along with regular orphans.
+- **FR-002** UX Must. [User] sees improved reindex output distinguishing
+  removal reasons. Two cases: `DEL ID — file deleted` (normal case) and
+  `DEL ID — corrupt kind field` (phantom case). Total count line remains
+  `Reindex complete: N synced, M unchanged, K removed, L errors`.
+- **FR-003** Feature Must. [User] can pass `--show-orphans` flag to
+  `forgeplan reindex` to preview what would be deleted BEFORE the trim
+  runs. For each orphan: print ID, last known title from LanceDB, and
+  `git log --all -- [path]` output showing last commit SHA, date, author,
+  and message. Also print copy-paste recovery recipe using those values.
+  With this flag, trim still happens (unless combined with `--dry-run`
+  if that exists — out of scope if not).
+- **FR-004** Docs Must. [Contributor] finds up-to-date documentation for
+  the new flag and fixed behavior: clap `#[arg(help)]` string on
+  `--show-orphans`, CHANGELOG.md v0.17.1 Fixed entry for the bug and
+  Added entry for the flag, CLAUDE.md reindex workflow mention.
+  **No feature lands without help text + changelog** (NOTE-044 rule).
 
 ## Non-Functional Requirements
 

--- a/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-044-reindex-trim-orphans-delete-lancedb-rows-without-md-backing-file-v0-17-1-hotfix.md
@@ -133,21 +133,42 @@ is broken.
   could exist). Current code skips these via `continue`; after fix they
   must be deleted along with regular orphans.
 - **FR-002** UX Must. [User] sees improved reindex output distinguishing
-  removal reasons. Two cases: `DEL ID — file deleted` (normal case) and
-  `DEL ID — corrupt kind field` (phantom case). Total count line remains
-  `Reindex complete: N synced, M unchanged, K removed, L errors`.
-- **FR-003** Feature Must. [User] can pass `--show-orphans` flag to
-  `forgeplan reindex` to preview what would be deleted BEFORE the trim
-  runs. For each orphan: print ID, last known title from LanceDB, and
-  `git log --all -- [path]` output showing last commit SHA, date, author,
-  and message. Also print copy-paste recovery recipe using those values.
-  With this flag, trim still happens (unless combined with `--dry-run`
-  if that exists — out of scope if not).
-- **FR-004** Docs Must. [Contributor] finds up-to-date documentation for
-  the new flag and fixed behavior: clap `#[arg(help)]` string on
-  `--show-orphans`, CHANGELOG.md v0.17.1 Fixed entry for the bug and
-  Added entry for the flag, CLAUDE.md reindex workflow mention.
-  **No feature lands without help text + changelog** (NOTE-044 rule).
+  removal reasons. Three cases: `DEL ID — no .md file found` (normal
+  missing-file case), `DEL ID — corrupt kind field` (phantom case),
+  and `DEL source --relation--> target — orphan relation (reason)`
+  (Phase 3 addition). Total count line becomes `Reindex complete: N
+  synced, M unchanged, K removed, L orphan relations, E errors`.
+- **FR-003** Core Must. [System] NEW Phase 3 in `reindex` MUST trim
+  orphan relations from `relations.lance` where source or target ID
+  no longer exists in the post-Phase-2 surviving artifact set. Reason
+  labels: "source missing", "target missing", "both source and target
+  missing". This is the fix for PROB-028 Layer 2 — orphan relations
+  accumulated in `relations.lance` surfaced as `?` phantoms in
+  `forgeplan tree` via relation graph traversal.
+- **FR-004** Docs Must. [Contributor] finds up-to-date documentation
+  for the fixed behavior: rustdoc on `pub async fn run()` explaining
+  the three-phase pipeline (Phase 1 upsert, Phase 2 trim artifacts,
+  Phase 3 trim orphan relations), CHANGELOG.md v0.17.1 Fixed entry,
+  CLAUDE.md status block mention. **No feature lands without
+  rustdoc + changelog** (NOTE-044 rule).
+
+### Deferred (from original Option D spec, NOT in v0.17.1)
+
+`--show-orphans` flag that would preview phantoms before trim and
+run `git log` per orphan with copy-paste recovery recipe was in the
+original Option D scope but was removed after ADI code investigation
+revealed the real bugs. Why deferred:
+
+1. Existing behavior trims by default (discovered during ADI), so
+   "preview before trim" only makes sense if default is warn-only.
+2. Changing default from trim → warn would be a regression for users
+   relying on auto-cleanup (rejected in the design discussion).
+3. The helper is nice-to-have for inspection but not need-to-have
+   for closing PROB-028 — the trim itself is the fix.
+4. If users later request a preview/inspection mode, it can be
+   shipped as `forgeplan reindex --dry-run` or a separate
+   `forgeplan orphans inspect` command without affecting the core
+   trim logic. Tracked as future enhancement.
 
 ## Non-Functional Requirements
 
@@ -157,23 +178,41 @@ is broken.
 | NFR-002 | Safety | Trim MUST check file existence per-row; a transient I/O error on file stat MUST skip that row (do not delete), not fail the whole reindex |
 | NFR-003 | Backward compat | Default behavior of `forgeplan reindex` must not cause data loss for users who did NOT intend to trim |
 
-## Design decision — RESOLVED: Option D
+## Design decision — RESOLVED: Option E (emerged during ADI)
 
 **Decision date**: 2026-04-09
-**Decided by**: gogocat (project owner)
+**Decided by**: gogocat (project owner initially chose Option D)
+**Revised by**: team-lead after ADI code investigation revealed Option D
+was based on incomplete information. Current scope is Option E:
+minimal bug fix inside existing trim pass, not a new feature.
 
-### Chosen: Option D — Warn-only default + two helper flags
+### Chosen: Option E — Minimal bug fix, preserve default-trim behavior
 
-Reindex by default **warns** about phantom rows but does not delete.
-Two opt-in flags handle removal and inspection:
+Reindex already trims by default in Phase 2 (discovered during ADI —
+the existing code at lines 137-175 of reindex.rs iterates records and
+deletes any whose file is missing). Two narrow bugs prevented phantom
+cleanup:
 
-- `forgeplan reindex` (default) — detects phantoms, prints warning
-  block with list and recovery hints. No mutation.
-- `forgeplan reindex --trim-orphans` — performs hard-delete of
-  phantom rows from LanceDB.
-- `forgeplan reindex --show-orphans` — for each phantom, runs
-  `git log --all -- [path]` to show last commit, date, author,
-  message. Lets user review "what was in here" before trimming.
+1. **Corrupt-kind skip** — `match record.kind.parse() { Err(_) =>
+   continue }` let rows with empty/null kind field escape trim.
+2. **No relation cascade** — deleting an artifact did not remove its
+   relations from `relations.lance`, causing phantom `?` rows in
+   `forgeplan tree` via relation graph traversal.
+
+### Fixes implemented in v0.17.1
+
+- **Phase 2 fix**: replace `continue` with `OrphanReason::CorruptKind`
+  case — unparseable kind = definite orphan, trim it.
+- **Phase 3 new**: iterate `get_all_relations()`, check source+target
+  against post-Phase-2 surviving set, delete orphan edges with
+  source/target/both-missing reason reporting.
+
+### Rejected: original Option D (warn-only default + --show-orphans)
+
+Would have REVERSED the existing trim-by-default behavior which would
+be a regression for users relying on auto-cleanup. The `--show-orphans`
+helper was nice-to-have but not needed after the root cause was found
+in existing trim logic.
 
 ### Why Option D (not A/B/C)
 

--- a/.forgeplan/prds/PRD-045-health-verdict-aggregator-reads-all-warning-signals-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-045-health-verdict-aggregator-reads-all-warning-signals-v0-17-1-hotfix.md
@@ -7,7 +7,7 @@ links:
   relation: based_on
 - target: PRD-043
   relation: informs
-status: draft
+status: active
 title: Health verdict aggregator reads all warning signals (v0.17.1 hotfix)
 ---
 
@@ -16,13 +16,31 @@ title: Health verdict aggregator reads all warning signals (v0.17.1 hotfix)
 ## Progress
 
 ```
-FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Verdict aggregator includes PRD-043 signals
-FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Three-level verdict output (healthy / attention / unhealthy)
-FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Next-actions list tied to verdict level
-FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update CHANGELOG + help text for health verdict change
+FR-001   ████████████████████████  1/1  Verdict aggregator reads PRD-043 signals (stubs+dups) ✓ v0.17.1
+FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Three-level verdict enum — deferred to v0.18
+FR-003   ████████████████████████  1/1  Next-actions include stubs/dups with concrete IDs     ✓ v0.17.1
+FR-004   ████████████████████████  1/1  CHANGELOG v0.17.1 Fixed entry                         ✓ v0.17.1
 ─────────────────────────────────────────────────
-TOTAL                               0/4  (  0%)
+TOTAL                               3/4  ( 75%) — v0.17.1 hotfix
+
+Deferred from this PRD:
+- FR-002: explicit Verdict enum (Healthy / NeedsAttention / Unhealthy).
+  v0.17.1 keeps the existing "next_actions is non-empty" implicit
+  signal — no "looks healthy" string when stubs/dups present. Making
+  it explicit via typed enum is cleaner but requires HealthReport
+  shape change which would break MCP JSON contract. Deferred to
+  v0.18 minor release. See NOTE-045 entry.
 ```
+
+**v0.17.1 delivered (commit b6f478e):**
+- `generate_next_actions` signature extended with 2 new params
+- Compute reordered: stubs/dups before next_actions
+- Stubs action includes concrete ID with supersede/deprecate recipe
+- Duplicates action includes concrete pair with deprecate recipe
+- 3 new unit tests covering stub/dup/healthy branches
+- Verified on dogfood: health now reports 3 concrete actions instead
+  of "Project looks healthy"
+- See EVID-067 for implementation evidence.
 
 ## Problem
 
@@ -199,3 +217,4 @@ real usage shows the defaults are wrong.
 | PRD-043 | informs (PRD-043 detection whose signals this aggregates) |
 | EVID-058 | informs (Sprint 13.1 PRD-043 implementation evidence) |
 | PRD-044 | sibling (paired v0.17.1 hotfix work) |
+

--- a/.forgeplan/prds/PRD-045-health-verdict-aggregator-reads-all-warning-signals-v0-17-1-hotfix.md
+++ b/.forgeplan/prds/PRD-045-health-verdict-aggregator-reads-all-warning-signals-v0-17-1-hotfix.md
@@ -1,0 +1,201 @@
+---
+depth: standard
+id: PRD-045
+kind: prd
+links:
+- target: PROB-029
+  relation: based_on
+- target: PRD-043
+  relation: informs
+status: draft
+title: Health verdict aggregator reads all warning signals (v0.17.1 hotfix)
+---
+
+# PRD-045: Health verdict aggregator — read ALL warning signals
+
+## Progress
+
+```
+FR-001   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Verdict aggregator includes PRD-043 signals
+FR-002   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Three-level verdict output (healthy / attention / unhealthy)
+FR-003   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Next-actions list tied to verdict level
+FR-004   ░░░░░░░░░░░░░░░░░░░░░░░░  0/1  Update CHANGELOG + help text for health verdict change
+─────────────────────────────────────────────────
+TOTAL                               0/4  (  0%)
+```
+
+## Problem
+
+`forgeplan health` currently prints a verdict line that contradicts its
+own warnings. Observed on dogfood workspace 2026-04-08 during v0.17.0
+final audit:
+
+```
+  duplicate pairs (5):
+    EVID-001 duplicates EVID-003 (100%)
+    EVID-002 duplicates EVID-004 (100%)
+    ...
+
+  Active stubs (8):
+    PRD-008 ... 6 markers
+    PRD-009 ... 6 markers
+    ...
+
+  Next actions:
+    1. Project looks healthy. Continue implementation.
+
+  Project looks healthy!
+```
+
+The verdict aggregator was written before Sprint 13.1 PRD-043 added
+stub detection and duplicate detection. When those signals were wired
+into display, the verdict roll-up was not updated to include them.
+This is a classic "feature added in detection but forgotten in summary
+aggregator" bug. The detection path prints warnings correctly; the
+verdict path reads only the older `orphans` and `blind_spots` signals
+and misses the Sprint 13.1 additions.
+
+Impact: users trust the verdict line and ignore real warnings sitting
+above it. CI gates pass when they should fail if `--fail-on stubs` is
+not explicitly set. AI agents calling `forgeplan_health` through MCP
+receive contradictory state and make wrong decisions downstream.
+
+## Goals
+
+- Verdict line reflects every displayed warning category
+- Three-level gradient verdict (healthy / needs attention / unhealthy)
+  rather than binary so light warnings do not equal heavy warnings
+- Next actions list non-empty whenever verdict is not healthy
+- Existing CI gates (`--fail-on`) continue working without changes
+- JSON output for `health --json` gains a verdict field without
+  breaking existing fields
+
+## Non-Goals
+
+- Changing exit codes of `--ci` mode without explicit user threshold
+- Adding new warning categories (this PRD is only plumbing, not new
+  detection)
+- Telemetry, metrics upload, or persistent health history
+- Configurable verdict thresholds (hard-coded for v0.17.1; can be
+  revisited in a future PRD if users request)
+
+## Target Users
+
+- CLI users running `forgeplan health` interactively and reading the
+  verdict line to decide whether to act
+- AI agents calling the `forgeplan_health` MCP tool and parsing the
+  verdict to decide next tool invocation
+- CI pipelines using `forgeplan health --ci --fail-on` to gate merges
+  on workspace health
+
+## User Journeys
+
+### Journey 1 — Dogfood maintainer running health
+
+1. Run `forgeplan health` on workspace with 8 active stubs + 5 duplicate pairs
+2. Output shows all warnings as today
+3. Verdict line at bottom: `Verdict: needs attention — 8 stubs, 5 duplicate pairs`
+4. Next actions section lists concrete commands per warning type
+
+### Journey 2 — CI pipeline with thresholds
+
+1. CI runs `forgeplan health --ci --fail-on stubs=0`
+2. Workspace has 1 stub
+3. Exit code 1; stderr includes `Workspace has 1 active stub which exceeds threshold 0`
+4. Verdict line: `Verdict: unhealthy — 1 stub exceeds --fail-on threshold`
+
+### Journey 3 — Clean workspace
+
+1. Run `forgeplan health` on fresh workspace with no warnings
+2. Verdict line: `Verdict: healthy — no warnings`
+3. Next actions: `No action needed.`
+
+## Functional Requirements
+
+- **FR-001** — Health verdict aggregator reads the active-stubs count,
+  duplicate-pairs count, orphans count, blind-spots count, and stale
+  count signals, rolling them into a single verdict level. All five
+  signals must contribute.
+- **FR-002** — Three verdict levels:
+  - `healthy` — all signal counts are zero
+  - `needs attention` — any signal count greater than zero but within
+    default warning thresholds (stubs under five, duplicates under
+    three, orphans under three, stale under twenty percent of active)
+  - `unhealthy` — any signal count exceeds the default critical
+    threshold OR any explicit user `--fail-on` threshold is breached
+- **FR-003** — Next actions list is generated from the non-zero signals.
+  One actionable command per warning category, with placeholders filled
+  from the actual offending IDs. Examples:
+  - stubs: suggest `forgeplan deprecate ID reason` or
+    `forgeplan supersede ID by NEW`
+  - duplicates: suggest `forgeplan deprecate ID reason duplicate of OTHER`
+  - orphans: suggest `forgeplan link ID OTHER relation informs`
+  - stale: suggest `forgeplan renew ID until DATE` or
+    `forgeplan refresh`
+- **FR-004** — Help text, CHANGELOG, and methodology guide updated per
+  NOTE-044 rule. The `forgeplan health help` output describes the three
+  verdict levels. CHANGELOG has an entry under v0.17.1 Fixed section.
+  CLAUDE.md workflow mentions the new verdict semantics.
+
+## Non-Functional Requirements
+
+- **NFR-001 Backward compat** — `--ci` mode exit codes remain unchanged
+  unless the user explicitly sets stricter `--fail-on` thresholds. CI
+  pipelines passing on v0.17.0 must continue passing on v0.17.1 with
+  the same config.
+- **NFR-002 Output parseable** — JSON mode adds a new verdict field but
+  retains all existing fields and their types unchanged. Downstream
+  tools parsing `health --json` should not break.
+- **NFR-003 Deterministic** — Same workspace state always produces the
+  same verdict. No randomness, no mtime dependence, no network calls.
+
+## Design note — three-level verdict
+
+One design question I resolved without user input: how many verdict
+levels to expose. Chose three (healthy, needs attention, unhealthy)
+rather than binary (healthy vs unhealthy).
+
+Reasoning: binary would over-alarm on normal workspaces where one stub
+should not equal fifty stubs in severity. Three levels match common
+traffic-light UX patterns and let CI gates progressively escalate via
+`--fail-on` thresholds. Thresholds between attention and unhealthy are
+hard-coded for v0.17.1 to avoid shipping a configuration surface in a
+patch release; making them configurable can happen in a future PRD if
+real usage shows the defaults are wrong.
+
+## Acceptance Criteria
+
+- FR-001: verdict function signature takes all five signal counts as
+  input parameters; test coverage exercises each parameter independently.
+- FR-002: unit test — zero signals produces `healthy` verdict; one stub
+  produces `needs attention`; ten stubs produces `unhealthy`.
+- FR-003: next actions list is empty only when verdict is healthy.
+  Otherwise contains at least one actionable command per warning type.
+  Commands use concrete IDs from the actual warning, not placeholders.
+- FR-004: `forgeplan health help` text describes the three levels.
+  CHANGELOG v0.17.1 has a Fixed entry for this bug. CLAUDE.md workflow
+  section mentions the new verdict semantics.
+- Integration test: create workspace with one stub PRD and one duplicate
+  pair, run health, assert verdict contains `needs attention` and next
+  actions include concrete remediation commands.
+- Unit test: verdict aggregator function exhaustively exercised with
+  every combination of signal presence.
+- E2E: release binary on dogfood workspace prints `Verdict: needs
+  attention` given the existing 8 stubs + 5 duplicates.
+
+## Affected Files
+
+- `crates/forgeplan-core/src/health/mod.rs` — verdict function
+- `crates/forgeplan-cli/src/commands/health.rs` — display + CI glue
+- `CHANGELOG.md` — v0.17.1 Fixed entry
+- `CLAUDE.md` — health workflow mention
+- `crates/forgeplan-cli/tests/health_test.rs` — integration tests
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PROB-029 | based_on (this closes PROB-029) |
+| PRD-043 | informs (PRD-043 detection whose signals this aggregates) |
+| EVID-058 | informs (Sprint 13.1 PRD-043 implementation evidence) |
+| PRD-044 | sibling (paired v0.17.1 hotfix work) |

--- a/.forgeplan/problems/PROB-028-phantom-rows-in-lancedb-persist-after-md-file-deletion-reindex-bug.md
+++ b/.forgeplan/problems/PROB-028-phantom-rows-in-lancedb-persist-after-md-file-deletion-reindex-bug.md
@@ -1,0 +1,107 @@
+---
+depth: tactical
+id: PROB-028
+kind: problem
+status: draft
+title: Phantom rows in LanceDB persist after .md file deletion — reindex bug
+---
+
+# PROB-028: Phantom rows in LanceDB persist after .md file deletion
+
+## Signal
+
+`forgeplan tree` displays artifacts with `?` for kind/status/title and `0.00`
+R_eff. Reproducible: NOTE-037 and NOTE-040 в `.forgeplan/dogfood` workspace
+showed up as phantom rows on 2026-04-08.
+
+```
+░░░░░░░░░░  0.00  ?     ?     │     ├─ NOTE-037 "?"
+░░░░░░░░░░  0.00  ?     ?     │     └─ NOTE-040 "?"
+```
+
+Verification:
+- `forgeplan get NOTE-037` → "Artifact 'NOTE-037' not found"
+- `ls .forgeplan/notes/NOTE-037*.md` → no match
+- `grep -rln NOTE-037 .forgeplan/lance/` → 4 binary lance files contain ID
+- `forgeplan reindex` ran multiple times, did NOT remove these orphan rows
+
+## Root cause hypothesis
+
+`reindex` walks `.forgeplan/*/*.md` files and writes them to LanceDB
+(upsert). It does NOT enumerate LanceDB rows and check whether each has
+a corresponding `.md` file on disk. When a user (or git pull) deletes
+an `.md` file, the row in `artifacts.lance` is left orphaned.
+
+ADR-003 explicitly says "files = source of truth, LanceDB = derived
+index." The current `reindex` is one-way (files → LanceDB) and never
+performs reverse trim (LanceDB rows without files → delete).
+
+## Constraints
+
+- ADR-003 must be respected: files are authoritative
+- Reindex must remain idempotent (running it twice = same end state)
+- Must not break legitimate sync from git (newly pulled files)
+- Must not delete rows that have a file but the file is unreadable
+  due to transient I/O issue — only delete when file is verifiably absent
+- Must distinguish "file deleted" from "file moved/renamed" (id-based,
+  not path-based)
+
+## Optimization Targets
+
+- Make `reindex` truly bidirectional: add a "trim orphans" pass
+- Surface phantom row count in `health` so users notice the drift
+- Zero phantom rows after `forgeplan reindex` on any clean workspace
+
+## Observation Indicators (Anti-Goodhart)
+
+- DO NOT optimize for "lowest LanceDB row count" — could mask failed
+  inserts as "trimmed orphans"
+- DO NOT optimize for "fastest reindex" if it skips the trim pass
+- Track: number of rows trimmed per reindex call (should be 0 on
+  steady state, > 0 only after manual file deletion)
+
+## Acceptance Criteria
+
+1. `reindex` deletes LanceDB rows whose `id` has no corresponding
+   `.md` file in the expected directory for that kind
+2. `reindex` reports trimmed count: "Reindex complete: N synced,
+   M unchanged, K removed (X trimmed orphans), 0 errors"
+3. After running `reindex` on the dogfood workspace, NOTE-037 and
+   NOTE-040 disappear from `forgeplan tree` output
+4. Idempotent: second `reindex` reports "0 trimmed orphans"
+5. Test: integration test creates artifact, deletes its .md file,
+   runs reindex, asserts row is removed and `forgeplan get` returns
+   not-found
+6. Cross-kind safety: only trim from the kind's directory (notes from
+   `.forgeplan/notes/`, prds from `.forgeplan/prds/`, etc.) — never
+   trim from a directory that wasn't scanned
+
+## Blast Radius
+
+- All forgeplan users (any workspace where files have been deleted
+  externally — git pull, manual cleanup, mv operations)
+- `tree`, `list`, `health`, `score`, `graph` commands all read from
+  LanceDB and would silently surface phantom rows until fix lands
+- LanceDB integrity: phantom rows can also break `link`/`unlink`
+  graphs if the orphan ID is referenced as a relation source/target
+- ADR-003 compliance: current behavior is a passive violation of
+  "files = source of truth"
+
+## Reversibility
+
+**HIGH** — pure additive bug fix in `reindex`. No schema migration
+needed. No public API change. Worst case: trim is too aggressive and
+deletes a row whose file was temporarily unreadable; user can re-run
+ingest or manually re-add. The fix should add an explicit confirmation
+flag (`--trim-orphans` opt-in OR `--no-trim` opt-out) to control the
+behavior, with sane default (probably opt-in for one release, then
+default-on after observation).
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-003 | informs (files-as-source-of-truth principle) |
+| PROB-027 | sibling (related reindex bug — cannot rebuild from scratch when lance dir missing) |
+| PRD-043 | sibling (methodology integrity, this is data integrity) |
+| EPIC-003 | context (found during v0.17.0 final dogfood audit 2026-04-08) |

--- a/.forgeplan/problems/PROB-029-forgeplan-health-shows-project-looks-healthy-despite-active-stubs-duplicates-warnings-verdict-logic-bug.md
+++ b/.forgeplan/problems/PROB-029-forgeplan-health-shows-project-looks-healthy-despite-active-stubs-duplicates-warnings-verdict-logic-bug.md
@@ -1,0 +1,113 @@
+---
+depth: tactical
+id: PROB-029
+kind: problem
+status: draft
+title: forgeplan health shows 'Project looks healthy' despite active stubs/duplicates warnings — verdict logic bug
+---
+
+# PROB-029: `forgeplan health` verdict contradicts its own warnings
+
+## Signal
+
+`forgeplan health` output on the dogfood workspace (2026-04-08) shows:
+
+```
+  ⧗ Possible duplicates (5):
+    EVID-001 ↔ EVID-003 (100%) — "Dogfood lifecycle test"
+    ... 4 more pairs ...
+
+  ⚠ Active stubs (8):
+    PRD-008 (prd) "..." — 6 markers
+    ... 7 more stubs ...
+
+  → Next actions:
+    1. Project looks healthy. Continue implementation.
+
+  Project looks healthy!
+```
+
+The same output **prints duplicate warnings AND stub warnings** (Sprint 13.1
+PRD-043 detection working correctly), then **immediately concludes "Project
+looks healthy!"**. The verdict logic doesn't read its own findings.
+
+## Root cause hypothesis
+
+The "Next actions" / "Project looks healthy" verdict is generated from a
+narrow set of checks (probably orphans + blind_spots + stale count), and
+does NOT factor in the newer PRD-043 signals (`possible_duplicates`,
+`active_stubs`). When PRD-043 was added in Sprint 13.1, the detection +
+display were wired but the **summary aggregator was not updated** to
+include the new signals.
+
+This is a classic "feature added in detection but forgotten in roll-up"
+bug — the kind PRD-043 was supposed to prevent for *artifacts*, ironically
+slipping through for *health logic*.
+
+## Constraints
+
+- Must not change the format of `health` output that scripts/CI parse
+  (`--ci` mode + `--fail-on` thresholds must remain compatible)
+- Must not produce false alarms — empty workspaces should still report
+  healthy
+- Must remain readable for humans (no flood of warnings)
+- Stale-but-deprecated artifacts should NOT count toward "unhealthy"
+  (only active artifacts contribute to health verdict)
+
+## Optimization Targets
+
+- Verdict accurately reflects the warnings shown
+- One unified "next actions" list ranked by severity
+- Workspace with active stubs OR duplicate pairs ≥ 1 → verdict !=
+  "looks healthy"
+
+## Observation Indicators (Anti-Goodhart)
+
+- DO NOT optimize for "shortest health output" — completeness > brevity
+- DO NOT mark every minor warning as "unhealthy" — gradient verdicts
+  ("healthy / needs attention / unhealthy") rather than binary
+- Track: false positive rate (workspaces marked unhealthy but the
+  warnings are tolerable in context)
+
+## Acceptance Criteria
+
+1. If `health` output contains any of: active stubs ≥ 1, duplicate
+   pairs ≥ 1, blind spots ≥ 1, orphans ≥ 1, the verdict line MUST NOT
+   say "Project looks healthy"
+2. Verdict has 3 levels:
+   - **healthy** (no warnings of any kind)
+   - **needs attention** (1+ warning, none critical)
+   - **unhealthy** (CRITICAL signals: orphans > threshold, active
+     stubs > threshold, blind spots > threshold)
+3. "Next actions" list is non-empty when verdict ≠ healthy and
+   includes specific commands to remediate (e.g., "deprecate duplicate
+   pair: forgeplan deprecate EVID-003 --reason superseded by EVID-001")
+4. `--ci` mode exit codes unchanged for backward compat
+5. Test: integration test creates a workspace with 1 stub PRD, runs
+   health, asserts verdict ≠ "healthy"
+
+## Blast Radius
+
+- All `forgeplan health` users (CLI human + CI/CD pipelines via `--ci`)
+- AI agents querying health via MCP `forgeplan_health` tool will get
+  more accurate state, will better self-correct
+- CI gates that depend on `--fail-on stubs=N` will start firing where
+  they didn't before — could be breaking change for projects with
+  pre-existing stubs (mitigated by `--fail-on` threshold tuning)
+
+## Reversibility
+
+**HIGH** — pure logic fix in the verdict aggregator. No schema, no
+public API change. Output format additions are backward-compatible
+(adding new lines, changing wording). The CI breaking-change risk is
+manageable via configurable thresholds (already exist per Sprint 13.1.5
+hardening — `IntegrityConfig`).
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| PRD-043 | based_on (this is the verdict roll-up gap that PRD-043 detection exposed) |
+| EVID-058 | informs (Sprint 13.1 PRD-043 implementation evidence) |
+| PROB-028 | sibling (sister bug found in same dogfood audit, both v0.17.1 hotfix candidates) |
+| EPIC-003 | context (found during v0.17.0 final dogfood audit 2026-04-08) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,77 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.17.1] — 2026-04-09 — Post-v0.17.0 dogfood hotfix
+
+Fixes two bugs found during the v0.17.0 final dogfood audit when running
+`forgeplan tree` and `forgeplan health` on the dogfood workspace itself.
+PRD-043 detection (Sprint 13.1) correctly flagged the issues but two
+upstream bugs prevented them from being auto-resolved.
+
+### Fixed
+
+- **PROB-028 — Phantom rows in `forgeplan tree`** (PRD-044).
+  `reindex` Phase 2 (orphan cleanup) previously skipped rows whose
+  `kind` field failed to parse via `continue`, letting corrupt/empty
+  kind rows escape trim forever. Additionally, orphan relations whose
+  source or target artifact had been deleted accumulated in the
+  relations table and surfaced as `?` phantoms in tree rendering.
+  - Fix 1: `Err(_) => continue` changed to treat unparseable kind as
+    a definite orphan (no valid kind means no valid directory means
+    no possible file). Rows with corrupt kind now get trimmed along
+    with normal orphans.
+  - Fix 2: new Phase 3 in `reindex` trims orphan relations where
+    source or target no longer exists in artifacts.
+  - Output now reports removal reason: `corrupt kind field` vs
+    `no .md file found` vs `orphan relation (source|target|both missing)`.
+  - `reindex` output gains a new counter: "K removed, N orphan relations"
+
+- **PROB-029 — `forgeplan health` verdict contradicted its own warnings**
+  (PRD-045). Sprint 13.1 added `active_stubs` and `possible_duplicates`
+  detection (PRD-043) and wired them into the warning display, but the
+  `generate_next_actions` summary function was never updated to read
+  those signals. Result: workspace with 8 stubs + 5 duplicate pairs
+  printed "Project looks healthy" at the bottom.
+  - Fix: `generate_next_actions` now takes `possible_duplicates` and
+    `active_stubs` as parameters; compute order reshuffled so signals
+    are available before the summary runs.
+  - Next actions for stubs suggest `forgeplan supersede ID --by NEW`
+    or `forgeplan deprecate ID --reason "abandoned"` with the concrete
+    offending ID.
+  - Next actions for duplicates suggest
+    `forgeplan deprecate B --reason "duplicate of A"` with the concrete
+    pair IDs.
+  - "Project looks healthy" message only appears when genuinely no
+    warnings of any category exist.
+
+### Methodology (NOTE-044 checklist addition)
+
+- Phase 1 Implementation gains new rule: "Every new CLI flag / command
+  / config option ships with ALL of these docs (no feature lands
+  without): clap `--help` text, CHANGELOG entry, CLAUDE.md workflow
+  section if user-facing, `docs/methodology/` subsection if
+  command-level." Red flag: a PR adding a flag/command without
+  touching clap help + CHANGELOG is incomplete — block merge.
+
+### Stats
+
+- 1131 tests pass (+3 from v0.17.0 — PRD-045 verdict aggregator tests)
+- 0 warnings on both default and `--features semantic-search` builds
+- Clippy strict (`-D warnings`) clean on Rust 1.94
+- Dogfood verification: `forgeplan tree` on dogfood workspace no
+  longer shows `?` phantoms; `forgeplan health` reports 3 concrete
+  next actions instead of "looks healthy"
+
+### Refs
+
+- PROB-028 (phantom rows reindex bug)
+- PROB-029 (health verdict logic bug)
+- PRD-044 (reindex trim orphans — closes PROB-028)
+- PRD-045 (health verdict aggregator — closes PROB-029)
+- NOTE-044 (sprint checklist framework, docs completeness rule added)
+- NOTE-046 (dogfood cleanup task — duplicate EVID pairs, deferred)
+- NOTE-047 (dogfood cleanup task — false-active stubs, deferred)
+
 ## [0.17.0] — 2026-04-08 — EPIC-003: Search, Discovery, Intelligence
 
 First release of EPIC-003. Adds keyword + semantic search, brownfield

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,9 @@ Forgeplan = Quint-code (decision engine, R_eff scoring, evidence decay)
 
 ## Текущий статус
 
-- **v0.17.0** released — **EPIC-003 complete** (Search, Discovery, Intelligence)
-- **~56 CLI команд**, **~47 MCP tools**, **1109 тестов** (+280 от v0.16)
+- **v0.17.1** hotfix 2026-04-09 — PROB-028 phantom rows + PROB-029 health verdict fixed
+- **v0.17.0** released 2026-04-08 — **EPIC-003 complete** (Search, Discovery, Intelligence)
+- **~56 CLI команд**, **~47 MCP tools**, **1131 тестов** (+283 от v0.16)
 - **0 warnings** на обоих feature configs (default + `semantic-search`)
 - EPIC-001 (foundation) ✅ | EPIC-002 (v2.0 vision) ✅ | **EPIC-003 (v0.17.0)** ✅
 - **7 PRDs активированы** в v0.17.0: PRD-035 (tags + discover), PRD-039 (BM25 search),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,29 @@
 # TODO — Forgeplan
 
-## Current: v0.17.0-rc — EPIC-003 complete, ready to tag
+## Current: v0.17.1 hotfix 2026-04-09 — post-dogfood fixes
+
+### v0.17.1 hotfix ✅
+- [x] PROB-028 phantom rows fixed (PRD-044): reindex parse-kind skip + orphan relation cascade
+- [x] PROB-029 health verdict fixed (PRD-045): generate_next_actions reads stubs/duplicates
+- [x] 1131 tests pass (+3 from v0.17.0)
+- [x] Clippy 1.94 strict clean (both feature configs)
+- [x] EVID-066, EVID-067 activated
+- [x] PRD-044, PRD-045 activated (progress bars reflect reality)
+- [x] CHANGELOG.md v0.17.1 entry under Fixed
+- [x] Cargo.toml version 0.17.0 → 0.17.1 (all 3 crates)
+- [x] CLAUDE.md status block updated to v0.17.1
+- [x] TODO.md updated (this block)
+- [x] NOTE-044 Sprint Checklist gained new rule: "Every new CLI flag + CHANGELOG + docs, no feature lands without"
+- [ ] Audit reviewer report (1 agent running)
+- [ ] PR release/v0.17.1 → main
+- [ ] Tag v0.17.1 + push (cargo-dist Release workflow auto-triggers)
+- [ ] Sync main → dev via PR (dev protected)
+- [ ] Hindsight retain v0.17.1 finale
+- [ ] Dogfood housekeeping NOTE-046/047 (manual pass, separate commit, not blocker)
+
+---
+
+## Previous: v0.17.0-rc — EPIC-003 complete, ready to tag
 
 ### Stats (v0.17.0)
 - ~56 CLI commands, ~47 MCP tools, **1109 tests** (+280 from v0.16)

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.17.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.17.1" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.17.1" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -132,46 +132,112 @@ pub async fn run() -> anyhow::Result<()> {
     }
 
     // Phase 2: Remove DB records whose .md file no longer exists (files-first cleanup)
+    //
+    // PRD-044 fix: previously `parse::<ArtifactKind>()` returning Err caused
+    // `continue`, which let rows with corrupt/empty kind escape trim forever
+    // (the NOTE-037/NOTE-040 phantom bug observed in v0.17.0 dogfood audit).
+    // Now we treat unparseable kind as a definite orphan: no valid kind =
+    // no valid directory = no possible file = trim it.
     let mut removed = 0usize;
     let all_records = store.list_records(None).await?;
     for record in &all_records {
-        let kind: forgeplan_core::artifact::types::ArtifactKind = match record.kind.parse() {
-            Ok(k) => k,
-            Err(_) => continue,
-        };
-        let dir = ws.join(kind.dir_name());
-        let slug = forgeplan_core::artifact::types::slugify(&record.title);
-        let filename = format!("{}-{}.md", record.id, slug);
-        let filepath = dir.join(&filename);
+        enum OrphanReason {
+            CorruptKind,
+            MissingFile,
+        }
 
-        if !filepath.exists() {
-            // Double-check: maybe file exists with different slug (title changed)
-            let mut found = false;
-            if dir.exists()
-                && let Ok(mut rd) = tokio::fs::read_dir(&dir).await
+        let orphan_reason: Option<OrphanReason> =
+            match record
+                .kind
+                .parse::<forgeplan_core::artifact::types::ArtifactKind>()
             {
-                while let Ok(Some(entry)) = rd.next_entry().await {
-                    let name = entry.file_name().to_string_lossy().to_string();
-                    let id_prefix = format!("{}-", record.id.to_uppercase());
-                    if name.to_uppercase().starts_with(&id_prefix) && name.ends_with(".md") {
-                        found = true;
-                        break;
+                Err(_) => Some(OrphanReason::CorruptKind),
+                Ok(kind) => {
+                    let dir = ws.join(kind.dir_name());
+                    let slug = forgeplan_core::artifact::types::slugify(&record.title);
+                    let filename = format!("{}-{}.md", record.id, slug);
+                    let filepath = dir.join(&filename);
+
+                    if filepath.exists() {
+                        None
+                    } else {
+                        // Double-check: maybe file exists with different slug (title changed)
+                        let mut found = false;
+                        if dir.exists()
+                            && let Ok(mut rd) = tokio::fs::read_dir(&dir).await
+                        {
+                            while let Ok(Some(entry)) = rd.next_entry().await {
+                                let name = entry.file_name().to_string_lossy().to_string();
+                                let id_prefix = format!("{}-", record.id.to_uppercase());
+                                if name.to_uppercase().starts_with(&id_prefix)
+                                    && name.ends_with(".md")
+                                {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if found {
+                            None
+                        } else {
+                            Some(OrphanReason::MissingFile)
+                        }
                     }
                 }
-            }
+            };
 
-            if !found {
-                store.delete_artifact(&record.id).await?;
-                common::log_change(&store, &record.id, "delete", "reindex").await;
-                println!("  DEL  {} — no .md file found, removed from DB", record.id);
-                removed += 1;
+        if let Some(reason) = orphan_reason {
+            store.delete_artifact(&record.id).await?;
+            common::log_change(&store, &record.id, "delete", "reindex").await;
+            let reason_label = match reason {
+                OrphanReason::CorruptKind => "corrupt kind field",
+                OrphanReason::MissingFile => "no .md file found",
+            };
+            println!("  DEL  {} — {}, removed from DB", record.id, reason_label);
+            removed += 1;
+        }
+    }
+
+    // Phase 3: Trim orphan relations — edges whose source or target artifact
+    // no longer exists. Before fix, orphan relations survived forever and
+    // caused phantom rows in `forgeplan tree` rendering (NOTE-037/038/040 bug
+    // from v0.17.0 dogfood audit). PRD-044 FR-001 extended scope.
+    let mut orphan_relations = 0usize;
+    let all_relations = store.get_all_relations().await?;
+    if !all_relations.is_empty() {
+        // Re-fetch fresh artifact ID set after Phase 2 trims so cascade works
+        let surviving_ids: std::collections::HashSet<String> = store
+            .list_records(None)
+            .await?
+            .into_iter()
+            .map(|r| r.id)
+            .collect();
+        for (source, target, relation) in &all_relations {
+            let source_exists = surviving_ids.contains(source);
+            let target_exists = surviving_ids.contains(target);
+            if !source_exists || !target_exists {
+                if let Err(e) = store.delete_relation(source, target, relation).await {
+                    eprintln!(
+                        "  WARN orphan relation {source} --{relation}--> {target} delete failed: {e}"
+                    );
+                    errors += 1;
+                } else {
+                    let why = match (source_exists, target_exists) {
+                        (false, false) => "both source and target missing",
+                        (false, true) => "source missing",
+                        (true, false) => "target missing",
+                        (true, true) => unreachable!(),
+                    };
+                    println!("  DEL  {source} --{relation}--> {target} — orphan relation ({why})");
+                    orphan_relations += 1;
+                }
             }
         }
     }
 
     println!(
-        "\nReindex complete: {} synced, {} unchanged, {} removed, {} errors.",
-        synced, skipped, removed, errors
+        "\nReindex complete: {} synced, {} unchanged, {} removed, {} orphan relations, {} errors.",
+        synced, skipped, removed, orphan_relations, errors
     );
     Ok(())
 }

--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -2,8 +2,26 @@ use crate::commands::common;
 
 /// Rebuild LanceDB index from .md files (files-first, RFC-004).
 ///
-/// Walks all artifact directories, parses frontmatter + body from each .md file,
-/// and upserts into LanceDB. Safety net when lazy sync missed changes.
+/// Three-phase pipeline:
+///
+/// **Phase 1** — walks all artifact directories, parses frontmatter + body
+/// from each .md file, and upserts into LanceDB. Safety net when lazy sync
+/// missed changes. Also restores typed relations from frontmatter `links:`
+/// blocks (F8 fix).
+///
+/// **Phase 2** — trims LanceDB artifact rows whose `.md` file no longer
+/// exists on disk (files = source of truth per ADR-003). Two reasons for
+/// trim: `MissingFile` (kind valid but file deleted, checks for title-change
+/// rename) and `CorruptKind` (parse-kind failure — v0.17.1 fix for
+/// PROB-028 Layer 1, where corrupt rows previously escaped cleanup).
+///
+/// **Phase 3** — trims orphan relations from `relations.lance` whose source
+/// or target artifact is no longer in `artifacts.lance` (v0.17.1 fix for
+/// PROB-028 Layer 2). Before this fix, deleting an artifact did not cascade
+/// to its relations, causing `forgeplan tree` to show `?` phantom rows via
+/// relation graph traversal (NOTE-037/038/040 dogfood bug). Iterates all
+/// relations, checks both source and target against post-Phase-2 surviving
+/// artifact set, deletes orphan edges with explicit reason.
 pub async fn run() -> anyhow::Result<()> {
     let (ws, store) = common::open_store().await?;
 

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -116,11 +116,23 @@ pub async fn health_report(store: &LanceStore) -> anyhow::Result<HealthReport> {
     let by_derived_status =
         compute_derived_status_breakdown(&non_evidence, &evidence_records, &outgoing);
 
-    let next_actions =
-        generate_next_actions(total, &by_status, &blind_spots, stale_count, &orphans);
-
+    // PRD-045 FR-001: compute PRD-043 signals BEFORE next_actions so the
+    // aggregator can see them. Before fix, these were computed after
+    // next_actions and the summary never knew about active stubs or
+    // duplicate pairs → verdict always said "Project looks healthy"
+    // even with 8 stubs and 5 duplicate pairs present.
     let possible_duplicates = find_duplicate_pairs(&all, DUPLICATE_SIMILARITY_THRESHOLD);
     let active_stubs = find_active_stubs(&all);
+
+    let next_actions = generate_next_actions(
+        total,
+        &by_status,
+        &blind_spots,
+        stale_count,
+        &orphans,
+        &possible_duplicates,
+        &active_stubs,
+    );
 
     Ok(HealthReport {
         total,
@@ -302,12 +314,36 @@ fn generate_next_actions(
     blind_spots: &[BlindSpot],
     stale_count: usize,
     orphans: &[String],
+    possible_duplicates: &[DuplicatePair],
+    active_stubs: &[ActiveStub],
 ) -> Vec<String> {
     let mut actions = Vec::new();
 
     let draft_count = by_status.get("draft").copied().unwrap_or(0);
     if draft_count == total && total > 0 {
         actions.push("All artifacts in Draft — review and activate ready ones".into());
+    }
+
+    // PRD-045 FR-001: PRD-043 stub detection signal
+    if !active_stubs.is_empty() {
+        let first = &active_stubs[0];
+        actions.push(format!(
+            "Fill or supersede {} active stub(s) — e.g. `forgeplan supersede {} --by <NEW>` or `forgeplan deprecate {} --reason \"abandoned\"`",
+            active_stubs.len(),
+            first.id,
+            first.id
+        ));
+    }
+
+    // PRD-045 FR-001: PRD-043 duplicate detection signal
+    if !possible_duplicates.is_empty() {
+        let first = &possible_duplicates[0];
+        actions.push(format!(
+            "Resolve {} duplicate pair(s) — e.g. `forgeplan deprecate {} --reason \"duplicate of {}\"`",
+            possible_duplicates.len(),
+            first.id_b,
+            first.id_a
+        ));
     }
 
     if !blind_spots.is_empty() {
@@ -716,8 +752,80 @@ mod tests {
         }];
         let orphans = vec!["O1".into(), "O2".into()];
 
-        let actions = generate_next_actions(5, &by_status, &blind_spots, 2, &orphans);
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let actions =
+            generate_next_actions(5, &by_status, &blind_spots, 2, &orphans, &dups, &stubs);
         assert!(actions.len() <= 3);
+    }
+
+    // PRD-045 FR-001: verdict aggregator reads stubs signal
+    #[test]
+    fn next_actions_includes_stub_remediation_when_stubs_present() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans: Vec<String> = Vec::new();
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs = vec![ActiveStub {
+            id: "PRD-008".into(),
+            kind: "prd".into(),
+            title: "CLI UX".into(),
+            markers_found: 6,
+            message: "stub".into(),
+        }];
+        let actions =
+            generate_next_actions(10, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        assert!(
+            actions.iter().any(|a| a.contains("PRD-008")),
+            "expected PRD-008 stub mentioned, got {actions:?}"
+        );
+        assert!(
+            !actions.iter().any(|a| a.contains("looks healthy")),
+            "should NOT say healthy when stubs present"
+        );
+    }
+
+    // PRD-045 FR-001: verdict aggregator reads duplicates signal
+    #[test]
+    fn next_actions_includes_duplicate_remediation_when_dups_present() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans: Vec<String> = Vec::new();
+        let dups = vec![DuplicatePair {
+            id_a: "EVID-001".into(),
+            id_b: "EVID-003".into(),
+            similarity: 1.0,
+            title_a: "Dogfood test".into(),
+            title_b: "Dogfood test".into(),
+            kind: "evidence".into(),
+        }];
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let actions =
+            generate_next_actions(10, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        assert!(
+            actions.iter().any(|a| a.contains("EVID-003")),
+            "expected EVID-003 duplicate mentioned, got {actions:?}"
+        );
+        assert!(
+            !actions.iter().any(|a| a.contains("looks healthy")),
+            "should NOT say healthy when duplicates present"
+        );
+    }
+
+    // PRD-045: clean workspace still says healthy
+    #[test]
+    fn next_actions_says_healthy_when_no_warnings() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans: Vec<String> = Vec::new();
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let actions =
+            generate_next_actions(5, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        assert!(
+            actions.iter().any(|a| a.contains("looks healthy")),
+            "expected healthy message, got {actions:?}"
+        );
     }
 
     fn stub_body() -> String {

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.17.1" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true


### PR DESCRIPTION
Routine post-release sync bringing dev up to date with main after v0.17.1 tag.

## Brings

- Merge of PR #161 (v0.17.1 hotfix): commit 907511d on main
- Tag v0.17.1 annotation on main
- 5 commits: shape, fix, closeout, doc gap closure, drift fix

## Fixes included

- PROB-028 reindex phantom rows (PRD-044): Phase 2 corrupt-kind skip + new Phase 3 orphan relation cascade trim
- PROB-029 health verdict contradiction (PRD-045): generate_next_actions reads all signals

## Quality

- 1131 tests pass (+3 from v0.17.0)
- Clippy 1.94 strict clean both feature configs
- Cargo.toml: 0.17.0 → 0.17.1 (all 3 crates)
- CHANGELOG v0.17.1 entry
- Dogfood verified clean

## No content changes

Fast-forward merge — dev already tracks release/v0.17.1 via shape branch. Only adds the merge commit 907511d and tag annotation.

## Refs

- v0.17.1 tag: https://github.com/ForgePlan/forgeplan/releases/tag/v0.17.1
- Release PR: #161
- PRDs activated: PRD-044, PRD-045
- EVIDs: EVID-066, EVID-067

🤖 Generated with [Claude Code](https://claude.com/claude-code)