### PR TITLE
chore: back-merge v0.22.0 into dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.22.0] — 2026-04-18 — Reversible destructive ops (PRD-055 complete)
+
+Completes the undo story started in v0.21.0. Every destructive operation —
+`delete`, `supersede`, `deprecate` — is now recoverable via a single tool
+call within a 30-day TTL window.
+
+### Added — wrapping of destructive ops (PRD-055 increment 2)
+
+All three destructive tool handlers now go through `soft_delete_capture`
+before mutating the store:
+
+- `forgeplan_delete`: writes a receipt with full snapshot (body, metadata,
+  outgoing + incoming relations), moves the markdown projection into
+  `.forgeplan/trash/`, then removes the store row.
+- `forgeplan_supersede`: writes a receipt capturing the original status,
+  then applies the lifecycle transition. Projection stays in place.
+- `forgeplan_deprecate`: same pattern.
+
+Crash invariant (PRD-055 ADR #4): receipt is written BEFORE the store
+mutation. A crash in between leaves a harmless orphan receipt which TTL
+purge later collects.
+
+Every destructive-op response now includes a `receipt_id` field and a
+`_next_action` hint pointing at `forgeplan_undo_last` or
+`forgeplan_restore <id>`.
+
+### Added — restore and undo-last tools (PRD-055 increment 3)
+
+- **`forgeplan_restore id=<ID>`** — finds the newest non-consumed receipt
+  for that ID, applies restore. For delete: recreates the store row,
+  moves the projection back, re-links all captured relations. For
+  supersede/deprecate: resets status to pre-op value and drops the new
+  link. Orphaned relation targets are tracked in `relations_skipped`.
+- **`forgeplan_undo_last within_hours=<N>`** — finds the newest
+  non-consumed receipt across all artifacts within the window (default
+  24h, max 720h), applies the same restore logic. Never guesses: returns
+  an explicit error if the window is empty.
+
+Transactional semantics (FR-011): receipt is marked consumed LAST.
+Collision handling (R-3): restore refuses if an artifact with the same
+ID already exists in the store.
+
+### Verification
+
+- **1255 tests pass / 0 fail** (+19 undo tests across receipt and restore
+  modules, +4 integration tests).
+- `cargo clippy --workspace --all-targets -D warnings`: clean.
+- `cargo fmt --check`: 0 diffs.
+
+### User-visible workflow
+
+Before: `forgeplan_delete PRD-048` → artifact permanently gone.
+
+After:
+```
+forgeplan_delete PRD-048
+  → receipt written, projection moved to trash, store row removed
+  → response: receipt_id + hint "reversible via forgeplan_undo_last"
+
+forgeplan_undo_last
+  → PRD-048 restored with identical body, metadata, relations
+```
+
+Refs: PRD-055 (now functionally complete), PRD-054.
+
+---
+
 ## [0.21.0] — 2026-04-18 — Activity log + soft-delete receipt infrastructure
 
 Builds on the v0.20.0 tool-quality work. Adds two pieces of observability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.21.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.21.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.22.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.22.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.21.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.22.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true


### PR DESCRIPTION
Syncs dev with main after v0.22.0 release.

- Cargo.toml 0.21.0 → 0.22.0
- Inter-crate pins updated
- CHANGELOG.md v0.22.0 entry

Zero new logic. Prevents the next feature branch from starting at 0.21.0 and hitting the same Cargo.toml conflict.