### PR TITLE
[sync] main → dev after v0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.18.0] — 2026-04-11 — Production BM25 + Russian morphology + quality gates
+
+Feature release upgrading the search engine and codifying quality rules.
+
+### Added
+
+- **Production BM25 engine** (`bm25` crate v2.3.2). Replaces 140 LOC
+  hand-written BM25 with production-quality implementation including
+  stemming, stop-word removal, and unicode segmentation.
+- **Russian morphology support**. `LanguageMode::Detect` with `whichlang`
+  auto-selects Snowball stemmer per document/query. "аутентификация"
+  now matches "аутентификации" via shared stem. 17 languages supported.
+- **Template noise stripping**. `strip_indexing_noise()` removes YAML
+  frontmatter, template placeholder lines `{...}`, markdown table rows
+  `|...|`, and HTML comments from BM25 index. Fixes false positives
+  where `forgeplan search "auth"` matched unrelated PRDs via `author:`
+  in frontmatter.
+- **O(N) batch search**. Single-pass `search_scores()` replaces O(N²)
+  per-record `.score()` calls. 193-artifact corpus: 0.23s.
+- **8-point verification checklist** in CLAUDE.md — mandatory before
+  every commit/PR. Covers: unit tests, edge cases, E2E on fresh
+  workspace, verbatim template test, dogfood stress test, regression
+  guard (A/B), negative tests, cross-language verification.
+
+### Changed
+
+- Health debt resolved: 8 active stubs deprecated/superseded, 5
+  duplicate EVID pairs deprecated, 3 orphan NOTEs linked. Health
+  dashboard reports "Project looks healthy!" with zero warnings.
+
+### Tests
+
+- 1150 tests pass (+19 from v0.17.2 baseline 1131).
+- New regression tests: Russian morphology (2), English stemming (1),
+  plural forms (1), stop-word resilience (1), noise stripping (2),
+  frontmatter false-positive guard (1).
+
 ## [0.17.2] — 2026-04-09 — Quality hotfix: scoring & search integrity
 
 Fixes **five** real bugs found during a dedicated /forge E2E verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,13 @@ Forgeplan = Quint-code (decision engine, R_eff scoring, evidence decay)
 
 ## Текущий статус
 
-- **v0.17.2** quality hotfix 2026-04-09 — PROB-030..034 fixed (BM25 prefix, R_eff
-  parser consistency, score breakdown, session state, **CRITICAL** multi-line
-  HTML comment shadow + fail-closed hardening for unclosed/unparseable fields)
-- **v0.17.1** hotfix 2026-04-09 — PROB-028 phantom rows + PROB-029 health verdict fixed
+- **v0.18.0** released 2026-04-11 — Production BM25 (`bm25` crate v2.3.2) +
+  Russian morphology (LanguageMode::Detect, Snowball stemmer) + template noise
+  stripping + O(N) batch search + 8-point verification checklist + health debt cleared
+- **v0.17.2** quality hotfix 2026-04-09 — PROB-030..034 + F1/F2 hardening
+- **v0.17.1** hotfix 2026-04-09 — PROB-028 phantom rows + PROB-029 health verdict
 - **v0.17.0** released 2026-04-08 — **EPIC-003 complete** (Search, Discovery, Intelligence)
-- **~56 CLI команд**, **~47 MCP tools**, **1143 тестов** (+12 от v0.17.0 baseline 1131)
+- **~56 CLI команд**, **~47 MCP tools**, **1150 тестов** (+19 от v0.17.0 baseline 1131)
 - **0 warnings** на обоих feature configs (default + `semantic-search`)
 - EPIC-001 (foundation) ✅ | EPIC-002 (v2.0 vision) ✅ | **EPIC-003 (v0.17.0)** ✅
 - **7 PRDs активированы** в v0.17.0: PRD-035 (tags + discover), PRD-039 (BM25 search),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.2"
+version = "0.18.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.2" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.17.2" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.18.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.18.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.17.2" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.18.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true


### PR DESCRIPTION
Sync v0.18.0 release (version bump + CHANGELOG + CLAUDE.md) back to dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)