### PR TITLE
[sync] main → dev after v0.17.2 release

### DIFF
--- a/.forgeplan/evidence/EVID-068-prob-030-bm25-prefix-fallback-verified-v0-17-2.md
+++ b/.forgeplan/evidence/EVID-068-prob-030-bm25-prefix-fallback-verified-v0-17-2.md
@@ -1,0 +1,75 @@
+---
+depth: tactical
+id: EVID-068
+kind: evidence
+links:
+- target: PROB-030
+  relation: informs
+status: active
+title: PROB-030 BM25 prefix fallback verified (v0.17.2)
+---
+
+# EVID-068: PROB-030 BM25 prefix fallback verified (v0.17.2)
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-09 |
+| Valid Until | 2026-07-08 |
+| Target | PROB-030 (hotfix target) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+**What**: query `auth` on corpus with PRD-001 "Authentication OAuth2 system"
+returns 2 exact results (0.80) — was 0 on v0.17.1 baseline.
+
+**How**: added `let kw = keyword_score(record, query); let keyword_channel = bm25_norm.max(kw);` in
+`crates/forgeplan-core/src/search/smart.rs` combined_score computation.
+
+**Corpus**: `/tmp/fp-e2e` with 4 PRDs, 1 RFC, 1 ADR.
+
+## Result
+
+- T1 `authentication` → 2 results (PRD-001 @ 0.80, RFC-001 @ 0.80) ✓
+- T2 `auth` (prefix, PROB-030) → 5 results incl. both Authentication artifacts at 0.80 ✓
+- T3 `OAu` (prefix) → PRD-001 @ 0.80 ✓
+- T4 `error handling` (multi-word) → PRD-002 @ 0.80 ✓
+- T5 `PAYMENT` (case) → PRD-003 @ 0.80 ✓
+- Regression tests: smart_search_prefix_query_falls_back_to_substring,
+  smart_search_exact_token_still_wins_over_prefix (both green)
+
+## Interpretation
+
+BM25 prefix fallback landed correctly — `search auth` now finds Authentication artifacts via substring channel without demoting exact-token BM25 hits. Users can search as they type, grep-like behavior.
+
+## Congruence Level Justification
+
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+CL3 — same-context T1 evidence: tests written and executed locally against the exact code they verify. No context shift.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-068 | informs |
+
+
+

--- a/.forgeplan/evidence/EVID-069-prob-031-score-rs-uses-core-parser-cl-consistency-v0-17-2.md
+++ b/.forgeplan/evidence/EVID-069-prob-031-score-rs-uses-core-parser-cl-consistency-v0-17-2.md
@@ -1,0 +1,73 @@
+---
+depth: tactical
+id: EVID-069
+kind: evidence
+links:
+- target: PROB-031
+  relation: informs
+status: active
+title: PROB-031 score.rs uses core parser — CL consistency (v0.17.2)
+---
+
+# EVID-069: PROB-031 score.rs uses core parser — CL consistency (v0.17.2)
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-09 |
+| Valid Until | 2026-07-08 |
+| Target | PROB-031 (hotfix target) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+**What**: CLI `score` command had local `parse_evidence_from_record`
+with CL0 default, duplicating (and contradicting) core's CL3-default parser.
+Removed the duplicate, imported core parser in `score.rs`. Display path and
+R_eff rollup now agree.
+
+**How**: deleted ~50 LOC from `crates/forgeplan-cli/src/commands/score.rs`,
+added `use forgeplan_core::scoring::evidence::parse_evidence_from_record;`.
+
+## Result
+
+- CLI integration test `score_uses_core_parser_with_cl3_default_when_no_structured_fields` green
+- E2E: bare evidence → R_eff=1.0 CL=3 (consistent) ✓
+- E2E: explicit CL0 → R_eff=0.10 CL=0 (consistent) ✓
+- Also closes attack surface: core parser implements PRD-035 H2 precedence
+  `min(tier_cl, explicit_cl)` preventing trust amplification via self-signed T1
+
+## Interpretation
+
+CLI and core now share one parser. Display breakdown and R_eff rollup are congruent by construction — no more lying `CL0=0.1 vs r_eff=1.00` contradiction. Also closes the H2 trust-amplification gap on the display path.
+
+## Congruence Level Justification
+
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+CL3 — same-context T1 evidence: CLI integration tests in the same workspace, exercising the exact parser unification.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-069 | informs |
+
+
+

--- a/.forgeplan/evidence/EVID-070-prob-032-score-breakdown-shows-real-kw-component-v0-17-2.md
+++ b/.forgeplan/evidence/EVID-070-prob-032-score-breakdown-shows-real-kw-component-v0-17-2.md
@@ -1,0 +1,70 @@
+---
+depth: tactical
+id: EVID-070
+kind: evidence
+links:
+- target: PROB-032
+  relation: informs
+status: active
+title: PROB-032 score breakdown shows real kw component (v0.17.2)
+---
+
+# EVID-070: PROB-032 score breakdown shows real kw component (v0.17.2)
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-09 |
+| Valid Until | 2026-07-08 |
+| Target | PROB-032 (hotfix target) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+**What**: `forgeplan search` showed `kw=0.0 sem=0.0 r=0.0 g=0.0` breakdown
+while total score was 0.57 — display lied about components.
+
+**How**: auto-fixed as side effect of PROB-030. Once `keyword_channel =
+bm25_norm.max(kw)` is passed into combined_score, the real value flows
+through to the breakdown display. No separate fix needed.
+
+## Result
+
+- E2E: `forgeplan search "auth"` now shows kw=0.80 (was 0.0) — breakdown honest
+- Total score equals sum of non-zero components (within rounding)
+- No separate regression test — covered by PROB-030 tests
+
+## Interpretation
+
+Score breakdown is now honest: `kw`, `sem`, `r`, `g` all reflect real values. Covered transitively by PROB-030 assertions — single source parser removes the 'display lies' class of bugs.
+
+## Congruence Level Justification
+
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+CL3 — same-context T1 evidence: transitive coverage proven by the same-session PROB-030 tests that exercise `combined_score` end-to-end.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-070 | informs |
+
+
+

--- a/.forgeplan/evidence/EVID-071-prob-033-new-evidence-phase-agnostic-after-route-v0-17-2.md
+++ b/.forgeplan/evidence/EVID-071-prob-033-new-evidence-phase-agnostic-after-route-v0-17-2.md
@@ -1,0 +1,73 @@
+---
+depth: tactical
+id: EVID-071
+kind: evidence
+links:
+- target: PROB-033
+  relation: informs
+status: active
+title: PROB-033 new evidence phase-agnostic after route (v0.17.2)
+---
+
+# EVID-071: PROB-033 new evidence phase-agnostic after route (v0.17.2)
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-09 |
+| Valid Until | 2026-07-08 |
+| Target | PROB-033 (hotfix target) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+**What**: `forgeplan route "..." && forgeplan new evidence "..."` printed
+confusing `Session: Cannot go from 'routing' to 'evidence'` warning even
+though the file WAS created. Legitimate backfill/audit workflows blocked
+by perceived error.
+
+**How**: `crates/forgeplan-cli/src/commands/new.rs` — `new evidence` no
+longer drives the session state machine. Only decision artifacts (prd, rfc,
+adr, epic, spec) advance to Shaping phase. State machine guardrail still
+applies at `activate` time (stub + validation gates).
+
+## Result
+
+- CLI integration test `new_evidence_works_in_routing_phase_without_session_warning` green
+- E2E on /tmp/fp-e2e: `route` → `new evidence` → file created, no warning on stderr
+- All existing session state tests still pass (no regression on decision artifact flow)
+
+## Interpretation
+
+Evidence creation is legitimate in ANY phase (backfill, audit, brownfield, import). Methodology guardrail still runs at `activate` (stub detection + validation), so we lose no trust while unblocking real workflows.
+
+## Congruence Level Justification
+
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+CL3 — same-context T1 evidence: CLI integration test on fresh workspace, reproduces the exact user-facing scenario from PROB-033 signal.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-071 | informs |
+
+
+

--- a/.forgeplan/evidence/EVID-072-prob-034-multi-line-html-comment-state-machine-in-extract-field-v0-17-2.md
+++ b/.forgeplan/evidence/EVID-072-prob-034-multi-line-html-comment-state-machine-in-extract-field-v0-17-2.md
@@ -1,0 +1,88 @@
+---
+depth: tactical
+id: EVID-072
+kind: evidence
+links:
+- target: PROB-034
+  relation: informs
+status: active
+title: PROB-034 multi-line HTML comment state machine in extract_field (v0.17.2)
+---
+
+# EVID-072: PROB-034 multi-line HTML comment state machine in extract_field (v0.17.2)
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-09 |
+| Valid Until | 2026-07-08 |
+| Target | PROB-034 (hotfix target) |
+
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+     These fields are REQUIRED for correct R_eff calculation.
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+**What** (CRITICAL): `extract_field` in `evidence.rs` skipped only lines
+LITERALLY starting with `<!--`, not lines INSIDE multi-line comment blocks.
+Evidence template ships with multi-line help comment containing
+`congruence_level: 0 | 1 | 2 | 3 (CL3=...)` — this placeholder leaked into
+the parser, `parse::<u8>()` failed, `explicit_cl = None`, fallback to CL3
+default. ALL evidence ever created via template had CL silently reset.
+
+**How**: added `in_multiline_comment: bool` state to `extract_field` loop.
+When `<!--` opens without closing `-->` on same line, skip all lines until
+closing `-->` is seen.
+
+**A/B proof** on identical `/tmp/fp-prob034-repro` workspace:
+
+| Binary                     | r_eff    | CL  | Verdict   |
+|----------------------------|----------|-----|-----------|
+| v0.17.1 (stashed, rebuilt) | 1.0000   | 3   | ❌ BUG     |
+| v0.17.2 (fix applied)      | 0.1000   | 0   | ✅ correct |
+
+Same workspace, same steps, two different binaries, opposite answers.
+
+## Result
+
+- 2 regression tests: extract_field_ignores_multiline_html_comments,
+  extract_field_multiline_comment_nested_fields_all_ignored (both green)
+- All 19 evidence tests pass after fix
+- E2E: PRD-001 with EVID-001 CL3 + EVID-002 CL0 → R_eff=0.10 (weakest link) ✓
+- Health dashboard correctly reports "At Risk" for PRD-001 after fix — scoring pipeline end-to-end honest
+- Full workspace: 1137 tests passed, 0 failed (+6 from v0.17.1 baseline 1131)
+- Blast radius: all 4 fields (verdict, congruence_level, evidence_type, source_tier)
+  fixed automatically since they share extract_field
+
+## Interpretation
+
+Trust calculus restored end-to-end. R_eff across all workspaces was silently inflated since v0.17.0 — the multi-line comment leak made every template-created evidence default to CL3 regardless of user intent. A/B on identical workspace proves the fix (v0.17.1 r_eff=1.00 vs v0.17.2 r_eff=0.10 for explicit CL0). F1/F2 hardening (audit C) closes the same-class latent bugs so the fix is defense-in-depth, not patchwork.
+
+## Congruence Level Justification
+
+<!-- Почему выбран именно этот CL:
+     CL3: тот же контекст, внутренний тест (penalty 0.0)
+     CL2: похожий контекст, related project (penalty 0.1)
+     CL1: другой контекст, внешняя документация (penalty 0.4)
+     CL0: противоположный контекст (penalty 0.9) -->
+
+CL3 — same-context T1 evidence: unit + integration tests + full A/B comparison on identical workspace using stashed v0.17.1 binary. Highest possible trust for a same-project scoring fix.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| ADR-072 | informs |
+
+
+

