### PR TITLE
Release v0.21.0 — Activity log + undo receipt infrastructure

### DIFF
--- a/.forgeplan/prds/PRD-054-activity-log-append-only-jsonl-log-of-mcp-tool-calls-with-query-tool.md
+++ b/.forgeplan/prds/PRD-054-activity-log-append-only-jsonl-log-of-mcp-tool-calls-with-query-tool.md
@@ -1,0 +1,297 @@
+---
+depth: standard
+id: PRD-054
+kind: prd
+status: draft
+title: Activity log — append-only JSONL log of MCP tool calls with query tool
+---
+
+# PRD-054: Activity log — append-only JSONL log of MCP tool calls with query tool
+
+## Executive Summary
+
+### Vision
+
+Every MCP tool invocation is recorded in an append-only JSONL log under `.forgeplan/logs/tools-YYYY-MM-DD.jsonl`. An agent or human operator can later query "what did the agent do in the last hour/day/session?" via `forgeplan_activity`. This closes the visibility gap that made it impossible to reconstruct agent behaviour after a session ended.
+
+### Problem
+
+When Claude Code (or any MCP client) calls forgeplan tools — 45 of them, dozens of times per session — there is no persistent record of those calls anywhere on disk. Diagnostic logs from the rmcp server are emitted to stderr, which Claude Code aggregates in its UI but discards when the session ends or the MCP subprocess restarts. The `forgeplan_journal` tool shows chronologically-ordered decision artifacts (ADR, Note, Problem, Solution) but not the thousands of read-and-write tool calls that produced them. There is no way to answer the question "what did the agent do in the last hour?" after the session window closes.
+
+Concretely, if the agent: creates a PRD that turns out wrong; activates an artifact prematurely before evidence lands; links evidence to the wrong target; spends several dollars of LLM tokens on a failed `forgeplan_reason` loop; or silently swallows an error because of a transient LanceDB issue — there is no forensic trail. Operators cannot diagnose why their workspace ended up in its current state, and agents resuming a session tomorrow have no memory of yesterday's attempts beyond whatever survived in committed artifacts.
+
+**Impact**:
+- **Operator**: cannot diagnose "why did my workspace end up in this state?" after the fact.
+- **Agent**: cannot self-correct — if it re-enters workspace tomorrow, no memory of yesterday's attempts.
+- **Security**: no audit trail for compliance scenarios (who read which artifact, who deleted what, when).
+- **Cost**: no way to attribute LLM-token spend to specific tool-call sequences.
+
+### Target Users
+
+| Persona | Описание | Ключевая боль |
+|---------|----------|---------------|
+| Solo developer | Uses forgeplan via Claude Code for personal projects | "What did I do yesterday? Why is this PRD half-filled?" |
+| AI agent | Claude Code / Cursor / Windsurf calling MCP tools autonomously | Cannot continue interrupted work without context |
+| Reviewer / compliance | Audits agent behaviour in regulated contexts | No way to prove what agent did without reproducible log |
+
+### Differentiators
+
+- **Append-only by design** — no log tampering possible without filesystem access.
+- **JSONL for grep/jq friendliness** — no binary log format, no DB query language to learn.
+- **Zero config** — file rotation by date, no setup.
+- **Agent-queryable** — `forgeplan_activity` returns structured JSON suitable for LLM context.
+
+---
+
+## Success Criteria
+
+| ID | Criterion | Metric | Current | Target | Timeframe | How to Measure |
+|----|-----------|--------|---------|--------|-----------|----------------|
+| SC-1 | Every MCP tool call is logged | Coverage of logged calls | 0 of 45 tools | 45 of 45 tools | v0.21.0 release | Integration test replays 10 calls, asserts 10 log lines |
+| SC-2 | Log write adds negligible latency | P95 overhead per call | unknown | < 2 ms per call | v0.21.0 release | Benchmark: 1000 no-op tool calls, measure overhead vs no-log build |
+| SC-3 | Agent can query "last N minutes" | Query response under real load | no tool | < 100 ms for 10000-entry log | v0.21.0 release | `forgeplan_activity --since 1h` on synthetic 10k log |
+| SC-4 | Log rotation prevents single file > 100 MB | File size bound | unbounded | rotated daily, one file per day | v0.21.0 release | 30-day synthetic load, check files/sizes |
+| SC-5 | No PII or secrets in log by default | Content sanitization | unknown | zero secrets in log body | v0.21.0 release | Inject API-key-looking string into title, assert log does not contain it |
+
+---
+
+## Product Scope
+
+### MVP (In-Scope)
+
+- **File layout**: `.forgeplan/logs/tools-YYYY-MM-DD.jsonl` — one file per UTC day, append-only. No log directory → auto-create on first write.
+- **Log entry schema** (per line, one JSON object):
+  - `ts`: ISO-8601 UTC timestamp with millisecond precision
+  - `tool`: MCP tool name (e.g. `"forgeplan_score"`)
+  - `args_hash`: SHA-256 of canonical JSON-serialized args (12-char hex prefix) — lets operators correlate repeats without storing args content
+  - `duration_ms`: integer wall-clock duration
+  - `status`: `"ok"` | `"tool_err"` | `"rpc_err"`
+  - `workspace`: absolute path to `.forgeplan/` (helps multi-workspace operators)
+  - `client_info`: optional `{name, version}` from MCP `initialize` — identifies which agent called
+- **Rotation**: file is opened in append mode, named by UTC date. New day → new file automatically.
+- **Privacy**: args CONTENT is never logged — only `args_hash`. Prevents secret leakage (API keys in task descriptions, PII in titles, etc.). A separate opt-in flag `log_args: true` in `.forgeplan/config.yaml` can enable full args logging for debugging.
+- **Two new MCP tools**:
+  - `forgeplan_activity` — query log with filters (`--since duration`, `--tool name`, `--status ok|err`, `--limit N`)
+  - `forgeplan_activity_stats` — aggregates per tool (call count, error rate, p50/p95 duration)
+- **CLI parity**: `forgeplan activity` subcommand mirrors MCP tool.
+- **Retention**: daily files kept forever by default (no auto-delete). Operator manually cleans old files.
+
+### Out of Scope
+
+- Undo mechanism (soft-delete, restore, undo_last) — will be **separate PRD-055** (Deep depth, 1 week).
+- Centralized log shipping (Syslog, Datadog, CloudWatch) — out of scope for v1.
+- Binary log format or log compression.
+- Full-text indexed search of args content.
+- Real-time streaming subscription (SSE, WebSocket).
+- GDPR right-to-erasure — logs are append-only by design; operator responsibility if needed.
+
+### Growth Vision
+
+- Integration with `forgeplan_recent` / `forgeplan_undo_last` in PRD-055.
+- Opt-in structured args logging for specific trusted tools.
+- Aggregated dashboards (weekly report, cost attribution).
+- Export to OpenTelemetry / SIEM systems.
+
+---
+
+## User Journeys
+
+### Journey 1: Solo developer reconstructs yesterday's session
+
+**Цель пользователя**: "Я вчера вечером что-то творил с forgeplan, сегодня workspace в странном состоянии. Что случилось?"
+
+| Шаг | Действие пользователя | Ответ системы | Заметки |
+|-----|----------------------|---------------|---------|
+| 1 | Open Claude Code, ask "what did you do yesterday in forgeplan?" | Agent calls `forgeplan_activity --since 24h` | Agent uses new tool |
+| 2 | Agent parses response | Sees 47 calls: 12 new, 8 update, 5 activate, 22 read-only | Structured JSON |
+| 3 | Agent reports summary | "Yesterday you created PRD-050..053, activated all four, then deprecated PRD-051. Here's the timeline." | Human-readable |
+| 4 | User asks "why did I deprecate PRD-051?" | Agent calls `forgeplan_get PRD-051` + checks `forgeplan_journal` | No extra tool |
+
+**Результат**: User reconstructs context in one tool call. Before: impossible.
+
+### Journey 2: Agent attributes LLM-token spend
+
+**Цель пользователя**: "Агент сжёг $3 на LLM за час. Куда?"
+
+| Шаг | Действие пользователя | Ответ системы | Заметки |
+|-----|----------------------|---------------|---------|
+| 1 | `forgeplan_activity_stats --since 1h --filter llm-only` | Per-tool stats | |
+| 2 | System returns | `{forgeplan_reason: 8 calls, avg 4200ms, errors 2; forgeplan_decompose: 3 calls, avg 6800ms, errors 0}` | |
+| 3 | User sees `forgeplan_reason` spent most time, 2 failed | Can dig: `forgeplan_activity --tool forgeplan_reason --status tool_err --since 1h` | |
+| 4 | Identifies runaway loop | Can raise `rate_limit.reason_per_hour` in config | Uses PRD-062 rate-limit |
+
+**Результат**: Cost attribution from log data, no external observability needed.
+
+### Journey 3: Compliance audit
+
+**Цель пользователя**: "Покажи все destructive operations (delete/supersede/deprecate) за неделю."
+
+| Шаг | Действие пользователя | Ответ системы | Заметки |
+|-----|----------------------|---------------|---------|
+| 1 | `forgeplan_activity --since 7d --tool forgeplan_delete,forgeplan_supersede,forgeplan_deprecate` | Filtered list | Multi-tool filter |
+| 2 | Export to JSONL stream | Each line is audit-ready | grep/jq friendly |
+| 3 | Review for anomalies | Any unexpected IDs? Unexpected agent client? | `client_info.name` field |
+
+**Результат**: Audit trail without separate compliance tooling.
+
+---
+
+## Functional Requirements
+
+- [ ] FR-001: MCP server can append one JSONL entry per tool invocation to the current day's log file (Journey 1/2/3, Must)
+- [ ] FR-002: Agent can query the log via `forgeplan_activity` with at minimum a time-window filter (Journey 1, Must)
+- [ ] FR-003: Agent can aggregate statistics via `forgeplan_activity_stats` grouped by tool name (Journey 2, Must)
+- [ ] FR-004: Operator can prevent sensitive args content from being written to the log by default (All, Must)
+- [ ] FR-005: Agent can filter activity log by tool name, status, and time window (Journey 3, Must)
+- [ ] FR-006: System can append a log entry without exceeding 2 ms p95 overhead per call (SC-2, Must)
+- [ ] FR-007: CLI user can invoke `forgeplan activity --since 1h` outside of MCP context for scripting (Should)
+- [ ] FR-008: System can recover gracefully from a corrupted or truncated log line (Should)
+- [ ] FR-009: Agent can receive `_next_action` hint from `forgeplan_activity` pointing at the next likely inspection step (Journey 2, Could)
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement | Metric | Condition | Measurement |
+|----|----------|-------------|--------|-----------|-------------|
+| NFR-001 | Performance | Log append latency | < 2 ms p95 | Under 100 tool calls/sec sustained | Benchmark `cargo bench --bench activity_log_write` |
+| NFR-002 | Durability | Log writes survive crash | No entry lost if process killed after successful `fsync` | SIGKILL immediately after tool handler returns Ok | Chaos test: kill -9 mid-run, replay, assert log matches pre-kill state |
+| NFR-003 | Correctness | Log is strictly append-only | Zero in-place edits, truncations, or reorderings | Across 10000 synthetic writes | Read-back check: bytes offset of line N stable across calls |
+| NFR-004 | Security | No secret strings in log body by default | Regex scan for API-key-shaped tokens returns 0 matches | Default config, full smoke replay | Test: inject "sk-…64 chars…" into task description, grep log — 0 hits |
+| NFR-005 | Portability | Works identically on macOS, Linux, Windows | Same log file format, same path resolution | Cross-platform CI | GitHub Actions matrix macos/ubuntu/windows passes integration test |
+| NFR-006 | Scalability | Query 10000-entry log within 100 ms | `forgeplan_activity --since 24h` on 10k synthetic log | Steady-state | Benchmark with synthetic generator |
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Happy path — tool call is logged
+
+```gherkin
+Given a fresh workspace with no existing log file
+When the agent calls forgeplan_health via MCP
+Then .forgeplan/logs/tools-YYYY-MM-DD.jsonl exists
+And the file contains exactly one JSONL line
+And the line parses to a valid JSON object with required fields: ts, tool, args_hash, duration_ms, status, workspace
+And the `tool` field equals "forgeplan_health"
+And the `status` field equals "ok"
+```
+
+### AC-2: Args content is not logged by default
+
+```gherkin
+Given a workspace with default config (no log_args flag)
+When the agent calls forgeplan_new kind=prd title="Secret key is sk-proj-ABC123..."
+Then the log line for that call exists
+And the line does NOT contain the substring "sk-proj-ABC123"
+And the line's args_hash field is a 12-char hex prefix
+And the line's tool field is "forgeplan_new"
+```
+
+### AC-3: Query by time window returns correct entries
+
+```gherkin
+Given a log containing 50 entries spanning 3 days
+When the agent calls forgeplan_activity --since 24h
+Then the response contains only entries from the last 24 hours
+And entries are sorted by ts ascending
+And total count is reported correctly
+And a _next_action hint is present
+```
+
+### AC-4: Query by tool name filter
+
+```gherkin
+Given a log containing 20 calls of various tools
+When the agent calls forgeplan_activity --tool forgeplan_score
+Then the response contains only entries with tool == "forgeplan_score"
+And entries from other tools are absent
+```
+
+### AC-5: Rotation across UTC day boundary
+
+```gherkin
+Given a workspace where today's log file has 10 entries
+When UTC midnight passes and the agent makes a new tool call
+Then a new file tools-YYYY-MM-DD.jsonl is created for the new day
+And the new file contains the new entry
+And yesterday's file is untouched
+```
+
+### AC-6: Corrupted line does not break query
+
+```gherkin
+Given a log file where line 5 is truncated (missing closing })
+When the agent calls forgeplan_activity --since 24h
+Then lines 1..4 and 6..end are returned
+And line 5 is reported in a "warnings" field with reason "parse error"
+And the tool does not panic or return RPC_ERROR
+```
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status | Owner |
+|-----------|------|--------|-------|
+| `tokio::fs` async file I/O | Runtime | Ready | stdlib |
+| `serde_json` for JSONL serialization | Runtime | Ready | workspace dep |
+| `chrono` for UTC date bucketing | Runtime | Ready | workspace dep |
+| No changes to existing 45 tool handlers | Internal | Will be wrapped at dispatch layer | — |
+
+---
+
+## Risks & Mitigations
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|------------|-------|
+| R-1 | fsync on every call causes perf regression | Medium | Medium | Measure NFR-001; if > 2 ms, batch writes with 100 ms window and fsync on flush | Core |
+| R-2 | Log file grows unbounded on long-lived workspaces | High | Medium | Daily rotation is MVP; compression / TTL-based cleanup deferred to PRD-066 | Core |
+| R-3 | Disk full → log write fails → tool fails silently | Medium | High | Log-write failure logs via tracing but does NOT fail the tool call (activity log is an observer, not a gate) | Core |
+| R-4 | Concurrent appends from 2 MCP processes interleave badly on some filesystems | Low | Medium | Use O_APPEND semantics (atomic appends on POSIX); add cross-platform integration test | Core |
+| R-5 | Args hash collisions hide distinct calls | Very Low | Low | 12-char hex of SHA-256 = 48 bits; collision probability ~2^-24 at 10k calls | — |
+
+---
+
+## Timeline
+
+| Milestone | Target Date | Description |
+|-----------|-------------|-------------|
+| PRD Approved | 2026-04-18 | This doc validated |
+| RFC Approved | 2026-04-19 | Architecture decided (append-only file, dispatch wrapper) |
+| MVP | 2026-04-20 | FR-001..006 shipped on dev |
+| v0.21.0 Release | 2026-04-22 | Tagged, binaries built, brew updated |
+
+---
+
+## Stakeholders
+
+| Role | Name | Sign-off |
+|------|------|----------|
+| Product Owner | user (project owner) | [ ] |
+| Engineering Lead | gogocat | [ ] |
+| Design | n/a | [x] |
+| QA | n/a (integrated with Rust test suite) | [x] |
+
+---
+
+## Affected Files
+
+- crates/forgeplan-core/src/activity/ (new module)
+- crates/forgeplan-core/src/config/ (add `log_args` flag)
+- crates/forgeplan-mcp/src/server.rs (wrap tool dispatch)
+- crates/forgeplan-cli/src/commands/activity.rs (new command)
+- crates/forgeplan-mcp/tests/activity_log.rs (new integration test)
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| PRD-055 | Sibling — undo mechanism builds on activity log | Draft (next) |
+| PRD-062 | Sibling — LLM rate limiting uses activity_stats | Draft (later) |
+| PROB-039 | Inspired by — post-v0.19.0 need for better diagnostics | Closed |
+
+---
+
+> **Next step**: После approve → создать RFC (архитектура: single writer task, tokio channel, dispatch wrapper).
+

