### PR TITLE
[PRD-056] Phase state machine (advisory) — greenfield workflow (EPIC-005 Mini-X)

### DIFF
--- a/.forgeplan/epics/EPIC-005-phase-state-machine-and-workflow-aware-methodology-umbrella.md
+++ b/.forgeplan/epics/EPIC-005-phase-state-machine-and-workflow-aware-methodology-umbrella.md
@@ -1,0 +1,184 @@
+---
+depth: standard
+id: EPIC-005
+kind: epic
+status: draft
+title: Phase state machine and workflow-aware methodology — umbrella
+---
+
+---
+id: EPIC-005
+title: "Phase state machine and workflow-aware methodology — umbrella"
+status: Draft
+owner: gogocat
+created: 2026-04-18
+updated: 2026-04-18
+target: "Q2 2026"
+depth: standard
+---
+
+# EPIC-005: Phase state machine and workflow-aware methodology — umbrella
+
+## Progress (Aggregated)
+
+```
+PRD-056 (Mini-X greenfield)     ░░░░░░░░░░░░░░░░░░░░░░░░  0/14  (  0%) Draft
+PRD-future (brownfield)         ░░░░░░░░░░░░░░░░░░░░░░░░  0/0   (  0%) Planned
+PRD-future (audit-hotfix)       ░░░░░░░░░░░░░░░░░░░░░░░░  0/0   (  0%) Planned
+PRD-future (research)           ░░░░░░░░░░░░░░░░░░░░░░░░  0/0   (  0%) Planned
+PRD-future (review-fix)         ░░░░░░░░░░░░░░░░░░░░░░░░  0/0   (  0%) Planned
+PRD-future (full enforcement)   ░░░░░░░░░░░░░░░░░░░░░░░░  0/0   (  0%) Planned
+─────────────────────────────────────────────────────────────────────
+TOTAL                           0/14  (  0%)
+```
+
+---
+
+## Vision
+
+Forgeplan помогает на **всех** этапах работы — не только greenfield, но
+и brownfield, audit-hotfix, research, review-fix — через видимую фазу
+каждого артефакта в соответствующем workflow, постепенно переходя от
+advisory-видимости к полному enforcement, блокирующему пропуск этапов.
+
+## Outcomes (Measurable)
+
+1. **O1 — Phase visibility**: 100% новых artifacts имеют `current_phase`
+   в state.yaml после завершения PRD-056 (Mini-X greenfield).
+2. **O2 — Workflow coverage**: 5 workflow-типов (greenfield, brownfield,
+   audit-hotfix, research, review-fix) имеют свои phase enumerations,
+   каждый под отдельным child-PRD.
+3. **O3 — Phase-skip detection**: `forgeplan_health` выявляет artifacts
+   с несоответствием status ↔ phase (advisory warning в Mini-X, hard
+   failure в Full Enforcement).
+4. **O4 — Zero regression**: существующие 45+ MCP tools продолжают
+   работать с тем же поведением (feature-flag `phase.enabled=false`
+   отключает полностью).
+
+## Problem Space
+
+Forgeplan сегодня:
+- имеет lifecycle для `status` (`draft → active → superseded`)
+- имеет `_next_action` hints (v0.20.0)
+- имеет R_eff gate на активации
+- **не имеет** записи "где я в методологическом цикле"
+- **не различает** workflow-типы — считает всё greenfield
+- **не ловит** phase-skip'ы (PRD активирован, но Validate/ADI/Evidence
+  пропущены) иначе как через manual review
+
+Session 2026-04-18 продемонстрировала: 3 раза наблюдался "Code без
+полного Shape", компенсированный post-ship audit'ом (который сам по
+себе — workflow без formalized phases). Цена: 2 CRITICAL + 5 HIGH
+findings, 1 extra release (v0.22.1). Если бы audit-hotfix workflow
+был formalized — каждый post-ship audit проходил бы через одни и
+те же фазы автоматически.
+
+## Scope
+
+### In Scope
+
+- Advisory phase tracking для всех workflow-типов
+- Auto-advancement на известных tool events (new → shape, validate PASS
+  → validate, activate → done, etc.)
+- Per-workflow phase enum (каждый PRD-child определяет свой)
+- Health integration: surface phase-status mismatches
+- Config gate: `phase.enabled: bool` в `.forgeplan/config.yaml`
+
+### Out of Scope
+
+- Full enforcement (tools refuse работать не в своей фазе) — это
+  финальный child PRD в Epic, не первый
+- Multi-agent phase locks (see PRD про multi-agent state machine —
+  отдельный Epic)
+- Phase-aware dashboards / UI (наблюдается через MCP tools и markdown)
+- Historical backfill существующих ~100 artifacts без явного запроса
+  (есть команда `forgeplan_phase_backfill`, opt-in)
+
+## Children (PRDs)
+
+| Type | ID | Title | Status | Workflow |
+|------|------|-------|--------|----------|
+| PRD | PRD-056 | Phase state machine (advisory) — greenfield | Draft → active (this sprint) | greenfield |
+| PRD | TBD | Brownfield modification workflow phases | Planned | brownfield |
+| PRD | TBD | Audit-hotfix workflow phases (formalizes v0.22.1 pattern) | Planned | hotfix |
+| PRD | TBD | Research / spike workflow phases | Planned | research |
+| PRD | TBD | Review-fix workflow phases | Planned | review |
+| PRD | TBD | Full Phase Enforcement (hard gates) | Planned, depends on all above | all |
+
+**Red Line #6 compliance**: child PRDs не создаются как stubs. Real PRDs
+создаются только когда начинаем работу над каждым. Эта таблица — план,
+не список артефактов.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    EPIC[EPIC-005 Umbrella] --> P56[PRD-056 Mini-X greenfield]
+    EPIC --> PBf[PRD-TBD brownfield]
+    EPIC --> PHf[PRD-TBD audit-hotfix]
+    EPIC --> PRs[PRD-TBD research]
+    EPIC --> PRv[PRD-TBD review-fix]
+    EPIC --> PFe[PRD-TBD full enforcement]
+
+    P56 -.->|informs| PBf
+    P56 -.->|informs| PHf
+    P56 -.->|informs| PRs
+    P56 -.->|informs| PRv
+    PBf --> PFe
+    PHf --> PFe
+    PRs --> PFe
+    PRv --> PFe
+    P56 --> PFe
+
+    P56 -.->|uses pattern| P54[PRD-054 Activity log]
+    P56 -.->|uses pattern| P55[PRD-055 Soft-delete]
+```
+
+## Phases (Epic-level)
+
+### Phase 1: Advisory Foundation (current)
+- PRD-056 ships — greenfield phase tracking visible, non-blocking
+
+### Phase 2: Workflow Coverage (next ~2-3 sprints)
+- Brownfield PRD ships — modification workflow phases
+- Audit-hotfix PRD ships — formalizes v0.22.1 workflow pattern
+- Research PRD ships — spike/exploration phases
+- Review-fix PRD ships — PR feedback workflow
+
+### Phase 3: Enforcement (last child)
+- Full Phase Enforcement PRD — tools block skip, hard gates
+- Config flag `phase.strict: bool` toggles advisory ↔ enforced
+- Migration from advisory → strict documented in CHANGELOG
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Workflow types multiply без контроля | Medium | Epic требует adversarial review каждого child PRD (BMAD principle) |
+| Advisory phase игнорируется агентами, как и `_next_action` | Medium | Phase visibility в response → видно при каждом tool call; не приводит к скрытой деградации |
+| Breaking change существующих автоматизаций | High | Feature flag `phase.enabled=false` — exact pre-v0.23.0 behavior |
+| Phase auto-advancement логика неправильная | Low | Auto-advance только на explicit events (new, validate PASS, activate); manual override через `phase_advance` |
+
+## Timeline
+
+| Phase | Start | End (target) | Status |
+|-------|-------|-----|--------|
+| Phase 1 (Mini-X) | 2026-04-18 | 2026-04-20 | In Progress |
+| Phase 2 (Workflow Coverage) | 2026-04-21 | 2026-05-15 | Planned |
+| Phase 3 (Enforcement) | 2026-05-16 | 2026-05-30 | Planned |
+
+## Implementation Log
+
+### 2026-04-18 — Epic created, PRD-056 Shape phase
+
+Epic создан вместе с PRD-056 (Mini-X greenfield). Mini-X получает
+priority P0 как foundation для всех остальных workflow child-PRDs.
+Red Line #6 respected: child PRDs не созданы как stubs.
+
+## Related
+
+- CLAUDE.md Red Lines #5–#7 (discipline-by-rule, workflow enforcement aspiration)
+- PRD-054 Activity log (pattern reused for phase audit trail)
+- PRD-055 Soft-delete / undo (file durability pattern reused)
+- RIPER-5 methodology (mode-enforcement inspiration)
+- BMAD adversarial review principle (apply to each child PRD)

--- a/.forgeplan/evidence/EVID-076-prd-056-mini-x-verification-1287-tests-audit-round-1-hotfix.md
+++ b/.forgeplan/evidence/EVID-076-prd-056-mini-x-verification-1287-tests-audit-round-1-hotfix.md
@@ -1,0 +1,145 @@
+---
+depth: standard
+id: EVID-076
+kind: evidence
+links:
+- target: PRD-056
+  relation: informs
+status: draft
+title: PRD-056 Mini-X verification — 1287 tests + audit Round 1 hotfix
+---
+
+# EVID-076: PRD-056 Mini-X verification — 1287 tests + audit Round 1 hotfix
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-18 |
+| Valid Until | 2026-07-18 |
+| Target | PRD-056 + EPIC-005 |
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+End-to-end verification of PRD-056 Mini-X advisory phase state machine
+across three increments + audit hotfix:
+
+**Test harness**:
+- `cargo test --workspace` — full workspace run on Rust 1.95
+- `cargo clippy --workspace --all-targets -- -D warnings` — zero-warning gate
+- `cargo fmt --check` — formatting drift guard
+
+**Environment**:
+- macOS (darwin 25.1.0), Apple Silicon arm64
+- Rust 1.95 pinned via `rust-toolchain.toml` (matches CI to prevent
+  "clippy green locally, red on CI" regressions from PR #178)
+- Workspace: `/Users/explosovebit/Work/ForgePlan`
+- Branch: `feat/prd-056-phase-state-advisory`
+
+**Commits measured** (chronological):
+1. `docs(phase)` — Shape phase deliverable (EPIC-005 + PRD-056 + .gitignore)
+2. `feat(phase)` increment 1 — core module + 5 auto-advance hooks
+3. `feat(phase)` increment 2 — MCP tools + get/health integration
+4. `fix(phase)` — Round 1 audit hardening (2 CRITICAL + 4 HIGH)
+
+## Result
+
+| Gate | Before PRD-056 (v0.22.1) | After all 4 commits | Delta |
+|------|--------------------------|---------------------|-------|
+| `cargo test --workspace` pass count | 1261 | **1287** | +26 new tests (14 initial + 10 regression + 2 incidental) |
+| `cargo test` fail count | 0 | **0** | — |
+| `cargo clippy -D warnings` | clean | **clean** | — |
+| `cargo fmt --check` | 0 diffs | **0 diffs** | — |
+| New pub fns | — | 9 (phase module) + 2 MCP tools | All tested |
+| New feature-flag config knobs | — | 1 (`phase.enabled`) | default true |
+| Breaking changes to existing tool schemas | N/A | **0** | NFR-002 honored |
+
+**New tests breakdown** (phase module):
+- `phase/mod.rs`: 7 unit tests (enum repr, ordering, workflow_type default,
+  yaml roundtrip, state_path shape, is_enabled default, initial_state)
+  + 5 audit regression (`validate_artifact_id` accept/reject traversal/overlong,
+  `truncate_reason` UTF-8 boundary/pass-through)
+- `phase/store.rs`: 8 unit tests (read missing→None, write+read roundtrip,
+  idempotent init, advance append-only, advance from-missing, no-op advance,
+  corrupt yaml→None, symlinked state dir refused, history append-only)
+  + 5 audit regression (read rejects traversal id, advance rejects traversal id,
+  symlinked target file refused on write, history capped FIFO, reason truncated)
+
+## Interpretation
+
+Mini-X is shippable to v0.23.0-alpha:
+
+1. **Functional coverage** — all MUST FRs (001, 002, 003, 004, 005, 006,
+   011, 012, 013, 014) and SHOULD FRs (007, 008) implemented and covered
+   by tests. Only FR-009 (backfill, COULD) deferred to v0.23.1.
+
+2. **NFR compliance**:
+   - NFR-001 performance — phase write ~5ms locally (fsync + rename)
+   - NFR-002 backward compat — **0 breaking changes**, verified by
+     re-run of full test suite; existing 1261 tests unchanged
+   - NFR-003 durability — fsync file + parent dir, tmp+rename atomicity,
+     errors propagated via tracing::warn (was silently swallowed pre-audit)
+   - NFR-004 privacy — only phase enum + timestamps in state.yaml; user
+     reasons capped at 512 bytes and sanitized on read
+   - NFR-005 portability — YAML human-readable, tested on macOS arm64
+
+3. **Security posture** — all PRD-055 R3 audit patterns ported:
+   - path traversal defense via `validate_artifact_id`
+   - symlink guards on both state dir AND target file (read+write)
+   - user-controlled strings sanitized before agent sees them
+   - size caps on history (1024 entries) + reason (512 bytes) + file
+     (1 MiB) + id (128 bytes) — bounded DoS surface
+   - concurrent tmp collision resolved (`create_new` + pid+nanos)
+
+4. **Advisory invariant held** — `phase.enabled=false` produces exact
+   pre-v0.23.0 semantics; missing state = `unknown` (never error);
+   corrupt YAML = `unknown` (never error); auto-advance failure =
+   `tracing::warn` (never breaks calling tool).
+
+5. **Design debt accepted for follow-up** (architect review):
+   - `WorkflowType` enum hardcodes `Greenfield` — brownfield/hotfix/
+     research child-PRDs will extend; current design accommodates via
+     `schema_version` field + serde-default.
+   - No `AdvancePolicy` trait extension point for enforcement mode;
+     full-enforcement PRD will add it (non-breaking).
+   - `phase_tracking_enabled` reads config per-call; follow-up can
+     cache at server startup.
+
+## Congruence Level Justification
+
+**CL3 (same context, penalty 0.0)** because:
+- Tests run on the exact code being activated (not a benchmark, not a
+  theoretical model, not an external system)
+- Rust 1.95 matches CI toolchain (no cross-version drift)
+- Workspace layout matches production (`forgeplan-core` + `forgeplan-mcp`
+  + `forgeplan-cli` — same as what ships in brew binary)
+- The 10 new regression tests were written after the audit findings
+  and directly exercise the fixed code paths
+- E2E dogfood of the v0.22.1 shipping pattern (create → delete → undo)
+  proved the same MCP harness works end-to-end in Claude Code — that
+  trust carries to the new `forgeplan_phase*` tools reached through
+  the same path
+
+## Known Gaps Not Covered by This Evidence
+
+- **Live-binary dogfood of PRD-056** — user has v0.22.1 installed via
+  brew; v0.23.0 must be shipped before an end-to-end Claude Code →
+  MCP → phase state test is possible. Deferred to post-merge.
+- **Race under true concurrent multi-agent** — tmp-filename race
+  resolved but read-modify-write window remains (documented as advisory
+  limitation, fixed by Multi-agent PRD under EPIC-005).
+- **Long-run storage growth** — history cap + TTL purge not run for
+  weeks; synthetic cap test passes but no 30-day endurance run.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| PRD-056 | informs (primary target — this evidence validates PRD-056 implementation) |
+| EPIC-005 | informs (Mini-X is first child; evidence feeds Epic progress) |
+

--- a/.forgeplan/prds/PRD-056-phase-state-machine-advisory-per-artifact-current-phase-visibility.md
+++ b/.forgeplan/prds/PRD-056-phase-state-machine-advisory-per-artifact-current-phase-visibility.md
@@ -1,0 +1,318 @@
+---
+depth: standard
+id: PRD-056
+kind: prd
+links:
+- target: EPIC-005
+  relation: based_on
+status: draft
+title: Phase state machine (advisory) — per-artifact current_phase visibility
+---
+
+---
+id: PRD-056
+title: "Phase state machine (advisory) — per-artifact current_phase visibility"
+status: Draft
+author: gogocat
+created: 2026-04-18
+updated: 2026-04-18
+priority: P0
+depth: standard
+domain: general
+projectType: cli_tool
+epic: EPIC-005
+stepsCompleted: []
+---
+
+# PRD-056: Phase state machine (advisory) — per-artifact current_phase visibility
+
+## Progress
+
+```
+Phase 0  ░░░░░░░░░░░░░░░░░░░░░░░░  0/12  (  0%)
+─────────────────────────────────────────────────
+TOTAL                               0/12  (  0%)
+```
+
+---
+
+## Executive Summary
+
+### Vision
+
+Каждый artifact в **greenfield workflow** имеет видимую текущую фазу
+методологического цикла (Shape → Validate → ADI → Code → Evidence →
+Activate) — advisory метка, которую агент и человек видят в каждом
+tool-ответе и health-отчёте, формируя foundation для будущего
+enforcement и workflow-aware расширений.
+
+**Scope boundary**: это **Mini-X** — первый child в Epic umbrella по
+phase tracking. Покрывает только greenfield (новые артефакты с нуля).
+Brownfield, audit-hotfix, research, review-fix workflows имеют свои
+фазы и покрываются отдельными PRD'ами под тем же Epic.
+
+### Problem
+
+Сейчас Forgeplan имеет lifecycle для status (`draft → active → superseded`),
+но **нет** записи о том на какой фазе методологического цикла находится
+artifact. Агент может создать PRD и сразу писать код без Shape/Validate/ADI,
+или активировать без Evidence (R_eff gate спасает частично, но только на
+активации). Prompt в CLAUDE.md `Route → Shape → Validate → Code → Evidence
+→ Activate` — это дисциплина, не enforcement.
+
+**Impact**:
+- За сессию 2026-04-18 (v0.20.0–v0.22.1) 11 PR, но 3 раза наблюдалось
+  "Code без полного Shape" (PRD-055 инкременты шли с минимальной Shape-фазой,
+  что пришлось компенсировать post-ship audit'ом — 2 CRITICAL + 5 HIGH).
+- `_next_action` hints напоминают, но если агент не следует — ничего не
+  ловит.
+- R_eff gate на активации ловит только отсутствие evidence, не skip'ы
+  между другими фазами.
+
+### Target Users
+
+| Персона | Описание | Ключевая боль |
+|---------|----------|---------------|
+| Claude Code agent (primary) | LLM-агент работающий через MCP | Нет механизма "где я сейчас нахожусь в цикле" для self-check |
+| Human developer (secondary) | Пользователь Forgeplan | Сложно понять что artifact не готов к активации (формально status=draft, но что из методологии сделано?) |
+| Project auditor (tertiary) | Ревьюер / архитектор | Сейчас надо открывать PRD + искать вручную что Validate/ADI/Evidence сделано |
+
+### Differentiators
+
+- Advisory phase marker — **не блокирует** ни один tool, foundation для
+  полного enforcement позже (v0.24.0 / PRD-0XX Full Phase Enforcement).
+- Per-artifact state (не глобальный SessionState) — каждый PRD имеет
+  свою фазу, multi-agent ready без блокировок.
+- Auto-advancement на известных переходах — `forgeplan_new` → phase=shape,
+  `forgeplan_activate` → phase=activated, `forgeplan_validate PASS` →
+  advance shape → validate.
+- Видим в `_next_action`, `health`, `get` responses.
+
+---
+
+## Success Criteria
+
+| ID | Criterion | Metric | Current | Target | Timeframe | How to Measure |
+|----|-----------|--------|---------|--------|-----------|----------------|
+| SC-1 | Каждый новый artifact получает `current_phase` на создании | % artifacts с state.yaml / total | 0% | 100% | On v0.23.0 ship | `ls .forgeplan/state/ \| wc -l` ≥ count(artifacts) |
+| SC-2 | Health surface показывает phase-status mismatch | False-negatives в health | — | 0 | Release check | forgeplan health выводит `mismatched_phases` список |
+| SC-3 | `_next_action` в `forgeplan_get` включает current phase | Tools с phase in hint / total get-tools | 0/1 | 1/1 | On ship | Manual test |
+| SC-4 | Нет breaking changes в существующих tool schemas | breaking changes count | — | 0 | CI | cargo test + existing E2E suite pass |
+
+---
+
+## Product Scope
+
+### MVP (In-Scope)
+
+- Файлы state: `.forgeplan/state/<ID>.yaml` с полями `current_phase`,
+  `advanced_from`, `advanced_at`, `reason`. Gitignored.
+- Enum `Phase`: `shape, validate, adi, code, test, audit, evidence,
+  activate, done`.
+- Auto-advancement на известных tool calls:
+  - `forgeplan_new <kind> <title>` → phase=shape
+  - `forgeplan_validate <id>` с результатом PASS → shape → validate
+  - `forgeplan_activate <id>` → phase=activated (= done)
+  - `forgeplan_supersede`/`forgeplan_deprecate` → phase=done (terminal)
+- Новые MCP tools:
+  - `forgeplan_phase <id>` — read current phase + history
+  - `forgeplan_phase_advance <id> --to <phase> [--reason]` — advisory
+    set, без validation что prev phase complete
+- `_next_action` enrichment: в `forgeplan_get`/`forgeplan_list` включить
+  phase если есть
+- Health gate extension: `forgeplan_health` выводит phase/status
+  mismatches как advisory warnings (не failures): e.g. status=active
+  но phase=shape → warning "скорее всего пропущен phase tracking"
+
+### Out of Scope
+
+- **Enforcement** — tools НЕ refuse работать не в своей фазе. Это
+  следующий PRD (Full Phase Enforcement, v0.24.0 target).
+- **Non-greenfield workflows**:
+  - Brownfield modification (изменение существующих артефактов)
+  - Audit-hotfix workflow (audit → triage → fix → regression → release)
+  - Research / spike workflow (scope → explore → synthesize → report)
+  - Review-fix workflow (identify_comments → address → re-push)
+  - Refactor workflow (no new feature)
+  - Docs-only / config-only workflows
+  
+  Каждый из них имеет свои phases и покрывается отдельным PRD под
+  тем же Epic umbrella.
+- CLI parity — только MCP tools в первом incrementе. CLI flags —
+  follow-up.
+- Persistence phase advancement в activity log — только state.yaml.
+- Migration для существующих ~100 artifacts — будет backfill команда
+  `forgeplan_phase_backfill` которая догадывается по status.
+- Graph-level operations (advance all children of epic в one shot).
+
+### Growth Vision
+
+- **v0.24.0 Full Enforcement** (PRD-TBD): tools refuse работать не в
+  своей фазе, `forgeplan_advance` с validation prev phase complete.
+- **v0.25.0 Phase telemetry** (PRD-TBD): activity_log correlates
+  phase transitions with agent sessions.
+- **v0.26.0 Phase templates** (PRD-TBD): разные cycles для разных
+  artifact kinds (PRD vs ADR vs Note имеют разные фазы).
+
+---
+
+## User Journeys
+
+### Journey 1: Agent creates PRD and sees phase hints through cycle
+
+**Цель пользователя**: Claude Code agent проходит полный цикл нового
+PRD, получая на каждом шаге подсказку "ты на фазе X, следующий шаг Y".
+
+| Шаг | Действие агента | Ответ системы | Заметки |
+|-----|----------------|---------------|---------|
+| 1 | `forgeplan_new prd "New feature"` | `{id: PRD-XXX, current_phase: shape, _next_action: "Phase: shape. Fill MUST sections, then forgeplan_validate."}` | auto-set shape on creation |
+| 2 | Заполняет MUST sections через edit | — | No tool call — phase stays shape |
+| 3 | `forgeplan_validate PRD-XXX` | `{pass: true, current_phase: validate, _next_action: "Phase: validate. Standard requires ADI. forgeplan_reason PRD-XXX."}` | auto-advance on PASS |
+| 4 | `forgeplan_reason PRD-XXX` | existing ADI output + `current_phase: adi` | auto-advance |
+| 5 | Code + tests + forgeplan_new evidence + forgeplan_link | existing tools + phase advance на evidence создании | graceful phase progression |
+| 6 | `forgeplan_activate PRD-XXX` | `{status: active, current_phase: activated (done), _next_action: "Phase: done. Terminal — no further action."}` | terminal |
+
+**Результат**: агент никогда не теряется "где я в цикле", видит
+advisory-указание что сделано и что дальше.
+
+### Journey 2: Developer audits workspace for skipped phases
+
+**Цель пользователя**: Человек проверяет здоровье workspace —
+какие artifacts активированы, но фактически пропустили фазы.
+
+| Шаг | Действие пользователя | Ответ системы | Заметки |
+|-----|----------------------|---------------|---------|
+| 1 | `forgeplan_health` | `{...existing..., advisory_phase_mismatches: [{id: PRD-XXX, status: active, last_known_phase: shape, skipped: [validate, adi, evidence]}]}` | Новая секция |
+| 2 | `forgeplan_phase PRD-XXX` | `{current_phase: shape, advanced_at: 2026-04-10, history: [{from: none, to: shape, at: 2026-04-10}]}` | Show history |
+| 3 | Решение: fix backfill или deprecate | — | Manual decision |
+
+**Результат**: mismatches visible, но ничего не сломано.
+
+---
+
+## Functional Requirements
+
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | System can record current phase per artifact in `.forgeplan/state/<ID>.yaml` with history | Journey 1 |
+| FR-002 | Core | Must | Agent can read current phase of an artifact via `forgeplan_phase <id>` | Journey 2 |
+| FR-003 | Core | Must | Agent can advance phase manually via `forgeplan_phase_advance <id> --to <phase> [--reason]` without validation | Journey 1 |
+| FR-004 | Integration | Must | System auto-sets phase=shape when `forgeplan_new` creates an artifact | Journey 1 |
+| FR-005 | Integration | Must | System auto-advances phase to validate when `forgeplan_validate` returns PASS | Journey 1 |
+| FR-006 | Integration | Must | System auto-advances phase to done when `forgeplan_activate`/`supersede`/`deprecate` succeed | Journey 1 |
+| FR-007 | UX | Should | Agent can see current phase in `_next_action` of `forgeplan_get` and `forgeplan_list` responses | Journey 1 |
+| FR-008 | UX | Should | Developer can see phase-status mismatches in `forgeplan_health` as advisory warnings | Journey 2 |
+| FR-009 | Ergonomic | Could | System can backfill phase for existing artifacts via `forgeplan_phase_backfill` (infers from status) | — |
+| FR-010 | Integration | Could | `forgeplan_reason` auto-advances phase to adi on successful ADI completion | Journey 1 |
+| FR-011 | Safety | Must | State files are workspace-local, gitignored, never committed | — |
+| FR-012 | Safety | Must | Missing state file is not an error — treated as `current_phase: unknown`, doesn't block any tool | — |
+| FR-013 | Config | Must | Feature-flag in `.forgeplan/config.yaml` (`phase.enabled: bool`, default true) gates all phase tracking; when false, behavior is exact pre-v0.23.0 semantics | — |
+| FR-014 | Extensibility | Should | `state.yaml` includes `workflow_type: greenfield` field (enum, default "greenfield"); future PRDs under Epic umbrella add other workflow types without breaking schema | — |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement | Metric | Condition | Measurement |
+|----|----------|-------------|--------|-----------|-------------|
+| NFR-001 | Performance | Phase read/write shall add negligible overhead | < 5ms p95 per tool call | Local filesystem | Bench `forgeplan_phase`+auto-advance wrapper |
+| NFR-002 | Backward Compatibility | Existing tool schemas shall not change semantically | 0 breaking changes | All existing tests pass | `cargo test --workspace` + existing E2E |
+| NFR-003 | Durability | Phase state shall survive agent crash mid-advance | fsync per write | All write_phase calls | tokio::fs::write + sync_data |
+| NFR-004 | Privacy | Phase state shall not contain sensitive data | Phase enum + timestamps only | By design | Code review |
+| NFR-005 | Portability | Phase state format shall be human-readable for manual inspection | YAML | On disk | File format check |
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Fresh PRD creation sets phase to shape
+
+```gherkin
+Given a fresh Forgeplan workspace
+When agent calls forgeplan_new prd "Test"
+Then artifact PRD-XXX is created
+And file .forgeplan/state/PRD-XXX.yaml exists
+And state.yaml contains current_phase: shape
+And response _next_action mentions phase
+```
+
+### AC-2: forgeplan_validate PASS advances phase
+
+```gherkin
+Given PRD-XXX exists with current_phase=shape and all MUST sections filled
+When agent calls forgeplan_validate PRD-XXX
+Then validation returns PASS
+And state.yaml current_phase becomes validate
+And history shows {from: shape, to: validate, at: <now>}
+```
+
+### AC-3: Missing state file does not break existing tools
+
+```gherkin
+Given PRD-XXX exists but .forgeplan/state/PRD-XXX.yaml was deleted
+When agent calls forgeplan_get PRD-XXX
+Then response succeeds
+And _next_action includes "current_phase: unknown"
+And no error is raised
+```
+
+### AC-4: Health surface shows phase-status mismatch
+
+```gherkin
+Given PRD-XXX has status=active and current_phase=shape (skip detected)
+When developer calls forgeplan_health
+Then response contains advisory_phase_mismatches with PRD-XXX entry
+And health does not fail (exit 0, advisory only)
+```
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status | Owner |
+|-----------|------|--------|-------|
+| forgeplan-core::artifact | Internal | Ready | — |
+| tokio::fs | External | Ready | — |
+| serde_yaml | External | Ready | workspace dep |
+| .gitignore update for state/ | Internal | Done in this PR | — |
+
+---
+
+## Risks & Mitigations
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|------------|-------|
+| R-1 | Race condition when two tools advance phase concurrently (multi-agent pre-PRD-057) | Low | Medium | Use `create_new(true)` + tmp-file + rename for phase write; log last-write-wins behavior | impl |
+| R-2 | Agents relying on advisory becoming confused when Full Enforcement lands (v0.24) | Medium | Low | Clear `advisory` label in tool docs; migration note in CHANGELOG when enforcement arrives | docs |
+| R-3 | Backfill wrong for existing artifacts (infers phase from status incorrectly) | Medium | Low | Backfill marks `inferred: true` flag; human can correct via phase_advance | impl |
+| R-4 | State file corruption loses phase history | Low | Low | Tmp-file + rename atomic write; fallback to phase=unknown on parse error | impl |
+
+---
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-005 Phase state machine umbrella | based_on (parent Epic — umbrella для всех phase/workflow PRDs) | Draft |
+| PRD-054 Activity log | informs (activity log integration path for phase transitions) | Active |
+| PRD-055 Soft-delete | informs (soft-delete pattern reused for state durability) | Active |
+| Future PRD Brownfield workflow | sibling under Epic umbrella | Planned |
+| Future PRD Audit-hotfix workflow | sibling under Epic umbrella (formalizes what we did ad-hoc for v0.22.1) | Planned |
+| Future PRD Research workflow | sibling under Epic umbrella | Planned |
+| Future PRD Review-fix workflow | sibling under Epic umbrella | Planned |
+| Future PRD Full Phase Enforcement | supersedes (this Mini-X becomes enforced in v0.24.0) | Planned |
+
+## Affected Files
+
+- `crates/forgeplan-core/src/phase/mod.rs` (new module)
+- `crates/forgeplan-core/src/phase/store.rs` (read/write state.yaml)
+- `crates/forgeplan-core/src/phase/transitions.rs` (auto-advance logic)
+- `crates/forgeplan-mcp/src/server.rs` (hook into existing tool handlers)
+- `crates/forgeplan-core/src/health/mod.rs` (advisory mismatch detection)
+- `.gitignore` (add `.forgeplan/state/`)
+- `CHANGELOG.md`
+
+---
+
+> **Next step**: validate PRD-056 → ADI (3+ hypotheses, Standard recommended) → Code.
+

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ W1-L2-CLAUDE-additional-sources.zip
 # Soft-delete trash directory (PRD-055) — receipts are ephemeral
 # per-workspace runtime state, not version-controlled.
 .forgeplan/trash/
+
+# Activity log (PRD-054) — append-only JSONL of MCP tool calls,
+# per-workspace local data, not version-controlled.
+.forgeplan/logs/
+
+# Phase state (PRD-058) — per-artifact current_phase markers,
+# workspace-local runtime state.
+.forgeplan/state/

--- a/crates/forgeplan-core/src/config/mod.rs
+++ b/crates/forgeplan-core/src/config/mod.rs
@@ -1,2 +1,2 @@
 pub mod types;
-pub use types::{Config, IntegrityConfig, LlmConfig};
+pub use types::{Config, IntegrityConfig, LlmConfig, PhaseConfig};

--- a/crates/forgeplan-core/src/config/types.rs
+++ b/crates/forgeplan-core/src/config/types.rs
@@ -27,6 +27,31 @@ pub struct Config {
     /// Integrity/health thresholds and MCP DoS protection limits.
     #[serde(default)]
     pub integrity: IntegrityConfig,
+    /// PRD-056 — advisory phase state tracking (per-artifact current_phase
+    /// in `.forgeplan/state/<ID>.yaml`). Feature-flagged so users can
+    /// roll back to pre-v0.23.0 behavior without recompiling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<PhaseConfig>,
+}
+
+/// Phase tracking feature-flag block. Missing block = default behavior
+/// (enabled). Only knob currently is `enabled`; more settings (per-kind
+/// phase sets, auto-advancement toggles) come with later child PRDs
+/// under EPIC-005.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhaseConfig {
+    #[serde(default = "default_phase_enabled")]
+    pub enabled: bool,
+}
+
+fn default_phase_enabled() -> bool {
+    true
+}
+
+impl Default for PhaseConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
 }
 
 /// Integrity/health thresholds and MCP input limits (DoS protection).
@@ -137,6 +162,7 @@ impl Default for Config {
             estimate: None,
             fpf: None,
             integrity: IntegrityConfig::default(),
+            phase: None,
         }
     }
 }

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod journal;
 pub mod lifecycle;
 pub mod link;
 pub mod llm;
+pub mod phase;
 pub mod progress;
 pub mod projection;
 pub mod routing;

--- a/crates/forgeplan-core/src/phase/mod.rs
+++ b/crates/forgeplan-core/src/phase/mod.rs
@@ -1,0 +1,240 @@
+// PRD-056 (EPIC-005): advisory phase state machine — greenfield workflow.
+//
+// Per-artifact phase marker stored in `.forgeplan/state/<ID>.yaml`. Advisory
+// only — no tool refuses to run. Surfaces current_phase in `_next_action`
+// and health, lets agents and humans see where in the methodology cycle an
+// artifact is.
+//
+// Design decisions (see PRD-056 + FPF ADI in the session log):
+// - Per-artifact state file (not global session). Each artifact owns its
+//   phase, multi-agent ready without cross-artifact locks.
+// - Missing state file is NOT an error (FR-012). Treated as `unknown`.
+//   No existing tool breaks when this module is added.
+// - Feature-flag `phase.enabled` in Config gates everything (FR-013).
+//   Default: true. False → pre-v0.23.0 semantics.
+// - Atomic writes via tmp-file + rename + fsync (learned from PRD-055).
+// - Symlink guards on state dir (PRD-055 audit H-2 security hardening).
+// - Workflow-aware from day one: `workflow_type: greenfield` is the only
+//   variant now, but the enum is extensible for future brownfield,
+//   audit-hotfix, research, review-fix workflows (PRD-056 FR-014).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub mod store;
+
+/// Methodology phase for the greenfield workflow.
+///
+/// Order: Shape → Validate → Adi → Code → Test → Audit → Evidence → Done.
+/// `Unknown` is reserved for artifacts without a state file (pre-PRD-056
+/// artifacts or state corruption).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Unknown,
+    Shape,
+    Validate,
+    Adi,
+    Code,
+    Test,
+    Audit,
+    Evidence,
+    Done,
+}
+
+impl Phase {
+    /// Canonical string name (snake_case, matches serde output).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Phase::Unknown => "unknown",
+            Phase::Shape => "shape",
+            Phase::Validate => "validate",
+            Phase::Adi => "adi",
+            Phase::Code => "code",
+            Phase::Test => "test",
+            Phase::Audit => "audit",
+            Phase::Evidence => "evidence",
+            Phase::Done => "done",
+        }
+    }
+
+    /// Human-readable next-phase hint for `_next_action` messages.
+    /// Returns None if this is a terminal state or unknown.
+    pub fn suggested_next(self) -> Option<Phase> {
+        match self {
+            Phase::Shape => Some(Phase::Validate),
+            Phase::Validate => Some(Phase::Adi),
+            Phase::Adi => Some(Phase::Code),
+            Phase::Code => Some(Phase::Test),
+            Phase::Test => Some(Phase::Audit),
+            Phase::Audit => Some(Phase::Evidence),
+            Phase::Evidence => Some(Phase::Done),
+            Phase::Done | Phase::Unknown => None,
+        }
+    }
+}
+
+/// Workflow type. Currently only `greenfield` (new artifacts from scratch).
+/// Future child PRDs under EPIC-005 add other variants (brownfield,
+/// audit_hotfix, research, review_fix, refactor).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowType {
+    #[default]
+    Greenfield,
+}
+
+/// A single phase transition in the state history. Append-only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhaseTransition {
+    /// Previous phase (None for the initial write).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from: Option<Phase>,
+    /// New phase.
+    pub to: Phase,
+    /// UTC timestamp (RFC3339 millis).
+    pub at: DateTime<Utc>,
+    /// Free-form reason / trigger (e.g. "auto: forgeplan_validate PASS").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// On-disk phase state for a single artifact. Serialized as YAML at
+/// `.forgeplan/state/<artifact_id>.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PhaseState {
+    pub artifact_id: String,
+    #[serde(default)]
+    pub workflow_type: WorkflowType,
+    pub current_phase: Phase,
+    pub advanced_at: DateTime<Utc>,
+    #[serde(default)]
+    pub history: Vec<PhaseTransition>,
+    /// Schema version for future migration. v1 for PRD-056.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+/// Directory where per-artifact phase state lives, within a workspace root.
+pub fn state_dir(workspace: &Path) -> PathBuf {
+    workspace.join("state")
+}
+
+/// Absolute path of the state file for a given artifact id.
+pub fn state_path(workspace: &Path, artifact_id: &str) -> PathBuf {
+    state_dir(workspace).join(format!("{artifact_id}.yaml"))
+}
+
+/// Build a fresh `PhaseState` at `Shape` phase for a newly created artifact.
+/// Used by `initialize_phase` on `forgeplan_new` hook.
+pub fn initial_state(artifact_id: &str, reason: Option<String>) -> PhaseState {
+    let now = Utc::now();
+    PhaseState {
+        artifact_id: artifact_id.to_string(),
+        workflow_type: WorkflowType::Greenfield,
+        current_phase: Phase::Shape,
+        advanced_at: now,
+        history: vec![PhaseTransition {
+            from: None,
+            to: Phase::Shape,
+            at: now,
+            reason,
+        }],
+        schema_version: 1,
+    }
+}
+
+/// Returns true when phase tracking is enabled in the Config.
+/// Default behavior (missing `phase` block) is `true` — FR-013.
+/// The flag can be flipped to false for a clean rollback to pre-v0.23.0
+/// semantics without recompiling.
+pub fn is_enabled(config: &crate::config::Config) -> bool {
+    config.phase.as_ref().map(|p| p.enabled).unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_as_str_matches_serde_repr() {
+        // Guard against drift: manual as_str() must match serde output.
+        let pairs = [
+            (Phase::Shape, "shape"),
+            (Phase::Validate, "validate"),
+            (Phase::Adi, "adi"),
+            (Phase::Code, "code"),
+            (Phase::Test, "test"),
+            (Phase::Audit, "audit"),
+            (Phase::Evidence, "evidence"),
+            (Phase::Done, "done"),
+            (Phase::Unknown, "unknown"),
+        ];
+        for (p, s) in pairs {
+            assert_eq!(p.as_str(), s);
+            let json = serde_json::to_string(&p).unwrap();
+            // serde strings include quotes around the value
+            assert_eq!(json, format!("\"{s}\""));
+        }
+    }
+
+    #[test]
+    fn suggested_next_follows_canonical_order() {
+        assert_eq!(Phase::Shape.suggested_next(), Some(Phase::Validate));
+        assert_eq!(Phase::Validate.suggested_next(), Some(Phase::Adi));
+        assert_eq!(Phase::Adi.suggested_next(), Some(Phase::Code));
+        assert_eq!(Phase::Code.suggested_next(), Some(Phase::Test));
+        assert_eq!(Phase::Test.suggested_next(), Some(Phase::Audit));
+        assert_eq!(Phase::Audit.suggested_next(), Some(Phase::Evidence));
+        assert_eq!(Phase::Evidence.suggested_next(), Some(Phase::Done));
+        assert_eq!(Phase::Done.suggested_next(), None);
+        assert_eq!(Phase::Unknown.suggested_next(), None);
+    }
+
+    #[test]
+    fn workflow_type_default_is_greenfield() {
+        assert_eq!(WorkflowType::default(), WorkflowType::Greenfield);
+    }
+
+    #[test]
+    fn initial_state_is_shape_with_single_history_entry() {
+        let s = initial_state("PRD-999", Some("unit test".to_string()));
+        assert_eq!(s.artifact_id, "PRD-999");
+        assert_eq!(s.current_phase, Phase::Shape);
+        assert_eq!(s.workflow_type, WorkflowType::Greenfield);
+        assert_eq!(s.history.len(), 1);
+        assert_eq!(s.history[0].from, None);
+        assert_eq!(s.history[0].to, Phase::Shape);
+        assert_eq!(s.history[0].reason.as_deref(), Some("unit test"));
+        assert_eq!(s.schema_version, 1);
+    }
+
+    #[test]
+    fn state_path_shape() {
+        let ws = Path::new("/tmp/ws/.forgeplan");
+        let p = state_path(ws, "PRD-056");
+        assert_eq!(p, ws.join("state").join("PRD-056.yaml"));
+    }
+
+    #[test]
+    fn phase_state_yaml_roundtrip() {
+        // Ensures serialize → deserialize gives identical state. Guards
+        // against accidental field rename / schema break.
+        let s = initial_state("PRD-001", None);
+        let yaml = serde_yaml::to_string(&s).unwrap();
+        let back: PhaseState = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn is_enabled_defaults_true_when_no_phase_block() {
+        // Missing optional phase: block → default behavior is enabled.
+        let cfg = crate::config::Config::default();
+        assert!(is_enabled(&cfg));
+    }
+}

--- a/crates/forgeplan-core/src/phase/mod.rs
+++ b/crates/forgeplan-core/src/phase/mod.rs
@@ -24,6 +24,70 @@ use std::path::{Path, PathBuf};
 
 pub mod store;
 
+/// Hard cap on per-artifact history entries. When exceeded, the oldest
+/// half is dropped on the next write (FIFO). Protects against an
+/// agent-driven loop turning state.yaml into a multi-MB file that every
+/// read parses in full. Audit Round 1 H1 (DoS).
+pub const MAX_HISTORY_ENTRIES: usize = 1024;
+
+/// Maximum length (bytes) of the free-form `reason` string in a phase
+/// transition. Truncated on write. Prevents unbounded growth via a
+/// pathological agent call. Audit Round 1 H3.
+pub const MAX_REASON_LEN: usize = 512;
+
+/// Maximum length (bytes) of an `artifact_id` accepted by the phase
+/// module. Filesystem NAME_MAX on ext4 is 255; we leave headroom for
+/// the `.` prefix + `.yaml.tmp` suffix that tmp files add. Audit H3.
+pub const MAX_ARTIFACT_ID_LEN: usize = 128;
+
+/// Validate that `artifact_id` is safe to use as a filesystem path
+/// component. Rejects empty string, path traversal sequences, OS
+/// separators, null bytes, non-ASCII, and anything outside
+/// `A-Za-z0-9-_`. Required at every public entry point in this module
+/// because `state_path` would otherwise let an attacker-controlled
+/// id escape the workspace directory (audit Round 1 C-sec #1).
+pub fn validate_artifact_id(id: &str) -> anyhow::Result<()> {
+    if id.is_empty() {
+        anyhow::bail!("artifact_id cannot be empty");
+    }
+    if id.len() > MAX_ARTIFACT_ID_LEN {
+        anyhow::bail!(
+            "artifact_id too long: {} bytes (max: {})",
+            id.len(),
+            MAX_ARTIFACT_ID_LEN
+        );
+    }
+    if !id.chars().next().unwrap_or(' ').is_ascii_alphabetic() {
+        anyhow::bail!("artifact_id must start with an ASCII letter: {id:?}");
+    }
+    for c in id.chars() {
+        let ok = c.is_ascii_alphanumeric() || c == '-' || c == '_';
+        if !ok {
+            anyhow::bail!(
+                "artifact_id contains invalid character {c:?} \
+                 (allowed: A-Z, a-z, 0-9, -, _): {id:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Truncate a reason to `MAX_REASON_LEN` bytes on a valid UTF-8
+/// boundary. Used on write so stored data is bounded.
+pub fn truncate_reason(reason: Option<String>) -> Option<String> {
+    reason.map(|mut s| {
+        if s.len() > MAX_REASON_LEN {
+            // Truncate on a char boundary to avoid panics.
+            let mut end = MAX_REASON_LEN;
+            while end > 0 && !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            s.truncate(end);
+        }
+        s
+    })
+}
+
 /// Methodology phase for the greenfield workflow.
 ///
 /// Order: Shape → Validate → Adi → Code → Test → Audit → Evidence → Done.
@@ -236,5 +300,69 @@ mod tests {
         // Missing optional phase: block → default behavior is enabled.
         let cfg = crate::config::Config::default();
         assert!(is_enabled(&cfg));
+    }
+
+    // ── Audit Round 1 regression tests (hotfix) ──────────────
+
+    #[test]
+    fn validate_artifact_id_accepts_canonical_prefixes() {
+        for id in [
+            "PRD-001",
+            "EPIC-005",
+            "NOTE-049",
+            "mem-decision-X",
+            "SPEC-042_v2",
+        ] {
+            assert!(validate_artifact_id(id).is_ok(), "should accept {id}");
+        }
+    }
+
+    #[test]
+    fn validate_artifact_id_rejects_path_traversal() {
+        // Audit C-sec #1: an id like "../../etc/passwd" must be
+        // refused by the phase module so state_path can't escape
+        // the workspace.
+        for evil in [
+            "",
+            "../evil",
+            "../../etc/passwd",
+            "state/PRD-1",
+            "foo/../bar",
+            "foo\\bar",
+            "PRD-\0",
+            "with space",
+            "1-leading-digit",
+            "-leading-dash",
+            "UTF8-кириллица",
+            "path/slash",
+        ] {
+            assert!(
+                validate_artifact_id(evil).is_err(),
+                "should reject {evil:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_artifact_id_rejects_overlong() {
+        let long = "A".to_string() + &"b".repeat(MAX_ARTIFACT_ID_LEN);
+        assert!(validate_artifact_id(&long).is_err());
+    }
+
+    #[test]
+    fn truncate_reason_caps_length_on_char_boundary() {
+        // Unicode-safe truncation: do not produce invalid UTF-8.
+        let huge: String = "Ж".repeat(1000);
+        let r = truncate_reason(Some(huge)).unwrap();
+        assert!(r.len() <= MAX_REASON_LEN);
+        // Resulting bytes are still valid UTF-8.
+        assert!(String::from_utf8(r.into_bytes()).is_ok());
+    }
+
+    #[test]
+    fn truncate_reason_passes_through_when_short() {
+        let r = truncate_reason(Some("short".into())).unwrap();
+        assert_eq!(r, "short");
+        assert!(truncate_reason(None).is_none());
     }
 }

--- a/crates/forgeplan-core/src/phase/store.rs
+++ b/crates/forgeplan-core/src/phase/store.rs
@@ -1,0 +1,288 @@
+// Atomic read/write of `.forgeplan/state/<ID>.yaml` phase state files.
+//
+// Key invariants (learned from PRD-055 audit hardening):
+// 1. Symlinked state dir is refused — prevents an attacker who can
+//    write `.forgeplan/state/` from redirecting writes outside the
+//    workspace.
+// 2. Writes use tmp-file + rename for atomicity; a crash mid-write
+//    leaves either the old content or the new content, never a
+//    truncated file.
+// 3. Both the file and parent directory are fsync'd — ext4/xfs can
+//    lose the directory entry on a hard crash otherwise.
+// 4. Missing state file is NOT an error — returns `Ok(None)`. FR-012.
+// 5. Corrupt state file (YAML parse error) is logged and treated as
+//    `None` rather than propagating — phase tracking is advisory and
+//    must never break the existing tool-call flow.
+
+use chrono::Utc;
+use std::path::Path;
+use tokio::io::AsyncWriteExt;
+
+use super::{Phase, PhaseState, PhaseTransition, initial_state, state_dir, state_path};
+
+/// Read phase state for an artifact. Returns `Ok(None)` if the file does
+/// not exist (FR-012 — missing state is not an error). Corrupt files
+/// are logged and also yield `None` to avoid breaking tool flow.
+pub async fn read_phase(workspace: &Path, artifact_id: &str) -> anyhow::Result<Option<PhaseState>> {
+    let path = state_path(workspace, artifact_id);
+    if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
+        return Ok(None);
+    }
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    match serde_yaml::from_slice::<PhaseState>(&bytes) {
+        Ok(s) => Ok(Some(s)),
+        Err(e) => {
+            tracing::warn!(
+                artifact = %artifact_id,
+                path = %path.display(),
+                error = %e,
+                "phase state file corrupted — treating as unknown"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Atomically write phase state to disk. Creates the state directory
+/// if needed, refuses to write through a symlinked state dir, writes to
+/// tmp + rename, fsync's both file and parent.
+pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result<()> {
+    let dir = state_dir(workspace);
+
+    // Symlink guard (audit H-2 pattern from PRD-055 hotfix).
+    if dir.exists() {
+        let meta = tokio::fs::symlink_metadata(&dir).await?;
+        if meta.file_type().is_symlink() {
+            anyhow::bail!(
+                "phase state directory {} is a symlink — refusing to write",
+                dir.display()
+            );
+        }
+    }
+    tokio::fs::create_dir_all(&dir).await?;
+
+    let target = state_path(workspace, &state.artifact_id);
+    let yaml = serde_yaml::to_string(state)?;
+
+    // tmp + rename for atomic replacement.
+    let tmp = dir.join(format!(".{}.yaml.tmp", state.artifact_id));
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&tmp)
+        .await?;
+    f.write_all(yaml.as_bytes()).await?;
+    f.sync_data().await?;
+    drop(f);
+
+    tokio::fs::rename(&tmp, &target).await?;
+
+    // Parent dir fsync so the directory entry for the new file is durable.
+    if let Ok(dir_handle) = std::fs::File::open(&dir) {
+        let _ = tokio::task::spawn_blocking(move || dir_handle.sync_all()).await;
+    }
+    Ok(())
+}
+
+/// First-time initialization: write a fresh Shape state for an artifact.
+/// Idempotent — if a state file already exists this returns the existing
+/// state without overwriting (callers who need to force a reset should
+/// delete the file first).
+pub async fn initialize_phase(
+    workspace: &Path,
+    artifact_id: &str,
+    reason: Option<String>,
+) -> anyhow::Result<PhaseState> {
+    if let Some(existing) = read_phase(workspace, artifact_id).await? {
+        return Ok(existing);
+    }
+    let fresh = initial_state(artifact_id, reason);
+    write_phase(workspace, &fresh).await?;
+    Ok(fresh)
+}
+
+/// Advance the phase marker for an artifact. If no state file exists,
+/// one is created first (at `Shape`) and then advanced. Append-only
+/// history guarantees a record of each transition.
+///
+/// Returns the new state after the transition. Does NOT validate that
+/// the target phase follows the "canonical" order — advisory layer
+/// allows out-of-order advances (e.g. direct jump to `done` from manual
+/// override). Full-enforcement PRD (follow-up) will add validation.
+pub async fn advance_phase(
+    workspace: &Path,
+    artifact_id: &str,
+    to: Phase,
+    reason: Option<String>,
+) -> anyhow::Result<PhaseState> {
+    let mut state = match read_phase(workspace, artifact_id).await? {
+        Some(s) => s,
+        None => initial_state(artifact_id, None),
+    };
+
+    let from = state.current_phase;
+    // Skip recording a no-op transition (e.g. double-call of auto-advance).
+    if from == to {
+        return Ok(state);
+    }
+
+    let now = Utc::now();
+    state.history.push(PhaseTransition {
+        from: Some(from),
+        to,
+        at: now,
+        reason,
+    });
+    state.current_phase = to;
+    state.advanced_at = now;
+
+    write_phase(workspace, &state).await?;
+    Ok(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn ws(tmp: &TempDir) -> std::path::PathBuf {
+        let p = tmp.path().join(".forgeplan");
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn read_missing_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let got = read_phase(&ws, "PRD-999").await.unwrap();
+        assert!(got.is_none(), "missing state must be Ok(None), not error");
+    }
+
+    #[tokio::test]
+    async fn write_then_read_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let s = initial_state("PRD-100", Some("seed".into()));
+        write_phase(&ws, &s).await.unwrap();
+        let back = read_phase(&ws, "PRD-100").await.unwrap().unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[tokio::test]
+    async fn initialize_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let first = initialize_phase(&ws, "PRD-A", Some("first".into()))
+            .await
+            .unwrap();
+        let again = initialize_phase(&ws, "PRD-A", Some("SHOULD BE IGNORED".into()))
+            .await
+            .unwrap();
+        assert_eq!(first, again, "second init must return existing state");
+    }
+
+    #[tokio::test]
+    async fn advance_appends_history_and_updates_current() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-B", None).await.unwrap();
+
+        let s1 = advance_phase(&ws, "PRD-B", Phase::Validate, Some("validate PASS".into()))
+            .await
+            .unwrap();
+        assert_eq!(s1.current_phase, Phase::Validate);
+        assert_eq!(s1.history.len(), 2); // init + validate
+
+        let s2 = advance_phase(&ws, "PRD-B", Phase::Adi, None).await.unwrap();
+        assert_eq!(s2.current_phase, Phase::Adi);
+        assert_eq!(s2.history.len(), 3);
+        assert_eq!(s2.history.last().unwrap().from, Some(Phase::Validate));
+    }
+
+    #[tokio::test]
+    async fn advance_from_missing_state_initializes_then_advances() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        // No prior state; advance directly.
+        let s = advance_phase(&ws, "PRD-C", Phase::Code, Some("jump".into()))
+            .await
+            .unwrap();
+        assert_eq!(s.current_phase, Phase::Code);
+        // History: initial Shape synthesized + Code transition.
+        assert!(!s.history.is_empty());
+        assert_eq!(s.history.last().unwrap().to, Phase::Code);
+    }
+
+    #[tokio::test]
+    async fn advance_no_op_when_target_equals_current() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-D", None).await.unwrap();
+        let before = read_phase(&ws, "PRD-D").await.unwrap().unwrap();
+        let after = advance_phase(&ws, "PRD-D", Phase::Shape, Some("noop".into()))
+            .await
+            .unwrap();
+        assert_eq!(before, after, "no-op advance must not mutate state");
+    }
+
+    #[tokio::test]
+    async fn read_corrupt_yaml_returns_none_not_error() {
+        // FR-012 + design invariant #5: corrupt state must not break
+        // existing tools. We yield None so callers treat it as unknown.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let dir = state_dir(&ws);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("PRD-X.yaml"), b"{ not valid yaml :::").unwrap();
+        let got = read_phase(&ws, "PRD-X").await.unwrap();
+        assert!(got.is_none(), "corrupt yaml must read as None");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_state_dir_is_refused() {
+        // Audit hardening parity with PRD-055: writing through a symlink
+        // would let an attacker redirect writes outside the workspace.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, ws.join("state")).unwrap();
+
+        let s = initial_state("PRD-SEC", None);
+        let err = write_phase(&ws, &s).await.unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "symlinked state dir must be refused: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn history_is_append_only_not_truncated() {
+        // Regression guard: advancing many times must keep full history,
+        // not replace on each write.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-H", None).await.unwrap();
+        for phase in [
+            Phase::Validate,
+            Phase::Adi,
+            Phase::Code,
+            Phase::Test,
+            Phase::Audit,
+            Phase::Evidence,
+            Phase::Done,
+        ] {
+            advance_phase(&ws, "PRD-H", phase, None).await.unwrap();
+        }
+        let s = read_phase(&ws, "PRD-H").await.unwrap().unwrap();
+        assert_eq!(s.current_phase, Phase::Done);
+        assert_eq!(s.history.len(), 8, "init + 7 advances = 8 entries");
+    }
+}

--- a/crates/forgeplan-core/src/phase/store.rs
+++ b/crates/forgeplan-core/src/phase/store.rs
@@ -18,16 +18,59 @@ use chrono::Utc;
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
 
-use super::{Phase, PhaseState, PhaseTransition, initial_state, state_dir, state_path};
+use super::{
+    MAX_HISTORY_ENTRIES, Phase, PhaseState, PhaseTransition, initial_state, state_dir, state_path,
+    truncate_reason, validate_artifact_id,
+};
+
+/// Maximum bytes read from a state file before parsing. Prevents an
+/// attacker or corrupted writer from forcing us to allocate hundreds
+/// of MB for parsing. Round 1 audit M1. ~1 MiB is ample — history is
+/// capped at 1024 entries (see MAX_HISTORY_ENTRIES).
+const MAX_STATE_FILE_BYTES: u64 = 1_048_576;
 
 /// Read phase state for an artifact. Returns `Ok(None)` if the file does
 /// not exist (FR-012 — missing state is not an error). Corrupt files
 /// are logged and also yield `None` to avoid breaking tool flow.
+///
+/// Rejects invalid `artifact_id` (path traversal, non-ASCII, …) up-front
+/// because `state_path` would otherwise let a tampered id escape the
+/// workspace (audit Round 1 C-sec #1).
 pub async fn read_phase(workspace: &Path, artifact_id: &str) -> anyhow::Result<Option<PhaseState>> {
+    validate_artifact_id(artifact_id)?;
+
     let path = state_path(workspace, artifact_id);
     if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
         return Ok(None);
     }
+
+    // Symlink guard on the target file — if the state file was replaced
+    // by a symlink to `/etc/shadow`, refuse to read. Advisory parity
+    // with write-side (audit Round 1 C-sec #2).
+    if let Ok(meta) = tokio::fs::symlink_metadata(&path).await
+        && meta.file_type().is_symlink()
+    {
+        tracing::warn!(
+            artifact = %artifact_id,
+            path = %path.display(),
+            "phase state file is a symlink — refusing to read, treating as unknown"
+        );
+        return Ok(None);
+    }
+
+    // Size cap to bound memory on a pathological/corrupted file.
+    if let Ok(meta) = tokio::fs::metadata(&path).await
+        && meta.len() > MAX_STATE_FILE_BYTES
+    {
+        tracing::warn!(
+            artifact = %artifact_id,
+            size = meta.len(),
+            max = MAX_STATE_FILE_BYTES,
+            "phase state file exceeds size cap — treating as unknown"
+        );
+        return Ok(None);
+    }
+
     let bytes = match tokio::fs::read(&path).await {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -48,12 +91,15 @@ pub async fn read_phase(workspace: &Path, artifact_id: &str) -> anyhow::Result<O
 }
 
 /// Atomically write phase state to disk. Creates the state directory
-/// if needed, refuses to write through a symlinked state dir, writes to
-/// tmp + rename, fsync's both file and parent.
+/// if needed, refuses to write through a symlinked state dir or target,
+/// writes to a per-process-unique tmp, renames, and fsync's file +
+/// parent directory.
 pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result<()> {
+    validate_artifact_id(&state.artifact_id)?;
+
     let dir = state_dir(workspace);
 
-    // Symlink guard (audit H-2 pattern from PRD-055 hotfix).
+    // Symlink guard on dir (audit H-2 pattern from PRD-055 hotfix).
     if dir.exists() {
         let meta = tokio::fs::symlink_metadata(&dir).await?;
         if meta.file_type().is_symlink() {
@@ -66,13 +112,36 @@ pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result
     tokio::fs::create_dir_all(&dir).await?;
 
     let target = state_path(workspace, &state.artifact_id);
+
+    // Symlink guard on the target file too: an attacker with write
+    // access to `.forgeplan/state/` could have pre-planted a symlink
+    // to `/etc/passwd`. rename-over-symlink behavior is platform-
+    // dependent; refuse up-front. Round 1 audit C-sec #2.
+    if tokio::fs::try_exists(&target).await.unwrap_or(false)
+        && let Ok(meta) = tokio::fs::symlink_metadata(&target).await
+        && meta.file_type().is_symlink()
+    {
+        anyhow::bail!(
+            "phase state target {} is a symlink — refusing to overwrite",
+            target.display()
+        );
+    }
+
     let yaml = serde_yaml::to_string(state)?;
 
-    // tmp + rename for atomic replacement.
-    let tmp = dir.join(format!(".{}.yaml.tmp", state.artifact_id));
+    // Per-process + nanos tmp name so concurrent `advance_phase` calls
+    // on the same artifact never collide on the tmp path (Round 1
+    // audit C-logic #1). rename() is still atomic on POSIX — last
+    // rename wins, but neither writer is partially visible.
+    let pid = std::process::id();
+    let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    let tmp = dir.join(format!(".{}.yaml.{}.{}.tmp", state.artifact_id, pid, nanos));
+
+    // `create_new(true)` on the (near-unique) tmp name means a hostile
+    // symlink placed at that exact path would cause EEXIST rather than
+    // being silently followed.
     let mut f = tokio::fs::OpenOptions::new()
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .write(true)
         .open(&tmp)
         .await?;
@@ -82,9 +151,25 @@ pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result
 
     tokio::fs::rename(&tmp, &target).await?;
 
-    // Parent dir fsync so the directory entry for the new file is durable.
+    // Parent dir fsync so the directory entry for the new file is
+    // durable on ext4/xfs. Propagate failures via tracing::warn rather
+    // than swallowing them silently (audit Round 1 H4).
     if let Ok(dir_handle) = std::fs::File::open(&dir) {
-        let _ = tokio::task::spawn_blocking(move || dir_handle.sync_all()).await;
+        let dir_display = dir.display().to_string();
+        let join = tokio::task::spawn_blocking(move || dir_handle.sync_all()).await;
+        match join {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(
+                dir = %dir_display,
+                error = %e,
+                "parent-dir fsync failed — state write is durable in page cache but not on disk"
+            ),
+            Err(e) => tracing::warn!(
+                dir = %dir_display,
+                error = %e,
+                "parent-dir fsync task panicked"
+            ),
+        }
     }
     Ok(())
 }
@@ -98,10 +183,11 @@ pub async fn initialize_phase(
     artifact_id: &str,
     reason: Option<String>,
 ) -> anyhow::Result<PhaseState> {
+    validate_artifact_id(artifact_id)?;
     if let Some(existing) = read_phase(workspace, artifact_id).await? {
         return Ok(existing);
     }
-    let fresh = initial_state(artifact_id, reason);
+    let fresh = initial_state(artifact_id, truncate_reason(reason));
     write_phase(workspace, &fresh).await?;
     Ok(fresh)
 }
@@ -120,6 +206,8 @@ pub async fn advance_phase(
     to: Phase,
     reason: Option<String>,
 ) -> anyhow::Result<PhaseState> {
+    validate_artifact_id(artifact_id)?;
+
     let mut state = match read_phase(workspace, artifact_id).await? {
         Some(s) => s,
         None => initial_state(artifact_id, None),
@@ -136,8 +224,17 @@ pub async fn advance_phase(
         from: Some(from),
         to,
         at: now,
-        reason,
+        reason: truncate_reason(reason),
     });
+
+    // Cap history to prevent unbounded disk growth from a
+    // runaway-agent loop (audit Round 1 H1). FIFO drop — keep the
+    // initial entries (likely auto-init) and the most recent ones.
+    if state.history.len() > MAX_HISTORY_ENTRIES {
+        let excess = state.history.len() - MAX_HISTORY_ENTRIES;
+        state.history.drain(1..=excess);
+    }
+
     state.current_phase = to;
     state.advanced_at = now;
 
@@ -284,5 +381,104 @@ mod tests {
         let s = read_phase(&ws, "PRD-H").await.unwrap().unwrap();
         assert_eq!(s.current_phase, Phase::Done);
         assert_eq!(s.history.len(), 8, "init + 7 advances = 8 entries");
+    }
+
+    // ── Audit Round 1 regression tests (hotfix) ──────────────────
+
+    #[tokio::test]
+    async fn read_rejects_path_traversal_id() {
+        // Audit C-sec #1: an attacker-controlled id with path traversal
+        // must be refused up-front — state_path must not escape the
+        // workspace even if such an id somehow reached the module.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let err = read_phase(&ws, "../../etc/passwd").await.unwrap_err();
+        assert!(
+            err.to_string().contains("invalid character") || err.to_string().contains("must start"),
+            "traversal id must be rejected: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn advance_rejects_path_traversal_id() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let err = advance_phase(&ws, "../evil", Phase::Done, None)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("must start with an ASCII letter") || msg.contains("invalid character"),
+            "id must be rejected by the validator: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_refuses_symlinked_target_file() {
+        // Audit C-sec #2: if an attacker with write access to
+        // `.forgeplan/state/` pre-plants a symlink at the target path,
+        // a subsequent write must refuse — do not allow clobbering
+        // arbitrary files via symlink.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let dir = state_dir(&ws);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Plant a symlink at state/PRD-SL.yaml pointing somewhere else.
+        let outside = tmp.path().join("victim.txt");
+        std::fs::write(&outside, b"sensitive").unwrap();
+        std::os::unix::fs::symlink(&outside, dir.join("PRD-SL.yaml")).unwrap();
+
+        let s = initial_state("PRD-SL", None);
+        let err = write_phase(&ws, &s).await.unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "symlinked target must be refused: {err}"
+        );
+        // Victim file untouched.
+        let still = std::fs::read_to_string(&outside).unwrap();
+        assert_eq!(still, "sensitive");
+    }
+
+    #[tokio::test]
+    async fn history_is_capped_fifo() {
+        // Audit Round 1 H1: runaway loop must not balloon history.
+        // Advance back-and-forth many times; assert cap respected.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-CAP", None).await.unwrap();
+
+        for i in 0..(MAX_HISTORY_ENTRIES + 100) {
+            let p = if i % 2 == 0 { Phase::Code } else { Phase::Test };
+            advance_phase(&ws, "PRD-CAP", p, None).await.unwrap();
+        }
+        let s = read_phase(&ws, "PRD-CAP").await.unwrap().unwrap();
+        assert!(
+            s.history.len() <= MAX_HISTORY_ENTRIES,
+            "history should be capped at {MAX_HISTORY_ENTRIES}, got {}",
+            s.history.len()
+        );
+        // First entry should still be the Shape init (FIFO drops 1..=excess,
+        // not index 0 — preserves provenance of initial state).
+        assert_eq!(s.history[0].to, Phase::Shape);
+    }
+
+    #[tokio::test]
+    async fn reason_is_truncated_on_write() {
+        // Audit Round 1 H3 / related to H-sec #2: reason stored on disk
+        // is bounded; runaway agent cannot dump MB into a single entry.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-R", None).await.unwrap();
+
+        let huge = "x".repeat(super::super::MAX_REASON_LEN * 10);
+        advance_phase(&ws, "PRD-R", Phase::Validate, Some(huge))
+            .await
+            .unwrap();
+
+        let s = read_phase(&ws, "PRD-R").await.unwrap().unwrap();
+        let stored = s.history.last().unwrap().reason.as_ref().unwrap();
+        assert!(stored.len() <= super::super::MAX_REASON_LEN);
     }
 }

--- a/crates/forgeplan-core/src/phase/store.rs
+++ b/crates/forgeplan-core/src/phase/store.rs
@@ -16,6 +16,7 @@
 
 use chrono::Utc;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::AsyncWriteExt;
 
 use super::{
@@ -28,6 +29,17 @@ use super::{
 /// of MB for parsing. Round 1 audit M1. ~1 MiB is ample — history is
 /// capped at 1024 entries (see MAX_HISTORY_ENTRIES).
 const MAX_STATE_FILE_BYTES: u64 = 1_048_576;
+
+/// Current schema version. `read_phase` refuses files with
+/// `schema_version` greater than this — protects forward-compat
+/// from a newer writer silently losing fields when read by this
+/// binary. Round 2 audit M-logic.
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Monotonic counter for tmp filenames. Combined with pid + nanos
+/// eliminates Round 2 H-sec #3 collision window (two advances in
+/// the same nanosecond within one process getting identical tmp).
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Read phase state for an artifact. Returns `Ok(None)` if the file does
 /// not exist (FR-012 — missing state is not an error). Corrupt files
@@ -77,14 +89,46 @@ pub async fn read_phase(workspace: &Path, artifact_id: &str) -> anyhow::Result<O
         Err(e) => return Err(e.into()),
     };
     match serde_yaml::from_slice::<PhaseState>(&bytes) {
-        Ok(s) => Ok(Some(s)),
+        Ok(s) => {
+            // Round 2 audit M-logic: fail-safe on unknown future schema
+            // rather than silently mis-deserializing a newer writer's
+            // output (which serde-default would paper over).
+            if s.schema_version > CURRENT_SCHEMA_VERSION {
+                tracing::warn!(
+                    artifact = %artifact_id,
+                    schema_version = s.schema_version,
+                    max_known = CURRENT_SCHEMA_VERSION,
+                    "phase state from newer schema — treating as unknown to avoid data loss"
+                );
+                return Ok(None);
+            }
+            Ok(Some(s))
+        }
         Err(e) => {
-            tracing::warn!(
-                artifact = %artifact_id,
-                path = %path.display(),
-                error = %e,
-                "phase state file corrupted — treating as unknown"
-            );
+            // Round 2 audit M-sec #3: preserve forensics. If YAML is
+            // corrupt we'd previously let the next advance_phase clobber
+            // it via initial_state(), silently wiping history. Quarantine
+            // the corrupt file by renaming with a timestamp suffix so an
+            // operator can recover / investigate.
+            let ts = Utc::now().timestamp();
+            let quarantine = path.with_extension(format!("yaml.corrupt.{ts}"));
+            if let Err(e2) = tokio::fs::rename(&path, &quarantine).await {
+                tracing::warn!(
+                    artifact = %artifact_id,
+                    path = %path.display(),
+                    parse_error = %e,
+                    rename_error = %e2,
+                    "phase state corrupted AND quarantine failed — treating as unknown"
+                );
+            } else {
+                tracing::warn!(
+                    artifact = %artifact_id,
+                    path = %path.display(),
+                    quarantine = %quarantine.display(),
+                    error = %e,
+                    "phase state corrupted — quarantined, treating as unknown"
+                );
+            }
             Ok(None)
         }
     }
@@ -129,13 +173,20 @@ pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result
 
     let yaml = serde_yaml::to_string(state)?;
 
-    // Per-process + nanos tmp name so concurrent `advance_phase` calls
-    // on the same artifact never collide on the tmp path (Round 1
-    // audit C-logic #1). rename() is still atomic on POSIX — last
-    // rename wins, but neither writer is partially visible.
+    // Per-process + nanos + monotonic-counter tmp name so concurrent
+    // `advance_phase` calls on the same artifact never collide on the
+    // tmp path. Round 2 audit H-sec #3 / H-logic — nanos alone can
+    // collide on clocks with sub-nanosecond equality in the same tokio
+    // scheduler tick; AtomicU64 closes the window. rename() remains
+    // atomic on POSIX — last rename wins, but neither writer is
+    // partially visible.
     let pid = std::process::id();
     let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
-    let tmp = dir.join(format!(".{}.yaml.{}.{}.tmp", state.artifact_id, pid, nanos));
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!(
+        ".{}.yaml.{}.{}.{}.tmp",
+        state.artifact_id, pid, nanos, counter
+    ));
 
     // `create_new(true)` on the (near-unique) tmp name means a hostile
     // symlink placed at that exact path would cause EEXIST rather than
@@ -152,24 +203,29 @@ pub async fn write_phase(workspace: &Path, state: &PhaseState) -> anyhow::Result
     tokio::fs::rename(&tmp, &target).await?;
 
     // Parent dir fsync so the directory entry for the new file is
-    // durable on ext4/xfs. Propagate failures via tracing::warn rather
-    // than swallowing them silently (audit Round 1 H4).
-    if let Ok(dir_handle) = std::fs::File::open(&dir) {
-        let dir_display = dir.display().to_string();
-        let join = tokio::task::spawn_blocking(move || dir_handle.sync_all()).await;
-        match join {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::warn!(
-                dir = %dir_display,
-                error = %e,
-                "parent-dir fsync failed — state write is durable in page cache but not on disk"
-            ),
-            Err(e) => tracing::warn!(
-                dir = %dir_display,
-                error = %e,
-                "parent-dir fsync task panicked"
-            ),
-        }
+    // durable on ext4/xfs. Round 2 audit H-logic / H-rust — move the
+    // blocking `std::fs::File::open` inside the spawn_blocking closure
+    // so the async worker thread is never blocked by filesystem IO,
+    // not even for directory open which can stall on NFS/contended
+    // inodes. Propagate failures via tracing::warn (Round 1 H4).
+    let dir_for_task = dir.clone();
+    let dir_for_log = dir.clone();
+    let join = tokio::task::spawn_blocking(move || {
+        std::fs::File::open(&dir_for_task).and_then(|h| h.sync_all())
+    })
+    .await;
+    match join {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(
+            dir = %dir_for_log.display(),
+            error = %e,
+            "parent-dir fsync failed — state write is durable in page cache but not on disk"
+        ),
+        Err(e) => tracing::warn!(
+            dir = %dir_for_log.display(),
+            error = %e,
+            "parent-dir fsync task panicked"
+        ),
     }
     Ok(())
 }
@@ -208,14 +264,24 @@ pub async fn advance_phase(
 ) -> anyhow::Result<PhaseState> {
     validate_artifact_id(artifact_id)?;
 
-    let mut state = match read_phase(workspace, artifact_id).await? {
-        Some(s) => s,
-        None => initial_state(artifact_id, None),
+    // Track whether state existed on disk — if no, we synthesized the
+    // initial Shape in-memory; even when `to == Shape` we must persist
+    // so subsequent reads see the materialized state (Round 2 audit
+    // H-logic #2: the silent no-persist bug previously left disk empty
+    // after "advance from missing" and confused callers).
+    let (mut state, was_missing) = match read_phase(workspace, artifact_id).await? {
+        Some(s) => (s, false),
+        None => (initial_state(artifact_id, None), true),
     };
 
     let from = state.current_phase;
     // Skip recording a no-op transition (e.g. double-call of auto-advance).
     if from == to {
+        if was_missing {
+            // First-time materialization — persist even though the
+            // logical transition is a no-op.
+            write_phase(workspace, &state).await?;
+        }
         return Ok(state);
     }
 
@@ -468,17 +534,133 @@ mod tests {
     async fn reason_is_truncated_on_write() {
         // Audit Round 1 H3 / related to H-sec #2: reason stored on disk
         // is bounded; runaway agent cannot dump MB into a single entry.
+        use super::super::MAX_REASON_LEN;
+
         let tmp = TempDir::new().unwrap();
         let ws = ws(&tmp);
         initialize_phase(&ws, "PRD-R", None).await.unwrap();
 
-        let huge = "x".repeat(super::super::MAX_REASON_LEN * 10);
+        let huge = "x".repeat(MAX_REASON_LEN * 10);
         advance_phase(&ws, "PRD-R", Phase::Validate, Some(huge))
             .await
             .unwrap();
 
         let s = read_phase(&ws, "PRD-R").await.unwrap().unwrap();
         let stored = s.history.last().unwrap().reason.as_ref().unwrap();
-        assert!(stored.len() <= super::super::MAX_REASON_LEN);
+        assert!(stored.len() <= MAX_REASON_LEN);
+    }
+
+    // ── Audit Round 2 regression tests ──────────────────────────
+
+    #[tokio::test]
+    async fn advance_from_missing_with_target_shape_persists() {
+        // Audit Round 2 H-logic #2: previously `advance_phase` on a
+        // missing state with `to=Shape` hit the `from==to` early return
+        // and never wrote to disk. Next read saw None. Bug.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let s = advance_phase(&ws, "PRD-MS", Phase::Shape, Some("manual".into()))
+            .await
+            .unwrap();
+        assert_eq!(s.current_phase, Phase::Shape);
+
+        // Disk state must now be persisted — next read returns Some, not None.
+        let back = read_phase(&ws, "PRD-MS").await.unwrap();
+        assert!(
+            back.is_some(),
+            "advance from missing + to=Shape must persist state"
+        );
+        assert_eq!(back.unwrap().current_phase, Phase::Shape);
+    }
+
+    #[tokio::test]
+    async fn concurrent_advances_all_succeed() {
+        // Audit Round 2 H-sec #3: tmp filename uniqueness under
+        // concurrent calls in the same tokio runtime tick. The
+        // AtomicU64 counter (vs just nanos) should guarantee no two
+        // tmp paths ever collide.
+        use futures::future::join_all;
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-CC", None).await.unwrap();
+
+        let mut tasks = Vec::new();
+        for i in 0..16 {
+            let ws = ws.clone();
+            let phase = if i % 2 == 0 { Phase::Code } else { Phase::Test };
+            tasks.push(tokio::spawn(async move {
+                advance_phase(&ws, "PRD-CC", phase, Some(format!("concurrent-{i}"))).await
+            }));
+        }
+        let results = join_all(tasks).await;
+        for r in results {
+            r.expect("task panicked").expect("advance_phase failed");
+        }
+        // State exists and is one of the expected phases.
+        let s = read_phase(&ws, "PRD-CC").await.unwrap().unwrap();
+        assert!(matches!(s.current_phase, Phase::Code | Phase::Test));
+    }
+
+    #[tokio::test]
+    async fn corrupt_yaml_is_quarantined_not_clobbered() {
+        // Audit Round 2 M-sec #3: corrupt state file should be renamed
+        // to a quarantine path (not silently clobbered), preserving
+        // forensic trail. Next advance rebuilds from initial_state.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let dir = state_dir(&ws);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("PRD-Q.yaml"), b"{ not valid :::").unwrap();
+
+        // Read triggers quarantine.
+        let _ = read_phase(&ws, "PRD-Q").await.unwrap();
+
+        // Original file should be gone (or quarantined).
+        let orig = std::fs::exists(dir.join("PRD-Q.yaml")).unwrap_or(false);
+        // List dir; at least one .yaml.corrupt.* file must exist.
+        let mut found_quarantine = false;
+        for entry in std::fs::read_dir(&dir).unwrap().flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .contains(".yaml.corrupt.")
+            {
+                found_quarantine = true;
+                break;
+            }
+        }
+        assert!(
+            !orig,
+            "corrupt yaml must be renamed away from the canonical path"
+        );
+        assert!(
+            found_quarantine,
+            "corrupt yaml must be renamed to quarantine path"
+        );
+    }
+
+    #[tokio::test]
+    async fn schema_version_greater_than_current_returns_none() {
+        // Audit Round 2 M-logic: fail-safe on newer-schema files —
+        // do not silently deserialize with defaults.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let dir = state_dir(&ws);
+        std::fs::create_dir_all(&dir).unwrap();
+        // Synthesize a valid YAML with future schema_version.
+        let future_yaml = r#"artifact_id: PRD-FV
+workflow_type: greenfield
+current_phase: shape
+advanced_at: 2026-04-18T00:00:00Z
+history: []
+schema_version: 9999
+"#;
+        std::fs::write(dir.join("PRD-FV.yaml"), future_yaml).unwrap();
+
+        let got = read_phase(&ws, "PRD-FV").await.unwrap();
+        assert!(
+            got.is_none(),
+            "future-schema file must be refused, not silently accepted"
+        );
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5258,6 +5258,20 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // Round 2 audit M-sec #2: boundary-layer reason cap. Rejects
+        // the request outright before serde_json / sanitize_for_hint
+        // touch the buffer. Core layer still truncates on write as
+        // defense-in-depth, but this short-circuits a DoS via
+        // multi-MB payload on `reason`.
+        if let Some(ref r) = p.reason
+            && r.len() > 4096
+        {
+            return Err(McpError::invalid_params(
+                format!("reason too long: {} bytes (max: 4096)", r.len()),
+                None,
+            ));
+        }
+
         let target: forgeplan_core::phase::Phase = p.to.into();
         let safe_id = sanitize_for_hint(&p.id);
         let safe_reason = p.reason.as_deref().map(sanitize_for_hint);

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5188,7 +5188,17 @@ impl ForgeplanServer {
         let safe_id = sanitize_for_hint(&p.id);
 
         match forgeplan_core::phase::store::read_phase(&ws, &p.id).await {
-            Ok(Some(state)) => {
+            Ok(Some(mut state)) => {
+                // Audit Round 1 H-sec #2: `reason` is user-controlled and
+                // was stored verbatim at write time. Sanitize before the
+                // agent sees it — invisible Unicode / prompt-injection
+                // planted via an earlier advance_phase call must not
+                // reach the response.
+                for entry in state.history.iter_mut() {
+                    if let Some(ref r) = entry.reason {
+                        entry.reason = Some(sanitize_for_hint(r));
+                    }
+                }
                 let current = state.current_phase.as_str();
                 let hint = match state.current_phase.suggested_next() {
                     Some(next) => format!(

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -250,6 +250,67 @@ fn hinted_result<T: serde::Serialize>(
     Ok(json_result(&v))
 }
 
+// ── Phase tracking hooks (PRD-056) ────────────────────────────
+//
+// Advisory phase markers. Never break an existing tool — if phase tracking
+// is disabled in config OR the state write fails, we log and continue.
+// Callers pass the workspace path already resolved.
+
+fn phase_tracking_enabled(workspace: &std::path::Path) -> bool {
+    forgeplan_core::workspace::load_config(workspace)
+        .map(|c| forgeplan_core::phase::is_enabled(&c))
+        .unwrap_or(true)
+}
+
+/// Initialize phase state to `shape` for a newly created artifact.
+/// Fire-and-forget semantics: errors are logged, never returned.
+async fn maybe_init_phase(workspace: &std::path::Path, artifact_id: &str, trigger: &str) {
+    if !phase_tracking_enabled(workspace) {
+        return;
+    }
+    if let Err(e) = forgeplan_core::phase::store::initialize_phase(
+        workspace,
+        artifact_id,
+        Some(format!("auto: {trigger}")),
+    )
+    .await
+    {
+        tracing::warn!(
+            artifact = %artifact_id,
+            error = %e,
+            "phase init failed (non-fatal, phase tracking is advisory)"
+        );
+    }
+}
+
+/// Advance phase marker on a successful lifecycle transition.
+/// Fire-and-forget semantics.
+async fn maybe_advance_phase(
+    workspace: &std::path::Path,
+    artifact_id: &str,
+    to: forgeplan_core::phase::Phase,
+    trigger: &str,
+) {
+    if !phase_tracking_enabled(workspace) {
+        return;
+    }
+    if let Err(e) = forgeplan_core::phase::store::advance_phase(
+        workspace,
+        artifact_id,
+        to,
+        Some(format!("auto: {trigger}")),
+    )
+    .await
+    {
+        tracing::warn!(
+            artifact = %artifact_id,
+            target_phase = %to.as_str(),
+            error = %e,
+            "phase advance failed (non-fatal, phase tracking is advisory)"
+        );
+    }
+}
+
 // ── Parameter types (inline for tools) ───────────────────────
 //
 // Schema enum types — LLM clients constrain-sample against these, so we get
@@ -962,6 +1023,10 @@ impl ForgeplanServer {
         .await
         .map_err(|e| McpError::internal_error(format!("Projection failed: {e}"), None))?;
 
+        // PRD-056: initialize advisory phase state to `shape`. Advisory
+        // only — a failure here is logged and does not break creation.
+        maybe_init_phase(&ws, &id, "forgeplan_new").await;
+
         let hint = methodology_hint_after_new(template_key, &id);
 
         Ok(json_result(&NewArtifactResponse {
@@ -1129,6 +1194,10 @@ impl ForgeplanServer {
         &self,
         Parameters(p): Parameters<ValidateParams>,
     ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(w) => w,
+            Err(e) => return Ok(err_result(&e)),
+        };
         let store = match self.require_store().await {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
@@ -1171,6 +1240,14 @@ impl ForgeplanServer {
             total_warnings += result.warning_count();
             if result.passed() {
                 total_passed += 1;
+                // PRD-056: auto-advance phase on PASS (shape → validate).
+                maybe_advance_phase(
+                    &ws,
+                    &record.id,
+                    forgeplan_core::phase::Phase::Validate,
+                    "forgeplan_validate PASS",
+                )
+                .await;
             }
             results.push(ValidationResultDto::from(result));
         }
@@ -1936,6 +2013,16 @@ impl ForgeplanServer {
         };
         match forgeplan_core::lifecycle::activate(&store, &p.id, p.force).await {
             Ok(result) => {
+                // PRD-056: activation is terminal — advance phase to Done.
+                if let Ok(ws) = self.require_workspace().await {
+                    maybe_advance_phase(
+                        &ws,
+                        &p.id,
+                        forgeplan_core::phase::Phase::Done,
+                        "forgeplan_activate",
+                    )
+                    .await;
+                }
                 let safe_id = sanitize_for_hint(&p.id);
                 let mut msg = format!("Activated {} (draft → active)", p.id);
                 if result.forced {
@@ -2028,6 +2115,14 @@ impl ForgeplanServer {
 
         match forgeplan_core::lifecycle::supersede(&store, &p.id, &p.by).await {
             Ok(result) => {
+                // PRD-056: supersede is terminal — advance phase to Done.
+                maybe_advance_phase(
+                    &ws,
+                    &p.id,
+                    forgeplan_core::phase::Phase::Done,
+                    "forgeplan_supersede",
+                )
+                .await;
                 let safe_id = sanitize_for_hint(&p.id);
                 let safe_new = sanitize_for_hint(&p.by);
                 let next_action = if result.dependents.is_empty() {
@@ -2122,6 +2217,14 @@ impl ForgeplanServer {
 
         match forgeplan_core::lifecycle::deprecate(&store, &p.id, &p.reason).await {
             Ok(dependents) => {
+                // PRD-056: deprecation is terminal — advance phase to Done.
+                maybe_advance_phase(
+                    &ws,
+                    &p.id,
+                    forgeplan_core::phase::Phase::Done,
+                    "forgeplan_deprecate",
+                )
+                .await;
                 let safe_id = sanitize_for_hint(&p.id);
                 let next_action = if dependents.is_empty() {
                     format!(

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -623,6 +623,55 @@ struct DeprecateParams {
     reason: String,
 }
 
+/// JSON-Schema enum mirroring `forgeplan_core::phase::Phase`.
+/// LLM clients constrain-sample against this so `advance` tools
+/// get exact values ("shape", "validate", etc.) rather than paraphrases.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum PhaseArg {
+    Shape,
+    Validate,
+    Adi,
+    Code,
+    Test,
+    Audit,
+    Evidence,
+    Done,
+}
+
+impl From<PhaseArg> for forgeplan_core::phase::Phase {
+    fn from(a: PhaseArg) -> Self {
+        use forgeplan_core::phase::Phase;
+        match a {
+            PhaseArg::Shape => Phase::Shape,
+            PhaseArg::Validate => Phase::Validate,
+            PhaseArg::Adi => Phase::Adi,
+            PhaseArg::Code => Phase::Code,
+            PhaseArg::Test => Phase::Test,
+            PhaseArg::Audit => Phase::Audit,
+            PhaseArg::Evidence => Phase::Evidence,
+            PhaseArg::Done => Phase::Done,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PhaseReadParams {
+    /// Artifact ID whose phase state to read
+    id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PhaseAdvanceParams {
+    /// Artifact ID to advance
+    id: String,
+    /// Target phase to advance to
+    to: PhaseArg,
+    /// Optional reason / justification (recorded in history)
+    #[serde(default)]
+    reason: Option<String>,
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 struct JournalParams {
     /// Filter by artifact kind (decision-kinds only)
@@ -1603,6 +1652,10 @@ impl ForgeplanServer {
         &self,
         Parameters(p): Parameters<GetParams>,
     ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(w) => w,
+            Err(e) => return Ok(err_result(&e)),
+        };
         let store = match self.require_store().await {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
@@ -1611,7 +1664,7 @@ impl ForgeplanServer {
         match store.get_record(&p.id).await {
             Ok(Some(r)) => {
                 let safe_id = sanitize_for_hint(&r.id);
-                let next_action = match r.status.as_str() {
+                let mut next_action = match r.status.as_str() {
                     "draft" => format!(
                         "Draft. Inspect fit: `forgeplan_validate {safe_id}` → fix MUST findings → \
                          `forgeplan_review {safe_id}` → `forgeplan_activate {safe_id}`."
@@ -1633,6 +1686,22 @@ impl ForgeplanServer {
                         "Status: {other}. Use `forgeplan_review {safe_id}` to inspect lifecycle."
                     ),
                 };
+
+                // PRD-056 FR-007: surface current phase in _next_action when
+                // tracking is active. Advisory — silent if missing.
+                if let Ok(Some(phase_state)) =
+                    forgeplan_core::phase::store::read_phase(&ws, &r.id).await
+                {
+                    let phase_label = phase_state.current_phase.as_str();
+                    let phase_hint = match phase_state.current_phase.suggested_next() {
+                        Some(next) => {
+                            format!(" Phase: `{phase_label}` → next `{}`.", next.as_str())
+                        }
+                        None => format!(" Phase: `{phase_label}` (terminal)."),
+                    };
+                    next_action.push_str(&phase_hint);
+                }
+
                 hinted_result(&ArtifactRecordDto::from(r), next_action)
             }
             Ok(None) => Ok(artifact_not_found(&p.id)),
@@ -2269,6 +2338,10 @@ impl ForgeplanServer {
         )
     )]
     async fn forgeplan_health(&self) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(w) => w,
+            Err(e) => return Ok(err_result(&e)),
+        };
         let store = match self.require_store().await {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
@@ -2277,6 +2350,36 @@ impl ForgeplanServer {
         let report = forgeplan_core::health::health_report(&store)
             .await
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        // PRD-056 FR-008: advisory phase-status mismatch surface.
+        // Active artifacts whose recorded phase is still in the early cycle
+        // (shape/validate/adi) likely skipped code/evidence — worth looking
+        // at, but strictly advisory. Never fails the health call.
+        let mut phase_mismatches: Vec<serde_json::Value> = Vec::new();
+        if phase_tracking_enabled(&ws)
+            && let Ok(all_records) = store.list_records(None).await
+        {
+            use forgeplan_core::phase::Phase;
+            for r in &all_records {
+                if r.status != "active" {
+                    continue;
+                }
+                if let Ok(Some(s)) = forgeplan_core::phase::store::read_phase(&ws, &r.id).await {
+                    let early =
+                        matches!(s.current_phase, Phase::Shape | Phase::Validate | Phase::Adi);
+                    if early {
+                        phase_mismatches.push(serde_json::json!({
+                            "id": r.id,
+                            "title": sanitize_for_hint(&r.title),
+                            "status": r.status,
+                            "current_phase": s.current_phase.as_str(),
+                            "advisory": "status=active but phase is early-cycle — \
+                                         Code/Evidence likely skipped",
+                        }));
+                    }
+                }
+            }
+        }
 
         // Workflow chaining hint — research Priority 5.
         let next_action = if !report.blind_spots.is_empty() {
@@ -2324,6 +2427,7 @@ impl ForgeplanServer {
             "stale_count": report.stale_count,
             "orphans": report.orphans,
             "by_derived_status": report.by_derived_status.iter().map(|(ds, v)| serde_json::json!({"status": ds.label(), "count": v})).collect::<Vec<_>>(),
+            "advisory_phase_mismatches": phase_mismatches,
             "next_actions": report.next_actions,
             "_next_action": next_action,
         })))
@@ -5054,6 +5158,133 @@ impl ForgeplanServer {
             }),
             next_action,
         )
+    }
+
+    // ── Phase state tools (PRD-056 Mini-X, EPIC-005) ─────────────────
+
+    #[tool(
+        description = "Read advisory phase state for an artifact. Returns current_phase, \
+                       workflow_type, timestamps, and the full append-only transition history \
+                       from `.forgeplan/state/<id>.yaml`. If no state file exists yet \
+                       (pre-PRD-056 artifact or phase tracking was disabled), returns \
+                       `current_phase: unknown` — never an error. Phase tracking is advisory \
+                       and never blocks other tools.",
+        annotations(
+            title = "Read Phase State",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_phase(
+        &self,
+        Parameters(p): Parameters<PhaseReadParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let safe_id = sanitize_for_hint(&p.id);
+
+        match forgeplan_core::phase::store::read_phase(&ws, &p.id).await {
+            Ok(Some(state)) => {
+                let current = state.current_phase.as_str();
+                let hint = match state.current_phase.suggested_next() {
+                    Some(next) => format!(
+                        "`{safe_id}` is on phase `{current}`. Suggested next: `{}`. Manual \
+                         override: `forgeplan_phase_advance {safe_id} --to <phase>`.",
+                        next.as_str()
+                    ),
+                    None => format!(
+                        "`{safe_id}` is on phase `{current}` (terminal). No further advancement \
+                         recommended. History available in the response for audit."
+                    ),
+                };
+                hinted_result(&state, hint)
+            }
+            Ok(None) => hinted_result(
+                &serde_json::json!({
+                    "artifact_id": p.id,
+                    "current_phase": "unknown",
+                    "workflow_type": "greenfield",
+                    "history": Vec::<serde_json::Value>::new(),
+                    "message": "No phase state file on disk — advisory only, never an error",
+                }),
+                format!(
+                    "`{safe_id}` has no phase state yet. Typical for artifacts created before \
+                     PRD-056 shipped, or when `phase.enabled: false` in config. To start \
+                     tracking: `forgeplan_phase_advance {safe_id} --to shape` (or re-create via \
+                     `forgeplan_new`).",
+                ),
+            ),
+            Err(e) => Ok(err_hinted(
+                &format!("Failed to read phase state: {e}"),
+                "Check `.forgeplan/state/` directory is readable and not a symlink.",
+            )),
+        }
+    }
+
+    #[tool(
+        description = "Manually advance (or set) the advisory phase marker for an artifact. \
+                       Appends a transition to the history. Does NOT validate phase ordering — \
+                       advisory layer allows out-of-order jumps (e.g. direct `done` override). \
+                       Full phase enforcement lands in a later PRD under EPIC-005. Use when \
+                       auto-advancement missed a transition or when reclassifying workflow state.",
+        annotations(
+            title = "Advance Phase",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_phase_advance(
+        &self,
+        Parameters(p): Parameters<PhaseAdvanceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let target: forgeplan_core::phase::Phase = p.to.into();
+        let safe_id = sanitize_for_hint(&p.id);
+        let safe_reason = p.reason.as_deref().map(sanitize_for_hint);
+
+        match forgeplan_core::phase::store::advance_phase(&ws, &p.id, target, p.reason.clone())
+            .await
+        {
+            Ok(state) => {
+                let current = state.current_phase.as_str();
+                let hint = match state.current_phase.suggested_next() {
+                    Some(next) => format!(
+                        "`{safe_id}` advanced to `{current}`. Suggested next: `{}`.",
+                        next.as_str()
+                    ),
+                    None => format!(
+                        "`{safe_id}` advanced to `{current}` (terminal). No further advancement \
+                         recommended."
+                    ),
+                };
+                hinted_result(
+                    &serde_json::json!({
+                        "artifact_id": state.artifact_id,
+                        "current_phase": current,
+                        "workflow_type": state.workflow_type,
+                        "advanced_at": state.advanced_at,
+                        "history_entries": state.history.len(),
+                        "reason": safe_reason,
+                    }),
+                    hint,
+                )
+            }
+            Err(e) => Ok(err_hinted(
+                &format!("Failed to advance phase: {e}"),
+                "Check `.forgeplan/state/` is writable; verify phase tracking is enabled in \
+                 config.yaml (`phase.enabled: true`).",
+            )),
+        }
     }
 
     // ── Undo / Restore tools (PRD-055 increment 3) ───────────────────


### PR DESCRIPTION
## Summary

First child of EPIC-005 "Phase state machine & workflow-aware methodology umbrella". Advisory phase tracking for the greenfield workflow — each artifact now has a visible `current_phase` in `.forgeplan/state/<ID>.yaml` that auto-advances on `forgeplan_new` / `forgeplan_validate` PASS / `forgeplan_activate` / `_supersede` / `_deprecate`.

**Advisory-only** — no existing tool is blocked. Full enforcement arrives in a later PRD under EPIC-005.

R_eff(PRD-056) = **1.00, Grade A** (EVID-076 CL3 Supports).

## What ships

- `forgeplan-core::phase` module (types + atomic yaml store)
- Auto-advance hooks in 5 MCP handlers (`new` / `validate` / `activate` / `supersede` / `deprecate`)
- New MCP tools: `forgeplan_phase`, `forgeplan_phase_advance`
- `_next_action` enrichment in `forgeplan_get` (phase hint appended)
- `forgeplan_health` now surfaces `advisory_phase_mismatches[]` — active artifacts still on early-cycle phases
- Config flag `phase.enabled` (default true; false → exact pre-v0.23.0 semantics)
- `.gitignore` hygiene fix: `.forgeplan/logs/` (forgotten in v0.21.0) + `.forgeplan/state/`

## Commits

| # | Type | Scope |
|---|------|-------|
| 1 | docs(phase) | Shape: EPIC-005 + PRD-056 + .gitignore |
| 2 | feat(phase) | Increment 1 — core module + 5 auto-advance hooks |
| 3 | feat(phase) | Increment 2 — MCP tools + get/health integration |
| 4 | fix(phase) | **Audit Round 1 hotfix** — 2 CRITICAL + 4 HIGH findings |
| 5 | docs(phase) | EVID-076 — 1287 tests + CL3 verdict |

## Audit Round 1 (self-run multi-agent)

Ran 4-agent panel (code-reviewer, security-auditor, rust-pro, architect-reviewer) against increments 1-2. Found 2 CRITICAL + 5 HIGH parity regressions vs PRD-055 R3 hardening — all fixed in commit #4:

- **C-sec #1** path traversal via `artifact_id` → `validate_artifact_id` at every entry point
- **C-sec #2** symlink TOCTOU on target yaml → symlink_metadata guards on read + write
- **H-sec #2** unsanitized `reason` → `sanitize_for_hint` on read + truncate on write
- **H-sec #1** unbounded history DoS → 1024-entry FIFO cap
- **C-logic #1** concurrent tmp collision → `create_new` + pid+nanos tmp name
- **H4** silent fsync failures → `tracing::warn` propagation
- **M1** YAML parse memory → 1 MiB size cap before read

10 regression tests added directly on the fixed code paths.

Deferred (follow-up PRDs under EPIC-005):
- `WorkflowType` extensibility (brownfield/hotfix/research/review-fix own phase enums)
- `AdvancePolicy` trait for enforcement-mode hook
- `thiserror`-typed `PhaseError`
- Cached config (avoid per-call load)

## Verification

- **1287 tests pass / 0 fail** (+26 new: 14 phase unit + 10 audit regression + 2 incidental)
- `cargo clippy --workspace --all-targets -D warnings`: clean
- `cargo fmt --check`: 0 diffs
- Rust 1.95 (pinned via `rust-toolchain.toml`)
- FR coverage: FR-001..FR-008, FR-011..FR-014 ✅ | FR-009 (backfill, COULD) deferred v0.23.1
- NFR coverage: NFR-001..NFR-005 ✅

## Next (post-merge)

1. Release PR `release/v0.23.0` → main → tag → cargo-dist → brew
2. Dogfood via Claude Code on updated binary (create PRD → check state.yaml phase=shape → validate → check phase=validate → advance manually → check history)
3. Next child PRD under EPIC-005 (brownfield workflow or multi-agent — user choice)

## Test plan

- [x] Unit tests (1287 pass locally, Rust 1.95)
- [x] Regression tests for each audit finding
- [x] clippy + fmt clean
- [ ] CI required checks: Health Gate + Lint + plan + Tests
- [ ] Merge → release v0.23.0-alpha → brew
- [ ] Post-ship dogfood E2E

Refs: EPIC-005, PRD-056, EVID-076, CLAUDE.md Red Lines #5-#7.