--- a/.forgeplan/notes/NOTE-048-epic-003-real-world-verification-gaps-8-features-unverified-on-real-data-list-with-triage.md
+++ b/.forgeplan/notes/NOTE-048-epic-003-real-world-verification-gaps-8-features-unverified-on-real-data-list-with-triage.md
@@ -1,0 +1,173 @@
+---
+depth: tactical
+id: NOTE-048
+kind: note
+status: active
+title: EPIC-003 real-world verification gaps — features unverified on real data, triage list
+---
+
+# NOTE-048: EPIC-003 real-world verification gaps
+
+Post-v0.17.1 quality audit found 4 real bugs (PROB-030..033) plus 7
+features with weak or no real-world verification. Unit tests pass
+for all of them, but unit tests verify **correctness** (does code do
+what we wrote), not **quality** (does the feature solve user's
+problem better than before).
+
+This NOTE is the planning input for a future verification sprint OR
+for a v0.17.2 hotfix + separate test coverage pass.
+
+## Real bugs found (4, shaped as PROBs)
+
+| PROB | Title | Severity | Repro |
+|---|---|---|---|
+| **PROB-030** | BM25 "auth" prefix returns 0 results despite Authentication artifacts | HIGH (regression from substring) | confirmed |
+| **PROB-031** | R_eff shows 1.00 when weakest evidence is CL0=0.1 (formula violation) | HIGH (corrupts FPF decisions) | confirmed |
+| **PROB-032** | Search score display breakdown shows 0.0 components when total is non-zero | MEDIUM (UX lie) | confirmed |
+| **PROB-033** | new evidence blocked by session state on fresh workspace | MEDIUM (blocks backfill workflow) | confirmed |
+
+## Features verified but weakly (observed to work on happy path)
+
+| Feature | What was tested | What was NOT tested |
+|---|---|---|
+| PRD-041 FPF rules | default 5 rules load + rendering | user-defined rules from config.yaml |
+| PRD-041 FPF check | rule match on draft PRD | tie-breaking when multiple rules at same priority |
+| PRD-040 R_eff CI | "insufficient (1 evidence)" label | CI bounds math with 3+ evidence |
+| PRD-043 Duplicate guard | detects similar titles during new | similarity threshold tuning, false-positive rate |
+| PRD-043 Stub detection | fires on fresh template | custom content with placeholders |
+| PRD-044 Reindex trim | orphan relation cleanup on dogfood | corrupt-kind path (no test workspace had one) |
+| PRD-045 Health verdict | concrete actions on dogfood | gradient levels (only binary tested) |
+
+## Features NOT verified on real data (7+)
+
+### Sprint 13.2 PRD-039 Smart Search v2
+
+- **Composable ArtifactFilter DSL** — `--status active --depth deep
+  --with-evidence --since 2026-04-01` combined queries on realistic
+  workspace never tested beyond single-flag cases
+- **Graph expansion 1-hop** — neighbor inclusion never verified
+  affects ranking appropriately
+- **BM25 ranking quality vs old substring** — no A/B benchmark on a
+  set of real queries with known relevance judgments
+
+### Sprint 13.3 PRD-035 p1 Tags + SourceTier
+
+- **Tag canonicalization** — `source=code` vs `Source=Code` handling
+- **SourceTier T1→CL3 mapping** — precedence with explicit CL fields
+  never tested with conflict cases
+- **Multiple tags per artifact** — `tag X a=1 b=2 c=3` flow
+
+### Sprint 13.4 PRD-035 p2 Discover MCP
+
+- **Full discover session E2E** — `discover` → multiple `finding`
+  calls → `complete` never run on a real brownfield project
+- **Session state persistence** — what happens when session
+  crashes mid-way
+- **Phase transitions during discovery** — documented but not tested
+
+### Sprint 13.5 PRD-040 Scoring Intelligence
+
+- **Skills Memory adaptive routing** — requires accumulated routing
+  history, never tested over 10+ routing decisions
+- **Exponential decay (90-day half-life)** — decay curve behavior
+  never verified beyond unit tests
+- **Confidence threshold 0.6** — picked in code, no real data to
+  validate it's the right value
+
+### Sprint 13.6 PRD-041 FPF Rules
+
+- **User-defined rules via .forgeplan/config.yaml** — config loading
+  path works (unit-tested) but never exercised with complex user rules
+- **Rule priority ties** — two rules at same priority, which wins?
+
+### Sprint 13.7 PRD-042 FPF KB Vector Search
+
+- **BGE-M3 semantic precision vs keyword on real queries** — the
+  `#[ignore]` test runs one trivial query ("confidence in evidence"),
+  never measured precision/recall on 200+ FPF sections
+- **--semantic fallback warning when feature ON but model fails**
+  — multiple runtime fallback paths unit-tested via closure injection
+  but not with real Embedder failing
+
+### Cross-feature workflows
+
+- **`forgeplan estimate` command** — listed in CLI help, never ran
+  on a real PRD to verify estimation quality
+- **Real v3→v4 schema migration on live workspace** — unit test
+  fixture exists, no end-to-end migration of a user's actual
+  workspace
+- **Reindex on 500+ artifact workspace** — performance untested
+- **MCP tools via real Claude Code client** — handler unit tests
+  exist, never exercised via actual MCP protocol invocation from
+  a client
+
+## Triage recommendation
+
+### Track 1: v0.17.2 hotfix (2 HIGH bugs, ~2 hours each)
+
+- **PROB-030** BM25 prefix fallback (add substring on 0 BM25 results)
+- **PROB-031** R_eff weakest-link formula investigation + fix
+- Shape PRD-046, PRD-047 per /forge
+- ADI with code investigation (lesson from v0.17.1)
+- Full cycle: code → tests → audit → evidence → activate → PR → tag
+
+### Track 2: Polish hotfix bundled with Track 1
+
+- **PROB-032** search score breakdown display (fix or remove)
+- **PROB-033** new evidence session state loosening
+- Lower severity but quick wins
+
+### Track 3: Verification sprint (Sprint 14.x)
+
+Dedicated test coverage + real-world verification pass. Focus on the
+7 feature areas above. Produces:
+
+- 10+ integration tests covering real workflows
+- Benchmark: BM25 vs substring precision/recall on labelled query set
+- Benchmark: BGE-M3 semantic search on 200+ FPF sections
+- Skills Memory training test with 20+ routing decisions
+- Real v3 workspace migration integration test
+- MCP real client test via mock Claude Code harness
+- Performance stress test on 500+ artifact workspace
+
+Produces one or more EVIDs documenting real quality measurements,
+not just unit test counts.
+
+## Lessons for NOTE-044 (methodology)
+
+Add to Phase 5 Manual UX verification:
+
+- **Dogfood test does NOT equal real-world test.** Dogfood is a
+  specific workspace with specific shape. Real-world verification
+  needs variety: fresh workspace, medium workspace, large workspace,
+  workspace with accumulated history.
+- **Quality != correctness.** Tests that assert "function returns
+  non-empty" don't prove the function solves the user's problem.
+  Add a "quality criteria" checklist per feature: before marking
+  done, answer "what would the user try first, and does our feature
+  handle it gracefully?"
+- **Prefix search is a common user expectation** — grep-like
+  behavior is the default mental model. Any new search system must
+  handle prefix queries or explicitly document they are not
+  supported.
+- **Root cause investigation is not bug triage.** Found bugs must
+  be investigated deeply (not just reported) before fix planning.
+  PROB-031 R_eff bug needs code walkthrough to find the actual
+  disconnect, not just "there's a number mismatch".
+- **Formula correctness is verifiable via exhaustive enumeration.**
+  For small state spaces (like CL × verdict × evidence_type × stale),
+  write a test that enumerates every combination and asserts the
+  formula produces the expected output. Unit tests that check
+  individual cases miss boundary interactions.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PROB-030 | informs (real bug found in audit) |
+| PROB-031 | informs (real bug found in audit) |
+| PROB-032 | informs (real bug found in audit) |
+| PROB-033 | informs (real bug found in audit) |
+| NOTE-044 | refines (adds lessons to sprint checklist) |
+| EPIC-003 | context (verification debt from the entire epic) |
+| EVID-065 | precedent (backfill pattern demonstrating PROB-033 workaround) |

