### PR TITLE
Release v0.23.1 — Multi-agent workspace lock foundation

### DIFF
--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -1,0 +1,355 @@
+---
+depth: standard
+id: PRD-057
+kind: prd
+links:
+- target: EPIC-005
+  relation: based_on
+status: draft
+title: Orchestrator dispatcher — parallel work plan for N sub-agents in shared workspace
+---
+
+---
+id: PRD-057
+title: "Orchestrator dispatcher — parallel work plan for N sub-agents in shared workspace"
+status: Draft
+author: gogocat
+created: 2026-04-19
+updated: 2026-04-19
+priority: P0
+depth: standard
+domain: general
+projectType: cli_tool
+epic: EPIC-005
+stepsCompleted: []
+---
+
+# PRD-057: Orchestrator dispatcher — parallel work plan for N sub-agents in shared workspace
+
+## Progress
+
+```
+Phase 0  ░░░░░░░░░░░░░░░░░░░░░░░░  0/14  (  0%)
+─────────────────────────────────────────────────
+TOTAL                               0/14  (  0%)
+```
+
+---
+
+## Executive Summary
+
+### Vision
+
+Когда orchestrator (человек или AI-агент) запускает 2–5 sub-agents в shared
+workspace Forgeplan'а, один MCP-вызов `forgeplan_dispatch --agents N` даёт
+**готовый план работы**: какие артефакты можно делать параллельно, какие
+сериально, кто над чем работает, с учётом зависимостей и overlap'а по коду.
+Это превращает Forgeplan из каталога артефактов в **активный диспетчер**
+для многоагентной разработки.
+
+### Problem
+
+Сейчас Forgeplan отлично хранит артефакты (PRD/RFC/ADR/Evidence) и их
+зависимости, но НЕ отвечает на главный вопрос multi-agent оркестратора:
+
+> «У меня 3 агента готовы. Кому что дать чтобы работали параллельно и
+> не наступали друг на друга?»
+
+Ответ сейчас — вручную: orchestrator читает `forgeplan_graph`, применяет
+`forgeplan_blocked`, смотрит `forgeplan_list --status draft`, анализирует
+`affected_files` в каждом PRD, держит всё в голове. Масштаб 2-5 агентов
+ломает человеческую способность это tracking'овать — начинается:
+- Двойная работа (2 агента берут один PRD)
+- File conflict (2 агента меняют один crate → race / merge hell)
+- Serial wasted (работа A ждёт B хотя могла бы идти параллельно с C)
+- Забытый blocker (PRD активирован пока его deps not ready)
+
+**Impact** — из собственного опыта этой session:
+- В ходе работы над PRD-055 увеличенно 3 incrementа: пришлось делать
+  serial (receipt → wrap → restore) один агентом. С dispatcher можно
+  было бы разделить на 3 агента.
+- Post-ship audit v0.22.1 + v0.23.0 Rounds 1+2: 4 agents работали
+  параллельно через `Agent` tool — но оркестрация была у меня в голове,
+  без Forgeplan'а как brain.
+- Существующие `graph`/`order`/`blocked` покрывают 80% нужной логики,
+  но нет agent-facing tool который собирает их в единый план.
+
+### Target Users
+
+| Персона | Описание | Ключевая боль |
+|---------|----------|---------------|
+| Orchestrator (primary) | Человек / AI-агент запускающий sub-agents через Task tool или MCP | Не видит за один вызов "что можно параллелить с N агентами безопасно" |
+| Sub-agent (secondary) | Отдельная Claude Code session / Task subagent работающая над одним артефактом | Не знает что кто-то уже работает над соседним PRD → конфликт |
+| Project auditor (tertiary) | Человек пересматривающий историю | Сейчас невозможно узнать "какой агент принял какое решение" без ручного git blame |
+
+### Differentiators
+
+- **Использует существующие primitives** — `forgeplan_graph` DAG, `forgeplan_order`
+  topological sort, `forgeplan_blocked` detector, `affected_files` frontmatter.
+  ~80% логики уже реализовано, новый tool собирает их в actionable план.
+- **Git-native claim protocol** — не нужна отдельная infrastructure.
+  `forgeplan_claim` пишет маркер в `.forgeplan/claims/<id>.yaml` +
+  (опционально) draft PR title `[WIP claim PRD-X by <agent>]`.
+  Другие агенты видят claim через MCP или git.
+- **File-overlap detection** — из `affected_files` frontmatter каждого артефакта,
+  dispatcher вычисляет Jaccard similarity между file sets. Артефакты с
+  overlap > threshold маркируются serial-only.
+- **Skill matching** — каждый артефакт имеет `domain: frontend/backend/api/infra`
+  в frontmatter; оркестратор передаёт skills каждого агента; dispatcher
+  матчит.
+- **Advisory, не enforced** — работает параллельно с `forgeplan_phase`
+  (PRD-056): dispatcher суґерирует план, claims — soft signal, оркестратор
+  может override. Full enforcement в v0.25+.
+
+---
+
+## Success Criteria
+
+| ID | Criterion | Metric | Current | Target | Timeframe | How to Measure |
+|----|-----------|--------|---------|--------|-----------|----------------|
+| SC-1 | `forgeplan_dispatch --agents N` возвращает работоспособный план в < 500 мс | p95 latency | — | < 500ms at 100 artifacts | v0.24.0 ship | bench test |
+| SC-2 | 0 false-positive "parallel" между артефактами у которых пересекаются affected_files | false-positive rate | — | 0% | v0.24.0 | integration test |
+| SC-3 | Orchestrator видит claim за < 100мс после того как другой agent заявил work | propagation latency | — | < 100ms | v0.24.0 | filesystem notify / poll test |
+| SC-4 | Нет breaking changes в существующих tools | breaking count | N/A | 0 | CI | cargo test |
+| SC-5 | Dogfood: 3 sub-agents работают параллельно без конфликта в одной сессии | conflict count | — | 0 | post-ship | manual E2E |
+
+---
+
+## Product Scope
+
+### MVP (In-Scope)
+
+**MCP tools**:
+- `forgeplan_dispatch --agents N [--skills csv] [--kind filter] [--epic ID]`:
+  возвращает план с bucket'ами per-agent + serial queue + reasoning
+- `forgeplan_claim <id> --agent <name> [--ttl <minutes>]`:
+  пишет `.forgeplan/claims/<id>.yaml` с agent_id + TTL + timestamp,
+  refuses if claim is already live and not expired
+- `forgeplan_release <id> --agent <name>`:
+  удаляет claim (или auto-expires по TTL)
+- `forgeplan_claims --active`:
+  список живых claims, сортировка по expiry
+
+**Core changes**:
+- `Claim` struct в forgeplan-core + `.forgeplan/claims/` dir (gitignored like state/)
+- `domain` поле в frontmatter (расширение existing `tags`): canonical values
+  frontend / backend / api / infra / docs / testing / general
+- `affected_files` в frontmatter: уже у нас частично есть, формализовать обязательность для P0-P1 PRD
+- `dispatch_plan` в forgeplan-core::routing — сборщик из graph+order+blocked+overlap
+
+**Coordination primitives**:
+- File lock на LanceDB writes (`.forgeplan/.lock` via `fs2::FileExt`):
+  сериализует `store.create_artifact` + `update_artifact` + `next_id`.
+  Concern только под lock — reads остаются concurrent.
+- Agent identity в activity log: MCP `clientInfo` уже приходит, сейчас
+  пишется только `client_info`. Добавить в frontmatter `last_modified_by`.
+
+**Integration**:
+- `forgeplan_health` surface active claims + expired unreleased claims
+- `_next_action` в `forgeplan_get` показывает кто claimed (если есть)
+
+### Out of Scope
+
+- **Agent-to-agent direct communication** — оркестратор единственный coordinator
+- **Cross-machine / cross-clone coordination** — только один shared workspace
+- **Skill-based auto-matching с ML** — простой csv-string match, не ML
+- **Rebalancing когда агент done** — один dispatch call, потом snapshot плана
+- **Priority queues** — обычный topological sort + first-ready-wins
+- **Distributed consensus** — git IS consensus layer (через PR/merge)
+- **Enforcement** — tools НЕ блокируют работу без claim (advisory); orchestrator может override
+- **Real-time filesystem notifications** (inotify / fsevents) — polling через MCP достаточно для 2-5 agents
+- **Full concurrency fix для `phase/store::advance_phase`** read-modify-write window —
+  remains as known limitation (2-5 agents на разных артефактах не триггерит)
+- **CLI parity** — только MCP tools в первом инкременте
+
+### Growth Vision
+
+- **v0.25 — enforcement mode**: `forgeplan_dispatch --strict` отказывает отдавать артефакт
+  без наличия skill match у агента; `forgeplan_update` требует active claim для modification
+- **v0.26 — cross-epic dispatch**: план на уровне workspace, не только Epic
+- **v0.27 — capability learning**: автоматический skill profiling агентов из
+  activity log (какие domains этот agent_id успешно закрывал раньше)
+- **Orchestra integration**: dispatch call создаёт Task'и в Orchestra автоматически
+
+---
+
+## User Journeys
+
+### Journey 1: Orchestrator getting a 3-agent plan for Epic work
+
+**Цель**: оркестратор хочет разделить EPIC-005 child PRDs между 3 sub-agents.
+
+| Шаг | Действие оркестратора | Ответ системы | Заметки |
+|-----|----------------------|---------------|---------|
+| 1 | `forgeplan_dispatch --agents 3 --epic EPIC-005` | Plan JSON с 3 buckets + serial queue + reasoning | 1 round-trip |
+| 2 | Читает план: agent1 → PRD-061 (brownfield), agent2 → PRD-062 (hotfix), agent3 → PRD-063 (research) | — | parallel-safe по dep graph и affected_files |
+| 3 | Каждому sub-agent'у передаёт: "работай над <ID>" | Sub-agent вызывает `forgeplan_claim <ID> --agent <self>` | soft signal |
+| 4 | Sub-agent'ы работают параллельно в своих worktrees / с file lock на LanceDB | — | no conflict |
+| 5 | Agent done → вызывает `forgeplan_release <id>` | Claim removed | slot свободен |
+| 6 | Orchestrator re-dispatch при новых готовых tasks | — | optional |
+
+### Journey 2: Sub-agent reads claim status before taking work
+
+**Цель**: sub-agent хочет взять `PRD-X` но вдруг кто-то уже работает.
+
+| Шаг | Действие | Ответ | Заметки |
+|-----|---------|-------|---------|
+| 1 | `forgeplan_claims --active` | List of live claims with agent_id + expires_at | — |
+| 2 | Видит что PRD-X claimed agent-orch, agent-worker-1 expires in 25m | — | informed decision |
+| 3 | Берёт другой unclaimed PRD-Y | `forgeplan_claim PRD-Y --agent self --ttl 30m` | lease set |
+| 4 | После работы `forgeplan_release PRD-Y` | Claim removed | — |
+
+### Journey 3: File overlap detection prevents conflict
+
+**Цель**: предотвратить что два агента получают PRD'ы которые оба меняют одни файлы.
+
+| Шаг | Действие orchestrator'а | Ответ | Заметки |
+|-----|------------------------|-------|---------|
+| 1 | `forgeplan_dispatch --agents 2` | Plan: agent1→PRD-056 (affected: crates/forgeplan-core), agent2→PRD-052 (affected: apps/website) | disjoint files |
+| 2 | Plan показывает "PRD-054 и PRD-055 отложены в serial: оба меняют crates/forgeplan-mcp" | — | dispatcher предотвратил ложный параллелизм |
+| 3 | Agent1 + agent2 работают параллельно | — | safe |
+| 4 | Когда один done, re-dispatch раздаёт следующий из serial queue | — | — |
+
+---
+
+## Functional Requirements
+
+| ID | Category | Priority | Requirement | Journey |
+|----|----------|----------|-------------|---------|
+| FR-001 | Core | Must | System can generate dispatch plan for N agents via `forgeplan_dispatch --agents N` returning buckets + serial queue + reasoning | Journey 1 |
+| FR-002 | Core | Must | Dispatch plan excludes artifacts with affected_files overlap > threshold (default 0.3 Jaccard) | Journey 3 |
+| FR-003 | Core | Must | Dispatch plan respects artifact dependency graph (blocked artifacts in serial queue, not parallel) | Journey 1 |
+| FR-004 | Core | Must | Agent can claim artifact via `forgeplan_claim <id> --agent <name> [--ttl <mins>]`; refuses if already claimed non-expired | Journey 2 |
+| FR-005 | Core | Must | Agent can release claim via `forgeplan_release <id>`; claims auto-expire by TTL (default 30m) | Journey 2 |
+| FR-006 | Core | Must | Agent can list active claims via `forgeplan_claims --active` with agent_id + expires_at | Journey 2 |
+| FR-007 | Core | Must | LanceDB writes serialized via workspace-level file lock (`.forgeplan/.lock`) to prevent concurrent corruption | — |
+| FR-008 | Core | Must | `next_id` allocation inside file lock — two concurrent `forgeplan_new` calls get different IDs | — |
+| FR-009 | Core | Must | MCP `client_info` (`name` + `version`) captured in `last_modified_by` field of artifact frontmatter on update | — |
+| FR-010 | UX | Should | Artifacts support `domain` field in frontmatter (enum: frontend, backend, api, infra, docs, testing, general) | Journey 1 |
+| FR-011 | UX | Should | `forgeplan_dispatch --skills csv` matches domain to agent skills (disjoint domains → parallel-safe) | Journey 1 |
+| FR-012 | UX | Should | `forgeplan_health` includes `active_claims` + `expired_unreleased_claims` advisory sections | — |
+| FR-013 | UX | Should | `forgeplan_get` `_next_action` includes claim info (claimed by, expires_at) when present | Journey 2 |
+| FR-014 | Safety | Must | Claims are gitignored (like state/ logs/ trash/) — per-workspace runtime state | — |
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement | Metric | Condition | Measurement |
+|----|----------|-------------|--------|-----------|-------------|
+| NFR-001 | Performance | dispatch computation shall complete within budget | p95 < 500ms | 100 artifacts, 10 edges avg | criterion bench |
+| NFR-002 | Backward Compatibility | No breaking changes in existing tool schemas | 0 | `cargo test` + pre-v0.23.0 integration | full workspace test run |
+| NFR-003 | Concurrency | LanceDB writes shall be serialized per workspace | no corruption | 10 concurrent `forgeplan_new` calls | multi-process stress test |
+| NFR-004 | Safety | Claim TTL shall auto-expire crashed agent holds | < 30m max hold | agent killed mid-work | simulate kill + check |
+| NFR-005 | Observability | dispatch_plan response includes reasoning — why each artifact was grouped / deferred | human-readable | every response | code review |
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Dispatch plan produces parallel bucket for disjoint artifacts
+
+```gherkin
+Given workspace has PRD-A (affected: crates/cli), PRD-B (affected: apps/website), PRD-C (affected: crates/cli + crates/core), all status=draft, no blockers
+When orchestrator calls `forgeplan_dispatch --agents 2`
+Then response contains buckets[0]={PRD-A} and buckets[1]={PRD-B} (disjoint file sets)
+And serial_queue contains PRD-C (file-overlap with PRD-A → deferred)
+And reasoning field explains why PRD-C was deferred
+```
+
+### AC-2: Claim prevents double-work
+
+```gherkin
+Given PRD-X has no active claim
+When agent-1 calls `forgeplan_claim PRD-X --agent agent-1 --ttl 30`
+Then claim is written to .forgeplan/claims/PRD-X.yaml
+And `forgeplan_claims --active` shows PRD-X claimed by agent-1
+
+Given agent-1 claim is still live
+When agent-2 calls `forgeplan_claim PRD-X --agent agent-2`
+Then response is error with message including agent-1 and expires_at
+And no second claim file is written
+```
+
+### AC-3: TTL expiration releases stale claim
+
+```gherkin
+Given PRD-Y claimed by agent-1 with ttl=1 minute, written 2 minutes ago
+When agent-2 calls `forgeplan_claim PRD-Y --agent agent-2`
+Then expired claim is ignored
+And new claim is written for agent-2
+And `forgeplan_claims --active` shows only agent-2 claim
+```
+
+### AC-4: Concurrent `forgeplan_new` produces unique IDs
+
+```gherkin
+Given workspace has 5 PRDs (last is PRD-005)
+When 3 agents simultaneously call `forgeplan_new prd "..."` (via MCP)
+Then agent-1 receives PRD-006, agent-2 receives PRD-007, agent-3 receives PRD-008
+And no two receive the same ID
+And all three markdown files exist on disk
+```
+
+### AC-5: Agent identity in frontmatter on update
+
+```gherkin
+Given PRD-Z exists without last_modified_by field
+When agent "orchestrator/1.0" calls `forgeplan_update PRD-Z --body "..."`
+Then PRD-Z markdown frontmatter contains `last_modified_by: orchestrator/1.0`
+And `last_modified_at` is set to current RFC3339 timestamp
+```
+
+---
+
+## Dependencies
+
+| Dependency | Type | Status | Owner |
+|-----------|------|--------|-------|
+| PRD-056 Phase state machine | Internal | Active (v0.23.0 shipped) | — |
+| EPIC-005 umbrella | Internal | Draft | — |
+| fs2 crate for file lock | External | Ready (workspace dep TBD) | — |
+| Existing `forgeplan_graph`/`order`/`blocked` | Internal | Ready | — |
+| MCP clientInfo protocol field | External | rmcp 1.3.0 supports it | — |
+
+---
+
+## Risks & Mitigations
+
+| ID | Risk | Probability | Impact | Mitigation | Owner |
+|----|------|-------------|--------|------------|-------|
+| R-1 | File lock становится bottleneck при >10 agents | Low | Medium | Target scale 2-5; LanceDB reads stay concurrent; lock только write-path | impl |
+| R-2 | `affected_files` не заполнен надёжно → overlap detection fails open | High | Medium | Default "treat as overlap if either has no files listed" — safe bias toward serial | impl + docs |
+| R-3 | TTL слишком короткий → legit long-running agent теряет claim | Medium | Low | Allow `--ttl` до 24h; default 30m balance safety + long work | ux |
+| R-4 | TTL слишком длинный → crashed agent блокирует работу часами | Medium | Medium | Orchestrator может force-release via `forgeplan_release <id> --force` с reason logged | impl |
+| R-5 | Agent identity collision (два sub-agents оба "worker-1") | Low | Low | Require unique agent_id per active claim; dispatcher refuses identical names в плане | impl |
+| R-6 | Dispatch даёт stale plan между call и claim (новый PRD создан meanwhile) | Medium | Low | Plan содержит `generated_at`; orchestrator re-dispatches если claim fails | ux |
+| R-7 | Multi-agent audit miss (этот PRD код не audited 2-3 агентами) | Medium | High | MANDATORY: 3-4 agent audit panel перед PR merge (как на PRD-056) | process |
+
+---
+
+## Related Artifacts
+
+| Artifact | Relation | Status |
+|----------|----------|--------|
+| EPIC-005 Phase state machine umbrella | based_on (parent Epic) | Draft |
+| PRD-056 Phase state machine (advisory) | informs (uses same workspace/state pattern) | Active (v0.23.0) |
+| Future PRD Full Phase Enforcement | informs (dispatcher will later use phase state for eligibility check) | Planned |
+
+## Affected Files
+
+- `crates/forgeplan-core/src/dispatch/mod.rs` (new module)
+- `crates/forgeplan-core/src/dispatch/plan.rs` (compute_dispatch_plan fn)
+- `crates/forgeplan-core/src/claim/mod.rs` (new module — claim/release/list)
+- `crates/forgeplan-core/src/artifact/frontmatter.rs` (add `domain`, `last_modified_by` fields)
+- `crates/forgeplan-core/src/db/store.rs` (wrap writes в workspace lock)
+- `crates/forgeplan-core/src/workspace.rs` (expose `workspace_lock` helper)
+- `crates/forgeplan-mcp/src/server.rs` (new tools: dispatch, claim, release, claims)
+- `crates/forgeplan-mcp/src/server.rs` (capture client_info в update hooks)
+- `.gitignore` (add `.forgeplan/claims/`)
+- `CHANGELOG.md`
+
+---
+
+> **Next step**: validate PRD-057 → ADI (3 hypotheses) → Code (increment 1: file lock + agent identity).
+

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,10 @@ W1-L2-CLAUDE-additional-sources.zip
 # Phase state (PRD-058) — per-artifact current_phase markers,
 # workspace-local runtime state.
 .forgeplan/state/