--- a/.forgeplan/prds/PRD-055-undo-and-soft-delete-reversible-destructive-operations-with-forgeplan-restore-and-forgeplan-undo-last.md
+++ b/.forgeplan/prds/PRD-055-undo-and-soft-delete-reversible-destructive-operations-with-forgeplan-restore-and-forgeplan-undo-last.md
@@ -1,0 +1,315 @@
+---
+depth: standard
+id: PRD-055
+kind: prd
+status: draft
+title: Undo and soft-delete — reversible destructive operations with forgeplan_restore and forgeplan_undo_last
+---
+
+# PRD-055: Undo and soft-delete — reversible destructive operations
+
+## Executive Summary
+
+### Vision
+
+Every destructive operation in Forgeplan (`delete`, `supersede`, `deprecate`) becomes reversible within a configurable time window. Agents and operators recover from mistakes or malicious prompt-injection without git gymnastics. The feature is wired into the existing activity log (PRD-054) so undo-last is a one-tool call, not a manual git archaeology session.
+
+### Problem
+
+In v0.20.0 a destructive operation is terminal. Once `forgeplan_delete PRD-048` runs, the artifact is gone from LanceDB and its markdown file is removed. Recovery requires `git checkout HEAD~N -- .forgeplan/prds/PRD-048-*.md` plus `forgeplan scan-import` — not something an agent can reason about safely, and impossible if the deletion happened in a working tree that was never committed.
+
+Concretely this creates three failure modes we have already seen in practice. An agent that hallucinates an artifact ID and calls `forgeplan_delete` with it can wipe unrelated work. A successful prompt-injection attack against a lifecycle tool turns into permanent data loss. A user who intends to `forgeplan_deprecate` and typos `forgeplan_delete` has no fast undo path. PRD-054 gave us visibility into what happened (the activity log records every call), but visibility without reversibility is only half the answer. Teams in regulated contexts additionally need a soft-delete pattern for compliance — some jurisdictions mandate that "deletion" means "marked inactive, recoverable for N days" rather than hard-erased.
+
+**Impact**:
+- Agent mistakes turn into permanent damage instead of recoverable slips.
+- Prompt-injection attacks (a threat class the R2/R3 audits closed at the hint level) still have a data-loss tail if the attacker reaches a destructive tool.
+- Manual recovery via git requires knowledge the agent doesn't have and the operator may not want to use.
+- Compliance scenarios cannot be supported with the current hard-delete semantics.
+
+### Target Users
+
+| Persona | Описание | Ключевая боль |
+|---------|----------|---------------|
+| Solo developer | Runs forgeplan via Claude Code for personal projects | "I told it to deprecate, it deleted. Now what?" |
+| AI agent | Claude Code / Cursor / Windsurf | No safe experimental mode — every destructive try is permanent |
+| Compliance-bound team | Uses forgeplan under SOC2 / HIPAA / GDPR constraints | Hard-delete incompatible with mandated retention windows |
+
+### Differentiators
+
+- **Zero-config**: trash directory and TTL-based cleanup work on default settings; no setup required.
+- **Uses existing activity log**: undo-last is cheap because PRD-054 already records every mutation.
+- **Cryptographically linked records**: each soft-delete receipt references the activity log entry it was produced from, so partial recovery is auditable.
+- **Two-level recovery**: `forgeplan_restore` for named targeted recovery, `forgeplan_undo_last` for "wait, don't, roll that back" speed.
+
+---
+
+## Success Criteria
+
+| ID | Criterion | Metric | Current | Target | Timeframe | How to Measure |
+|----|-----------|--------|---------|--------|-----------|----------------|
+| SC-1 | Every destructive op is reversible within TTL | Coverage of reversible ops | 0/3 (delete, supersede, deprecate all terminal) | 3/3 via soft-delete + lifecycle-replay | v0.21.0 | Integration test: call each destructive tool on a fresh artifact, call restore, assert artifact is back with identical body + relations |
+| SC-2 | Restore preserves full artifact state | Round-trip fidelity | n/a | Byte-identical body, identical metadata, equivalent relation graph | v0.21.0 | Hash artifact body before + after delete/restore cycle; assert relations recovered |
+| SC-3 | Trash directory has a bounded size | TTL enforcement | n/a | Entries older than TTL are purged on next invocation | v0.21.0 | Backdate a trash entry, invoke any tool, assert purge runs |
+| SC-4 | Undo-last finds the right operation | Correctness under concurrent load | n/a | Picks the last destructive op by activity log, not last mutation | v0.21.0 | Seed log with mixed destructive + non-destructive ops; undo_last reverses only the most recent destructive one |
+| SC-5 | Restore response latency | User-visible delay | n/a | < 100 ms p95 for one artifact | v0.21.0 | Benchmark: 100 restore cycles on real workspace, measure p95 |
+
+---
+
+## Product Scope
+
+### MVP (In-Scope)
+
+Soft-delete infrastructure under `.forgeplan/trash/`. When a destructive tool runs, we do not remove LanceDB rows or markdown files. Instead we create a receipt file that captures what changed and move the markdown projection into trash. The receipt is a structured JSON document containing the operation kind, the original artifact state (frontmatter + body + relations), the activity-log entry hash, and a TTL deadline.
+
+Two new MCP tools. `forgeplan_restore` takes an artifact ID and recovers the most recent soft-delete receipt for that ID: markdown back to its original path, LanceDB row re-created from receipt contents, relations re-linked. `forgeplan_undo_last` reads the activity log, finds the most recent successful destructive call across all tools, and applies the equivalent restore logic to that target.
+
+Default TTL: 30 days. Configurable via `.forgeplan/config.yaml` under `undo.ttl_days`. Purge of expired receipts runs lazily — on any invocation of `forgeplan_restore` or the first destructive op of a session. No background daemon.
+
+Activity log integration: each soft-delete writes one activity entry for the original tool call (unchanged) plus companion entry recording the receipt ID. Each restore writes a `forgeplan_restore` activity entry with the restored target.
+
+CLI parity: `forgeplan restore <id>` and `forgeplan undo-last` mirror the MCP tools for scripted use.
+
+Transactional semantics: if any step of restore fails partway through, the artifact is either fully back or remains in trash. Pattern: stage all changes in memory → validate → apply atomically.
+
+### Out of Scope
+
+Multi-artifact undo ("restore everything deleted in the last session") — deferred. Requires session boundary tracking we don't have. For v1 the user runs restore N times for N artifacts.
+
+Undo for non-destructive operations. Creating an artifact and then wanting to undo that is just delete; no separate undo path needed. Body update rollback is ambiguous (revert to which prior state? activity log keeps args hash only, not content).
+
+Cross-workspace undo. Receipts are scoped to the workspace where the destructive operation happened. No global trash.
+
+Cryptographic signing of receipts. Append-only JSONL + filesystem permissions is the same trust boundary as the activity log.
+
+### Growth Vision
+
+A `forgeplan_diff <id> --from <receipt-id>` tool to inspect what a receipt contains before restoring. A batch mode that restores all receipts in a time window. Remote backup of trash to a git-lfs branch for multi-device recovery. Integration with Orchestra's task history.
+
+---
+
+## User Journeys
+
+### Journey 1: Solo developer recovers from a typo
+
+**Цель пользователя**: "Я хотел deprecate, а нажал delete. Верни."
+
+- [ ] Agent runs `forgeplan_delete PRD-045` → receipt written, markdown moved to `.forgeplan/trash/`, LanceDB row removed
+- [ ] User: "wait, I didn't mean that" → Agent calls `forgeplan_undo_last`
+- [ ] Tool reads activity log, finds the delete op, calls restore internally
+- [ ] PRD-045 is back: markdown in place, LanceDB row restored, relations restored
+- [ ] Agent reports: "Restored PRD-045. Use `forgeplan_deprecate PRD-045 --reason ...` if that's what you meant"
+
+**Результат**: One-call recovery. Latency < 1s.
+
+### Journey 2: Compliance audit — destructive op window
+
+**Цель пользователя**: "Show all destructive operations in the last 30 days and which ones were reverted."
+
+- [ ] `forgeplan_activity --since 720h --tool forgeplan_delete,forgeplan_supersede,forgeplan_deprecate` → 47 destructive calls (uses PRD-054)
+- [ ] Cross-reference with `forgeplan_activity --tool forgeplan_restore` → 6 restores logged
+- [ ] Operator sees 41 destructive ops that were NOT reverted
+- [ ] Reviews trash directory for those 41 receipts if needed; receipt files are inspectable
+- [ ] Reverts any surprising ones via `forgeplan_restore <id>`
+
+**Результат**: Full audit + selective recovery, no git required.
+
+### Journey 3: Agent safely experiments
+
+**Цель пользователя**: "Try deprecating PRD-051 and see what breaks. If nothing, keep it. If something, undo."
+
+- [ ] Agent: `forgeplan_deprecate PRD-051 --reason "testing"` → receipt written, status → deprecated
+- [ ] Agent runs dependent checks, finds broken link → sees 3 orphans surface in `forgeplan_blindspots`
+- [ ] Agent: `forgeplan_undo_last` → PRD-051 back to active, orphans gone
+
+**Результат**: Lower-risk agent autonomy. Opens the "try and observe" pattern.
+
+---
+
+## Functional Requirements
+
+- [ ] FR-001: System can move an artifact's markdown projection into trash instead of hard-deleting on filesystem when delete is invoked (Journey 1/3, Must)
+- [ ] FR-002: System can write a soft-delete receipt containing original body, frontmatter, and relation graph (All, Must)
+- [ ] FR-003: Agent can recover a soft-deleted artifact by ID via restore (Journey 1/2/3, Must)
+- [ ] FR-004: Agent can reverse the most recent destructive operation via undo-last (Journey 1/3, Must)
+- [ ] FR-005: System can purge trash receipts older than the configured TTL on demand, without a background daemon (SC-3, Must)
+- [ ] FR-006: Soft-delete semantics apply equally to supersede and deprecate in addition to delete (SC-1, Must)
+- [ ] FR-007: Operator can configure TTL via `undo.ttl_days`; default 30 (Must)
+- [ ] FR-008: Restore preserves the artifact's relation graph — both outgoing and incoming links — identically to pre-delete state (SC-2, Must)
+- [ ] FR-009: CLI user can invoke restore and undo-last outside of MCP (Should)
+- [ ] FR-010: Trash receipts cryptographically reference the originating activity log entry via content hash (Should)
+- [ ] FR-011: Restore is transactional — either fully succeeds or leaves trash untouched on failure (Must)
+- [ ] FR-012: Both tools return a workflow hint pointing at plausible follow-up (Journey 1, Could)
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement | Metric | Condition | Measurement |
+|----|----------|-------------|--------|-----------|-------------|
+| NFR-001 | Performance | Soft-delete overhead vs hard-delete | < 10 ms p95 extra latency | One artifact with evidence links | Benchmark delete with and without soft-delete flag |
+| NFR-002 | Performance | Restore single artifact | < 100 ms p95 | Real workspace with 212 artifacts and 500 relations | Micro-benchmark restore cycle |
+| NFR-003 | Durability | Receipt write survives process kill | fsync before ack | SIGKILL immediately after destructive tool returns Ok | Chaos test: kill mid-op, verify receipt recoverable |
+| NFR-004 | Correctness | No lost data on crash mid-op | Invariant: artifact is always either in store OR in trash, never neither | Randomized crash tests | Inject panic at each await point; assert invariant |
+| NFR-005 | Storage | Trash disk usage bounded by TTL | Purge on demand | 30-day default, 100 deletes per day | Synthetic load test, check directory size |
+| NFR-006 | Portability | Works on macOS, Linux, Windows | Same file-rename semantics | CI matrix | GH Actions matrix passes integration test |
+| NFR-007 | Security | Trash directory inherits workspace permissions | No widening of access | Default umask respected | Inspect stat output on trash dir |
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Soft-delete preserves artifact body
+
+```gherkin
+Given PRD-100 exists with body "Hello world" and one evidence link
+When the agent calls forgeplan_delete PRD-100
+Then PRD-100 is not visible via forgeplan_list
+And trash contains a receipt file for PRD-100
+And the receipt contains "Hello world" as the body
+And the receipt captures the evidence link
+```
+
+### AC-2: Restore brings artifact back with identical body
+
+```gherkin
+Given PRD-100 was soft-deleted in the last 30 days
+And trash contains its receipt
+When the agent calls forgeplan_restore PRD-100
+Then PRD-100 is visible via forgeplan_list with status draft or its prior status
+And forgeplan_get PRD-100 returns a body byte-identical to the pre-delete body
+And all original relations are restored
+And the receipt is marked as consumed
+```
+
+### AC-3: Undo-last reverses only the most recent destructive op
+
+```gherkin
+Given an activity log with (in order) forgeplan_delete on PRD-A, forgeplan_score on PRD-B, forgeplan_deprecate on PRD-C
+When the agent calls forgeplan_undo_last
+Then PRD-C is restored to its prior active status
+And PRD-A remains soft-deleted
+And the operation is recorded in the activity log as forgeplan_restore
+```
+
+### AC-4: TTL purge removes only expired receipts
+
+```gherkin
+Given two receipts in trash: one dated today, one dated 35 days ago
+And undo.ttl_days is 30
+When any destructive tool is invoked
+Then the 35-day-old receipt is removed from disk
+And today's receipt remains
+```
+
+### AC-5: Transactional restore — mid-op failure leaves trash untouched
+
+```gherkin
+Given PRD-200 has a soft-delete receipt
+And the workspace's store is deliberately made read-only to simulate failure
+When the agent calls forgeplan_restore PRD-200
+Then the tool returns an error result with recovery guidance
+And the receipt for PRD-200 is still present in trash
+And no partial row for PRD-200 exists in store
+```
+
+### AC-6: Supersede goes through soft-delete too
+
+```gherkin
+Given PRD-300 is active
+When the agent calls forgeplan_supersede PRD-300 --by PRD-301
+Then PRD-300 gets a soft-delete receipt preserving its full state
+And forgeplan_undo_last can restore PRD-300 to active
+And the supersede link to PRD-301 is undone on restore
+```
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status | Owner |
+|-----------|------|--------|-------|
+| PRD-054 activity log | Internal | Shipped | — |
+| tokio fs rename operations | Runtime | Ready | stdlib |
+| serde_json for receipt serialization | Runtime | Ready | workspace dep |
+| No upstream lifecycle logic changes — soft-delete wrapper sits above it | Internal | — | — |
+
+---
+
+## Risks & Mitigations
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|------------|-------|
+| R-1 | Race: two concurrent deletes of same ID produce duplicate receipts | Low | Medium | Receipt path includes timestamp + random suffix; restore picks the newest non-consumed | Core |
+| R-2 | TTL purge deletes receipt the user wanted | High | High | Default TTL 30 days is generous; purge writes activity log entry so audit trail remains | Core |
+| R-3 | Restore overwrites an artifact re-created with the same ID after delete | Medium | Medium | Restore refuses if store already has an artifact with that ID; prompts operator to resolve | Core |
+| R-4 | Trash fills disk on long-lived project | Medium | Medium | NFR-005 plus TTL; document escape hatch | Core |
+| R-5 | Relation restore fails silently if target artifact is also deleted | Medium | High | Restore validates each link target exists; orphan links become warnings in response, not silent drops | Core |
+| R-6 | Crash between "remove from store" and "write receipt" loses data | Low | Critical | Write receipt FIRST, then remove from store. Replay on startup: trash entries without matching removal are no-ops | Core |
+
+---
+
+## Timeline
+
+| Milestone | Target Date | Description |
+|-----------|-------------|-------------|
+| PRD Approved | 2026-04-18 | This doc validated |
+| Architecture inline | 2026-04-18 | Key decisions in Architecture section below |
+| MVP | 2026-04-20 | FR-001..006, 011 shipped |
+| v0.21.0 Release | 2026-04-22 | Tagged, brew updated |
+
+---
+
+## Stakeholders
+
+| Role | Name | Sign-off |
+|------|------|----------|
+| Product Owner | user (project owner) | [ ] |
+| Engineering Lead | gogocat | [ ] |
+| Design | n/a | [x] |
+| QA | n/a (integrated with Rust test suite) | [x] |
+
+---
+
+## Architecture (inline decisions)
+
+**Decision 1: Soft-delete via move-to-trash plus receipt, not store tombstone.**
+We considered adding a `deleted_at` column and filtering at query time. Rejected: pollutes every query path with filter logic, doesn't help if someone nukes the store file, and makes trash inspection require a separate tool. Move-to-trash plus receipt is filesystem-native, greppable, and survives store corruption.
+
+**Decision 2: Receipt format is JSON, not binary.**
+Same rationale as activity log: operators should be able to cat and jq a receipt without special tooling. JSON for receipts adds some size overhead but trash is low-traffic.
+
+**Decision 3: One receipt per operation, not one per artifact.**
+If the same artifact is deleted, restored, deleted again, each call produces its own receipt. Restore picks the newest non-consumed. Makes the history inspectable — you can see how many times someone tried to delete a given artifact.
+
+**Decision 4: Write receipt BEFORE lifecycle mutation, not after.**
+Crash invariant: trash is the source of truth during the critical section. A crash between write_receipt and remove_from_store leaves orphan trash — harmless, purged by TTL. Reverse order would be fatal data loss.
+
+**Decision 5: TTL purge runs lazily on invocation, not via background task.**
+A background cron in an MCP server is added complexity and another failure mode. On-demand purge when restore or the first destructive op of a session runs is enough.
+
+**Decision 6: Relations are captured in the receipt, not re-derived on restore.**
+Re-deriving would require diffing the store against a snapshot. Capturing in receipt is O(1) and works even if the related artifacts were themselves deleted afterwards.
+
+---
+
+## Affected Files
+
+- crates/forgeplan-core/src/undo/ (new module — receipt format, trash I/O, TTL purge)
+- crates/forgeplan-core/src/lifecycle/ (wrap destructive ops with soft-delete)
+- crates/forgeplan-mcp/src/server.rs (add restore and undo-last handlers; wire soft-delete into destructive handlers)
+- crates/forgeplan-cli/src/commands/restore.rs (new)
+- crates/forgeplan-cli/src/commands/undo.rs (new)
+- crates/forgeplan-core/src/config/ (add undo.ttl_days field)
+- crates/forgeplan-mcp/tests/undo_integration.rs (new)
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| PRD-054 | Depends on — soft-delete wires into activity log | Shipped |
+| PROB-039 | Motivates — prompt-injection tail | Closed |
+
+---
+
+> **Next step**: approved PRD → immediate code phase.
+

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ plan-dist-manifest.json
 *.png
 !.github/assets/*.png
 *.pen
+W1-L2-CLAUDE-additional-sources.zip

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ plan-dist-manifest.json
 !.github/assets/*.png
 *.pen
 W1-L2-CLAUDE-additional-sources.zip
+
+# Soft-delete trash directory (PRD-055) — receipts are ephemeral
+# per-workspace runtime state, not version-controlled.
+.forgeplan/trash/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,148 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.21.0] — 2026-04-18 — Activity log + soft-delete receipt infrastructure
+
+Builds on the v0.20.0 tool-quality work. Adds two pieces of observability
+and recovery infrastructure that make agent-driven use of forgeplan
+materially safer.
+
+### Added — Activity log (PRD-054)
+
+Every MCP tool invocation is now recorded in an append-only JSONL file at
+`.forgeplan/logs/tools-YYYY-MM-DD.jsonl`. One file per UTC day, daily
+rotation happens automatically on first write. Each entry captures
+timestamp, tool name, SHA-256-prefix hash of args (args content is
+NOT logged by default — prevents secrets in titles / descriptions from
+leaking into the log), duration, status (`ok` / `tool_err` / `rpc_err`),
+workspace path, and optional client info.
+
+Two new MCP tools surface the log:
+
+- `forgeplan_activity` — query with `since_hours` (default 24, max 720),
+  `tool` (comma-separated filter), `status`, `limit` (max 5000). Returns
+  entries, warnings about corrupted lines, and a `_next_action` hint.
+- `forgeplan_activity_stats` — per-tool aggregates (count, err_count,
+  p50/p95/total ms), sorted by total time descending.
+
+Dispatch wrapper sits on top of rmcp's `ToolRouter.call` — any existing
+or future tool is logged automatically without per-handler changes. Log
+writes fire-and-forget via `tokio::spawn` so the tool response path adds
+zero latency. Log-write failures are observed via `tracing::warn` and
+never fail the parent tool call.
+
+CLI parity is planned for a future release.
+
+### Added — Soft-delete receipt infrastructure (PRD-055, increment 1 of 3)
+
+Foundation for reversible destructive operations. New module
+`forgeplan-core::undo` provides the receipt data model, JSON
+serialization, trash directory layout, TTL-based lazy purge, and
+cross-platform filesystem rename with fallback to copy+remove for
+cross-device moves.
+
+Does NOT yet wire into `forgeplan_delete` / `forgeplan_supersede` /
+`forgeplan_deprecate` — those still do hard-delete. Wiring is
+planned for v0.22.0. This release ships the underlying primitives so
+integration tests and tooling can exercise the receipt format now.
+
+Key design decisions documented inline in [PRD-055](.forgeplan/prds/PRD-055-undo-and-soft-delete-reversible-destructive-operations-with-forgeplan-restore-and-forgeplan-undo-last.md):
+1. Move-to-trash plus receipt, not store tombstone column
+2. JSON format, not binary
+3. One receipt per operation (inspectable history)
+4. Write receipt BEFORE mutation (crash invariant — orphan receipts are
+   harmless, but the reverse order would cause data loss)
+5. Lazy TTL purge on invocation, no background daemon
+6. Relations captured in receipt, not re-derived on restore
+
+Default TTL: 30 days. Configurable per-workspace once the wiring lands
+in v0.22.0.
+
+### Changed — Developer experience
+
+- Pinned Rust toolchain to 1.95 via `rust-toolchain.toml` — prevents
+  the class of bug where `cargo clippy` passes locally but fails on CI
+  due to a version skew between developer and runner (hit PR #178 on
+  first push with `clippy::unnecessary_sort_by`).
+
+### Verification
+
+- **1245 tests pass / 0 fail** (+31 new across activity + undo modules,
+  of which 18 in activity and 13 in undo).
+- `cargo clippy --workspace --all-targets -D warnings`: clean.
+- `cargo fmt --check`: 0 diffs.
+- E2E smoke on fresh tempdir: activity log writes 3 JSONL lines across
+  3 tool calls, no secret content leaks into log body.
+
+### Scope trade-offs
+
+`forgeplan_restore` and `forgeplan_undo_last` MCP tools are deferred to
+v0.22.0 along with the wrapping of destructive ops. Shipping the
+primitives now exercises the receipt format under real CI and lets the
+wiring increment land as a cleaner, smaller PR.
+
+Refs: PRD-054, PRD-055.
+
+---
+
+## [0.20.0] — 2026-04-18 — MCP silent-failure hotfix + tool quality (3-round audit)
+
+Originally a v0.19.1 hotfix for two independent silent failures blocking
+MCP adoption in v0.19.0 — users who ran `brew install forgeplan &&
+forgeplan mcp install --client claude && restart Claude Code` got
+**zero tools visible**. Grew via three full audit rounds into a feature
+release: every tool now carries workflow guidance and is hardened
+against invisible prompt-injection.
+
+### Fixed — the original hotfix
+
+- **`ServerCapabilities::default()` returned empty `{}`** — per MCP spec,
+  clients skip `tools/list` when `tools` capability is absent. All 45
+  tools invisible after `forgeplan mcp install`. Fix:
+  `ServerCapabilities::builder().enable_tools().build()`.
+- **`.mcp.json` carried `transport: "stdio"` field** — not MCP spec,
+  silently ignored by Claude Code, compounded the capability miss. Fix:
+  drop `transport`; `smart_merge` narrowly removes legacy entries.
+
+### Added — tool discoverability
+
+- **ToolAnnotations on all 45 tools** — `title`, `readOnlyHint`,
+  `destructiveHint`, `idempotentHint`, `openWorldHint`. Claude Code now
+  auto-approves safe reads and warns before destructive ops.
+- **Schema enums × 6** — `relation`, `kind`, `status`, `journal.kind`,
+  `phase`, `grade` switched from prose strings to JSON-Schema enums.
+  LLMs constrain-sample against these so `"informs"` is verbatim, not
+  paraphrased as `"inform"`.
+- **`_next_action` on 42/42 tools** — 34 as structured JSON field on
+  success, 8 as `_next_action:` prose in error text (via `err_hinted` /
+  `artifact_not_found` / `llm_err`). Every response — success or
+  error — tells the agent what to do next.
+
+### Security — invisible prompt-injection hardening
+
+- **`sanitize_for_hint()`** strips structural punctuation plus invisible
+  Unicode classes: zero-width joiners, bidi overrides/isolates, BOM,
+  soft-hyphen, variation selectors, tag characters. Applied at every
+  `format!` splice of user-controlled values. 15 new unit tests.
+- **`llm_err` no longer echoes upstream error bodies** — provider errors
+  sometimes include request IDs and header fragments; now logged only.
+
+### Fixed — silent-failure class
+
+- `unwrap_or(Value::Null)` replaced with `hinted_result<T>()` helper —
+  serialization failure surfaces as `McpError::internal_error` instead
+  of a `Null` response.
+- `forgeplan_blocked.blocked_count` was reporting `cycles.len()` instead
+  of `blocked.len()`; fixed.
+- `forgeplan_fpf_check` dead match arms (`"deny"/"block"/"warn"`) —
+  core emits `EXPLORE`/`INVESTIGATE`/`EXPLOIT`; match rewritten.
+- Race-condition panic in `forgeplan_link` when artifact deleted
+  concurrently — fixed.
+
+Refs: PROB-039, PRD-048, three audit rounds evidence.
+
+---
+
 ## [0.19.0] — 2026-04-16 — One-command MCP install + Clippy 1.95 + website i18n RU
 
 Feature release: `forgeplan mcp install` for frictionless AI agent setup,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.19.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.19.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.19.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,9 +2348,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.21.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.19.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.19.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.21.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.21.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -28,6 +28,8 @@ pulldown-cmark = "0.13"
 petgraph.workspace = true
 fastembed = { version = "5", optional = true }
 bm25 = { version = "2.3.2", features = ["language_detection"] }
+sha2 = "0.10"
+tracing = "0.1"
 
 [features]
 default = []

--- a/crates/forgeplan-core/src/activity/mod.rs
+++ b/crates/forgeplan-core/src/activity/mod.rs
@@ -1,0 +1,368 @@
+//! Activity log — append-only JSONL record of every MCP tool invocation.
+//!
+//! Closes the audit-trail gap identified after v0.20.0: diagnostic logs
+//! went to stderr only and were lost on session end. With this module,
+//! every tool call produces one JSONL line at
+//! `.forgeplan/logs/tools-YYYY-MM-DD.jsonl`.
+//!
+//! # Design decisions (PRD-054)
+//!
+//! - **Append-only**: files opened with `O_APPEND`; no in-place edits.
+//! - **Daily rotation**: one file per UTC date. No config needed.
+//! - **No args content by default**: we log `args_hash` only (12-char
+//!   hex of SHA-256). Secrets in titles / descriptions / body don't
+//!   leak into the log. Full args logging is opt-in via config flag.
+//! - **Observer, not a gate**: log-write failures are traced via
+//!   `tracing::warn` but never fail the tool call. The log is a
+//!   diagnostic aid, not a prerequisite.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+
+pub mod query;
+
+/// One entry in the activity log. Serializes to one JSONL line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivityEntry {
+    /// ISO-8601 UTC timestamp with millisecond precision.
+    pub ts: String,
+
+    /// MCP tool name (e.g. `"forgeplan_score"`).
+    pub tool: String,
+
+    /// 12-char hex prefix of SHA-256 of canonicalized JSON args.
+    /// Lets operators correlate repeated calls without exposing args content.
+    pub args_hash: String,
+
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+
+    /// Outcome: `"ok"` | `"tool_err"` | `"rpc_err"`.
+    pub status: String,
+
+    /// Absolute path to the `.forgeplan/` directory (multi-workspace aware).
+    pub workspace: String,
+
+    /// Optional `{name, version}` from MCP `initialize.clientInfo`.
+    /// Helps distinguish Claude Code vs Cursor vs Windsurf vs scripts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_info: Option<ClientInfo>,
+
+    /// Opt-in: raw args JSON. Disabled by default; enable with
+    /// `activity.log_args: true` in `.forgeplan/config.yaml`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientInfo {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// Status constants for the `status` field.
+pub mod status {
+    pub const OK: &str = "ok";
+    pub const TOOL_ERR: &str = "tool_err";
+    pub const RPC_ERR: &str = "rpc_err";
+}
+
+/// Compute the args hash: first 12 hex chars of SHA-256 of canonical
+/// JSON. Stable across equivalent input shapes (serde_json sorts map
+/// keys when serialized via this helper).
+pub fn compute_args_hash(args: &serde_json::Value) -> String {
+    // Canonical form: sorted keys, no whitespace. `to_string()` on a
+    // Value does not sort keys, so we round-trip through serde_json to
+    // a BTreeMap-like structure. Simpler: use serde_json::to_vec with
+    // the value; even if key order varies across serializations of the
+    // same logical input, it's consistent enough for hash collision
+    // purposes (we're not doing cryptographic equality). For strict
+    // stability we'd need a canonical JSON lib; acceptable trade-off
+    // for v1.
+    let bytes = serde_json::to_vec(args).unwrap_or_default();
+    let hash = Sha256::digest(&bytes);
+    hex_prefix(&hash, 12)
+}
+
+fn hex_prefix(bytes: &[u8], n_chars: usize) -> String {
+    const HEX: &[u8] = b"0123456789abcdef";
+    let mut out = String::with_capacity(n_chars);
+    let n_bytes = n_chars.div_ceil(2);
+    for byte in bytes.iter().take(n_bytes) {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0F) as usize] as char);
+    }
+    out.truncate(n_chars);
+    out
+}
+
+/// Resolve the current day's log file path:
+/// `<workspace>/logs/tools-YYYY-MM-DD.jsonl`.
+pub fn log_file_for(workspace: &Path, at: DateTime<Utc>) -> PathBuf {
+    let date = at.format("%Y-%m-%d").to_string();
+    workspace.join("logs").join(format!("tools-{date}.jsonl"))
+}
+
+/// Append one entry to the log. Creates the logs directory on demand.
+///
+/// Returns `Err` only on catastrophic I/O failures. Callers should
+/// treat activity logging as best-effort — swallow errors via
+/// `let _ = append(...).await.inspect_err(...)` so that log-write
+/// failures never fail the parent tool call.
+pub async fn append(workspace: &Path, entry: &ActivityEntry) -> anyhow::Result<()> {
+    let now = Utc::now();
+    let path = log_file_for(workspace, now);
+
+    // Ensure parent directory exists.
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    // Serialize to one line. Never include unescaped newlines.
+    let mut line = serde_json::to_string(entry)?;
+    line.push('\n');
+
+    // Open in append mode. O_APPEND is atomic for writes <= PIPE_BUF
+    // on POSIX; good enough for our line sizes (~500 bytes).
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    file.write_all(line.as_bytes()).await?;
+    // We do NOT fsync every write — would dominate latency. The OS
+    // will flush on close or after a short interval; worst case on
+    // SIGKILL we lose <1 sec of entries. For durability-critical
+    // deployments, a future `activity.fsync: per_entry` flag can opt in.
+    Ok(())
+}
+
+/// Fire-and-forget helper: appends without surfacing errors.
+/// Used from MCP dispatch wrapper where a log-write failure must
+/// never block the tool response.
+pub async fn append_best_effort(workspace: &Path, entry: &ActivityEntry) {
+    if let Err(e) = append(workspace, entry).await {
+        tracing::warn!("activity log append failed for tool={}: {}", entry.tool, e);
+    }
+}
+
+/// Build an entry with automatic timestamp + args hash.
+pub fn make_entry(
+    tool: impl Into<String>,
+    args: &serde_json::Value,
+    duration_ms: u64,
+    status: impl Into<String>,
+    workspace: &Path,
+    client_info: Option<ClientInfo>,
+    include_args: bool,
+) -> ActivityEntry {
+    let ts = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    ActivityEntry {
+        ts,
+        tool: tool.into(),
+        args_hash: compute_args_hash(args),
+        duration_ms,
+        status: status.into(),
+        workspace: workspace.display().to_string(),
+        client_info,
+        args: if include_args {
+            Some(args.clone())
+        } else {
+            None
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn hash_is_deterministic_for_same_input() {
+        let v1 = serde_json::json!({"id": "PRD-001"});
+        let v2 = serde_json::json!({"id": "PRD-001"});
+        assert_eq!(compute_args_hash(&v1), compute_args_hash(&v2));
+    }
+
+    #[test]
+    fn hash_differs_for_different_input() {
+        let v1 = serde_json::json!({"id": "PRD-001"});
+        let v2 = serde_json::json!({"id": "PRD-002"});
+        assert_ne!(compute_args_hash(&v1), compute_args_hash(&v2));
+    }
+
+    #[test]
+    fn hash_is_12_hex_chars() {
+        let v = serde_json::json!({});
+        let h = compute_args_hash(&v);
+        assert_eq!(h.len(), 12);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn log_file_path_uses_utc_date() {
+        let workspace = Path::new("/tmp/ws/.forgeplan");
+        let ts = DateTime::parse_from_rfc3339("2026-04-18T23:59:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let path = log_file_for(workspace, ts);
+        assert_eq!(
+            path,
+            Path::new("/tmp/ws/.forgeplan/logs/tools-2026-04-18.jsonl")
+        );
+    }
+
+    #[tokio::test]
+    async fn append_creates_file_and_directory() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let entry = make_entry(
+            "forgeplan_health",
+            &serde_json::json!({}),
+            42,
+            status::OK,
+            &ws,
+            None,
+            false,
+        );
+        append(&ws, &entry).await.unwrap();
+
+        let path = log_file_for(&ws, Utc::now());
+        assert!(path.exists(), "log file should exist: {}", path.display());
+
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(content.matches('\n').count(), 1);
+        let parsed: ActivityEntry = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.tool, "forgeplan_health");
+        assert_eq!(parsed.status, "ok");
+        assert_eq!(parsed.duration_ms, 42);
+    }
+
+    #[tokio::test]
+    async fn append_is_append_only() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        for i in 0..5u64 {
+            let entry = make_entry(
+                "forgeplan_health",
+                &serde_json::json!({"n": i}),
+                i,
+                status::OK,
+                &ws,
+                None,
+                false,
+            );
+            append(&ws, &entry).await.unwrap();
+        }
+
+        let path = log_file_for(&ws, Utc::now());
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(content.lines().count(), 5);
+        // Verify entries appear in insertion order.
+        let entries: Vec<ActivityEntry> = content
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        for (i, e) in entries.iter().enumerate() {
+            assert_eq!(e.duration_ms, i as u64);
+        }
+    }
+
+    #[tokio::test]
+    async fn args_content_omitted_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let entry = make_entry(
+            "forgeplan_new",
+            &serde_json::json!({"title": "Secret API key is sk-proj-ABC123DEADBEEF"}),
+            10,
+            status::OK,
+            &ws,
+            None,
+            false, // include_args = false
+        );
+        append(&ws, &entry).await.unwrap();
+        let path = log_file_for(&ws, Utc::now());
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(
+            !content.contains("sk-proj-ABC123"),
+            "secret leaked into log: {content}"
+        );
+        assert!(
+            !content.contains("Secret API key"),
+            "args content leaked into log"
+        );
+        // But the hash must be present.
+        let parsed: ActivityEntry = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.args_hash.len(), 12);
+        assert!(parsed.args.is_none());
+    }
+
+    #[tokio::test]
+    async fn args_included_when_flag_set() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let entry = make_entry(
+            "forgeplan_new",
+            &serde_json::json!({"kind": "prd", "title": "test"}),
+            5,
+            status::OK,
+            &ws,
+            None,
+            true, // include_args = true
+        );
+        append(&ws, &entry).await.unwrap();
+        let path = log_file_for(&ws, Utc::now());
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let parsed: ActivityEntry = serde_json::from_str(content.trim()).unwrap();
+        assert!(parsed.args.is_some());
+        let args = parsed.args.unwrap();
+        assert_eq!(args["kind"], "prd");
+    }
+
+    #[tokio::test]
+    async fn append_best_effort_swallows_errors() {
+        // Workspace under a read-only parent that doesn't exist and
+        // can't be created: use a NUL-byte in the path to force failure.
+        // Simpler: use a path that is a file, so mkdir fails.
+        let tmp = TempDir::new().unwrap();
+        let blocker = tmp.path().join("logs");
+        tokio::fs::write(&blocker, b"I am a file, not a directory")
+            .await
+            .unwrap();
+        let ws = tmp.path();
+        let entry = make_entry(
+            "forgeplan_health",
+            &serde_json::json!({}),
+            1,
+            status::OK,
+            ws,
+            None,
+            false,
+        );
+        // Should not panic, should not propagate error.
+        append_best_effort(ws, &entry).await;
+    }
+
+    #[test]
+    fn client_info_serializes_conditionally() {
+        let entry = ActivityEntry {
+            ts: "2026-04-18T00:00:00.000Z".into(),
+            tool: "forgeplan_health".into(),
+            args_hash: "abc123def456".into(),
+            duration_ms: 1,
+            status: "ok".into(),
+            workspace: "/tmp".into(),
+            client_info: None,
+            args: None,
+        };
+        let s = serde_json::to_string(&entry).unwrap();
+        assert!(!s.contains("client_info"), "None field should be skipped");
+        assert!(!s.contains("\"args\""));
+    }
+}

--- a/crates/forgeplan-core/src/activity/query.rs
+++ b/crates/forgeplan-core/src/activity/query.rs
@@ -171,7 +171,8 @@ pub fn compute_stats(entries: &[ActivityEntry]) -> Vec<ToolStats> {
         });
     }
     // Sort by total time descending — puts costliest tools first.
-    out.sort_by(|a, b| b.total_ms.cmp(&a.total_ms));
+    // Use `sort_by_key` with `Reverse` per clippy 1.95 `unnecessary_sort_by`.
+    out.sort_by_key(|s| std::cmp::Reverse(s.total_ms));
     out
 }
 

--- a/crates/forgeplan-core/src/activity/query.rs
+++ b/crates/forgeplan-core/src/activity/query.rs
@@ -1,0 +1,383 @@
+//! Query layer on top of the append-only JSONL log.
+//!
+//! Streams through daily log files, filters by time/tool/status, and
+//! returns parsed entries. Corrupted lines are skipped with a warning
+//! so a malformed single entry never breaks the query.
+//!
+//! All reads are sequential — the log is small relative to LanceDB
+//! (10k lines = ~5 MB) and we'd rather keep the format grep-friendly
+//! than build an index.
+
+use super::{ActivityEntry, log_file_for};
+use chrono::{DateTime, Duration, Utc};
+use std::path::Path;
+use tokio::io::AsyncBufReadExt;
+
+/// Filters applied to an activity query.
+#[derive(Debug, Clone, Default)]
+pub struct QueryFilter {
+    /// Only return entries with `ts` within this window from now.
+    pub since: Option<Duration>,
+
+    /// Only entries whose `tool` field exactly matches any of these names.
+    /// Empty = no filter.
+    pub tools: Vec<String>,
+
+    /// Only entries whose `status` matches any of these. Empty = no filter.
+    pub statuses: Vec<String>,
+
+    /// Max number of entries to return (from the end — most recent).
+    /// None = no cap.
+    pub limit: Option<usize>,
+}
+
+/// Result of a query: parsed entries plus warnings about corrupted lines.
+#[derive(Debug)]
+pub struct QueryResult {
+    pub entries: Vec<ActivityEntry>,
+    pub total_scanned: usize,
+    pub warnings: Vec<String>,
+}
+
+/// Run a query against the activity log. Reads today's file plus prior
+/// days' files if `since` extends into them.
+pub async fn query(workspace: &Path, filter: &QueryFilter) -> anyhow::Result<QueryResult> {
+    let now = Utc::now();
+    let threshold: Option<DateTime<Utc>> = filter.since.map(|d| now - d);
+
+    // Determine which date-bucket files to scan. If `since` is 1 hour,
+    // only today. If 48 hours, today + yesterday. Etc.
+    let days_back: i64 = match filter.since {
+        Some(d) => (d.num_seconds() / 86_400) + 1,
+        None => 0, // only today's file if no since
+    };
+
+    let mut entries: Vec<ActivityEntry> = Vec::new();
+    let mut total_scanned = 0usize;
+    let mut warnings: Vec<String> = Vec::new();
+
+    // Scan from oldest to newest so output is naturally chronological.
+    let start_day = days_back.max(0);
+    for days_ago in (0..=start_day).rev() {
+        let ts = now - Duration::days(days_ago);
+        let path = log_file_for(workspace, ts);
+        if !path.exists() {
+            continue;
+        }
+        let file = tokio::fs::File::open(&path).await?;
+        let reader = tokio::io::BufReader::new(file);
+        let mut lines = reader.lines();
+        let mut line_no = 0usize;
+        while let Some(line) = lines.next_line().await? {
+            line_no += 1;
+            total_scanned += 1;
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<ActivityEntry>(&line) {
+                Ok(entry) => {
+                    if matches(&entry, filter, threshold) {
+                        entries.push(entry);
+                    }
+                }
+                Err(e) => {
+                    warnings.push(format!(
+                        "parse error in {}:{}: {}",
+                        path.display(),
+                        line_no,
+                        e
+                    ));
+                }
+            }
+        }
+    }
+
+    // Apply limit — keep most recent.
+    if let Some(limit) = filter.limit
+        && entries.len() > limit
+    {
+        let drop = entries.len() - limit;
+        entries.drain(..drop);
+    }
+
+    Ok(QueryResult {
+        entries,
+        total_scanned,
+        warnings,
+    })
+}
+
+fn matches(entry: &ActivityEntry, filter: &QueryFilter, threshold: Option<DateTime<Utc>>) -> bool {
+    if let Some(threshold) = threshold {
+        match DateTime::parse_from_rfc3339(&entry.ts) {
+            Ok(ts) => {
+                if ts.with_timezone(&Utc) < threshold {
+                    return false;
+                }
+            }
+            Err(_) => return false, // unparseable ts => skip
+        }
+    }
+    if !filter.tools.is_empty() && !filter.tools.iter().any(|t| t == &entry.tool) {
+        return false;
+    }
+    if !filter.statuses.is_empty() && !filter.statuses.iter().any(|s| s == &entry.status) {
+        return false;
+    }
+    true
+}
+
+/// Per-tool statistics across the filtered entry set.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ToolStats {
+    pub tool: String,
+    pub count: usize,
+    pub err_count: usize,
+    pub p50_ms: u64,
+    pub p95_ms: u64,
+    pub total_ms: u64,
+}
+
+/// Compute aggregated per-tool statistics.
+pub fn compute_stats(entries: &[ActivityEntry]) -> Vec<ToolStats> {
+    use std::collections::BTreeMap;
+    let mut by_tool: BTreeMap<String, Vec<u64>> = BTreeMap::new();
+    let mut errors_by_tool: BTreeMap<String, usize> = BTreeMap::new();
+
+    for e in entries {
+        by_tool
+            .entry(e.tool.clone())
+            .or_default()
+            .push(e.duration_ms);
+        if e.status != super::status::OK {
+            *errors_by_tool.entry(e.tool.clone()).or_default() += 1;
+        }
+    }
+
+    let mut out: Vec<ToolStats> = Vec::with_capacity(by_tool.len());
+    for (tool, mut durations) in by_tool {
+        durations.sort_unstable();
+        let count = durations.len();
+        let total_ms: u64 = durations.iter().sum();
+        let p50 = percentile(&durations, 50.0);
+        let p95 = percentile(&durations, 95.0);
+        out.push(ToolStats {
+            tool: tool.clone(),
+            count,
+            err_count: *errors_by_tool.get(&tool).unwrap_or(&0),
+            p50_ms: p50,
+            p95_ms: p95,
+            total_ms,
+        });
+    }
+    // Sort by total time descending — puts costliest tools first.
+    out.sort_by(|a, b| b.total_ms.cmp(&a.total_ms));
+    out
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = (p / 100.0 * sorted.len() as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{append, make_entry, status};
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn seed(ws: &Path, n: usize, tool: &str, status_str: &str, duration: u64) {
+        for _ in 0..n {
+            let entry = make_entry(
+                tool,
+                &serde_json::json!({}),
+                duration,
+                status_str,
+                ws,
+                None,
+                false,
+            );
+            append(ws, &entry).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_workspace_returns_empty_result() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let r = query(&ws, &QueryFilter::default()).await.unwrap();
+        assert_eq!(r.entries.len(), 0);
+        assert_eq!(r.total_scanned, 0);
+    }
+
+    #[tokio::test]
+    async fn since_filter_scopes_time_window() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        seed(&ws, 3, "forgeplan_health", status::OK, 10).await;
+
+        let r = query(
+            &ws,
+            &QueryFilter {
+                since: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.entries.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn tool_filter_matches_exact_name() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        seed(&ws, 2, "forgeplan_health", status::OK, 10).await;
+        seed(&ws, 3, "forgeplan_score", status::OK, 20).await;
+
+        let r = query(
+            &ws,
+            &QueryFilter {
+                tools: vec!["forgeplan_score".into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.entries.len(), 3);
+        assert!(r.entries.iter().all(|e| e.tool == "forgeplan_score"));
+    }
+
+    #[tokio::test]
+    async fn status_filter_selects_errors() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        seed(&ws, 2, "forgeplan_health", status::OK, 10).await;
+        seed(&ws, 1, "forgeplan_reason", status::TOOL_ERR, 5000).await;
+
+        let r = query(
+            &ws,
+            &QueryFilter {
+                statuses: vec![status::TOOL_ERR.into()],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].status, "tool_err");
+    }
+
+    #[tokio::test]
+    async fn limit_keeps_most_recent() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        for i in 0..5u64 {
+            let entry = make_entry(
+                "forgeplan_health",
+                &serde_json::json!({"n": i}),
+                i,
+                status::OK,
+                &ws,
+                None,
+                false,
+            );
+            append(&ws, &entry).await.unwrap();
+        }
+        let r = query(
+            &ws,
+            &QueryFilter {
+                limit: Some(2),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r.entries.len(), 2);
+        // Two most recent = durations 3 and 4.
+        assert_eq!(r.entries[0].duration_ms, 3);
+        assert_eq!(r.entries[1].duration_ms, 4);
+    }
+
+    #[tokio::test]
+    async fn corrupted_line_is_reported_in_warnings() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        // Write one good + one corrupt + one good line directly.
+        let path = log_file_for(&ws, Utc::now());
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        let good = make_entry(
+            "forgeplan_health",
+            &serde_json::json!({}),
+            1,
+            status::OK,
+            &ws,
+            None,
+            false,
+        );
+        let good_line = serde_json::to_string(&good).unwrap();
+        let mixed = format!("{good_line}\n{{truncated json without closing\n{good_line}\n");
+        tokio::fs::write(&path, mixed).await.unwrap();
+
+        let r = query(&ws, &QueryFilter::default()).await.unwrap();
+        assert_eq!(r.entries.len(), 2, "two good lines recovered");
+        assert_eq!(r.warnings.len(), 1);
+        assert!(r.warnings[0].contains("parse error"));
+    }
+
+    #[test]
+    fn stats_computes_percentiles() {
+        let entries: Vec<ActivityEntry> = (1..=100)
+            .map(|i| ActivityEntry {
+                ts: "2026-04-18T00:00:00.000Z".into(),
+                tool: "forgeplan_health".into(),
+                args_hash: "x".repeat(12),
+                duration_ms: i as u64,
+                status: "ok".into(),
+                workspace: "/tmp".into(),
+                client_info: None,
+                args: None,
+            })
+            .collect();
+        let s = compute_stats(&entries);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].count, 100);
+        assert_eq!(s[0].p50_ms, 50);
+        assert_eq!(s[0].p95_ms, 95);
+    }
+
+    #[test]
+    fn stats_counts_errors_separately() {
+        let entries = vec![
+            ActivityEntry {
+                ts: "2026-04-18T00:00:00.000Z".into(),
+                tool: "forgeplan_reason".into(),
+                args_hash: "x".repeat(12),
+                duration_ms: 5000,
+                status: "ok".into(),
+                workspace: "/tmp".into(),
+                client_info: None,
+                args: None,
+            },
+            ActivityEntry {
+                ts: "2026-04-18T00:00:01.000Z".into(),
+                tool: "forgeplan_reason".into(),
+                args_hash: "x".repeat(12),
+                duration_ms: 100,
+                status: "tool_err".into(),
+                workspace: "/tmp".into(),
+                client_info: None,
+                args: None,
+            },
+        ];
+        let s = compute_stats(&entries);
+        assert_eq!(s[0].count, 2);
+        assert_eq!(s[0].err_count, 1);
+    }
+}

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -33,5 +33,6 @@ pub mod session;
 pub mod stale;
 pub mod status;
 pub mod template;
+pub mod undo;
 pub mod validation;
 pub mod workspace;

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod artifact;
 pub mod changelog;
 pub mod config;

--- a/crates/forgeplan-core/src/undo/mod.rs
+++ b/crates/forgeplan-core/src/undo/mod.rs
@@ -1,0 +1,574 @@
+//! Soft-delete receipt infrastructure (PRD-055, increment 1).
+//!
+//! Receipt format + trash I/O + TTL purge. Does NOT wire into destructive
+//! tool handlers yet — that is increment 2. Does NOT add restore /
+//! undo-last tools — that is increment 3.
+//!
+//! # Design
+//!
+//! When a destructive op runs we write a JSON receipt to
+//! `.forgeplan/trash/<kind>-<id>-<timestamp>-<rand>.json` capturing the
+//! full pre-operation state of the artifact (frontmatter + body +
+//! relations). The markdown projection is MOVED into the trash
+//! directory alongside the receipt, rather than hard-deleted.
+//!
+//! ## Crash invariant
+//!
+//! Order of operations is: write receipt → remove from store.
+//! A crash after write_receipt leaves a harmless orphan receipt which
+//! TTL purge eventually collects. A crash after remove_from_store but
+//! before write_receipt would be fatal data loss, so we avoid that
+//! ordering entirely.
+//!
+//! ## TTL purge
+//!
+//! Receipts older than `undo.ttl_days` (default 30) are removed on
+//! demand — specifically on entry to any `forgeplan_restore` call or
+//! when wrapping the first destructive op of a session. No background
+//! daemon.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+
+/// Default TTL in days if `undo.ttl_days` is not configured.
+pub const DEFAULT_TTL_DAYS: u32 = 30;
+
+/// Which destructive operation produced this receipt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DestructiveOp {
+    Delete,
+    Supersede,
+    Deprecate,
+}
+
+impl DestructiveOp {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Delete => "delete",
+            Self::Supersede => "supersede",
+            Self::Deprecate => "deprecate",
+        }
+    }
+}
+
+/// A relation pair captured at soft-delete time so restore can re-link.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedRelation {
+    /// Source artifact ID.
+    pub from: String,
+    /// Target artifact ID.
+    pub to: String,
+    /// Relation kind (e.g. "informs", "based_on", "supersedes").
+    pub relation: String,
+    /// Whether this artifact was the source (`Outgoing`) or the target
+    /// (`Incoming`) of the relation at delete time. Restore uses this
+    /// to know which direction to re-create.
+    pub direction: RelationDirection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationDirection {
+    Outgoing,
+    Incoming,
+}
+
+/// The full pre-operation state of an artifact, captured so `restore`
+/// can reproduce it byte-for-byte.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactSnapshot {
+    pub id: String,
+    pub kind: String,
+    pub status: String,
+    pub title: String,
+    pub depth: String,
+    pub body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_epic: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub valid_until: Option<String>,
+    #[serde(default)]
+    pub relations: Vec<CapturedRelation>,
+    /// Absolute path where the markdown projection lived before the
+    /// destructive op. Restore writes the body back to this path.
+    pub projection_path: String,
+}
+
+/// A soft-delete receipt — one JSON file per destructive operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Receipt {
+    /// Stable unique ID of this receipt (used for CLI references).
+    /// Format: `<kind>-<id>-<utc_ms>-<rand4>`.
+    pub receipt_id: String,
+    /// When the operation happened (ISO-8601 UTC millis).
+    pub ts: String,
+    /// Kind of destructive op.
+    pub op: DestructiveOp,
+    /// Full state of the artifact before the op.
+    pub snapshot: ArtifactSnapshot,
+    /// Optional reason string supplied to `forgeplan_deprecate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional replacement artifact ID supplied to
+    /// `forgeplan_supersede`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<String>,
+    /// Absolute path (in trash) where the original markdown projection
+    /// was moved to.
+    pub trashed_projection: String,
+    /// Activity-log entry hash this receipt corresponds to (ties the
+    /// receipt to PRD-054 log entry for audit correlation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub activity_log_hash: Option<String>,
+    /// Once a restore succeeds, the receipt is marked consumed so
+    /// restore cannot double-apply the same recovery.
+    #[serde(default)]
+    pub consumed: bool,
+}
+
+/// Path to the trash directory inside a workspace.
+pub fn trash_dir(workspace: &Path) -> PathBuf {
+    workspace.join("trash")
+}
+
+/// Compose a unique receipt file path inside the trash directory.
+pub fn receipt_path(workspace: &Path, receipt_id: &str) -> PathBuf {
+    trash_dir(workspace).join(format!("receipt-{receipt_id}.json"))
+}
+
+/// Compose a stable path for the moved markdown body, derived from
+/// receipt_id so we can find them as a pair.
+pub fn trashed_projection_path(workspace: &Path, receipt_id: &str) -> PathBuf {
+    trash_dir(workspace).join(format!("body-{receipt_id}.md"))
+}
+
+/// Generate a fresh receipt ID. Format: `<kind>-<id>-<utc_ms>-<rand4>`.
+/// Collision-free for >50k receipts per second per workspace.
+pub fn generate_receipt_id(kind: &str, artifact_id: &str) -> String {
+    let now = Utc::now();
+    let ms = now.timestamp_millis();
+    // Cheap non-crypto random suffix from nanoseconds. Adequate for a
+    // single-writer-per-workspace service.
+    let rand = now.timestamp_subsec_nanos() & 0xFFFF;
+    format!(
+        "{}-{}-{}-{:04x}",
+        safe_segment(kind),
+        safe_segment(artifact_id),
+        ms,
+        rand
+    )
+}
+
+/// Make a string safe to use as a filename segment. Keeps alphanumeric
+/// and `-` / `_`; replaces anything else with `_`. Not a security
+/// boundary — artifact IDs are already validated upstream.
+fn safe_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Write a receipt to disk. Creates the trash directory on demand.
+///
+/// PRD-055 Architecture Decision 4: crash invariant requires this is
+/// called BEFORE the corresponding store mutation. We fsync the
+/// receipt file before returning so partial writes don't leave an
+/// ambiguous state.
+pub async fn write_receipt(workspace: &Path, receipt: &Receipt) -> anyhow::Result<PathBuf> {
+    let dir = trash_dir(workspace);
+    tokio::fs::create_dir_all(&dir).await?;
+
+    let path = receipt_path(workspace, &receipt.receipt_id);
+    let json = serde_json::to_vec_pretty(receipt)?;
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create_new(true) // fail if collision — should never happen given ID format
+        .write(true)
+        .open(&path)
+        .await?;
+    file.write_all(&json).await?;
+    file.sync_data().await?;
+    Ok(path)
+}
+
+/// Read back a receipt from disk.
+pub async fn read_receipt(path: &Path) -> anyhow::Result<Receipt> {
+    let bytes = tokio::fs::read(path).await?;
+    let receipt: Receipt = serde_json::from_slice(&bytes)?;
+    Ok(receipt)
+}
+
+/// Move markdown projection into trash alongside the receipt. Uses
+/// `rename` which is atomic on the same filesystem. If the projection
+/// is on a different mount, falls back to copy+remove.
+pub async fn trash_projection(
+    workspace: &Path,
+    receipt_id: &str,
+    original_path: &Path,
+) -> anyhow::Result<PathBuf> {
+    let dir = trash_dir(workspace);
+    tokio::fs::create_dir_all(&dir).await?;
+    let target = trashed_projection_path(workspace, receipt_id);
+
+    match tokio::fs::rename(original_path, &target).await {
+        Ok(()) => Ok(target),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Nothing to move — record that fact in the receipt.
+            // Caller decides whether this is an error (delete on an
+            // artifact that had no projection is legitimate).
+            anyhow::bail!("projection not found at {}", original_path.display())
+        }
+        Err(e) if is_cross_device(&e) => {
+            // Cross-device rename → copy + remove.
+            tokio::fs::copy(original_path, &target).await?;
+            tokio::fs::remove_file(original_path).await?;
+            Ok(target)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn is_cross_device(e: &std::io::Error) -> bool {
+    // libc::EXDEV = 18 on Linux/macOS. Windows uses ERROR_NOT_SAME_DEVICE.
+    // raw_os_error() returns the platform-specific code.
+    matches!(e.raw_os_error(), Some(18))
+}
+
+/// List all non-consumed receipts in the workspace trash, newest first.
+pub async fn list_receipts(workspace: &Path) -> anyhow::Result<Vec<Receipt>> {
+    let dir = trash_dir(workspace);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut entries = tokio::fs::read_dir(&dir).await?;
+    let mut receipts = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("receipt-") && n.ends_with(".json"))
+        {
+            match read_receipt(&path).await {
+                Ok(r) => receipts.push(r),
+                Err(e) => {
+                    tracing::warn!("skipping unreadable receipt {}: {}", path.display(), e);
+                }
+            }
+        }
+    }
+    // Newest first. Receipt IDs embed `<ms>` so ascending `ts` sort works.
+    receipts.sort_by(|a, b| b.ts.cmp(&a.ts));
+    Ok(receipts)
+}
+
+/// Find the most recent non-consumed receipt for a given artifact ID.
+pub async fn find_latest_for(
+    workspace: &Path,
+    artifact_id: &str,
+) -> anyhow::Result<Option<Receipt>> {
+    let all = list_receipts(workspace).await?;
+    Ok(all
+        .into_iter()
+        .find(|r| r.snapshot.id == artifact_id && !r.consumed))
+}
+
+/// Mark a receipt as consumed on disk (rewrite the file in place).
+/// Called by restore after a successful recovery so undo-last won't
+/// re-apply the same receipt.
+pub async fn mark_consumed(workspace: &Path, receipt_id: &str) -> anyhow::Result<()> {
+    let path = receipt_path(workspace, receipt_id);
+    let mut receipt = read_receipt(&path).await?;
+    if receipt.consumed {
+        return Ok(());
+    }
+    receipt.consumed = true;
+    let json = serde_json::to_vec_pretty(&receipt)?;
+    // Write to a temp file and rename to atomically replace.
+    let tmp = path.with_extension("json.tmp");
+    tokio::fs::write(&tmp, &json).await?;
+    tokio::fs::rename(&tmp, &path).await?;
+    Ok(())
+}
+
+/// Purge receipts (and their paired projection bodies) older than
+/// `ttl_days`. Returns number of receipts removed.
+///
+/// Lazily invoked from `forgeplan_restore` and from the wrapper around
+/// any destructive tool. No background daemon per PRD-055 Architecture
+/// Decision 5.
+pub async fn purge_expired(workspace: &Path, ttl_days: u32) -> anyhow::Result<usize> {
+    let dir = trash_dir(workspace);
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let threshold = Utc::now() - Duration::days(i64::from(ttl_days));
+    let all = list_receipts(workspace).await?;
+    let mut removed = 0usize;
+
+    for receipt in all {
+        let ts = match DateTime::parse_from_rfc3339(&receipt.ts) {
+            Ok(t) => t.with_timezone(&Utc),
+            Err(_) => continue, // unparseable → skip, don't purge
+        };
+        if ts < threshold {
+            let receipt_file = receipt_path(workspace, &receipt.receipt_id);
+            let body_file = trashed_projection_path(workspace, &receipt.receipt_id);
+            let _ = tokio::fs::remove_file(&receipt_file).await;
+            let _ = tokio::fs::remove_file(&body_file).await;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_snapshot(id: &str) -> ArtifactSnapshot {
+        ArtifactSnapshot {
+            id: id.into(),
+            kind: "prd".into(),
+            status: "active".into(),
+            title: format!("Sample artifact {id}"),
+            depth: "standard".into(),
+            body: "# Body\n\nHello world.\n".into(),
+            author: Some("tester".into()),
+            parent_epic: None,
+            valid_until: None,
+            relations: vec![CapturedRelation {
+                from: id.into(),
+                to: "EVID-001".into(),
+                relation: "informs".into(),
+                direction: RelationDirection::Outgoing,
+            }],
+            projection_path: format!("/ws/.forgeplan/prds/{id}-sample.md"),
+        }
+    }
+
+    fn sample_receipt(id: &str) -> Receipt {
+        let receipt_id = generate_receipt_id("prd", id);
+        Receipt {
+            receipt_id: receipt_id.clone(),
+            ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            op: DestructiveOp::Delete,
+            snapshot: sample_snapshot(id),
+            reason: None,
+            replacement: None,
+            trashed_projection: format!("/ws/.forgeplan/trash/body-{receipt_id}.md"),
+            activity_log_hash: Some("abc123def456".into()),
+            consumed: false,
+        }
+    }
+
+    #[test]
+    fn receipt_id_is_unique() {
+        let a = generate_receipt_id("prd", "PRD-001");
+        let b = generate_receipt_id("prd", "PRD-001");
+        // Best effort — with ms + nanos combined, collisions should be
+        // astronomically rare. Accept equality only if clocks are at
+        // nanosecond resolution the same, which is practically never.
+        assert_ne!(a, b);
+        assert!(a.starts_with("prd-PRD-001-"));
+    }
+
+    #[test]
+    fn safe_segment_drops_path_separators() {
+        assert_eq!(safe_segment("a/b"), "a_b");
+        assert_eq!(safe_segment("a\\b"), "a_b");
+        assert_eq!(safe_segment("PRD-001"), "PRD-001");
+        assert_eq!(safe_segment("evil..id"), "evil__id");
+    }
+
+    #[tokio::test]
+    async fn write_read_receipt_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let r = sample_receipt("PRD-001");
+        let path = write_receipt(&ws, &r).await.unwrap();
+        assert!(path.exists());
+        let back = read_receipt(&path).await.unwrap();
+        assert_eq!(back.receipt_id, r.receipt_id);
+        assert_eq!(back.snapshot.body, r.snapshot.body);
+        assert_eq!(back.op, DestructiveOp::Delete);
+        assert_eq!(back.snapshot.relations.len(), 1);
+        assert_eq!(back.snapshot.relations[0].to, "EVID-001");
+    }
+
+    #[tokio::test]
+    async fn list_receipts_sorted_newest_first() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        // Seed 3 receipts with increasing timestamps.
+        for i in 0..3 {
+            let mut r = sample_receipt(&format!("PRD-00{i}"));
+            r.ts = (Utc::now() + Duration::seconds(i))
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+            // Force unique receipt_id despite same-nanosecond calls
+            r.receipt_id = format!("prd-PRD-00{i}-{}-aaaa", i);
+            write_receipt(&ws, &r).await.unwrap();
+        }
+        let listed = list_receipts(&ws).await.unwrap();
+        assert_eq!(listed.len(), 3);
+        // Newest first.
+        assert_eq!(listed[0].snapshot.id, "PRD-002");
+        assert_eq!(listed[1].snapshot.id, "PRD-001");
+        assert_eq!(listed[2].snapshot.id, "PRD-000");
+    }
+
+    #[tokio::test]
+    async fn find_latest_for_skips_consumed() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let mut r1 = sample_receipt("PRD-001");
+        r1.receipt_id = "prd-PRD-001-111-aaaa".into();
+        r1.ts = "2026-04-18T10:00:00.000Z".into();
+        r1.consumed = true;
+        write_receipt(&ws, &r1).await.unwrap();
+
+        let mut r2 = sample_receipt("PRD-001");
+        r2.receipt_id = "prd-PRD-001-222-bbbb".into();
+        r2.ts = "2026-04-18T09:00:00.000Z".into();
+        // r2 is older BUT not consumed — find_latest_for should return it.
+        write_receipt(&ws, &r2).await.unwrap();
+
+        let found = find_latest_for(&ws, "PRD-001").await.unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().receipt_id, "prd-PRD-001-222-bbbb");
+    }
+
+    #[tokio::test]
+    async fn mark_consumed_persists() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let r = sample_receipt("PRD-001");
+        let receipt_id = r.receipt_id.clone();
+        write_receipt(&ws, &r).await.unwrap();
+        mark_consumed(&ws, &receipt_id).await.unwrap();
+
+        let path = receipt_path(&ws, &receipt_id);
+        let back = read_receipt(&path).await.unwrap();
+        assert!(back.consumed);
+    }
+
+    #[tokio::test]
+    async fn mark_consumed_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let r = sample_receipt("PRD-001");
+        let receipt_id = r.receipt_id.clone();
+        write_receipt(&ws, &r).await.unwrap();
+        mark_consumed(&ws, &receipt_id).await.unwrap();
+        // Second call must not fail.
+        mark_consumed(&ws, &receipt_id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn purge_removes_expired_keeps_fresh() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        // Expired receipt — 35 days old.
+        let mut old = sample_receipt("PRD-OLD");
+        old.receipt_id = "prd-PRD-OLD-111-aaaa".into();
+        old.ts =
+            (Utc::now() - Duration::days(35)).to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let old_path = write_receipt(&ws, &old).await.unwrap();
+        // Pretend there's a paired body file.
+        let body_path = trashed_projection_path(&ws, &old.receipt_id);
+        tokio::fs::write(&body_path, b"old body").await.unwrap();
+
+        // Fresh receipt — 1 day old.
+        let mut fresh = sample_receipt("PRD-FRESH");
+        fresh.receipt_id = "prd-PRD-FRESH-222-bbbb".into();
+        fresh.ts =
+            (Utc::now() - Duration::days(1)).to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let fresh_path = write_receipt(&ws, &fresh).await.unwrap();
+
+        let removed = purge_expired(&ws, 30).await.unwrap();
+        assert_eq!(removed, 1);
+        assert!(!old_path.exists(), "expired receipt should be removed");
+        assert!(!body_path.exists(), "paired body should be removed");
+        assert!(fresh_path.exists(), "fresh receipt must survive");
+    }
+
+    #[tokio::test]
+    async fn purge_on_empty_trash_returns_zero() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let removed = purge_expired(&ws, 30).await.unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[tokio::test]
+    async fn trash_projection_moves_file() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let src_dir = tmp.path().join(".forgeplan/prds");
+        tokio::fs::create_dir_all(&src_dir).await.unwrap();
+        let src = src_dir.join("PRD-001-sample.md");
+        tokio::fs::write(&src, b"# PRD-001\n\nHello\n")
+            .await
+            .unwrap();
+
+        let target = trash_projection(&ws, "prd-PRD-001-111-aaaa", &src)
+            .await
+            .unwrap();
+        assert!(target.exists(), "projection moved into trash");
+        assert!(!src.exists(), "original is gone");
+        let content = tokio::fs::read_to_string(&target).await.unwrap();
+        assert!(content.contains("Hello"));
+    }
+
+    #[tokio::test]
+    async fn trash_projection_missing_file_errors() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let nowhere = tmp.path().join("ghost.md");
+        let err = trash_projection(&ws, "prd-x-111-aaaa", &nowhere).await;
+        assert!(err.is_err(), "missing file should error");
+    }
+
+    #[test]
+    fn destructive_op_round_trips_through_serde() {
+        for op in [
+            DestructiveOp::Delete,
+            DestructiveOp::Supersede,
+            DestructiveOp::Deprecate,
+        ] {
+            let s = serde_json::to_string(&op).unwrap();
+            let back: DestructiveOp = serde_json::from_str(&s).unwrap();
+            assert_eq!(op, back);
+        }
+    }
+
+    #[tokio::test]
+    async fn corrupted_receipt_file_does_not_break_list() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let dir = trash_dir(&ws);
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        // Write a bogus receipt file.
+        tokio::fs::write(dir.join("receipt-bogus.json"), b"this is not json")
+            .await
+            .unwrap();
+        // And one good one.
+        let good = sample_receipt("PRD-001");
+        write_receipt(&ws, &good).await.unwrap();
+        let listed = list_receipts(&ws).await.unwrap();
+        assert_eq!(listed.len(), 1, "good receipt survives corrupt neighbour");
+    }
+}

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.19.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.21.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -7,7 +7,7 @@ use rmcp::handler::server::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::schemars;
-use rmcp::{ErrorData as McpError, tool, tool_handler, tool_router};
+use rmcp::{ErrorData as McpError, tool, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tokio::sync::RwLock;
@@ -406,6 +406,31 @@ struct InitParams {
     /// Force reinitialize even if workspace exists
     #[serde(default)]
     force: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ActivityQueryParams {
+    /// Time window in hours back from now (e.g. 1 = last hour, 24 = last day).
+    /// Omit for today-only scope. Values 1..=720 (30 days).
+    #[serde(default)]
+    since_hours: Option<u32>,
+    /// Filter by tool name. Repeat with comma to match multiple:
+    /// `"forgeplan_score,forgeplan_activate"`.
+    #[serde(default)]
+    tool: Option<String>,
+    /// Filter by status: `ok`, `tool_err`, or `rpc_err`. Omit for all.
+    #[serde(default)]
+    status: Option<String>,
+    /// Cap result set (most recent N). Default 500, max 5000.
+    #[serde(default)]
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ActivityStatsParams {
+    /// Time window in hours. Default 24.
+    #[serde(default)]
+    since_hours: Option<u32>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -4630,11 +4655,161 @@ impl ForgeplanServer {
             "_next_action": "Run forgeplan health to validate discovery, then forgeplan validate each new artifact",
         })))
     }
+
+    // ── Activity log query tools (PRD-054) ───────────────────────────
+
+    #[tool(
+        description = "Query the activity log — append-only JSONL record of every MCP tool \
+                       invocation at .forgeplan/logs/tools-YYYY-MM-DD.jsonl. Use this to \
+                       reconstruct what the agent did over a time window, attribute LLM-token \
+                       spend, or audit destructive operations. Params: since_hours (default 24, \
+                       max 720), tool (comma-separated names to filter), status (ok/tool_err/\
+                       rpc_err), limit (default 500, max 5000 — keeps most recent).",
+        annotations(
+            title = "Activity Log Query",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_activity(
+        &self,
+        Parameters(p): Parameters<ActivityQueryParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let since = p.since_hours.unwrap_or(24).clamp(1, 720);
+        let limit = p.limit.unwrap_or(500).clamp(1, 5000) as usize;
+
+        let tools: Vec<String> = p
+            .tool
+            .as_deref()
+            .map(|s| s.split(',').map(|t| t.trim().to_string()).collect())
+            .unwrap_or_default();
+
+        let statuses: Vec<String> = p
+            .status
+            .as_deref()
+            .map(|s| vec![s.to_string()])
+            .unwrap_or_default();
+
+        let filter = forgeplan_core::activity::query::QueryFilter {
+            since: Some(chrono::Duration::hours(since as i64)),
+            tools,
+            statuses,
+            limit: Some(limit),
+        };
+
+        let result = forgeplan_core::activity::query::query(&ws, &filter)
+            .await
+            .map_err(|e| McpError::internal_error(format!("activity query failed: {e}"), None))?;
+
+        let next_action = if result.entries.is_empty() {
+            format!(
+                "No tool calls in the last {since} hour(s). Log file may not exist yet (run a \
+                 tool first) or the window is too narrow — try `since_hours=720` for the last \
+                 month."
+            )
+        } else {
+            let top_tool = {
+                let stats = forgeplan_core::activity::query::compute_stats(&result.entries);
+                stats.first().map(|s| s.tool.clone())
+            };
+            match top_tool {
+                Some(t) => format!(
+                    "{} entries in window. Busiest tool: `{t}`. Use \
+                     `forgeplan_activity_stats` to see per-tool breakdown, or filter: \
+                     `forgeplan_activity tool={t}`.",
+                    result.entries.len()
+                ),
+                None => format!("{} entries in window.", result.entries.len()),
+            }
+        };
+
+        hinted_result(
+            &serde_json::json!({
+                "entries": result.entries,
+                "total_scanned": result.total_scanned,
+                "returned": result.entries.len(),
+                "warnings": result.warnings,
+                "since_hours": since,
+            }),
+            next_action,
+        )
+    }
+
+    #[tool(
+        description = "Aggregate statistics from the activity log grouped by tool name: count, \
+                       error count, p50/p95 duration, total time. Use to attribute LLM-token \
+                       spend and identify slow tools. Params: since_hours (default 24, max 720).",
+        annotations(
+            title = "Activity Stats",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_activity_stats(
+        &self,
+        Parameters(p): Parameters<ActivityStatsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let since = p.since_hours.unwrap_or(24).clamp(1, 720);
+        let filter = forgeplan_core::activity::query::QueryFilter {
+            since: Some(chrono::Duration::hours(since as i64)),
+            tools: vec![],
+            statuses: vec![],
+            limit: None,
+        };
+
+        let result = forgeplan_core::activity::query::query(&ws, &filter)
+            .await
+            .map_err(|e| McpError::internal_error(format!("activity query failed: {e}"), None))?;
+
+        let stats = forgeplan_core::activity::query::compute_stats(&result.entries);
+        let total_calls: usize = stats.iter().map(|s| s.count).sum();
+        let total_errors: usize = stats.iter().map(|s| s.err_count).sum();
+        let total_ms: u64 = stats.iter().map(|s| s.total_ms).sum();
+
+        let next_action = if stats.is_empty() {
+            format!(
+                "No activity in the last {since} hour(s). Try `since_hours=720` for a longer \
+                 window."
+            )
+        } else {
+            let top = &stats[0];
+            format!(
+                "{total_calls} total call(s), {total_errors} error(s), {total_ms} ms total. Top \
+                 by time: `{}` ({} call(s), p95 {}ms). Drill down: \
+                 `forgeplan_activity tool={}`.",
+                top.tool, top.count, top.p95_ms, top.tool
+            )
+        };
+
+        hinted_result(
+            &serde_json::json!({
+                "stats": stats,
+                "total_calls": total_calls,
+                "total_errors": total_errors,
+                "total_ms": total_ms,
+                "since_hours": since,
+            }),
+            next_action,
+        )
+    }
 }
 
 // ── ServerHandler ────────────────────────────────────────────
 
-#[tool_handler]
 impl rmcp::ServerHandler for ForgeplanServer {
     fn get_info(&self) -> ServerInfo {
         // CRITICAL: must declare `tools` capability so MCP clients
@@ -4651,6 +4826,71 @@ impl rmcp::ServerHandler for ForgeplanServer {
                  When present, follow this hint — it guides the correct methodology workflow: \
                  Shape → Validate → Code → Evidence → Activate.",
             )
+    }
+
+    async fn list_tools(
+        &self,
+        _params: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::ListToolsResult, McpError> {
+        Ok(rmcp::model::ListToolsResult {
+            next_cursor: None,
+            tools: self.tool_router.list_all(),
+            meta: Default::default(),
+        })
+    }
+
+    // Auto-generated dispatch by rmcp's ToolRouter, WRAPPED with activity
+    // logging (PRD-054). Replaces what `#[tool_handler]` would generate:
+    // we call the same ToolRouter but capture start time / tool name /
+    // args / status and append one JSONL entry per call, best-effort.
+    //
+    // Logging is observer-only: a log-write failure must never fail the
+    // tool call. We use `append_best_effort` which swallows errors.
+    async fn call_tool(
+        &self,
+        params: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let start = std::time::Instant::now();
+        let tool_name = params.name.to_string();
+        // params.arguments is Option<JsonObject>; convert to Value for hashing.
+        let args_val = params
+            .arguments
+            .as_ref()
+            .map(|obj| serde_json::Value::Object(obj.clone()))
+            .unwrap_or(serde_json::Value::Null);
+
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, params, context);
+        let result = self.tool_router.call(tcc).await;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        let status = match &result {
+            Ok(r) if r.is_error.unwrap_or(false) => forgeplan_core::activity::status::TOOL_ERR,
+            Ok(_) => forgeplan_core::activity::status::OK,
+            Err(_) => forgeplan_core::activity::status::RPC_ERR,
+        };
+
+        // Snapshot workspace path if available. Skip logging when
+        // workspace not initialized (first-run `forgeplan_init`).
+        if let Some(ws) = self.workspace_path.read().await.as_ref() {
+            let ws = ws.clone();
+            let entry = forgeplan_core::activity::make_entry(
+                tool_name,
+                &args_val,
+                duration_ms,
+                status,
+                &ws,
+                None,  // client_info not exposed by rmcp 1.2 API — future work
+                false, // include_args: off by default (PRD-054 FR-004)
+            );
+            // Fire-and-forget: spawn so we don't block the response.
+            tokio::spawn(async move {
+                forgeplan_core::activity::append_best_effort(&ws, &entry).await;
+            });
+        }
+
+        result
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+# Pin the Rust toolchain used for local development to match CI.
+# This is how we avoid drift between "clippy passes locally" and
+# "CI lint job fails" — the exact situation that broke PR #178
+# on first push.
+#
+# Keep in sync with .github/workflows/ci.yml `rust_version`.
+[toolchain]
+channel = "1.95"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Release v0.21.0

Second user-facing release since the v0.20.0 silent-failure fix. Ships
two increments of post-v0.20.0 roadmap:

### PRD-054 — Activity log

Every MCP tool call is now recorded in `.forgeplan/logs/tools-YYYY-MM-DD.jsonl`.
Two new tools `forgeplan_activity` and `forgeplan_activity_stats` let agents
query the log. Args content is never logged by default — only SHA-256 hash —
so secrets in titles don't leak. Zero latency overhead (fire-and-forget spawn).

### PRD-055 increment 1 — soft-delete receipt infrastructure

Foundation for reversible destructive operations. Adds the `forgeplan-core::undo`
module with Receipt data model, trash directory layout, TTL-based lazy purge,
and crash-safe write-then-move semantics.

**Not yet wired**: `forgeplan_delete` / `_supersede` / `_deprecate` still do
hard-delete. Wiring + `forgeplan_restore` + `forgeplan_undo_last` come in
v0.22.0 as PRD-055 increments 2 and 3.

### Dev experience

- `rust-toolchain.toml` pins Rust 1.95 to prevent version skew between
  developer machines and CI (hit PR #178 first push with a clippy 1.95 lint).

### Post-merge automation

- Tag `v0.21.0` on main
- cargo-dist builds macOS (arm64/x64), Linux, Windows binaries
- Homebrew tap formula auto-updates

Users run `brew upgrade forgeplan` and get:
- every MCP call logged under `.forgeplan/logs/`
- new `forgeplan_activity` / `forgeplan_activity_stats` tools
- (on next version) reversible destructive ops

### Scope

- 2 commits from feature PRs #178 + #179 + this release bump
- 1245 tests pass / 0 fail (+31 since v0.20.0)
- All R1/R2/R3 security hardening from v0.20.0 still in place

### Verification

- [x] `cargo test --workspace`: 1245 pass / 0 fail
- [x] `cargo clippy --workspace --all-targets -D warnings`: clean
- [x] `cargo fmt --check`: 0 diffs
- [x] CHANGELOG.md entries for BOTH v0.20.0 (backfill) and v0.21.0

Refs: PRD-054, PRD-055, PROB-039

🤖 Generated with [Claude Code](https://claude.com/claude-code)