--- a/.forgeplan/problems/PROB-030-bm25-search-regression-auth-prefix-returns-0-results-despite-existing-authentication-artifacts.md
+++ b/.forgeplan/problems/PROB-030-bm25-search-regression-auth-prefix-returns-0-results-despite-existing-authentication-artifacts.md
@@ -1,0 +1,124 @@
+---
+depth: tactical
+id: PROB-030
+kind: problem
+status: draft
+title: BM25 search regression — prefix queries return 0 results despite existing matches
+---
+
+# PROB-030: BM25 prefix search regression
+
+## Signal
+
+On a test workspace with 9 PRDs including 2 titled "Authentication":
+
+```bash
+$ forgeplan search "auth"
+  No results for "auth"
+
+$ forgeplan search "OAu"
+  No results for "OAu"
+
+$ forgeplan search "OAuth2"    # exact token works
+Found 2 result(s) for "OAuth2" (smart search):
+  0.43  PRD-002 [prd|draft] "Authentication OAuth2 system"
+  0.43  PRD-001 [prd|draft] "Authentication system redesign with OAuth2 1"
+```
+
+BM25 tokenization splits titles into whole tokens ("authentication",
+"oauth2"), so prefix queries like "auth" or "OAu" don't match because
+they are not complete tokens.
+
+**This is a REGRESSION** from v0.16.0 and earlier substring-based
+search, which matched any substring — users could type "auth" and
+find "Authentication". Sprint 13.2 PRD-039 replaced substring with
+BM25 ranking for better precision on full-word queries but lost
+prefix matching as a side effect.
+
+## Repro
+
+```bash
+cd $(mktemp -d)
+forgeplan init -y
+forgeplan new prd "Authentication OAuth2 system"
+forgeplan new prd "Authentication system redesign"
+forgeplan search "auth"
+# Expected: both PRDs returned (users expect grep-like partial match)
+# Actual:   "No results for auth"
+```
+
+## Root cause hypothesis
+
+Sprint 13.2 BM25 implementation in `forgeplan-core/src/search/`
+tokenizes both the query and the document text into whole words,
+then computes term frequency / inverse document frequency. Whole-word
+tokens "auth" and "authentication" are different tokens — BM25 sees
+no match.
+
+Possible fixes (not chosen yet, for ADI phase):
+
+1. **Fallback substring on 0 BM25 results** — if BM25 returns nothing,
+   fall back to old substring matching with a lower score ceiling.
+   Preserves BM25 ranking when it finds matches + restores grep
+   behavior when users type prefixes.
+
+2. **Prefix/stem tokenizer** — expand query tokens to prefix-matches
+   against the index. Adds `auth*` → `authentication|authorized|
+   authority` at query time. More invasive.
+
+3. **Hybrid: substring + BM25** — always check both, merge results.
+   Most expensive.
+
+4. **Document explicit "exact tokens only" behavior** — not a fix,
+   just tell users they need full words. Regression remains.
+
+Option 1 is recommended for scope of hotfix.
+
+## Constraints
+
+- Must preserve BM25 ranking quality when full tokens match (don't
+  drop to substring mode unnecessarily)
+- Must not slow down searches significantly
+- Substring fallback should have clearly lower score so users can
+  see "this is a fuzzy match, not exact"
+- Backward compat: existing tests passing BM25 full-token queries
+  must still pass
+
+## Acceptance Criteria
+
+1. `search "auth"` with existing "Authentication" artifacts returns
+   those artifacts (possibly at a lower rank than exact-token matches)
+2. `search "authentication"` still returns same results as today
+   (full-token BM25 path unchanged)
+3. Output includes an indicator when results came from fallback
+   path (e.g., "fuzzy match" tag or visibly lower score)
+4. New integration test covers prefix queries
+5. Existing BM25 tests pass unchanged
+
+## Impact
+
+**HIGH** — user-facing search regression. Users switching from
+v0.16 to v0.17 will hit this on their first prefix search and get
+zero results. First impression quality matters.
+
+## Blast Radius
+
+- All CLI `forgeplan search` users
+- MCP `forgeplan_search` tool consumers (AI agents relying on
+  substring)
+- Sprint 13.2 PRD-039 FR-001 acceptance implicit assumption
+
+## Reversibility
+
+HIGH — additive fallback, no schema change, feature-flag not
+required for patch.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-039 | informs (Sprint 13.2 BM25 implementation that introduced this) |
+| EVID-065 | informs (Sprint 13.2 backfill evidence — did not catch this regression) |
+| EPIC-003 | context |
+| PROB-031 | sibling (quality audit 2026-04-09 found both) |
+| NOTE-048 | sibling (EPIC-003 verification gaps list) |

--- a/.forgeplan/problems/PROB-030-bm25-search-regression-auth-prefix-returns-0-results-despite-existing-authentication-artifacts.md
+++ b/.forgeplan/problems/PROB-030-bm25-search-regression-auth-prefix-returns-0-results-despite-existing-authentication-artifacts.md
@@ -2,8 +2,8 @@
 depth: tactical
 id: PROB-030
 kind: problem
-status: draft
-title: BM25 search regression — prefix queries return 0 results despite existing matches
+status: active
+title: BM25 search regression — 'auth' prefix returns 0 results despite existing 'Authentication' artifacts
 ---
 
 # PROB-030: BM25 prefix search regression
@@ -122,3 +122,4 @@ required for patch.
 | EPIC-003 | context |
 | PROB-031 | sibling (quality audit 2026-04-09 found both) |
 | NOTE-048 | sibling (EPIC-003 verification gaps list) |
+

--- a/.forgeplan/problems/PROB-031-r-eff-rollup-shows-1-00-when-weakest-evidence-is-cl0-0-1-violates-weakest-link-formula.md
+++ b/.forgeplan/problems/PROB-031-r-eff-rollup-shows-1-00-when-weakest-evidence-is-cl0-0-1-violates-weakest-link-formula.md
@@ -2,7 +2,7 @@
 depth: tactical
 id: PROB-031
 kind: problem
-status: draft
+status: active
 title: R_eff rollup shows 1.00 when weakest evidence is CL0 = 0.1 — violates weakest-link formula
 ---
 
@@ -109,3 +109,4 @@ values can be recomputed cheaply via batch score pass.
 | EPIC-003 | context |
 | PROB-030 | sibling (quality audit 2026-04-09) |
 | NOTE-048 | sibling (verification gaps list) |
+

--- a/.forgeplan/problems/PROB-031-r-eff-rollup-shows-1-00-when-weakest-evidence-is-cl0-0-1-violates-weakest-link-formula.md
+++ b/.forgeplan/problems/PROB-031-r-eff-rollup-shows-1-00-when-weakest-evidence-is-cl0-0-1-violates-weakest-link-formula.md
@@ -1,0 +1,111 @@
+---
+depth: tactical
+id: PROB-031
+kind: problem
+status: draft
+title: R_eff rollup shows 1.00 when weakest evidence is CL0 = 0.1 — violates weakest-link formula
+---
+
+# PROB-031: R_eff weakest-link formula violated in rollup
+
+## Signal
+
+```
+$ forgeplan score PRD-004
+  Evidence breakdown:
+    EVID-001 [Supports] CL0 = 0.1
+  R_eff:        1.00 -- Adequate
+  Confidence:   insufficient (1 evidence)
+```
+
+Per-item score correctly computed as 0.1 (CL0 penalty 0.9 applied to
+Supports=1.0 → 1.0 - 0.9 = 0.1). But the R_eff rollup displays 1.00,
+**contradicting the per-item breakdown above it**.
+
+Per ADR-005 and Quint-code documentation, `R_eff = min(evidence_scores)`
+— trust equals the weakest link, NEVER average. With one evidence
+at 0.1, R_eff should be 0.1, not 1.00.
+
+## Repro
+
+```bash
+cd $(mktemp -d)
+forgeplan init -y
+forgeplan new prd "Test PRD"
+forgeplan new evidence "Test evidence"
+forgeplan link EVID-001 PRD-001 --relation informs
+forgeplan score PRD-001
+# Expected: R_eff 0.1
+# Actual:   R_eff 1.00
+```
+
+## Root cause hypothesis
+
+Initial trace through `r_eff_recursive` in `scoring/reff.rs:227`:
+1. evidence_items = [EVID-001 with CL0]
+2. self_score = score_evidence_full(EVID-001) = max(1.0 - 0.9 - 0, 0) = 0.1
+3. deps loop: EVID-001 IS in deps (relation="informs" is dep relation)
+4. Line 312-321: skip draft status → continue → min_dep_score stays 1.0
+5. Line 364: deps.is_empty() is FALSE → final_score = self_score.min(min_dep_score) = 0.1.min(1.0) = 0.1
+
+Expected: 0.1. But displayed: 1.00. Possible issues:
+
+- **Two code paths compute R_eff differently** — score command vs
+  tree view vs HealthReport each might call different function
+- **CL default mismatch** — parse_evidence_from_record might return
+  CL3 (default) when no structured fields, then display code
+  recomputes CL0 separately causing drift
+- **LanceDB cache stale** — r_eff_score column cached from an older
+  recomputation and not updated
+
+Need deep investigation during fix sprint.
+
+## Constraints
+
+- ADR-005 weakest-link principle is canonical — must not switch to
+  average or any other aggregation
+- Must not corrupt existing r_eff_score values during fix
+- CL determination must be consistent across all code paths
+  (score, tree, health, fpf check)
+- Backward compat with existing FPF rules engine which reads r_eff
+
+## Acceptance Criteria
+
+1. `score PRD-001` with 1 evidence at CL0 shows R_eff = 0.1
+2. `tree` view for PRD-001 shows matching R_eff (no drift)
+3. Stored `r_eff_score` in LanceDB matches displayed value after
+   re-run of `forgeplan score`
+4. FPF rules fire on correct values (blind-spot should fire for
+   r_eff < 0.01 but NOT for 0.1 — clear distinction)
+5. Integration test: create PRD + CL0 evidence, assert score command
+   R_eff matches per-item breakdown min
+
+## Impact
+
+**HIGH** — FPF rule engine quality is degraded because it reads
+wrong R_eff. Health dashboard blind-spot detection may miss or
+wrongly flag artifacts. Tree view shows misleading progress bars.
+Users get bad decisions from the tool they trust for quality gating.
+
+## Blast Radius
+
+- Anyone using `forgeplan score` or `forgeplan tree`
+- Anyone whose evidence lacks explicit structured fields (very common)
+- FPF rules engine decisions
+- Health dashboard signals
+- MCP `forgeplan_score` tool output to AI agents
+
+## Reversibility
+
+HIGH — computation logic fix, no schema change. Stored r_eff_score
+values can be recomputed cheaply via batch score pass.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| ADR-005 | informs (weakest-link canonical formula) |
+| PRD-040 | informs (R_eff CI — point estimate is wrong) |
+| EPIC-003 | context |
+| PROB-030 | sibling (quality audit 2026-04-09) |
+| NOTE-048 | sibling (verification gaps list) |