+
+# Claim / lease files (PRD-057) — per-artifact agent claim markers,
+# workspace-local runtime state, auto-expire by TTL.
+.forgeplan/claims/
+
+# Workspace advisory lock file (PRD-057) — fs2 flock on .forgeplan/.lock
+.forgeplan/.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.23.1] — 2026-04-19 — Multi-agent workspace lock foundation (PRD-057 Inc 1)
+
+First safety primitive for multi-agent workflow — workspace-level file
+lock that serializes LanceDB write operations across 2-5 concurrent
+sub-agents sharing a `.forgeplan/` directory. Patch bump, no breaking
+changes, no new user-facing tools.
+
+### Added
+
+- **`forgeplan-core::workspace::lock`** module with `WorkspaceLock`
+  RAII guard and `acquire_workspace_lock` async helper. Uses `fs2`
+  flock primitive (Unix) / LockFileEx (Windows). Released automatically
+  on drop including process crash.
+- **30-second timeout** with exponential backoff (10ms → 1000ms) —
+  no indefinite hang if a sibling agent is stuck.
+- **Symlink guards** on both workspace directory and lock file
+  (parity with PRD-055 R3 + PRD-056 hardening).
+- **`#[must_use]`** on guard — compiler catches accidental immediate
+  drop via `let _ =`.
+
+### Wrapped with lock (all MCP write entry points)
+
+- `forgeplan_new` — prevents duplicate ID collision under concurrent
+  `next_id` allocation.
+- `forgeplan_update`
+- `forgeplan_delete`
+- `forgeplan_supersede`
+- `forgeplan_deprecate`
+
+### Hygiene
+
+- `.gitignore`: `.forgeplan/.lock` and `.forgeplan/claims/` (prep for
+  PRD-057 Inc 2-4).
+
+### Verification
+
+- **1297 tests pass / 0 fail** (+6 new regression tests:
+  - `acquire_creates_lock_file`
+  - `lock_releases_on_drop`
+  - `concurrent_acquirers_serialize_and_total_time` (strengthened
+    with wall-time lower bound)
+  - `timeout_surfaces_when_lock_held`
+  - `symlinked_workspace_dir_is_refused` (unix)
+  - `symlinked_lock_file_is_refused` (unix)
+- `cargo clippy --workspace --all-targets -D warnings`: clean.
+- `cargo fmt --check`: 0 diffs.
+- Rust 1.95 toolchain pinned via `rust-toolchain.toml`.
+
+### Audit
+
+5-agent audit Round 1 (security + logic + arch + rust + task-completion)
+found 1 CRITICAL + 2 HIGH + 4 MEDIUM — **all fixed** in the same PR
+before merge. Net verdict: APPROVE_WITH_FIXES from all 5 agents post-
+hotfix.
+
+### Not included — planned for v0.24.0
+
+- `Claim` module + `forgeplan_claim` / `_release` / `_claims` MCP
+  tools (PRD-057 Inc 3).
+- Agent identity capture (`client_info` → `last_modified_by`
+  frontmatter field) (PRD-057 Inc 2).
+- `forgeplan_dispatch --agents N` tool (PRD-057 Inc 4) — the dispatcher
+  that suggests parallel-safe buckets based on dep graph, file-overlap
+  Jaccard, and domain-skill matching.
+
+Refs: EPIC-005, PRD-057 Inc 1, PR #192.
+
+---
+
 ## [0.23.0] — 2026-04-18 — Advisory phase state machine (PRD-056, EPIC-005)
 
 First shipped child of **EPIC-005 "Phase state machine & workflow-aware

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ dependencies = [
  "bm25",
  "chrono",
  "fastembed",
+ "fs2",
  "futures",
  "lancedb",
  "petgraph",
@@ -2380,6 +2381,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0"
+version = "0.23.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ petgraph = "0.8"
 notify = "7"
 notify-debouncer-mini = "0.5"
 dotenvy = "0.15"
+fs2 = "0.4"
 
 [profile.release]
 strip = true          # strip debug symbols (-16%)

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.23.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.23.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.23.1" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.23.1" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -31,6 +31,7 @@ bm25 = { version = "2.3.2", features = ["language_detection"] }
 sha2 = "0.10"
 tracing = "0.1"
 rand = "0.8"
+fs2.workspace = true
 
 [features]
 default = []

--- a/crates/forgeplan-core/src/workspace/lock.rs
+++ b/crates/forgeplan-core/src/workspace/lock.rs
@@ -5,40 +5,61 @@
 // same workspace (2-5 sub-agents sharing `.forgeplan/`).
 //
 // Design decisions:
-// - **Advisory lock via `fs2::FileExt::lock_exclusive`** — OS primitive
-//   (flock on Unix, LockFileEx on Windows). Blocks until acquired (no
-//   busy loop). Released automatically when the `LockFile` guard drops,
-//   including on process crash (OS-level release).
+// - **Advisory lock via `fs2::FileExt`** — OS primitive (flock on Unix,
+//   LockFileEx on Windows). Released automatically when the guard
+//   drops, including on process crash (OS-level release).
 // - **Single lock file per workspace** — `.forgeplan/.lock`. One lock
 //   serializes all writes, which is sufficient for the 2-5 agent target
 //   scale where writes are rare relative to reads.
-// - **spawn_blocking wrapper** — `fs2` is synchronous; we wrap acquisition
-//   in `tokio::task::spawn_blocking` so the async runtime is not stalled
-//   while waiting for the lock.
-// - **Graceful degradation on lock-file IO errors** — if the lock file
-//   cannot be created (e.g. read-only FS), we return the error so the
-//   caller can decide to proceed unlocked or bail. LanceDB internal
-//   locking still provides some safety.
+// - **spawn_blocking wrapper** — `fs2` is synchronous; acquisition runs
+//   on a blocking thread so the async runtime is not stalled.
+// - **Bounded wait via `try_lock_exclusive` + backoff** — prevents
+//   indefinite hang on stuck sibling agent (audit Round 1 H-1). Default
+//   ceiling 30s with exponential backoff (10ms → 1000ms).
+// - **Symlink guards** — workspace dir AND lock-file path must not be
+//   symlinks (audit Round 1 C-sec #1, parity with PRD-055 R3 + PRD-056).
+// - **Graceful error propagation** — on unlock failure in Drop, log via
+//   `tracing::warn` instead of swallowing (audit Round 1 M-3).
 
 use anyhow::Context;
 use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Default upper bound on lock acquisition wait. A misbehaving sibling
+/// agent stuck holding the lock for longer surfaces as a clean timeout
+/// error instead of an indefinite hang.
+pub const DEFAULT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// RAII guard for an acquired workspace lock. Releases on drop via
-/// `fs2::FileExt::unlock` (implicit when the file handle is closed by
-/// Rust's Drop impl, belt-and-suspenders here).
+/// `fs2::FileExt::unlock`, logging any error through `tracing::warn!`.
+#[must_use = "dropping the WorkspaceLock releases the lock immediately — bind it to a named variable for the intended scope"]
 pub struct WorkspaceLock {
-    _file: File,
-    _path: PathBuf,
+    file: File,
+}
+
+impl std::fmt::Debug for WorkspaceLock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkspaceLock")
+            .field("file", &"<held>")
+            .finish()
+    }
 }
 
 impl Drop for WorkspaceLock {
     fn drop(&mut self) {
-        // Explicit unlock — `File`'s Drop will also close + release,
-        // but being explicit documents the intent and survives
-        // future refactors that might stash `_file`.
-        let _ = self._file.unlock();
+        // Explicit unlock. `File`'s own Drop also closes + releases,
+        // but being explicit documents intent and survives future
+        // refactors. Errors are logged rather than swallowed silently
+        // (audit Round 1 — no more `let _ =`).
+        if let Err(e) = self.file.unlock() {
+            tracing::warn!(
+                error = %e,
+                "workspace lock unlock failed — OS flock is still released on file close, \
+                 but explicit unlock errored (NFS / stale fd?)"
+            );
+        }
     }
 }
 