--- a/.forgeplan/problems/PROB-032-search-score-display-breakdown-shows-all-0-0-when-total-score-is-non-zero.md
+++ b/.forgeplan/problems/PROB-032-search-score-display-breakdown-shows-all-0-0-when-total-score-is-non-zero.md
@@ -2,7 +2,7 @@
 depth: tactical
 id: PROB-032
 kind: problem
-status: draft
+status: active
 title: Search score display breakdown shows all 0.0 when total score is non-zero
 ---
 
@@ -96,3 +96,4 @@ HIGH — pure display code fix OR removal of misleading line.
 | PRD-039 | informs (Sprint 13.2 BM25 introduced breakdown) |
 | PROB-030 | sibling (both BM25 regressions from quality audit) |
 | NOTE-048 | sibling |
+

--- a/.forgeplan/problems/PROB-032-search-score-display-breakdown-shows-all-0-0-when-total-score-is-non-zero.md
+++ b/.forgeplan/problems/PROB-032-search-score-display-breakdown-shows-all-0-0-when-total-score-is-non-zero.md
@@ -1,0 +1,98 @@
+---
+depth: tactical
+id: PROB-032
+kind: problem
+status: draft
+title: Search score display breakdown shows all 0.0 when total score is non-zero
+---
+
+# PROB-032: Search score breakdown lies about components
+
+## Signal
+
+```
+$ forgeplan search "api error"
+Found 9 result(s) for "api error":
+
+  0.57  PRD-004 [prd|draft] "Error handling for API endpoints"
+        kw=0.0 sem=0.0 r=0.0 g=0.0       ← all components zero
+  0.02  PRD-002 [prd|draft] "Authentication OAuth2 system"
+        kw=0.0 sem=0.0 r=0.0 g=0.0
+  ...
+```
+
+Total score is 0.57 for PRD-004, but the breakdown `kw=0.0 sem=0.0
+r=0.0 g=0.0` shows all components as zero. **Zero + zero + zero +
+zero ≠ 0.57**. The display is lying to the user about score
+composition.
+
+## Repro
+
+```bash
+cd $(mktemp -d)
+forgeplan init -y
+forgeplan new prd "Error handling for API endpoints"
+forgeplan new prd "Something unrelated"
+forgeplan search "api error"
+# Check that the breakdown line shows zero components but total
+# score is non-zero
+```
+
+## Root cause hypothesis
+
+PRD-039 Smart Search v2 (Sprint 13.2) adds multiple scoring
+components: BM25 (kw), semantic (sem), R_eff boost (r), granularity
+boost (g). Each result gets per-component scores and a total.
+
+The display layer reads component scores from `SmartSearchResult`
+struct but something in the computation path doesn't populate them
+for the "single-token match" case, while still producing a non-zero
+total via a different aggregation.
+
+Two candidate bugs:
+1. Display reads wrong fields (r_eff_boost instead of bm25_score)
+2. Computation doesn't write components to struct, total is
+   synthesized separately
+3. Normalization zeroes components but preserves total
+
+Need code investigation in `crates/forgeplan-core/src/search/`.
+
+## Constraints
+
+- Either fix breakdown to show true components (each non-zero when
+  contributing), or remove the breakdown line entirely
+- Must not change total score ranking
+- Must not regress existing search tests
+
+## Acceptance Criteria
+
+1. For a query that matches primarily via BM25, the `kw=X` component
+   shows a non-zero value that contributes to the total
+2. Sum of displayed components approximately equals the total score
+   (within rounding)
+3. If no sensible breakdown can be computed, remove the breakdown
+   display line entirely rather than show lies
+4. Existing `cli_fpf_search_*` and search tests still pass
+
+## Impact
+
+**MEDIUM** — UX confusion, not data corruption. Users trying to
+understand ranking see contradictory info. Undermines trust in
+search quality.
+
+## Blast Radius
+
+- CLI `forgeplan search` output only
+- MCP `forgeplan_search` output if it exposes breakdown too
+
+## Reversibility
+
+HIGH — pure display code fix OR removal of misleading line.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-039 | informs (Sprint 13.2 BM25 introduced breakdown) |
+| PROB-030 | sibling (both BM25 regressions from quality audit) |
+| NOTE-048 | sibling |

--- a/.forgeplan/problems/PROB-033-forgeplan-new-evidence-blocked-by-session-state-machine-on-fresh-workspace.md
+++ b/.forgeplan/problems/PROB-033-forgeplan-new-evidence-blocked-by-session-state-machine-on-fresh-workspace.md
@@ -1,0 +1,89 @@
+---
+depth: tactical
+id: PROB-033
+kind: problem
+status: draft
+title: forgeplan new evidence blocked by session state machine on fresh workspace
+---
+
+# PROB-033: Session state machine blocks legitimate evidence creation
+
+## Signal
+
+```
+$ forgeplan init -y
+$ forgeplan new prd "Test PRD"
+$ forgeplan new evidence "Test evidence"
+  Session: Cannot go from 'routing' to 'evidence'. Create artifact and code first
+  Hint: Create artifact: `forgeplan new prd "Title"`
+```
+
+Session state machine (PRD-019 Layer 3 Methodology Enforcement)
+expects progression Idle → Routing → Shaping → Coding → Evidence
+→ PR. Creating evidence in "routing" phase is blocked.
+
+## Problem severity
+
+Block is intentional by design but has bad UX for legitimate
+scenarios:
+
+- **Backfill** — user documents evidence for code shipped in the
+  past (EVID-065 backfill pattern used during v0.17.0 final audit)
+- **Import from external** — evidence from benchmark run outside
+  the tool
+- **Brownfield discovery** — evidence for artifacts mined from
+  legacy docs
+- **Quality audit** — during /forge audit reviewer captures
+  evidence pointing at a bug
+
+## Constraints
+
+- Must not weaken stub detection — empty evidence still blocked
+  from activation
+- Must preserve state machine guardrail for new work
+- Must not silently advance state for users who want it
+
+## Candidate fixes
+
+1. `--force` flag bypass
+2. Auto-advance on first PRD present
+3. Remove state check from `new evidence` (activate still enforces)
+4. **Phase-agnostic `new` commands** — `new` never fails on state,
+   only `activate` does. Cleanest.
+
+Option 4 preferred.
+
+## Acceptance Criteria
+
+1. `forgeplan new evidence` works on any workspace state without
+   `--force`
+2. `forgeplan activate EVID-XXX` still requires PRD exists +
+   structured fields + not stub
+3. Existing session state tests for other transitions still pass
+4. Integration test: fresh workspace → new prd → new evidence →
+   success
+
+## Impact
+
+**MEDIUM** — blocks backfill and audit workflows. Not data
+corruption, UX regression for power users.
+
+## Blast Radius
+
+- CLI `forgeplan new evidence` on fresh/routing workspaces
+- MCP equivalent if same check used
+- Scripts and automation
+
+## Reversibility
+
+HIGH — loosening a check is safe.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-019 | informs (methodology enforcement layer 3) |
+| PRD-043 | informs (stub detection stays at activate) |
+| EVID-058 | informs (Sprint 13.1 implementation) |
+| EVID-065 | informs (backfill pattern worked around this) |
+| NOTE-048 | sibling |

--- a/.forgeplan/problems/PROB-033-forgeplan-new-evidence-blocked-by-session-state-machine-on-fresh-workspace.md
+++ b/.forgeplan/problems/PROB-033-forgeplan-new-evidence-blocked-by-session-state-machine-on-fresh-workspace.md
@@ -2,7 +2,7 @@
 depth: tactical
 id: PROB-033
 kind: problem
-status: draft
+status: active
 title: forgeplan new evidence blocked by session state machine on fresh workspace
 ---
 
@@ -87,3 +87,4 @@ HIGH — loosening a check is safe.
 | EVID-058 | informs (Sprint 13.1 implementation) |
 | EVID-065 | informs (backfill pattern worked around this) |
 | NOTE-048 | sibling |
+

--- a/.forgeplan/problems/PROB-034-multi-line-html-comments-in-evidence-template-shadow-real-structured-fields-critical.md
+++ b/.forgeplan/problems/PROB-034-multi-line-html-comments-in-evidence-template-shadow-real-structured-fields-critical.md
@@ -1,0 +1,173 @@
+---
+depth: deep
+id: PROB-034
+kind: problem
+status: active
+title: Multi-line HTML comments in evidence template shadow real structured fields (CRITICAL)
+---
+
+# PROB-034: Multi-line HTML comments silently break congruence_level parsing
+
+## Signal
+
+Found during /forge E2E verification sprint (v0.17.2 hotfix). On a fresh
+workspace with v0.17.1 release binary:
+
+```bash
+$ forgeplan new prd "Target"
+$ forgeplan new evidence "Test"
+$ sed -i.bak 's/^congruence_level: 3$/congruence_level: 0/' \
+    .forgeplan/evidence/EVID-001-test.md
+$ forgeplan reindex && forgeplan link EVID-001 PRD-001 --relation informs
+$ forgeplan score PRD-001 --json | jq '.r_eff, .evidence[0].congruence_level'
+1.0000   ← WRONG, should be 0.10
+3        ← WRONG, should be 0
+```
+
+User explicitly set `congruence_level: 0` in the Structured Fields section,
+but the parser returned CL3. This breaks the entire weakest-link R_eff
+formula for any evidence created via `forgeplan new evidence`.
+
+## A/B proof on identical workspace
+
+| Binary                           | r_eff   | display CL | Verdict    |
+|----------------------------------|---------|------------|------------|
+| v0.17.1 (baseline, no fix)       | 1.0000  | CL=3       | ❌ BUG      |
+| v0.17.2 (multi-line fix applied) | 0.1000  | CL=0       | ✅ correct  |
+
+Same `.forgeplan/` directory, two different binaries, opposite answers.
+This is a 100% reproducible prod bug, not a test-script artifact.
+
+## Root cause
+
+`crates/forgeplan-core/src/scoring/evidence.rs::extract_field` skipped only
+lines *starting* with `<!--`, not lines *inside* a multi-line comment block:
+
+```rust
+// v0.17.1 (broken):
+if trimmed.starts_with('|') || trimmed.starts_with("<!--") {
+    continue;
+}
+```
+
+The evidence template ships with a helpful multi-line comment:
+
+```markdown
+<!-- Fill in the Structured Fields section below for R_eff scoring.
+
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
+-->
+```
+
+The line `     congruence_level: 0 | 1 | 2 | 3 (CL3=...)` does NOT start
+with `<!--`, so `extract_field` matched it, returning the string
+`"0 | 1 | 2 | 3 (CL3=..."`. Then:
+
+```rust
+let explicit_cl = extract_field(&record.body, "congruence_level")
+    .and_then(|s| s.parse::<u8>().ok())   // fails on non-numeric string
+    .filter(|&n| n <= 3);                 // → None
+```
+
+`parse::<u8>()` failed silently → `explicit_cl = None` → fallback to CL3
+default. The **real** `congruence_level: 0` below in the Structured Fields
+section was never inspected because `extract_field` returns the **first**
+match and short-circuits.
+
+## Blast radius
+
+**CRITICAL — entire scoring system compromised since PRD-035 template.**
+
+- **All fields affected**: `verdict`, `congruence_level`, `evidence_type`,
+  `source_tier` — all are declared in the same template comment block.
+- **All evidence affected**: every artifact created via `forgeplan new
+  evidence` inherits the template comment. Ingested/imported evidence with
+  multi-line comments also affected.
+- **All R_eff scores affected**: the weakest-link formula reads penalized
+  CL values. If all evidence silently defaults to CL3, R_eff is
+  artificially inflated across the whole project.
+- **Health dashboard lies**: artifacts with "weak evidence" (CL0-1) show as
+  "high R_eff" — blind spots stay hidden.
+- **PRD-040 confidence intervals broken**: CI is built from per-evidence
+  scores that were all wrong.
+
+Every R_eff number reported by v0.17.0 and v0.17.1 in a real workspace is
+potentially inflated.
+
+## Fix
+
+`extract_field` now implements a proper multi-line HTML comment state
+machine:
+
+```rust
+let mut in_multiline_comment = false;
+for line in body.lines() {
+    let trimmed = line.trim();
+
+    if in_multiline_comment {
+        if trimmed.contains("-->") {
+            in_multiline_comment = false;
+        }
+        continue;
+    }
+    if trimmed.starts_with("<!--") {
+        if !trimmed.contains("-->") {
+            in_multiline_comment = true;
+        }
+        continue;
+    }
+
+    if trimmed.starts_with('|') { continue; }
+
+    if let Some(rest) = trimmed.strip_prefix(&prefix) {
+        let val = rest.trim();
+        if !val.is_empty() { return Some(val.to_string()); }
+    }
+}
+```
+
+Two regression tests added:
+1. `extract_field_ignores_multiline_html_comments` — replicates the real
+   evidence template scenario end-to-end.
+2. `extract_field_multiline_comment_nested_fields_all_ignored` — guards
+   against multiple `key: value` lines hiding inside a single comment.
+
+## Acceptance Criteria
+
+1. ✅ `extract_field` skips lines inside multi-line `<!-- ... -->` blocks.
+2. ✅ `extract_field_ignores_html_comments` (single-line) still passes.
+3. ✅ Multi-line regression tests pass.
+4. ✅ E2E: `forgeplan new evidence` → edit congruence_level → reindex →
+   `forgeplan score --json` returns the correct CL, not CL3 default.
+5. ✅ A/B test on same workspace with v0.17.1 vs v0.17.2 binaries shows
+   corrected R_eff.
+6. ✅ Full `cargo test --workspace` green (1137/1137).
+
+## Impact
+
+**CRITICAL** — trust calculus was silently blind since v0.17.0. Fix is
+mandatory for any user relying on R_eff for decision quality.
+
+## Blast Radius
+
+- `forgeplan_core::scoring::evidence::extract_field` (single function, one
+  state machine addition)
+- All callers (`congruence_level`, `verdict`, `evidence_type`,
+  `source_tier`) benefit automatically
+
+## Reversibility
+
+HIGH — 20-line state machine addition, heavily tested. No behavior change
+for docs without multi-line comments.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-040 | informs (scoring intelligence relied on correct CL parsing) |
+| PRD-043 | informs (methodology integrity assumed honest R_eff) |
+| PROB-031 | sibling (the visible symptom — CLI had its own duplicate parser too) |
+| NOTE-048 | informs (real-world verification gaps — this is exactly why) |
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,116 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.17.2] — 2026-04-09 — Quality hotfix: scoring & search integrity
+
+Fixes **five** real bugs found during a dedicated /forge E2E verification
+sprint on a fresh workspace (separate from the dogfood audit that produced
+v0.17.1). Each bug was reproduced on the v0.17.1 release binary before
+fixing, and the fix verified A/B on an identical workspace.
+
+The headline fix is **PROB-034 (CRITICAL)** — a silent trust-calculus
+regression present since v0.17.0 that inflated R_eff scores across every
+workspace using the default evidence template.
+
+### Fixed
+
+- **PROB-034 (CRITICAL) — Multi-line HTML comments shadowed real
+  structured fields in `extract_field`.**
+  `crates/forgeplan-core/src/scoring/evidence.rs::extract_field` skipped
+  only lines *literally starting* with `<!--`, not lines *inside* a
+  multi-line comment block. The evidence template ships with a help
+  comment:
+  ```markdown
+  <!--
+       verdict: supports | weakens | refutes
+       congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed)
+  -->
+  ```
+  The placeholder line `congruence_level: 0 | 1 | 2 | 3 (CL3=...)` does
+  not start with `<!--`, so the parser matched it, `parse::<u8>()` failed
+  on the non-numeric string, `explicit_cl` became `None`, and the
+  **real** `congruence_level: X` in the Structured Fields section below
+  was never inspected. Every evidence artifact ever created via the
+  default template silently reset to CL3 (no penalty), artificially
+  inflating R_eff across every workspace since v0.17.0.
+  - Fix: `extract_field` now implements a proper multi-line comment
+    state machine — tracks an `in_multiline_comment` boolean, skipping
+    all lines between `<!--` and `-->` when they span multiple lines.
+  - Affects all fields parsed via `extract_field`: `verdict`,
+    `congruence_level`, `evidence_type`, `source_tier` — all were
+    silently defaulted. The fix is transitive.
+  - A/B verification on `/tmp/fp-prob034-repro` with identical workspace:
+    v0.17.1 binary → `r_eff=1.0000, CL=3`; v0.17.2 binary →
+    `r_eff=0.1000, CL=0` (correct for explicit CL0 evidence).
+  - Regression tests: `extract_field_ignores_multiline_html_comments`,
+    `extract_field_multiline_comment_nested_fields_all_ignored`.
+
+- **PROB-030 — BM25 prefix queries returned 0 results.**
+  `crates/forgeplan-core/src/search/smart.rs` computed `keyword_score`
+  (substring match) for diagnostics but passed only `bm25_norm` to
+  `combined_score`. BM25 is token-based, so `auth` did not match the
+  token `authentication`, and prefix queries silently returned nothing.
+  - Fix: `let keyword_channel = bm25_norm.max(kw);` — BM25 still wins
+    on exact-token matches (richer signal), but substring fallback kicks
+    in when BM25 returns 0 for prefix queries.
+  - Regression tests: `smart_search_prefix_query_falls_back_to_substring`,
+    `smart_search_exact_token_still_wins_over_prefix`.
+
+- **PROB-031 — CLI `score` command had its own divergent evidence
+  parser.** The CLI `parse_evidence_from_record` in `score.rs`
+  duplicated core's function but with a different default CL (CL0 vs
+  CL3), creating a visible contradiction: display said
+  `CL0 = 0.1` while the `r_eff_recursive` rollup computed `1.00` via
+  core's parser. The local CLI parser also did NOT implement the
+  PRD-035 Sprint 13.3 H2 security precedence
+  (`min(tier_cl, explicit_cl)`), opening a trust-amplification attack
+  surface on the display path.
+  - Fix: deleted the local duplicate and `extract_field` helper;
+    imported `forgeplan_core::scoring::evidence::parse_evidence_from_record`.
+    Display and rollup now read identical values by construction.
+  - Regression test:
+    `score_uses_core_parser_with_cl3_default_when_no_structured_fields`.
+
+- **PROB-032 — `forgeplan search` breakdown line lied about
+  components.** Display showed `kw=0.0 sem=0.0 r=0.0 g=0.0` while total
+  was 0.57. Caused by PROB-030: `kw` was computed but never flowed into
+  `combined_score`.
+  - Auto-fixed as side effect of PROB-030. Breakdown now shows real
+    component values.
+
+- **PROB-033 — `forgeplan new evidence` printed confusing session
+  warning after `forgeplan route`.** The session state machine
+  attempted a `Routing → Evidence` transition, which is disallowed.
+  The file WAS created, but stderr showed
+  `Session: Cannot go from 'routing' to 'evidence'` — blocking
+  legitimate backfill, audit, brownfield, and evidence-import flows
+  in perception if not in fact.
+  - Fix: `forgeplan new evidence` is now phase-agnostic — it never
+    drives the session state machine. Only decision artifacts
+    (prd/rfc/adr/epic/spec) advance to Shaping phase. Methodology
+    guardrail still enforces at `activate` time via PRD-043 stub
+    detection + validation gates.
+  - Regression test:
+    `new_evidence_works_in_routing_phase_without_session_warning`.
+
+### Tests
+
+- 1137 tests pass (+6 from v0.17.1 baseline 1131).
+- 6 new regression tests cover PROB-030 (2), PROB-031 (1), PROB-033 (1),
+  PROB-034 (2).
+- `cargo fmt --check` clean, `cargo clippy --workspace --all-targets --
+  -D warnings` clean on both default and `semantic-search` feature.
+
+### Impact
+
+If you are upgrading from v0.17.0 or v0.17.1 and you have evidence
+artifacts in your workspace, your R_eff scores were potentially
+inflated by the CL3 default (PROB-034). Re-run `forgeplan score` on
+critical PRDs after upgrade — any evidence that explicitly set
+`congruence_level` in Structured Fields will now be honored, and weak
+CL values may cause R_eff to drop. This is correct behavior; the
+previous values were silently wrong.
+
 ## [0.17.1] — 2026-04-09 — Post-v0.17.0 dogfood hotfix
 
 Fixes two bugs found during the v0.17.0 final dogfood audit when running

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,12 @@ Forgeplan = Quint-code (decision engine, R_eff scoring, evidence decay)
 
 ## Текущий статус
 