@@ -47,46 +68,110 @@ pub fn lock_path(workspace: &Path) -> PathBuf {
     workspace.join(".lock")
 }
 
-/// Acquire an exclusive workspace-level lock. Blocking — uses
-/// `tokio::task::spawn_blocking` so async callers don't stall the
-/// runtime. Returns a guard that releases on drop.
-///
-/// For 2-5 agent scale this is simple and safe. For larger scale
-/// (10+ agents) a per-artifact or per-operation lock scheme would
-/// be needed, but that is out of scope for PRD-057.
-pub async fn acquire_workspace_lock(workspace: &Path) -> anyhow::Result<WorkspaceLock> {
-    let path = lock_path(workspace);
-    // Ensure workspace dir exists — the lock file sits under it.
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .with_context(|| format!("could not create lock parent dir {}", parent.display()))?;
+/// Validate that a filesystem path (workspace dir or lock file) is not
+/// a symlink. Audit Round 1 C-sec #1 — parity with PRD-055 R3 and
+/// PRD-056 hardening. An attacker who plants a symlink where we expect
+/// a real dir / file could redirect the lock onto arbitrary targets.
+async fn refuse_if_symlink(path: &Path, label: &str) -> anyhow::Result<()> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                anyhow::bail!(
+                    "{label} at {} is a symlink — refusing to open (parity with PRD-055 R3)",
+                    path.display()
+                );
+            }
+            Ok(())
+        }
+        // Path does not exist yet — fine, caller will create it.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
     }