+- **v0.17.2** quality hotfix 2026-04-09 — PROB-030..034 fixed (BM25 prefix, R_eff
+  parser consistency, score breakdown, session state, **CRITICAL** multi-line
+  HTML comment shadow + fail-closed hardening for unclosed/unparseable fields)
 - **v0.17.1** hotfix 2026-04-09 — PROB-028 phantom rows + PROB-029 health verdict fixed
 - **v0.17.0** released 2026-04-08 — **EPIC-003 complete** (Search, Discovery, Intelligence)
-- **~56 CLI команд**, **~47 MCP tools**, **1131 тестов** (+283 от v0.16)
+- **~56 CLI команд**, **~47 MCP tools**, **1143 тестов** (+12 от v0.17.0 baseline 1131)
 - **0 warnings** на обоих feature configs (default + `semantic-search`)
 - EPIC-001 (foundation) ✅ | EPIC-002 (v2.0 vision) ✅ | **EPIC-003 (v0.17.0)** ✅
 - **7 PRDs активированы** в v0.17.0: PRD-035 (tags + discover), PRD-039 (BM25 search),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/TODO.md
+++ b/TODO.md
@@ -1,25 +1,36 @@
 # TODO — Forgeplan
 
-## Current: v0.17.1 hotfix 2026-04-09 — post-dogfood fixes
+## Current: v0.17.2 quality hotfix 2026-04-09 — E2E verification sprint
 
-### v0.17.1 hotfix ✅
-- [x] PROB-028 phantom rows fixed (PRD-044): reindex parse-kind skip + orphan relation cascade
-- [x] PROB-029 health verdict fixed (PRD-045): generate_next_actions reads stubs/duplicates
-- [x] 1131 tests pass (+3 from v0.17.0)
-- [x] Clippy 1.94 strict clean (both feature configs)
-- [x] EVID-066, EVID-067 activated
-- [x] PRD-044, PRD-045 activated (progress bars reflect reality)
-- [x] CHANGELOG.md v0.17.1 entry under Fixed
-- [x] Cargo.toml version 0.17.0 → 0.17.1 (all 3 crates)
-- [x] CLAUDE.md status block updated to v0.17.1
+### v0.17.2 hotfix P0
+- [x] PROB-030 BM25 prefix fallback (smart.rs `max(bm25_norm, kw)`)
+- [x] PROB-031 score.rs imports core parser (deleted local duplicate with CL0 default)
+- [x] PROB-032 breakdown display (auto-fixed by PROB-030)
+- [x] PROB-033 `new evidence` phase-agnostic (no session warning)
+- [x] **PROB-034 CRITICAL** multi-line HTML comment state machine in extract_field
+- [x] F1 fail-closed on unclosed `<!--` (unclosed → CL0 + warn)
+- [x] F2 fail-closed on unparseable congruence_level (garbage → CL0 + warn)
+- [x] evidence template simplified (single-line comments only, no booby-trap)
+- [x] 12 new regression tests (total 1143 pass, +12 from 1131)
+- [x] Cargo.toml workspace + cross-crate refs → 0.17.2
+- [x] CHANGELOG.md v0.17.2 entry
+- [x] CLAUDE.md status block updated to v0.17.2
 - [x] TODO.md updated (this block)
-- [x] NOTE-044 Sprint Checklist gained new rule: "Every new CLI flag + CHANGELOG + docs, no feature lands without"
-- [ ] Audit reviewer report (1 agent running)
-- [ ] PR release/v0.17.1 → main
-- [ ] Tag v0.17.1 + push (cargo-dist Release workflow auto-triggers)
-- [ ] Sync main → dev via PR (dev protected)
-- [ ] Hindsight retain v0.17.1 finale
-- [ ] Dogfood housekeeping NOTE-046/047 (manual pass, separate commit, not blocker)
+- [x] 4-agent audit completed (A code, B tests, C security, D docs)
+- [x] All audit blockers addressed in-scope
+- [x] PROB-034 card + EVID-068..072 created
+- [ ] EVID-068..072 Interpretation + CL Justification filled (audit D)
+- [ ] PROB-030..034 + EVID-068..072 activated
+- [ ] PR release/v0.17.2 → main
+- [ ] Tag v0.17.2 + push (cargo-dist auto-triggers)
+- [ ] Sync main → dev via PR
+- [ ] Hindsight retain v0.17.2 finale
+- [ ] PROB-035 "extract_field hardening" filed for follow-up sprint (code-fence, token-boundary substring)
+
+### v0.17.1 hotfix ✅ (shipped)
+- [x] PROB-028 phantom rows (PRD-044)
+- [x] PROB-029 health verdict (PRD-045)
+- [x] CHANGELOG + tag + cargo-dist + sync done
 
 ---
 

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.1" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.17.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.17.2" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.17.2" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-cli/src/commands/new.rs
+++ b/crates/forgeplan-cli/src/commands/new.rs
@@ -192,13 +192,19 @@ pub async fn run(kind_str: &str, title: &str, allow_duplicate: bool) -> Result<(
         println!("\n  * {}", h);
     }
 
-    // Session: advance to Shaping (for decision artifacts) or Evidence (for evidence kind)
-    let phase = if template_key == "evidence" {
-        forgeplan_core::session::Phase::Evidence
-    } else if matches!(template_key, "prd" | "rfc" | "adr" | "epic" | "spec") {
+    // Session: advance to Shaping for decision artifacts only.
+    //
+    // PROB-033 fix: `new evidence` is phase-agnostic — creating evidence is a
+    // legitimate operation in ANY session state (backfill from shipped code,
+    // audit findings, brownfield import, external benchmark). The state machine
+    // guardrail still applies at `activate` time (stub detection + validation),
+    // so loosening `new` is safe.
+    //
+    // Notes/problems/evidence never drive the state machine; they're orthogonal
+    // to the decision pipeline.
+    let phase = if matches!(template_key, "prd" | "rfc" | "adr" | "epic" | "spec") {
         forgeplan_core::session::Phase::Shaping
     } else {
-        // Notes, problems, etc. — don't change phase
         return Ok(());
     };
     common::advance_session(phase, Some(&id));

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -5,8 +5,9 @@ use chrono::{NaiveDate, Utc};
 use forgeplan_core::artifact::frontmatter::Frontmatter;
 use forgeplan_core::artifact::types::{ArtifactKind, Mode};
 use forgeplan_core::db::store::ArtifactFilter;
+use forgeplan_core::scoring::evidence::parse_evidence_from_record;
 use forgeplan_core::scoring::fgr;
-use forgeplan_core::scoring::reff::{self, EvidenceItem, EvidenceType, Verdict};
+use forgeplan_core::scoring::reff::{self, EvidenceItem};
 
 use crate::commands::common;
 use crate::ui;
@@ -372,55 +373,19 @@ fn score_grade(v: f64) -> &'static str {
     }
 }
 
-/// Parse evidence fields from an ArtifactRecord's body.
-/// Evidence metadata is stored in the body as YAML-like fields.
-fn parse_evidence_from_record(record: &forgeplan_core::db::store::ArtifactRecord) -> EvidenceItem {
-    // Parse verdict from body (look for "verdict:" line)
-    let verdict = extract_field(&record.body, "verdict")
-        .map(|s| match s.to_lowercase().as_str() {
-            "supports" => Verdict::Supports,
-            "weakens" => Verdict::Weakens,
-            "refutes" => Verdict::Refutes,
-            _ => Verdict::Supports,
-        })
-        .unwrap_or(Verdict::Supports);
-
-    // Parse congruence_level
-    let cl = extract_field(&record.body, "congruence_level")
-        .and_then(|s| s.parse::<u8>().ok())
-        .map(|v| v.min(3))
-        .unwrap_or(0);
-
-    let valid_until = record.valid_until.as_deref().and_then(|s| {
-        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
-            .ok()
-            .or_else(|| {
-                NaiveDate::parse_from_str(s, "%Y-%m-%d")
-                    .ok()
-                    .and_then(|d| d.and_hms_opt(23, 59, 59))
-            })
-    });
-
-    EvidenceItem {
-        id: record.id.clone(),
-        evidence_type: EvidenceType::Measurement,
-        verdict,
-        congruence_level: cl,
-        valid_until,
-    }
-}
-
-/// Extract a simple "key: value" from body text.
-fn extract_field(body: &str, key: &str) -> Option<String> {
-    let prefix = format!("{}:", key);
-    for line in body.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix(&prefix) {
-            let val = rest.trim();
-            if !val.is_empty() {
-                return Some(val.to_string());
-            }
-        }
-    }
-    None
-}
+// PROB-031 fix: removed local `parse_evidence_from_record` and `extract_field`
+// — they duplicated forgeplan_core::scoring::evidence::parse_evidence_from_record
+// but with a DIFFERENT default: CL0 (penalty 0.9) vs core's CL3 (no penalty,
+// trust-local default).
+//
+// This caused a visible contradiction: the per-item "breakdown" line used CLI
+// parser and showed "EVID-001 [Supports] CL0 = 0.1" while the R_eff rollup
+// used core's parser via r_eff_recursive and computed 1.00 (CL3 default).
+//
+// Also: the core parser implements the PRD-035 Sprint 13.3 H2 security
+// precedence (`min(tier_cl, explicit_cl)`) that prevents trust amplification
+// via self-signed T1 evidence. The CLI local parser did not implement this,
+// opening the same attack surface on the display path.
+//
+// Fix: import the core parser and delete the local duplicate. Both paths
+// now agree on CL and on formula.

--- a/crates/forgeplan-cli/tests/cli_integration_test.rs
+++ b/crates/forgeplan-cli/tests/cli_integration_test.rs
@@ -3595,3 +3595,160 @@ fn new_rejects_too_long_title_no_orphan_row() {
         .success()
         .stdout(predicate::str::contains("PRD-001").not());
 }
+
+// ── PROB-031 regression: score uses core parser (CL3 default) ──────
+
+#[test]
+fn score_uses_core_parser_with_cl3_default_when_no_structured_fields() {
+    // PROB-031: the CLI `score` command previously had a LOCAL copy of
+    // `parse_evidence_from_record` with CL0 (penalty 0.9) as the default.
+    // The core parser defaults to CL3 (trust-local). That caused a visible
+    // lie: breakdown showed "CL0 = 0.1" while R_eff rollup computed 1.00
+    // via core parser through r_eff_recursive. Fix: import core parser in
+    // score.rs, delete local duplicate.
+    let tmp = TempDir::new().unwrap();
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["new", "prd", "Target"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["new", "evidence", "Bare evid no fields"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["link", "EVID-001", "PRD-001", "--relation", "informs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let output = forgeplan()
+        .args(["score", "PRD-001", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let r_eff = json["r_eff"].as_f64().expect("r_eff number");
+    assert!(
+        r_eff > 0.9,
+        "R_eff must be ~1.0 (CL3 default), got {} — CLI parser may have regressed to CL0 default",
+        r_eff
+    );
+    let evidence_arr = json["evidence"].as_array().expect("evidence array");
+    assert_eq!(evidence_arr.len(), 1);
+    let cl = evidence_arr[0]["congruence_level"]
+        .as_u64()
+        .expect("cl number");
+    assert_eq!(
+        cl, 3,
+        "display path must agree with rollup path — both CL3 (not CL0)"
+    );
+}
+
+#[test]
+fn score_respects_explicit_cl0_in_body() {
+    // PROB-031 inverse guard (audit B gap): prove the parser actually
+    // reads explicit congruence_level from the body and is not silently
+    // hardcoded to CL3. This is the counterpart to the CL3-default test.
+    let tmp = TempDir::new().unwrap();
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["new", "prd", "Target"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["new", "evidence", "Low confidence cross-domain benchmark"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    // Edit the template default congruence_level: 3 to 0 in-place.
+    let evid_path = tmp
+        .path()
+        .join(".forgeplan/evidence/EVID-001-low-confidence-cross-domain-benchmark.md");
+    let body = std::fs::read_to_string(&evid_path).unwrap();
+    let body = body.replace("congruence_level: 3", "congruence_level: 0");
+    std::fs::write(&evid_path, body).unwrap();
+
+    forgeplan()
+        .args(["reindex"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["link", "EVID-001", "PRD-001", "--relation", "informs"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let output = forgeplan()
+        .args(["score", "PRD-001", "--json"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    let r_eff = json["r_eff"].as_f64().expect("r_eff number");
+    assert!(
+        r_eff < 0.2,
+        "explicit CL0 must yield R_eff ~0.10, got {} — parser may be ignoring body values",
+        r_eff
+    );
+    let cl = json["evidence"][0]["congruence_level"]
+        .as_u64()
+        .expect("cl number");
+    assert_eq!(
+        cl, 0,
+        "display must show CL0 matching rollup — proves parser reads body"
+    );
+}
+
+// ── PROB-033 regression: new evidence is phase-agnostic ─────────────
+
+#[test]
+fn new_evidence_works_in_routing_phase_without_session_warning() {
+    // PROB-033: after `forgeplan route`, session was Routing. `new evidence`
+    // tried Routing → Evidence transition (not allowed) and printed a
+    // confusing warning. Fix: `new evidence` is phase-agnostic — it never
+    // drives the state machine. Methodology guardrail stays at `activate`.
+    let tmp = TempDir::new().unwrap();
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+    forgeplan()
+        .args(["route", "add auth feature"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let output = forgeplan()
+        .args(["new", "evidence", "Backfill benchmark"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "new evidence must succeed");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Cannot go from"),
+        "no confusing session transition warning on phase-agnostic new evidence, got stderr: {}",
+        stderr
+    );
+    assert!(
+        tmp.path()
+            .join(".forgeplan/evidence/EVID-001-backfill-benchmark.md")
+            .exists(),
+        "evidence file must be created"
+    );
+}

--- a/crates/forgeplan-core/src/scoring/evidence.rs
+++ b/crates/forgeplan-core/src/scoring/evidence.rs
@@ -68,9 +68,39 @@ pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
         .and_then(|s| SourceTier::parse(&s))
         .map(|t| t.to_congruence_level());
 
-    let explicit_cl = extract_field(&record.body, "congruence_level")
-        .and_then(|s| s.parse::<u8>().ok())
-        .map(|v| v.min(3));
+    // PROB-034 follow-up (F2, audit C): distinguish "field absent" from
+    // "field present but garbage". Absent → trust-local CL3 default (policy
+    // for workspace-created evidence). Garbage → fail-closed to CL0 + warn
+    // (user declared something, we refuse to guess what).
+    let explicit_cl_raw = extract_field(&record.body, "congruence_level");
+    let explicit_cl: Option<u8> = match &explicit_cl_raw {
+        Some(raw) => match raw.parse::<u8>() {
+            Ok(n) if n <= 3 => Some(n),
+            _ => {
+                eprintln!(
+                    "warn: evidence {} has unparseable congruence_level='{}' — fail-closed to CL0 (penalty 0.9) to prevent silent trust inflation",
+                    record.id, raw
+                );
+                Some(0)
+            }
+        },
+        None => None,
+    };
+
+    // PROB-034 follow-up (F1, audit C): unclosed multi-line HTML comment
+    // swallows the entire remainder of the body → extract_field returns
+    // None for every field → silent CL3 default. Same trust-inflation class
+    // as PROB-034 itself. Detect and fail-closed to CL0.
+    let unclosed_comment = body_has_unclosed_html_comment(&record.body);
+    let explicit_cl = if unclosed_comment && explicit_cl.is_none() {
+        eprintln!(
+            "warn: evidence {} has an unclosed '<!--' comment block — fail-closed to CL0 (penalty 0.9) to prevent silent trust inflation",
+            record.id
+        );
+        Some(0)
+    } else {
+        explicit_cl
+    };
 
     if let (Some(tcl), Some(ecl)) = (tier_cl, explicit_cl)
         && tcl != ecl
@@ -124,16 +154,78 @@ pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
 /// Extract a simple "key: value" from body text.
 ///
 /// Skips markdown table rows (lines starting with `|`) and HTML comments
-/// to avoid matching template placeholder values like `| CL | 0 / 1 / 2 / 3 |`.
+/// (both single-line `<!-- ... -->` and MULTI-LINE blocks) to avoid matching
+/// template placeholder values like:
+///
+/// ```text
+/// <!--
+///      congruence_level: 0 | 1 | 2 | 3 (CL3=..., CL0=...)
+/// -->
+/// ```
+///
+/// PROB-034: previously only lines literally starting with `<!--` were
+/// skipped, so inner lines of multi-line comments leaked into the parser
+/// and shadowed real structured fields below (the first match wins). Every
+/// evidence created via `forgeplan new evidence` had its congruence_level
+/// silently reset to the CL3 default because the template comment's
+/// placeholder value `"0 | 1 | 2 | 3 (CL3=...)"` matched first, then
+/// `parse::<u8>()` failed, and the real `congruence_level: X` below was
+/// never inspected.
+///
 /// Only matches standalone `key: value` lines (structured fields).
-pub fn extract_field(body: &str, key: &str) -> Option<String> {
-    let prefix = format!("{key}:");
+/// Returns true if `body` contains an unclosed multi-line HTML comment
+/// (a `<!--` opening that never sees a matching `-->` before EOF).
+///
+/// Used by `parse_evidence_from_record` to fail-closed on malformed bodies:
+/// an unclosed comment swallows every subsequent line in `extract_field`,
+/// which would silently make all structured fields default to CL3 — the
+/// same trust-inflation class as PROB-034.
+pub fn body_has_unclosed_html_comment(body: &str) -> bool {
+    let mut in_comment = false;
     for line in body.lines() {
         let trimmed = line.trim();
-        // Skip markdown table rows and HTML comments — these are template placeholders
-        if trimmed.starts_with('|') || trimmed.starts_with("<!--") {
+        if in_comment {
+            if trimmed.contains("-->") {
+                in_comment = false;
+            }
             continue;
         }
+        if trimmed.starts_with("<!--") && !trimmed.contains("-->") {
+            in_comment = true;
+        }
+    }
+    in_comment
+}
+
+pub fn extract_field(body: &str, key: &str) -> Option<String> {
+    let prefix = format!("{key}:");
+    let mut in_multiline_comment = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        // Multi-line HTML comment state machine. Handles blocks that span
+        // multiple lines (`<!--` on one line, `-->` several lines later).
+        // Single-line comments `<!-- ... -->` open and close on the same
+        // line, so `in_multiline_comment` stays false after processing.
+        if in_multiline_comment {
+            if trimmed.contains("-->") {
+                in_multiline_comment = false;
+            }
+            continue;
+        }
+        if trimmed.starts_with("<!--") {
+            if !trimmed.contains("-->") {
+                in_multiline_comment = true;
+            }
+            continue;
+        }
+
+        // Skip markdown table rows — template placeholders like
+        // `| CL | 0 / 1 / 2 / 3 |`.
+        if trimmed.starts_with('|') {
+            continue;
+        }
+
         if let Some(rest) = trimmed.strip_prefix(&prefix) {
             let val = rest.trim();
             if !val.is_empty() {
@@ -175,6 +267,116 @@ mod tests {
     fn extract_field_ignores_html_comments() {
         let body = "<!-- congruence_level: 0 | 1 | 2 | 3 -->\ncongruence_level: 3\n";
         assert_eq!(extract_field(body, "congruence_level"), Some("3".into()));
+    }
+
+    #[test]
+    fn extract_field_ignores_multiline_html_comments() {
+        // PROB-034: the evidence template ships with a MULTI-LINE help
+        // comment explaining valid values. Previously only lines literally
+        // starting with `<!--` were skipped, so the placeholder leaked
+        // into the parser and shadowed the real field below.
+        let body = r#"<!-- Fill in the Structured Fields section below.
+
+     evidence_type: measurement | test | benchmark | audit
+     verdict: supports | weakens | refutes
+     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed)
+-->
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 0
+"#;
+        assert_eq!(
+            extract_field(body, "congruence_level"),
+            Some("0".into()),
+            "multi-line comment must not shadow real structured field"
+        );
+        assert_eq!(extract_field(body, "verdict"), Some("supports".into()));
+        assert_eq!(
+            extract_field(body, "evidence_type"),
+            Some("measurement".into())
+        );
+    }
+
+    #[test]
+    fn body_has_unclosed_html_comment_detects_dangling_open() {
+        // PROB-034 follow-up (F1): unclosed `<!--` should be flagged so
+        // parse_evidence_from_record can fail-closed to CL0.
+        assert!(body_has_unclosed_html_comment("<!-- unclosed"));
+        assert!(body_has_unclosed_html_comment(
+            "before\n<!-- starts here\nnever closes\n"
+        ));
+        // Closed single-line should NOT flag.
+        assert!(!body_has_unclosed_html_comment("<!-- closed -->"));
+        // Closed multi-line should NOT flag.
+        assert!(!body_has_unclosed_html_comment(
+            "<!--\nstill inside\n-->\nafter"
+        ));
+        // No comments should NOT flag.
+        assert!(!body_has_unclosed_html_comment("plain text\nno html"));
+    }
+
+    #[test]
+    fn unclosed_comment_forces_cl0_fail_closed() {
+        // PROB-034 follow-up (F1, audit C MEDIUM): body with unclosed
+        // `<!--` that hides the real congruence_level below → parser
+        // must fail-closed to CL0, not silently default to CL3.
+        let body = "<!-- oops forgot to close this\ncongruence_level: 3\nverdict: supports\n";
+        let record = mk_record(body);
+        let item = parse_evidence_from_record(&record);
+        assert_eq!(
+            item.congruence_level, 0,
+            "unclosed comment must fail-closed to CL0, got CL{}",
+            item.congruence_level
+        );
+    }
+
+    #[test]
+    fn unparseable_congruence_level_forces_cl0_fail_closed() {
+        // PROB-034 follow-up (F2, audit C MEDIUM): when congruence_level
+        // field is present but cannot be parsed as u8 0..=3, fail-closed
+        // to CL0 instead of silently defaulting to CL3.
+        let body = "## Structured Fields\n\ncongruence_level: high\nverdict: supports\n";
+        let record = mk_record(body);
+        let item = parse_evidence_from_record(&record);
+        assert_eq!(
+            item.congruence_level, 0,
+            "unparseable 'high' must fail-closed to CL0, got CL{}",
+            item.congruence_level
+        );
+    }
+
+    #[test]
+    fn parse_evidence_on_verbatim_template_returns_cl3_default() {
+        // PROB-034 verbatim template guard: the shipped template has
+        // multi-line comments + default Structured Fields with CL3.
+        // When loaded AS-IS without any user edit, parser should return
+        // CL3 (trust-local default for freshly created evidence).
+        let template = include_str!("../../../../templates/evidence/_TEMPLATE.md");
+        let record = mk_record(template);
+        let item = parse_evidence_from_record(&record);
+        assert_eq!(
+            item.congruence_level, 3,
+            "verbatim template must parse to default CL3, got CL{} — parser may have regressed on multi-line comment handling",
+            item.congruence_level
+        );
+        // evidence_type should be measurement (template default).
+        matches!(item.evidence_type, EvidenceType::Measurement);
+    }
+
+    #[test]
+    fn extract_field_multiline_comment_nested_fields_all_ignored() {
+        // Guard against a variant where the comment contains multiple
+        // lines each mentioning the key — none should leak.
+        let body = r#"<!--
+congruence_level: 3
+congruence_level: 0
+-->
+congruence_level: 2
+"#;
+        assert_eq!(extract_field(body, "congruence_level"), Some("2".into()));
     }
 
     #[test]

--- a/crates/forgeplan-core/src/search/smart.rs
+++ b/crates/forgeplan-core/src/search/smart.rs
@@ -135,8 +135,13 @@ pub fn smart_search(
         .filter_map(|record| {
             let raw_bm25 = bm25.score(record, query);
             let bm25_norm = Bm25Index::normalize(raw_bm25);
-            // Keep substring keyword_score for diagnostics / backward compat.
+            // PROB-030 fix: BM25 is token-based — queries like "auth" don't
+            // match the "authentication" token. Users expect grep-like prefix
+            // behavior. We take max(BM25, substring) so BM25 still wins on
+            // exact-token matches (richer signal) but falls back to substring
+            // when BM25 returns 0 for partial/prefix queries.
             let kw = keyword_score(record, query);
+            let keyword_channel = bm25_norm.max(kw);
             let sem = semantic_scores
                 .and_then(|m| m.get(&record.id))
                 .copied()
@@ -145,8 +150,13 @@ pub fn smart_search(
                 .map(|g| g.degree_centrality(&record.id))
                 .unwrap_or(0.0);
             let is_active = record.status.eq_ignore_ascii_case("active");
-            // Use BM25 (richer signal) as the keyword channel for combined score.
-            let score = combined_score(bm25_norm, sem, record.r_eff_score, is_active, centrality);
+            let score = combined_score(
+                keyword_channel,
+                sem,
+                record.r_eff_score,
+                is_active,
+                centrality,
+            );
 
             if score > 0.0 {
                 Some(SmartSearchResult {
@@ -725,5 +735,81 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "PRD-001");
         assert!(results[0].expanded_from.is_none());
+    }
+
+    // ── PROB-030 regression: BM25 prefix fallback ───────────────────
+
+    #[test]
+    fn smart_search_prefix_query_falls_back_to_substring() {
+        // PROB-030: BM25 is token-based — the prefix "auth" does not match
+        // the token "authentication", so BM25 alone returns 0. Users expect
+        // grep-like prefix behavior. The fix: combined keyword channel =
+        // max(bm25_norm, substring_keyword_score), so substring match wins
+        // when BM25 is silent.
+        let records = vec![
+            make_record(
+                "PRD-001",
+                "Authentication OAuth2 system",
+                "user login flow",
+                "active",
+                0.0,
+            ),
+            make_record(
+                "PRD-002",
+                "Unrelated topic",
+                "nothing about logins",
+                "active",
+                0.0,
+            ),
+        ];
+        let results = smart_search(&records, "auth", None, None, None, 10);
+        assert_eq!(
+            results.len(),
+            1,
+            "prefix query 'auth' must find 'Authentication' via substring fallback"
+        );
+        assert_eq!(results[0].id, "PRD-001");
+        assert!(
+            results[0].score > 0.0,
+            "score must be non-zero for a matching prefix query"
+        );
+    }
+
+    #[test]
+    fn smart_search_prefix_unicode_cyrillic() {
+        // PROB-030 follow-up (audit B): substring fallback must work
+        // for non-ASCII prefixes like `"аут"` matching `"аутентификация"`.
+        let records = vec![
+            make_record(
+                "PRD-001",
+                "Система аутентификации OAuth2",
+                "логин и сессии",
+                "active",
+                0.0,
+            ),
+            make_record("PRD-002", "Платежи", "обработка карт", "active", 0.0),
+        ];
+        let results = smart_search(&records, "аут", None, None, None, 10);
+        assert!(!results.is_empty(), "cyrillic prefix must find record");
+        assert_eq!(results[0].id, "PRD-001");
+        assert!(results[0].score > 0.0);
+    }
+
+    #[test]
+    fn smart_search_exact_token_still_wins_over_prefix() {
+        // PROB-030 regression guard: substring fallback must NOT suppress
+        // BM25's richer signal for exact-token matches. Docs with more TF
+        // of the exact query term should still rank higher than docs that
+        // only match via substring.
+        let records = vec![
+            make_record("PRD-001", "Auth", "auth auth auth auth", "active", 0.0),
+            make_record("PRD-002", "Authentication", "login only", "active", 0.0),
+        ];
+        let results = smart_search(&records, "auth", None, None, None, 10);
+        assert!(results.len() >= 2);
+        assert_eq!(
+            results[0].id, "PRD-001",
+            "exact-token doc with higher TF must still beat substring-only match"
+        );
     }
 }

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.17.2" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/templates/evidence/_TEMPLATE.md
+++ b/templates/evidence/_TEMPLATE.md
@@ -7,12 +7,7 @@
 | Valid Until | YYYY-MM-DD |
 | Target | ADR-{NNN} (решение которое подтверждаем/опровергаем) |
 
-<!-- Fill in the Structured Fields section below for R_eff scoring.
-     These fields are REQUIRED for correct R_eff calculation.
-     evidence_type: measurement | test | benchmark | audit
-     verdict: supports | weakens | refutes
-     congruence_level: 0 | 1 | 2 | 3 (CL3=same context, CL0=opposed context)
--->
+<!-- REQUIRED for R_eff scoring. Legal values documented in templates/evidence/README.md. -->
 
 ## Structured Fields
 
@@ -34,11 +29,7 @@ congruence_level: 3
 
 ## Congruence Level Justification
 
-<!-- Почему выбран именно этот CL:
-     CL3: тот же контекст, внутренний тест (penalty 0.0)
-     CL2: похожий контекст, related project (penalty 0.1)
-     CL1: другой контекст, внешняя документация (penalty 0.4)
-     CL0: противоположный контекст (penalty 0.9) -->
+<!-- Legend: CL3 same-context (penalty 0.0); CL2 related (0.1); CL1 external (0.4); CL0 opposed (0.9). -->
 
 {Обоснование выбранного Congruence Level}
 


### PR DESCRIPTION
Sync v0.17.2 release back to dev. Resolves CLAUDE.md + TODO.md conflicts in favor of main (v0.17.2 is authoritative).

Follows the standard release flow: dev → release/v0.17.2 → main (tag) → sync/main-to-dev-v0.17.2 → dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)