+}
+
+/// Acquire an exclusive workspace-level lock. Uses `try_lock_exclusive`
+/// with exponential backoff up to `timeout`. Returns a typed timeout
+/// error if the lock cannot be obtained in time (audit Round 1 H-1).
+///
+/// For 2-5 agent scale this is simple and safe.
+pub async fn acquire_workspace_lock(workspace: &Path) -> anyhow::Result<WorkspaceLock> {
+    acquire_workspace_lock_with_timeout(workspace, DEFAULT_LOCK_TIMEOUT).await
+}
+
+/// Same as `acquire_workspace_lock` but with a caller-specified timeout.
+/// Use shorter timeouts in tight loops (e.g. 5s in dispatch) and longer
+/// for interactive handlers. A timeout of `Duration::ZERO` means
+/// "try once, fail fast".
+pub async fn acquire_workspace_lock_with_timeout(
+    workspace: &Path,
+    timeout: Duration,
+) -> anyhow::Result<WorkspaceLock> {
+    // Symlink guard on the workspace directory itself (C-sec #1).
+    refuse_if_symlink(workspace, "workspace directory").await?;
+    tokio::fs::create_dir_all(workspace)
+        .await
+        .with_context(|| format!("could not create workspace dir {}", workspace.display()))?;
+
+    let path = lock_path(workspace);
+
+    // Symlink guard on the lock file (C-sec #1). Must happen BEFORE
+    // `open(create:true)` which would follow a pre-planted symlink.
+    refuse_if_symlink(&path, "lock file").await?;
 
     let path_clone = path.clone();
     let file = tokio::task::spawn_blocking(move || -> anyhow::Result<File> {
-        let f = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .truncate(false)
-            .open(&path_clone)
-            .with_context(|| format!("could not open lock file {}", path_clone.display()))?;
-        f.lock_exclusive().with_context(|| {
-            format!(
-                "could not acquire exclusive lock on {}",
-                path_clone.display()
-            )
-        })?;
-        Ok(f)
+        open_and_lock_with_backoff(&path_clone, timeout)
     })
     .await
     .context("lock acquisition task panicked")??;
 
-    Ok(WorkspaceLock {
-        _file: file,
-        _path: path,
-    })
+    let _ = path; // suppress unused-var lint when debug disabled
+    Ok(WorkspaceLock { file })
+}
+
+/// Blocking helper: open the lock file and repeatedly `try_lock_exclusive`
+/// with exponential backoff until the lock is held or the timeout elapses.
+fn open_and_lock_with_backoff(path: &Path, timeout: Duration) -> anyhow::Result<File> {
+    // Minimal OpenOptions: create if missing, write-only. Previously
+    // had `.read(true).truncate(false)` — unnecessary (audit Round 1 L-1).
+    let f = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .with_context(|| format!("could not open lock file {}", path.display()))?;
+
+    let start = std::time::Instant::now();
+    let mut delay = Duration::from_millis(10);
+    const MAX_DELAY: Duration = Duration::from_millis(1000);
+
+    loop {
+        match f.try_lock_exclusive() {
+            Ok(()) => return Ok(f),
+            Err(e) => {
+                // Distinguish "already locked" from other IO errors —
+                // retry on would-block, fail-fast on anything else.
+                let transient = e.kind() == std::io::ErrorKind::WouldBlock;
+                if !transient {
+                    return Err(anyhow::anyhow!(
+                        "could not acquire lock on {}: {e}",
+                        path.display()
+                    ));
+                }
+                if start.elapsed() >= timeout {
+                    anyhow::bail!(
+                        "workspace lock {} held by another agent; timed out after {:?}",
+                        path.display(),
+                        timeout
+                    );
+                }
+                std::thread::sleep(delay);
+                // Exponential backoff, capped — avoids busy loop without
+                // starving latency for the typical short-held case.
+                delay = std::cmp::min(delay * 2, MAX_DELAY);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -94,42 +179,49 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn ws(tmp: &TempDir) -> std::path::PathBuf {
+        tmp.path().join(".forgeplan")
+    }
+
     #[tokio::test]
     async fn acquire_creates_lock_file() {
         let tmp = TempDir::new().unwrap();
-        let ws = tmp.path().to_path_buf();
+        let ws = ws(&tmp);
         let _guard = acquire_workspace_lock(&ws).await.unwrap();
         assert!(lock_path(&ws).exists(), "lock file must be created");
     }
 
     #[tokio::test]
     async fn lock_releases_on_drop() {
-        // Two sequential acquisitions from the same async task succeed —
-        // the first guard is dropped before the second tries.
         let tmp = TempDir::new().unwrap();
-        let ws = tmp.path().to_path_buf();
+        let ws = ws(&tmp);
         {
             let _g1 = acquire_workspace_lock(&ws).await.unwrap();
-        } // drop here
+        }
         let _g2 = acquire_workspace_lock(&ws).await.unwrap();
     }
 
     #[tokio::test]
-    async fn concurrent_acquirers_serialize() {
-        // Two concurrent tasks both acquire — second must wait for first
-        // to release. We detect serialization by checking that at most
-        // one guard is alive at any observable checkpoint.
+    async fn concurrent_acquirers_serialize_and_total_time() {
+        // Audit Round 1: strengthen the serialize test with wall-time
+        // lower-bound assertion — if serialization were broken, peak=1
+        // could still accidentally hold but total time would drop below
+        // the serial lower bound.
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::time::{Duration, sleep};
+        use tokio::time::{Instant, sleep};
 
         let tmp = TempDir::new().unwrap();
-        let ws = Arc::new(tmp.path().to_path_buf());
+        let ws = Arc::new(ws(&tmp));
         let in_flight = Arc::new(AtomicUsize::new(0));
         let max_in_flight = Arc::new(AtomicUsize::new(0));
 
+        let hold_ms = 30;
+        let n = 4usize;
+        let started = Instant::now();
+
         let mut handles = Vec::new();
-        for _ in 0..4 {
+        for _ in 0..n {
             let ws = ws.clone();
             let in_flight = in_flight.clone();
             let max_in_flight = max_in_flight.clone();
@@ -137,17 +229,88 @@ mod tests {
                 let _g = acquire_workspace_lock(&ws).await.unwrap();
                 let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
                 max_in_flight.fetch_max(current, Ordering::SeqCst);
-                sleep(Duration::from_millis(20)).await;
+                sleep(Duration::from_millis(hold_ms)).await;
                 in_flight.fetch_sub(1, Ordering::SeqCst);
             }));
         }
         for h in handles {
             h.await.unwrap();
         }
+        let elapsed = started.elapsed();
         let peak = max_in_flight.load(Ordering::SeqCst);
         assert_eq!(
             peak, 1,
             "exclusive lock: at most 1 concurrent holder, got {peak}"
         );
+        // Serial lower bound: n holders × hold_ms, minus small slack for
+        // test scheduling jitter.
+        let expected_min = Duration::from_millis(hold_ms * n as u64 - 10);
+        assert!(
+            elapsed >= expected_min,
+            "elapsed {elapsed:?} < serial lower bound {expected_min:?} — serialization suspect"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_surfaces_when_lock_held() {
+        // Audit H-1: timeout returns a clear error instead of hanging.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        let _first = acquire_workspace_lock(&ws).await.unwrap();
+
+        let started = std::time::Instant::now();
+        let err = acquire_workspace_lock_with_timeout(&ws, Duration::from_millis(200))
+            .await
+            .unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert!(
+            err.to_string().contains("timed out") || err.to_string().contains("held by"),
+            "timeout error must explain cause: {err}"
+        );
+        // Should respect timeout approximately — not instant, not 30s.
+        assert!(
+            elapsed >= Duration::from_millis(200) && elapsed < Duration::from_millis(2_000),
+            "elapsed {elapsed:?} outside expected [200ms, 2s] timeout window"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_workspace_dir_is_refused() {
+        // Audit Round 1 C-sec #1: refuse pre-planted symlink as workspace.
+        let tmp = TempDir::new().unwrap();
+        let real = tmp.path().join("real");
+        std::fs::create_dir_all(&real).unwrap();
+        let sym = tmp.path().join("symlinked-ws");
+        std::os::unix::fs::symlink(&real, &sym).unwrap();
+
+        let err = acquire_workspace_lock(&sym).await.unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "symlinked workspace must be refused: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_lock_file_is_refused() {
+        // Audit Round 1 C-sec #1: refuse pre-planted symlink as lock file.
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let victim = tmp.path().join("victim.txt");
+        std::fs::write(&victim, b"sensitive").unwrap();
+        std::os::unix::fs::symlink(&victim, ws.join(".lock")).unwrap();
+
+        let err = acquire_workspace_lock(&ws).await.unwrap_err();
+        assert!(
+            err.to_string().contains("symlink"),
+            "symlinked lock file must be refused: {err}"
+        );
+        // Victim untouched.
+        let still = std::fs::read_to_string(&victim).unwrap();
+        assert_eq!(still, "sensitive");
     }
 }

--- a/crates/forgeplan-core/src/workspace/lock.rs
+++ b/crates/forgeplan-core/src/workspace/lock.rs
@@ -1,0 +1,153 @@
+// PRD-057 increment 1 — workspace-level advisory file lock.
+//
+// Serializes LanceDB write operations (`store.create_artifact`,
+// `update_artifact`, `next_id`) across concurrent MCP sessions in the
+// same workspace (2-5 sub-agents sharing `.forgeplan/`).
+//
+// Design decisions:
+// - **Advisory lock via `fs2::FileExt::lock_exclusive`** — OS primitive
+//   (flock on Unix, LockFileEx on Windows). Blocks until acquired (no
+//   busy loop). Released automatically when the `LockFile` guard drops,
+//   including on process crash (OS-level release).
+// - **Single lock file per workspace** — `.forgeplan/.lock`. One lock
+//   serializes all writes, which is sufficient for the 2-5 agent target
+//   scale where writes are rare relative to reads.
+// - **spawn_blocking wrapper** — `fs2` is synchronous; we wrap acquisition
+//   in `tokio::task::spawn_blocking` so the async runtime is not stalled
+//   while waiting for the lock.
+// - **Graceful degradation on lock-file IO errors** — if the lock file
+//   cannot be created (e.g. read-only FS), we return the error so the
+//   caller can decide to proceed unlocked or bail. LanceDB internal
+//   locking still provides some safety.
+
+use anyhow::Context;
+use fs2::FileExt;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+/// RAII guard for an acquired workspace lock. Releases on drop via
+/// `fs2::FileExt::unlock` (implicit when the file handle is closed by
+/// Rust's Drop impl, belt-and-suspenders here).
+pub struct WorkspaceLock {
+    _file: File,
+    _path: PathBuf,
+}
+
+impl Drop for WorkspaceLock {
+    fn drop(&mut self) {
+        // Explicit unlock — `File`'s Drop will also close + release,
+        // but being explicit documents the intent and survives
+        // future refactors that might stash `_file`.
+        let _ = self._file.unlock();
+    }
+}
+
+/// Path to the workspace lock file under `.forgeplan/.lock`.
+pub fn lock_path(workspace: &Path) -> PathBuf {
+    workspace.join(".lock")
+}
+
+/// Acquire an exclusive workspace-level lock. Blocking — uses
+/// `tokio::task::spawn_blocking` so async callers don't stall the
+/// runtime. Returns a guard that releases on drop.
+///
+/// For 2-5 agent scale this is simple and safe. For larger scale
+/// (10+ agents) a per-artifact or per-operation lock scheme would
+/// be needed, but that is out of scope for PRD-057.
+pub async fn acquire_workspace_lock(workspace: &Path) -> anyhow::Result<WorkspaceLock> {
+    let path = lock_path(workspace);
+    // Ensure workspace dir exists — the lock file sits under it.
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("could not create lock parent dir {}", parent.display()))?;
+    }
+
+    let path_clone = path.clone();
+    let file = tokio::task::spawn_blocking(move || -> anyhow::Result<File> {
+        let f = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&path_clone)
+            .with_context(|| format!("could not open lock file {}", path_clone.display()))?;
+        f.lock_exclusive().with_context(|| {
+            format!(
+                "could not acquire exclusive lock on {}",
+                path_clone.display()
+            )
+        })?;
+        Ok(f)
+    })
+    .await
+    .context("lock acquisition task panicked")??;
+
+    Ok(WorkspaceLock {
+        _file: file,
+        _path: path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn acquire_creates_lock_file() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().to_path_buf();
+        let _guard = acquire_workspace_lock(&ws).await.unwrap();
+        assert!(lock_path(&ws).exists(), "lock file must be created");
+    }
+
+    #[tokio::test]
+    async fn lock_releases_on_drop() {
+        // Two sequential acquisitions from the same async task succeed —
+        // the first guard is dropped before the second tries.
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().to_path_buf();
+        {
+            let _g1 = acquire_workspace_lock(&ws).await.unwrap();
+        } // drop here
+        let _g2 = acquire_workspace_lock(&ws).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_acquirers_serialize() {
+        // Two concurrent tasks both acquire — second must wait for first
+        // to release. We detect serialization by checking that at most
+        // one guard is alive at any observable checkpoint.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use tokio::time::{Duration, sleep};
+
+        let tmp = TempDir::new().unwrap();
+        let ws = Arc::new(tmp.path().to_path_buf());
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let ws = ws.clone();
+            let in_flight = in_flight.clone();
+            let max_in_flight = max_in_flight.clone();
+            handles.push(tokio::spawn(async move {
+                let _g = acquire_workspace_lock(&ws).await.unwrap();
+                let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_in_flight.fetch_max(current, Ordering::SeqCst);
+                sleep(Duration::from_millis(20)).await;
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+        let peak = max_in_flight.load(Ordering::SeqCst);
+        assert_eq!(
+            peak, 1,
+            "exclusive lock: at most 1 concurrent holder, got {peak}"
+        );
+    }
+}

--- a/crates/forgeplan-core/src/workspace/mod.rs
+++ b/crates/forgeplan-core/src/workspace/mod.rs
@@ -1,2 +1,5 @@
 pub mod init;
+pub mod lock;
+
 pub use init::{ARTIFACT_DIRS, FORGEPLAN_DIR, find_workspace, init_workspace, load_config};
+pub use lock::{WorkspaceLock, acquire_workspace_lock, lock_path};

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.23.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.23.1" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -965,6 +965,22 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // PRD-057: serialize the next_id → create_artifact critical
+        // section against concurrent sub-agents sharing this workspace.
+        // Without the lock, two agents invoking forgeplan_new in the
+        // same millisecond could both get e.g. PRD-057 and then collide
+        // on the projection file. Held for the whole handler.
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Check `.forgeplan/` is writable. Lock is held by \
+                         another agent — retry in a few seconds.",
+                ));
+            }
+        };
+
         // DoS protection: enforce configurable input limits.
         let integrity_config = workspace::load_config(&ws)
             .map(|c| c.integrity)

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1748,6 +1748,20 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // PRD-057 Round 1 audit H-2: FR-007 requires serialization of
+        // ALL LanceDB writes, not just forgeplan_new. Hold the lock for
+        // the full handler so concurrent update + delete + supersede
+        // from different sub-agents cannot corrupt LanceDB state.
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry in a few seconds — another sub-agent holds the lock.",
+                ));
+            }
+        };
+
         // Verify exists
         let pre_record = store
             .get_record(&p.id)
@@ -1901,6 +1915,17 @@ impl ForgeplanServer {
         let store = match self.require_store().await {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
+        };
+
+        // PRD-057 FR-007 — serialize write critical section.
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry — another sub-agent holds the lock.",
+                ));
+            }
         };
 
         let record = match store.get_record(&p.id).await {
@@ -2170,6 +2195,17 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // PRD-057 FR-007 — serialize write critical section.
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry — another sub-agent holds the lock.",
+                ));
+            }
+        };
+
         // PRD-055: capture the original state BEFORE lifecycle transition
         // so undo can restore status=active (or prior) and drop the
         // supersede link. Projection stays on disk — only status changes.
@@ -2272,6 +2308,17 @@ impl ForgeplanServer {
         let store = match self.require_store().await {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
+        };
+
+        // PRD-057 FR-007 — serialize write critical section.
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry — another sub-agent holds the lock.",
+                ));
+            }
         };
 
         // PRD-055: capture original state before lifecycle transition.


### PR DESCRIPTION
## Summary

Patch release of PRD-057 Inc 1 — workspace-level file lock for multi-agent safety. Bundles PR #192 (merged to dev) + version bump + CHANGELOG.

## What users get

When 2-5 sub-agents work in the same `.forgeplan/` workspace (orchestrator + workers via Task tool), LanceDB writes are now serialized via `.forgeplan/.lock`:

- No duplicate PRD-NNN collision under concurrent `forgeplan_new`
- No LanceDB corruption from concurrent writes
- Clean 30s timeout with exponential backoff — no indefinite hang
- Released automatically on drop including process crash

## Numbers

- 1297 tests / 0 fail (+6 new regression tests)
- 5-agent audit Round 1: 1 CRIT + 2 HIGH + 4 MED fixed
- Rust 1.95 pinned via rust-toolchain.toml
- clippy + fmt clean

## What's NOT in v0.23.1

Planned for v0.24.0 under same PRD-057:
- Claim/Release tools (PRD-057 Inc 2-3)
- Agent identity (`client_info` → `last_modified_by`)
- `forgeplan_dispatch` — the parallel planning brain

## Test plan

- [ ] CI: Health Gate + Lint + plan + Tests
- [ ] Merge → tag v0.23.1 → cargo-dist → brew formula PR
- [ ] Back-merge main → dev

Refs: EPIC-005, PRD-057 Inc 1, PR #192.