### PR TITLE
[PRD-057] Multi-agent orchestrator dispatcher (Inc 2-4) — v0.24.0

### DIFF
--- a/.forgeplan/evidence/EVID-077-prd-057-multi-agent-dispatcher-r3-audit-closed-1391-tests-full-pipeline-e2e.md
+++ b/.forgeplan/evidence/EVID-077-prd-057-multi-agent-dispatcher-r3-audit-closed-1391-tests-full-pipeline-e2e.md
@@ -1,0 +1,151 @@
+---
+depth: tactical
+id: EVID-077
+kind: evidence
+links:
+- target: PRD-057
+  relation: supports
+status: draft
+title: PRD-057 multi-agent dispatcher — R3 audit closed, 1391 tests, full pipeline E2E
+---
+
+# EVID-077: PRD-057 multi-agent dispatcher — R3 audit closed, 1391 tests, full pipeline E2E
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-19 |
+| Valid Until | 2026-07-19 |
+| Target | PRD-057 |
+
+## Structured Fields
+
+evidence_type: measurement
+verdict: supports
+congruence_level: 3
+
+## Measurement
+
+End-to-end validation of the PRD-057 multi-agent dispatcher stack (Inc 2
+agent identity + Inc 3 claim protocol + Inc 4 orchestrator dispatcher),
+including the R2 and R3 adversarial audit hotfixes. All seven feature
+commits on `feat/prd-057-inc-2-4-dispatcher` from 0331c38 through
+be13960 verified together.
+
+Validation methods:
+1. `cargo test --workspace` — full unit + integration suite on the
+   commit stack (7 commits: Inc 2, Inc 3, R2 hotfix, Inc 4, R3 hotfix,
+   dogfood E2E, workflow variations).
+2. `cargo fmt --all --check` + `cargo clippy --workspace --all-targets
+   -- -D warnings` — zero diffs, zero warnings on the strict CI gate.
+3. Multi-agent adversarial audits: 3-agent mid-sprint panel after Inc 3
+   and 4-agent final panel after Inc 4 (rust-pro + security-expert +
+   architect-reviewer + production-validator). Every HIGH/MED finding
+   closed via targeted commits with regression tests.
+4. PRD-057 per-FR / per-AC task-completion audit: every FR-001..014
+   mapped to specific implementation location + test, every AC-1..5
+   mapped to covering test.
+
+## Result
+
+**Tests**: 1391 passing / 0 failing across 16 test binaries. Delta vs
+pre-PRD-057 baseline: +94 tests (identity + claim + dispatch cores +
+MCP wiring + dogfood + workflow + AC-4 concurrent E2E + audit
+regression guards).
+
+**FR coverage (14/14)**:
+- FR-001..003 → `forgeplan_core::dispatch::compute_dispatch_plan` +
+  graph::topological::kahn_sort integration in MCP handler.
+- FR-004..006, FR-014 → `forgeplan_core::claim::ClaimStore` +
+  `forgeplan_claim/release/claims` MCP tools; `.forgeplan/claims/` in
+  .gitignore.
+- FR-007, FR-008 → `workspace::lock` guards held across every write
+  handler (forgeplan_new, _update, _delete, _claim, _release,
+  _phase_advance, _supersede, _deprecate); dispatcher and claims list
+  are lockless reads per R2 audit architect MED.
+- FR-009 → `ForgeplanServer::current_identity` captured from
+  `peer.peer_info()`, stamped into frontmatter via
+  `projection::stamp_agent_identity` on new + update paths.
+- FR-010..011 → `normalize_dispatch_domain` + `skill_match` in core;
+  per-agent `agent_skills` via `DispatchParams`.
+- FR-012 → `forgeplan_health` response body carries `active_claims` +
+  `active_claim_count` + `skipped_claim_files`.
+- FR-013 → `forgeplan_get` `_next_action` hint appends claim holder
+  and expires_at when a live claim exists.
+
+**AC coverage (5/5)**:
+- AC-1 → `disjoint_artifacts_go_to_separate_buckets` +
+  `overlapping_artifacts_force_one_to_serial` + dogfood variant.
+- AC-2 → `claim_rejects_active_different_agent` +
+  `claim_rejects_existing_claim_by_different_agent` (MCP boundary).
+- AC-3 → `claim_takes_over_expired_claim` (Core).
+- AC-4 → `concurrent_forgeplan_new_emits_unique_ids` spawns 3 parallel
+  MCP calls on one workspace and asserts 3 distinct IDs + 3 markdown
+  files. Previously covered only by the Inc 1 lock-level proxy test.
+- AC-5 → `stamp_best_effort_writes_captured_identity` +
+  `render_projection_preserves_unknown_fm_across_rerender` +
+  `dispatch_workflow_full_cycle_new_claim_update_release_redispatch`.
+
+**Audit findings closed**:
+- R2 mid-sprint (3 agents): 3 HIGH + 5 MED + 1 LOW — path traversal in
+  ClaimStore, release empty-agent bypass, fragile forgeplan_release
+  force path, atomic tempfile+rename writes, Unicode/control char
+  rejection in AgentIdentity, MAX_CLAIM_FILE_BYTES cap, lockless
+  forgeplan_claims (read-only). Regression guards: 14 tests.
+- R3 final (4 agents): 2 HIGH + 7 MED + 6 LOW + 1 FR gap + 2 FR missing
+  — unbounded agents OOM → MAX_AGENTS clamp, affected_files fragmented
+  (FM key vs markdown section) → extract_affected_files body fallback,
+  blocked artifacts filtered out of dispatch, FR-012 + FR-013 added,
+  Jaccard boundary `>=`, scalar form accept, Unicode domain rejection,
+  MAX_SKILLS_PER_AGENT + MAX_AFFECTED_FILES bounds, defensive id
+  traversal guard, claimed_set case-normalization. Regression guards:
+  11 tests.
+
+**Dogfood E2E (10 tests)**: empty workspace, 1-agent conflict serialize,
+5-agent distribute evenly (PRD-057 target upper bound), over-MAX
+rejection, markdown-section fallback, blocked-artifact skip, claim/
+release full cycle, skill routing, health claims surface, forgeplan_get
+claim hint. All exercise the real ForgeplanServer + LanceStore +
+filesystem projection stack.
+
+**Workflow coverage (4 tests)**: kind filter, threshold=0 conservative,
+threshold=1 permissive, full new→claim→identity→release→dispatch cycle.
+
+## Interpretation
+
+PRD-057 delivers the core value proposition end-to-end: a single
+`forgeplan_dispatch --agents N` call hands the orchestrator a
+parallel-safe work plan for N sub-agents with explicit reasoning.
+Inc 2 identity tracking closes the "who did what" audit gap. Inc 3
+claim protocol gives sub-agents the soft-coordination signal the PRD
+called for, with TTL safety against silent crashes (NFR-004). The
+write-serialization guarantee (FR-007, FR-008) is carried forward from
+Inc 1 and extended to every new write handler introduced in Inc 3 via
+the audit-validated `workspace_lock` pattern.
+
+Two-round adversarial audit pressure applied AFTER feature commits
+found 21 substantive issues (5 HIGH, 12 MED, 7 LOW, 3 missing FR / gap)
+that unit tests missed — consistent with the established pattern across
+PRD-055, PRD-056, PRD-057. Every one is now closed with a targeted
+regression test, raising the test count to 1391.
+
+The stack is ready to ship as v0.24.0. Deferred items (shared kv_yaml
+abstraction, HTTP/SSE identity, DispatchDecision enum for i18n, agent
+profiles persistence) are architecture improvements documented in PRD
+progress and do not block the current functional scope.
+
+## Congruence Level Justification
+
+CL3 (same-context): the evidence is the project's own test suite and
+audit trail against the exact artifact under review (PRD-057). The
+tests run against the production code paths, not mocked/simulated
+equivalents. Measurement artifacts (test counts, audit commits, code
+locations) are all traceable in-repo.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| PRD-057 | supports |
+| EPIC-005 | informs |
+

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -32,9 +32,9 @@ stepsCompleted: []
 Inc 1 (lock)          ████████████████████████  3/3   (100%)  ✅ v0.23.1 merged
 Inc 2 (identity)      ████████████████████████  3/3   (100%)  ✅ FR-009 + AC-5
 Inc 3 (claims)        ████████████████████████  4/4   (100%)  ✅ FR-004..006,014 + AC-2,3
-Inc 4 (dispatch)      ░░░░░░░░░░░░░░░░░░░░░░░░  0/4   (  0%)
+Inc 4 (dispatch)      ████████████████████████  4/4   (100%)  ✅ FR-001..003, FR-010, FR-011, AC-1
 ─────────────────────────────────────────────────────────
-TOTAL                                           10/14  ( 71%)
+TOTAL                                           14/14  (100%)
 ```
 
 **Inc 2 delivered (2026-04-19)**:
@@ -62,6 +62,18 @@ TOTAL                                           10/14  ( 71%)
 - LOW×1: TTL clamp at MCP boundary matches advertised schema
 - +14 new regression tests (9 claim hardening + 5 identity hardening), 1352 total
 - Defer to v0.25+: shared `kv_yaml` abstraction extraction, HTTP/SSE identity refactor, ADR for claim/phase separation
+
+**Inc 4 delivered (2026-04-19)**:
+- `forgeplan-core::dispatch` module: `ArtifactCandidate`, `DispatchPlan`, `compute_dispatch_plan`
+- `jaccard()` + `conflicts()` + `skill_match()` primitives
+- Least-loaded-first greedy bucket packing (distributes work, not dumps to agent 0)
+- Empty `affected_files` biases to serial (R-2 mitigation — no declared files = shared-ground)
+- Claim-aware: skips artifacts in `ClaimStore::list_active_map` (Inc 3 forward-compat)
+- Deterministic output — same input produces identical plan (important for orchestrator cache)
+- `forgeplan_dispatch --agents N [--kind --epic --status --agent_skills --overlap_threshold]` MCP tool
+- Read-only — no workspace lock, never mutates state, safe for 1 Hz polling
+- Hydrates `affected_files` + `domain` + `parent_epic` from preserved frontmatter (Inc 2 infrastructure)
+- +15 new tests (13 Core dispatch + 1 MCP validation + 1 MCP wiring), 1366 total
 
 ---
 

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -29,12 +29,14 @@ stepsCompleted: []
 ## Progress
 
 ```
-Inc 1 (lock)          ████████████████████████  3/3   (100%)  ✅ v0.23.1 merged
-Inc 2 (identity)      ████████████████████████  3/3   (100%)  ✅ FR-009 + AC-5
-Inc 3 (claims)        ████████████████████████  4/4   (100%)  ✅ FR-004..006,014 + AC-2,3
-Inc 4 (dispatch)      ████████████████████████  4/4   (100%)  ✅ FR-001..003, FR-010, FR-011, AC-1
+Inc 1 (lock)          ████████████████████████  FR-007, FR-008 + AC-4 coverage
+Inc 2 (identity)      ████████████████████████  FR-009 + AC-5
+Inc 3 (claims)        ████████████████████████  FR-004..006, FR-014 + AC-2, AC-3
+Inc 4 (dispatch)      ████████████████████████  FR-001, FR-002, FR-003, FR-010, FR-011 + AC-1
+R3 hotfix             ████████████████████████  FR-012, FR-013 closed; HIGH/MED regressions fixed
 ─────────────────────────────────────────────────────────
-TOTAL                                           14/14  (100%)
+FR coverage           14/14 functional requirements
+AC coverage            5/5 acceptance criteria (AC-4 via concurrent E2E test)
 ```
 
 **Inc 2 delivered (2026-04-19)**:
@@ -74,6 +76,30 @@ TOTAL                                           14/14  (100%)
 - Read-only — no workspace lock, never mutates state, safe for 1 Hz polling
 - Hydrates `affected_files` + `domain` + `parent_epic` from preserved frontmatter (Inc 2 infrastructure)
 - +15 new tests (13 Core dispatch + 1 MCP validation + 1 MCP wiring), 1366 total
+
+**R3 final-audit hotfix (2026-04-19, 4 agents: rust-pro + security + architect + production-validator):**
+- HIGH×2: unbounded `agents` OOM → clamped `MAX_AGENTS=64`; `affected_files` fragmented (FM key vs `## Affected Files` section) → dispatcher falls back to `validation::checks::extract_affected_files(body)` for legacy artifacts
+- MED (FR-003): blocked artifacts now filtered out of dispatch via `graph::topological::kahn_sort` — PRD promise now enforced end-to-end
+- MED (FR-012): `forgeplan_health` surfaces `active_claims` + `skipped_claim_files` counts
+- MED (FR-013): `forgeplan_get` `_next_action` includes claim info (holder + expiry)
+- MED (rust-pro M-1): Jaccard boundary changed from `>` to `>=` — MCP tool docstring now matches behaviour
+- MED (rust-pro M-2): `affected_files` accepts scalar `"a.rs"` + CSV string forms — silent drop on common user typo eliminated
+- MED (rust-pro M-4): dispatch response surfaces `skipped_parse_errors` + `blocked_count` — parse failures no longer masquerade as "no files declared"
+- MED (security CWE-176): `normalize_dispatch_domain` rejects non-ASCII characters (Cyrillic `е` homograph attack); `MAX_SKILLS_PER_AGENT=32`
+- LOW: claim-set ID casing normalized to uppercase (lowercase-imported IDs still match); `MAX_AFFECTED_FILES=512` + per-path length cap; defensive id traversal guard in `read_dispatch_fm_fields`
+- LOW: stale `"forgeplan_dispatch (when implemented)"` hint updated
+- AC-4 E2E: `concurrent_forgeplan_new_emits_unique_ids` — 3 parallel MCP calls → 3 distinct IDs + 3 markdown files (previously only the Inc 1 lock-level proxy existed)
+- +11 regression tests (5 Core dispatch hardening + 5 parse/normalize + 1 AC-4 E2E), 1377 total
+
+**Deferred to v0.25+ (tracked):**
+- Shared `kv_yaml` abstraction — `phase::store` + `claim` + future dispatch-cache share pattern
+- Per-request identity capture for HTTP/SSE transport (stdio covers today's scope)
+- `load_frontmatter_full` primitive in `artifact::store` — ~10 call sites reimplement read→parse pattern
+- `ListFilter::parent_epic` push-down so epic filter stays in LanceDB instead of O(n) post-hydration
+- `DispatchDecision` enum for `reasoning` (currently free-form, blocks i18n)
+- `ClaimStore::list_active_map` → `HashMap<String, Claim>` preserving agent_id for PRD R-5 holder-based routing
+- ADR for claim (ephemeral) vs phase state (durable) separation
+- Agent profiles (`.forgeplan/agents/<agent_id>.yaml`) — reserved path, v0.27 Growth Vision item
 
 ---
 

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -29,10 +29,21 @@ stepsCompleted: []
 ## Progress
 
 ```
-Phase 0  ░░░░░░░░░░░░░░░░░░░░░░░░  0/14  (  0%)
-─────────────────────────────────────────────────
-TOTAL                               0/14  (  0%)
+Inc 1 (lock)          ████████████████████████  3/3   (100%)  ✅ v0.23.1 merged
+Inc 2 (identity)      ████████████████████████  3/3   (100%)  ✅ FR-009 + AC-5
+Inc 3 (claims)        ░░░░░░░░░░░░░░░░░░░░░░░░  0/4   (  0%)
+Inc 4 (dispatch)      ░░░░░░░░░░░░░░░░░░░░░░░░  0/4   (  0%)
+─────────────────────────────────────────────────────────
+TOTAL                                            6/14  ( 43%)
 ```
+
+**Inc 2 delivered (2026-04-19)**:
+- `AgentIdentity` struct in `forgeplan-core::artifact::identity`
+- Unknown-frontmatter preservation via `KNOWN_FM_KEYS` + `filter_preserved` in `projection`
+- `projection::stamp_agent_identity` helper
+- `ForgeplanServer::stamp_identity_best_effort` wired into `forgeplan_new` + `forgeplan_update`
+- `call_tool` wrapper captures `peer.peer_info()` → cached in server + logged to activity JSONL
+- 13 new tests (6 identity + 4 projection preservation + 4 MCP stamp wiring), 1314 total
 
 ---
 

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -5,7 +5,7 @@ kind: prd
 links:
 - target: EPIC-005
   relation: based_on
-status: draft
+status: active
 title: Orchestrator dispatcher — parallel work plan for N sub-agents in shared workspace
 ---
 
@@ -419,4 +419,5 @@ And `last_modified_at` is set to current RFC3339 timestamp
 ---
 
 > **Next step**: validate PRD-057 → ADI (3 hypotheses) → Code (increment 1: file lock + agent identity).
+
 

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -31,10 +31,10 @@ stepsCompleted: []
 ```
 Inc 1 (lock)          ████████████████████████  3/3   (100%)  ✅ v0.23.1 merged
 Inc 2 (identity)      ████████████████████████  3/3   (100%)  ✅ FR-009 + AC-5
-Inc 3 (claims)        ░░░░░░░░░░░░░░░░░░░░░░░░  0/4   (  0%)
+Inc 3 (claims)        ████████████████████████  4/4   (100%)  ✅ FR-004..006,014 + AC-2,3
 Inc 4 (dispatch)      ░░░░░░░░░░░░░░░░░░░░░░░░  0/4   (  0%)
 ─────────────────────────────────────────────────────────
-TOTAL                                            6/14  ( 43%)
+TOTAL                                           10/14  ( 71%)
 ```
 
 **Inc 2 delivered (2026-04-19)**:
@@ -44,6 +44,15 @@ TOTAL                                            6/14  ( 43%)
 - `ForgeplanServer::stamp_identity_best_effort` wired into `forgeplan_new` + `forgeplan_update`
 - `call_tool` wrapper captures `peer.peer_info()` → cached in server + logged to activity JSONL
 - 13 new tests (6 identity + 4 projection preservation + 4 MCP stamp wiring), 1314 total
+
+**Inc 3 delivered (2026-04-19)**:
+- `forgeplan-core::claim` module: `Claim` struct, `ClaimStore`, `ClaimError`
+- TTL bounds: 1 min ≤ `ttl` ≤ 24 h, default 30 min
+- Same-agent calls renew; expired claims transparently taken over (AC-3)
+- `forgeplan_claim`, `forgeplan_release`, `forgeplan_release --force`, `forgeplan_claims` MCP tools
+- Agent resolution: explicit `agent` param > cached MCP `clientInfo` > hinted error
+- All writes serialized via `workspace_lock` (Inc 1 pattern extended)
+- 24 new tests (17 Core ClaimStore + 7 MCP wiring), 1338 total
 
 ---
 

--- a/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
+++ b/.forgeplan/prds/PRD-057-orchestrator-dispatcher-parallel-work-plan-for-n-sub-agents-in-shared-workspace.md
@@ -54,6 +54,15 @@ TOTAL                                           10/14  ( 71%)
 - All writes serialized via `workspace_lock` (Inc 1 pattern extended)
 - 24 new tests (17 Core ClaimStore + 7 MCP wiring), 1338 total
 
+**R2 mid-sprint audit hotfix (2026-04-19, 3 agents):**
+- HIGH×1: path traversal in `ClaimStore::path_for` → `validate_id` guard at every entry point
+- HIGH×2: `release` empty-agent bypass + `forgeplan_release` fragile force path → agent check before FS, deterministic resolution order
+- MED×4: atomic `tempfile+rename` writes (`claim::atomic_write` + `projection::atomic_markdown_write`), Unicode/control-char rejection in `AgentIdentity::new`, `list_active_with_stats` surfaces malformed-file count, `forgeplan_claims` no longer holds workspace lock (read-only)
+- MED×1: `list_active_map` for O(1) dispatcher lookups (Inc 4 forward-compat)
+- LOW×1: TTL clamp at MCP boundary matches advertised schema
+- +14 new regression tests (9 claim hardening + 5 identity hardening), 1352 total
+- Defer to v0.25+: shared `kv_yaml` abstraction extraction, HTTP/SSE identity refactor, ADR for claim/phase separation
+
 ---
 
 ## Executive Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,106 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.24.0] — 2026-04-19 — Orchestrator dispatcher for 2-5 sub-agents (PRD-057 complete)
+
+Forgeplan now dispatches work. One MCP call — `forgeplan_dispatch
+--agents N` — hands the orchestrator a parallel-safe plan: which
+artifacts each sub-agent should work on, which defer to a serial queue,
+and human-readable reasoning for every decision. Ends the manual
+"read graph + blocked + list + mental overlap calc" loop that was the
+original PRD-057 problem statement.
+
+Four increments (Inc 2, 3, 4) + two adversarial audit rounds (R2 3-agent
+mid-sprint, R3 4-agent final) + 94 net new tests (1391 total). Builds
+on the Inc 1 workspace lock shipped in v0.23.1.
+
+### Added — Agent identity (Inc 2, FR-009 + AC-5)
+
+- **`AgentIdentity`** captures which MCP client last mutated an artifact
+  via `clientInfo` and stamps `last_modified_by: name/version` into
+  frontmatter on every write.
+- **Unknown-frontmatter preservation** — `projection` now keeps
+  agent-owned fm fields (`last_modified_by`, `domain`,
+  `affected_files`) across re-renders triggered by unrelated tools.
+- **Unicode / control-char rejection** in `AgentIdentity::new` — blocks
+  bidi override, ZWJ, RTL, newlines, path separators.
+- **Activity log** carries the captured `clientInfo` — previous `None`
+  TODO closed.
+
+### Added — Claim protocol (Inc 3, FR-004..006, FR-014, AC-2..3)
+
+- **`ClaimStore`** — soft-coordination signal "agent X works on ID
+  until T". YAML files at `.forgeplan/claims/<ID>.yaml` (gitignored).
+  TTL 1 min..24 h, default 30 min. Same-agent calls renew; expired
+  claims transparently overwritten.
+- **Three new MCP tools**: `forgeplan_claim`, `forgeplan_release`
+  (`force: true` orchestrator escape hatch), `forgeplan_claims`.
+- **Atomic writes** via tempfile + rename.
+- **64 KB YAML cap** + path-traversal guard (R2 security HIGH fix).
+
+### Added — Orchestrator dispatcher (Inc 4, FR-001..003, FR-010..011, AC-1)
+
+- **`forgeplan_dispatch`** returns `{buckets, serial_queue, reasoning,
+  candidate_count, claimed_count, blocked_count, skipped_parse_errors}`.
+- **Jaccard file-overlap detection** (0.3 default threshold).
+  Empty `affected_files` biases to serial (R-2 safety).
+- **Least-loaded-first greedy packing** — distributes, deterministic.
+- **Graph-aware** — blocked artifacts excluded via `kahn_sort`.
+- **Claim-aware** — claimed artifacts skipped with reasoning.
+- **Skill matching** via `agent_skills` vs artifact `domain`.
+- **Markdown-section fallback** — legacy artifacts with only
+  `## Affected Files` body section are hydrated via
+  `extract_affected_files(body)`.
+- **Input clamps**: `MAX_AGENTS=64`, `MAX_SKILLS_PER_AGENT=32`,
+  `MAX_AFFECTED_FILES=512`, 512-byte path cap (R3 CWE-770 fix).
+
+### Added — Integration surface (FR-012, FR-013)
+
+- **`forgeplan_health`** body includes `active_claims`,
+  `active_claim_count`, `skipped_claim_files`.
+- **`forgeplan_get`** `_next_action` appends claim holder + expiry
+  when a live claim exists.
+
+### Security
+
+- Path traversal refusal in `ClaimStore` (CWE-22).
+- Unicode homograph rejection in `domain` (CWE-176).
+- Resource caps on `agents`, skills, file lists, YAML size (CWE-400/770).
+- Control chars rejected in agent identity.
+
+### Performance
+
+- Read-only tools (`dispatch`, `claims`, `health`, `get`) don't acquire
+  the workspace lock — orchestrator 1 Hz polling doesn't serialize
+  writers (R2 architect MED).
+- `ClaimStore::list_active_map` for O(1) dispatcher joins.
+
+### Testing
+
+- **+94 tests** (1297 → 1391). 13 dispatch algorithm, 26 claim store
+  (inc. hardening), 14 MCP wiring + validation, 10 dogfood E2E, 4
+  workflow variations, 1 AC-4 concurrent-forgeplan_new unique-ID E2E.
+- **Two adversarial audit rounds** (R2 3-agent, R3 4-agent with
+  production-validator for FR/AC task-completion) — 30 findings
+  closed with regression tests.
+
+### Deferred to v0.25+
+
+- Shared `kv_yaml` abstraction across `phase::store` + `claim` + future
+  dispatch-cache.
+- Per-request identity for HTTP/SSE transports.
+- `load_frontmatter_full` primitive to dedupe 10 read→parse sites.
+- `ListFilter::parent_epic` push-down.
+- `DispatchDecision` structured enum for `reasoning` (i18n).
+- `list_active_map → HashMap<String, Claim>` for holder-based routing.
+- ADR separating claim (ephemeral) from phase (durable) state.
+- Agent profiles at `.forgeplan/agents/<agent_id>.yaml` (v0.27 roadmap).
+
+### References
+
+- PRD-057 `.forgeplan/prds/PRD-057-*.md`
+- EVID-077 `.forgeplan/evidence/EVID-077-*.md` — R_eff=1.00, CL3
+
 ## [0.23.1] — 2026-04-19 — Multi-agent workspace lock foundation (PRD-057 Inc 1)
 
 First safety primitive for multi-agent workflow — workspace-level file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2368,6 +2368,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.1"
+version = "0.24.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.23.1" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.23.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.24.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.24.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/src/artifact/identity.rs
+++ b/crates/forgeplan-core/src/artifact/identity.rs
@@ -11,6 +11,43 @@
 
 use chrono::Utc;
 
+/// Maximum permitted length of `name` or `version` — long enough to cover
+/// realistic clientInfo values ("claude-code/1.0.50", "cursor-ide/0.42")
+/// while short enough to keep frontmatter scannable and reject pathological
+/// inputs.
+const MAX_FIELD_LEN: usize = 64;
+
+/// Reject control chars, bidi-override / ZWJ / RTL class, newlines, path
+/// separators, and the `/` delimiter we use in `as_frontmatter_value()`.
+/// Mirrors the Round-1 `sanitize_for_hint` defence class — a malicious
+/// clientInfo name like `"orchestrator\u{202E}drowssap"` must not land
+/// verbatim in markdown where human auditors and downstream LLMs consume
+/// it (R2 audit MED, security-expert finding).
+fn is_identity_char_forbidden(c: char) -> bool {
+    // Explicit path separators + our delimiter.
+    if matches!(c, '/' | '\\' | '\0') {
+        return true;
+    }
+    // Control characters (covers \n, \r, \t, \u{0007} bell, etc.).
+    if c.is_control() {
+        return true;
+    }
+    // Unicode format / invisible classes commonly used to disguise prompts.
+    matches!(
+        c,
+        '\u{200B}'..='\u{200F}'   // ZWSP..RLM
+            | '\u{202A}'..='\u{202E}' // bidi override
+            | '\u{2060}'..='\u{2064}' // word joiner / invisibles
+            | '\u{2066}'..='\u{2069}' // bidi isolate
+            | '\u{FEFF}'              // BOM
+            | '\u{FFF9}'..='\u{FFFB}' // interlinear annotation
+            | '\u{E0000}'..='\u{E007F}' // tag characters
+            | '\u{180E}'              // Mongolian vowel separator
+            | '\u{00AD}'              // soft hyphen
+            | '\u{FE00}'..='\u{FE0F}' // variation selectors
+    )
+}
+
 /// Identity of the caller that last mutated an artifact.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentIdentity {
@@ -19,11 +56,26 @@ pub struct AgentIdentity {
 }
 
 impl AgentIdentity {
-    /// Construct from name + version. Both are trimmed; empty name is rejected.
+    /// Construct from name + version. Both are trimmed. Returns `None` when:
+    /// - `name` is empty
+    /// - either field exceeds `MAX_FIELD_LEN` bytes
+    /// - either field contains a forbidden character (control, bidi, ZWJ,
+    ///   path separator, the `/` delimiter) — see `is_identity_char_forbidden`
+    ///
+    /// Failure → caller uses `AgentIdentity::unknown()` so the system
+    /// stays attributable even when the client lies.
     pub fn new(name: impl Into<String>, version: impl Into<String>) -> Option<Self> {
         let name = name.into().trim().to_string();
         let version = version.into().trim().to_string();
         if name.is_empty() {
+            return None;
+        }
+        if name.len() > MAX_FIELD_LEN || version.len() > MAX_FIELD_LEN {
+            return None;
+        }
+        if name.chars().any(is_identity_char_forbidden)
+            || version.chars().any(is_identity_char_forbidden)
+        {
             return None;
         }
         Some(Self {
@@ -103,5 +155,65 @@ mod tests {
             chrono::DateTime::parse_from_rfc3339(&s).is_ok(),
             "not RFC3339: {s}"
         );
+    }
+
+    // ── R2 audit hardening: control chars + path separators + overlong ──
+
+    #[test]
+    fn new_rejects_newlines_and_control_chars() {
+        // R2 audit MED (security): YAML frontmatter injection attempt.
+        assert!(AgentIdentity::new("foo\nbar", "1.0").is_none());
+        assert!(AgentIdentity::new("tab\there", "1.0").is_none());
+        assert!(AgentIdentity::new("bell\u{0007}", "1.0").is_none());
+        assert!(AgentIdentity::new("cr\rlf", "1.0").is_none());
+    }
+
+    #[test]
+    fn new_rejects_bidi_and_zwj_disguise() {
+        // R2 audit MED (security): prompt-injection via invisible Unicode —
+        // the same defence Round-1 applied to sanitize_for_hint must cover
+        // clientInfo too.
+        for bad in [
+            "orch\u{202E}drawkcab", // RLO
+            "agent\u{200B}zwsp",    // ZWSP
+            "client\u{200D}zwj",    // ZWJ
+            "bom\u{FEFF}prefix",    // BOM
+            "tag\u{E0041}chars",    // TAG-A
+        ] {
+            assert!(
+                AgentIdentity::new(bad, "1.0").is_none(),
+                "expected rejection of {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_rejects_path_separators_and_delimiter() {
+        assert!(AgentIdentity::new("../evil", "1.0").is_none());
+        assert!(AgentIdentity::new("foo/bar", "1.0").is_none());
+        assert!(AgentIdentity::new("foo\\bar", "1.0").is_none());
+        assert!(AgentIdentity::new("foo\0bar", "1.0").is_none());
+        // Version must also reject the delimiter — otherwise
+        // `name/version/extra` breaks round-tripping.
+        assert!(AgentIdentity::new("foo", "1/2").is_none());
+    }
+
+    #[test]
+    fn new_rejects_overlong_fields() {
+        let long = "x".repeat(65);
+        assert!(AgentIdentity::new(long.as_str(), "1.0").is_none());
+        assert!(AgentIdentity::new("ok", long.as_str()).is_none());
+        // At the boundary the value is accepted.
+        let ok = "x".repeat(64);
+        assert!(AgentIdentity::new(ok.as_str(), "1.0").is_some());
+    }
+
+    #[test]
+    fn new_accepts_realistic_mcp_client_info() {
+        // Must still pass for the real-world values we expect.
+        assert!(AgentIdentity::new("claude-code", "1.0.50").is_some());
+        assert!(AgentIdentity::new("cursor-ide", "0.42").is_some());
+        assert!(AgentIdentity::new("windsurf", "2024.10").is_some());
+        assert!(AgentIdentity::new("worker-1", "").is_some());
     }
 }

--- a/crates/forgeplan-core/src/artifact/identity.rs
+++ b/crates/forgeplan-core/src/artifact/identity.rs
@@ -1,0 +1,107 @@
+//! Agent identity — tracks which MCP client (or caller) last modified an
+//! artifact. Written into markdown frontmatter as `last_modified_by` +
+//! `last_modified_at` on every write that flows through a stamping call
+//! site (currently the MCP write handlers).
+//!
+//! Kept transport-agnostic: takes `name` + `version` as plain strings so
+//! the forgeplan-mcp crate can convert `rmcp::model::Implementation` into
+//! an `AgentIdentity` without pulling rmcp types into forgeplan-core.
+//!
+//! PRD-057 FR-009 + AC-5.
+
+use chrono::Utc;
+
+/// Identity of the caller that last mutated an artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentIdentity {
+    pub name: String,
+    pub version: String,
+}
+
+impl AgentIdentity {
+    /// Construct from name + version. Both are trimmed; empty name is rejected.
+    pub fn new(name: impl Into<String>, version: impl Into<String>) -> Option<Self> {
+        let name = name.into().trim().to_string();
+        let version = version.into().trim().to_string();
+        if name.is_empty() {
+            return None;
+        }
+        Some(Self {
+            name,
+            version: if version.is_empty() {
+                "unknown".to_string()
+            } else {
+                version
+            },
+        })
+    }
+
+    /// Sentinel used when the caller did not supply identity (direct CLI or
+    /// pre-PRD-057 integration). Surfaces as `unknown/0` in frontmatter so
+    /// auditors can still see *something* non-silent.
+    pub fn unknown() -> Self {
+        Self {
+            name: "unknown".to_string(),
+            version: "0".to_string(),
+        }
+    }
+
+    /// Canonical frontmatter value: `{name}/{version}`.
+    ///
+    /// AC-5 shape: `orchestrator/1.0`.
+    pub fn as_frontmatter_value(&self) -> String {
+        format!("{}/{}", self.name, self.version)
+    }
+}
+
+/// Current UTC timestamp formatted as RFC3339 — the canonical format for
+/// `last_modified_at`. Isolated here so tests can mock, and so every call
+/// site emits identical formatting.
+pub fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_rejects_empty_name() {
+        assert!(AgentIdentity::new("", "1.0").is_none());
+        assert!(AgentIdentity::new("   ", "1.0").is_none());
+    }
+
+    #[test]
+    fn new_trims_whitespace() {
+        let id = AgentIdentity::new("  orchestrator  ", " 1.0 ").unwrap();
+        assert_eq!(id.name, "orchestrator");
+        assert_eq!(id.version, "1.0");
+    }
+
+    #[test]
+    fn new_defaults_empty_version_to_unknown() {
+        let id = AgentIdentity::new("cli", "").unwrap();
+        assert_eq!(id.version, "unknown");
+    }
+
+    #[test]
+    fn unknown_sentinel_shape() {
+        let id = AgentIdentity::unknown();
+        assert_eq!(id.as_frontmatter_value(), "unknown/0");
+    }
+
+    #[test]
+    fn as_frontmatter_value_formats_slash() {
+        let id = AgentIdentity::new("orchestrator", "1.0").unwrap();
+        assert_eq!(id.as_frontmatter_value(), "orchestrator/1.0");
+    }
+
+    #[test]
+    fn now_rfc3339_is_parseable() {
+        let s = now_rfc3339();
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&s).is_ok(),
+            "not RFC3339: {s}"
+        );
+    }
+}

--- a/crates/forgeplan-core/src/artifact/mod.rs
+++ b/crates/forgeplan-core/src/artifact/mod.rs
@@ -1,5 +1,6 @@
 pub mod delta;
 pub mod frontmatter;
+pub mod identity;
 pub mod sections;
 pub mod store;
 pub mod types;

--- a/crates/forgeplan-core/src/claim/mod.rs
+++ b/crates/forgeplan-core/src/claim/mod.rs
@@ -13,7 +13,14 @@
 
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
+/// Upper bound on a single claim YAML file. Matches the 64 KB cap in
+/// `artifact::frontmatter::parse_frontmatter` — defense against a
+/// pathological claim file (billion-laughs attempt, oversized note) on
+/// `get` / `list_active` deserialization. R1-audit security finding.
+const MAX_CLAIM_FILE_BYTES: u64 = 65_536;
 
 /// Minimum permitted TTL — claims shorter than this would churn more than
 /// they coordinate. Orchestrators can still force-release earlier.
@@ -74,20 +81,94 @@ pub enum ClaimError {
         held_by: String,
         requester: String,
     },
-    #[error("ttl {0:?} outside permitted range ({MIN_TTL:?}..={MAX_TTL:?})")]
+    #[error("ttl out of permitted range (1 minute..=24 hours)")]
     TtlOutOfRange(Duration),
     #[error("artifact id must be non-empty")]
     EmptyId,
+    #[error(
+        "artifact id contains invalid characters (allowed: A-Z, a-z, 0-9, '-', '_'; must start with a letter): {0:?}"
+    )]
+    InvalidId(String),
     #[error("agent id must be non-empty")]
     EmptyAgent,
+    #[error("claim file exceeds {MAX_CLAIM_FILE_BYTES} bytes — refusing to parse")]
+    FileTooLarge,
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("yaml error: {0}")]
     Yaml(#[from] serde_yaml::Error),
 }
 
+/// Validate an artifact ID is safe for filesystem use.
+///
+/// Refuses path-traversal segments (`..`, `/`, `\\`, null bytes, leading
+/// `.`) and any character outside `[A-Za-z0-9_-]`. Parallels
+/// `db::store::validate_id_for_filter` but returns a typed ClaimError so
+/// MCP error hints remain structured.
+///
+/// Security (R2 audit HIGH #1): without this, `id="../../etc/passwd"`
+/// would escape `.forgeplan/claims/` via `Path::join`; `release` would
+/// then `remove_file` arbitrary paths the process can write.
+fn validate_id(id: &str) -> Result<(), ClaimError> {
+    if id.is_empty() {
+        return Err(ClaimError::EmptyId);
+    }
+    let first = id.chars().next().unwrap_or(' ');
+    if !first.is_ascii_alphabetic() {
+        return Err(ClaimError::InvalidId(id.to_string()));
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ClaimError::InvalidId(id.to_string()));
+    }
+    // Belt-and-suspenders — should be unreachable after the charset check
+    // but explicit rejection of traversal sequences is cheap insurance.
+    if id.contains("..") || id.contains('/') || id.contains('\\') || id.contains('\0') {
+        return Err(ClaimError::InvalidId(id.to_string()));
+    }
+    Ok(())
+}
+
+/// Atomic file write via `write to tempfile → rename` so a crash mid-write
+/// never produces a truncated target. R2 audit MED (rust-pro + architect):
+/// `tokio::fs::write` was a single non-atomic syscall; a SIGKILL between
+/// truncate and write left a zero-byte YAML that blocked every subsequent
+/// `get`.
+async fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "atomic_write: path has no parent",
+        )
+    })?;
+    tokio::fs::create_dir_all(parent).await?;
+    let tmp = parent.join(format!(
+        ".{}.tmp.{}",
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "anon".to_string()),
+        std::process::id(),
+    ));
+    tokio::fs::write(&tmp, bytes).await?;
+    // `tokio::fs::rename` is atomic on POSIX and "atomic on same volume" on
+    // Windows (MoveFileEx with MOVEFILE_REPLACE_EXISTING). Good enough for
+    // workspace-local writes.
+    match tokio::fs::rename(&tmp, path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Clean up tempfile on failure — otherwise repeated writes
+            // would accumulate orphans.
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(e)
+        }
+    }
+}
+
 /// On-disk claim store rooted at `<workspace>/claims/`.
 #[derive(Debug, Clone)]
+#[must_use = "ClaimStore is a lightweight handle — bind it before calling methods"]
 pub struct ClaimStore {
     dir: PathBuf,
 }
@@ -115,14 +196,11 @@ impl ClaimStore {
     /// as absent so downstream logic can acquire without a separate purge
     /// step (AC-3).
     pub async fn get(&self, id: &str) -> Result<Option<Claim>, ClaimError> {
-        if id.is_empty() {
-            return Err(ClaimError::EmptyId);
-        }
+        validate_id(id)?;
         let path = self.path_for(id);
-        let raw = match tokio::fs::read_to_string(&path).await {
-            Ok(s) => s,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(e) => return Err(ClaimError::Io(e)),
+        let raw = match read_bounded(&path).await? {
+            Some(s) => s,
+            None => return Ok(None),
         };
         let claim: Claim = serde_yaml::from_str(&raw)?;
         if claim.is_expired() {
@@ -134,17 +212,14 @@ impl ClaimStore {
 
     /// Raw get without TTL filtering. Exposed for diagnostics (`--include-expired`).
     pub async fn get_including_expired(&self, id: &str) -> Result<Option<Claim>, ClaimError> {
-        if id.is_empty() {
-            return Err(ClaimError::EmptyId);
-        }
+        validate_id(id)?;
         let path = self.path_for(id);
-        match tokio::fs::read_to_string(&path).await {
-            Ok(raw) => {
+        match read_bounded(&path).await? {
+            Some(raw) => {
                 let claim: Claim = serde_yaml::from_str(&raw)?;
                 Ok(Some(claim))
             }
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(e) => Err(ClaimError::Io(e)),
+            None => Ok(None),
         }
     }
 
@@ -165,9 +240,7 @@ impl ClaimStore {
         ttl: Duration,
         note: Option<String>,
     ) -> Result<Claim, ClaimError> {
-        if id.is_empty() {
-            return Err(ClaimError::EmptyId);
-        }
+        validate_id(id)?;
         if agent.is_empty() {
             return Err(ClaimError::EmptyAgent);
         }
@@ -198,7 +271,7 @@ impl ClaimStore {
         };
 
         let yaml = serde_yaml::to_string(&claim)?;
-        tokio::fs::write(self.path_for(id), yaml).await?;
+        atomic_write(&self.path_for(id), yaml.as_bytes()).await?;
         Ok(claim)
     }
 
@@ -211,9 +284,12 @@ impl ClaimStore {
     ///
     /// Missing claim is a no-op (not an error) to make release idempotent.
     pub async fn release(&self, id: &str, agent: &str, force: bool) -> Result<(), ClaimError> {
-        if id.is_empty() {
-            return Err(ClaimError::EmptyId);
-        }
+        validate_id(id)?;
+        // R2 audit HIGH #2 (rust-pro): the empty-agent guard must run BEFORE
+        // the filesystem read so that a bogus `release("X", "", false)` call
+        // on a missing claim doesn't silently succeed. Only `force = true`
+        // legitimately waives the agent requirement (orchestrator reaping
+        // a dead holder without knowing whose it is).
         if !force && agent.is_empty() {
             return Err(ClaimError::EmptyAgent);
         }
@@ -242,28 +318,86 @@ impl ClaimStore {
     /// ascending (earliest-expiring first). Expired claims are skipped
     /// (not returned, not removed — purging is a separate concern).
     pub async fn list_active(&self) -> Result<Vec<Claim>, ClaimError> {
+        Ok(self.list_active_with_stats().await?.0)
+    }
+
+    /// Map view of `list_active` — keyed by claim ID uppercased. O(1)
+    /// lookups when joining against a large artifact graph (Inc 4
+    /// dispatcher needs `claims.get(id)` per artifact; iterating a Vec
+    /// would be `O(artifacts × claims)`).
+    pub async fn list_active_map(&self) -> Result<BTreeMap<String, Claim>, ClaimError> {
+        let mut out = BTreeMap::new();
+        for c in self.list_active().await? {
+            out.insert(c.id.clone(), c);
+        }
+        Ok(out)
+    }
+
+    /// Like `list_active` but also returns the count of YAML files that
+    /// were skipped because they failed to parse or exceeded the size cap.
+    /// R2 audit MED (rust-pro + security): previous behaviour silently
+    /// dropped malformed files — an attacker could plant a truncated file
+    /// at `claims/<id>.yaml` to make an artifact appear unclaimed to the
+    /// dispatcher while still holding live-ish state. Callers can surface
+    /// the skip count so audit listings don't lie by omission.
+    pub async fn list_active_with_stats(&self) -> Result<(Vec<Claim>, usize), ClaimError> {
         if !self.dir.exists() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let mut out = Vec::new();
+        let mut skipped = 0usize;
         let mut rd = tokio::fs::read_dir(&self.dir).await?;
         while let Some(entry) = rd.next_entry().await? {
             let path = entry.path();
             if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
                 continue;
             }
-            let raw = match tokio::fs::read_to_string(&path).await {
-                Ok(s) => s,
-                Err(_) => continue, // skip unreadable files rather than fail the whole list
-            };
-            if let Ok(claim) = serde_yaml::from_str::<Claim>(&raw)
-                && !claim.is_expired()
-            {
-                out.push(claim);
+            match read_bounded(&path).await {
+                Ok(Some(raw)) => match serde_yaml::from_str::<Claim>(&raw) {
+                    Ok(claim) if !claim.is_expired() => out.push(claim),
+                    Ok(_) => { /* expired — drop silently; expected */ }
+                    Err(e) => {
+                        skipped += 1;
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "claim file failed to parse — skipped from list_active"
+                        );
+                    }
+                },
+                Ok(None) => { /* disappeared mid-scan — ignore */ }
+                Err(e) => {
+                    skipped += 1;
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "claim file read failed — skipped from list_active"
+                    );
+                }
             }
         }
         out.sort_by_key(|c| c.expires_at);
-        Ok(out)
+        Ok((out, skipped))
+    }
+}
+
+/// Read a file with the MAX_CLAIM_FILE_BYTES cap enforced. Returns
+/// `Ok(None)` for missing file; otherwise errors on size-violation or I/O
+/// failure. Centralized so every read path (`get`, `list_active`) applies
+/// the same protection.
+async fn read_bounded(path: &Path) -> Result<Option<String>, ClaimError> {
+    let meta = match tokio::fs::metadata(path).await {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(ClaimError::Io(e)),
+    };
+    if meta.len() > MAX_CLAIM_FILE_BYTES {
+        return Err(ClaimError::FileTooLarge);
+    }
+    match tokio::fs::read_to_string(path).await {
+        Ok(s) => Ok(Some(s)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(ClaimError::Io(e)),
     }
 }
 
@@ -595,5 +729,155 @@ mod tests {
         let store = ClaimStore::new(ws(&tmp));
         // Directory never created — must not error.
         assert!(store.list_active().await.unwrap().is_empty());
+    }
+
+    // ── R2 audit hardening ────────────────────────────────────────────
+
+    #[test]
+    fn validate_id_rejects_path_traversal() {
+        // R2 audit HIGH #1 (security): before this guard, id="../../etc/passwd"
+        // would escape the claims dir via Path::join.
+        for bad in [
+            "..",
+            "../foo",
+            "../../etc/passwd",
+            "foo/bar",
+            "foo\\bar",
+            "foo\0bar",
+            ".hidden",
+            "",
+            "123-leading-digit",
+        ] {
+            assert!(validate_id(bad).is_err(), "expected rejection of {bad:?}");
+        }
+    }
+
+    #[test]
+    fn validate_id_accepts_forgeplan_shapes() {
+        for good in ["PRD-001", "EPIC-042", "note-slug", "PROB-036", "mem-abc"] {
+            assert!(validate_id(good).is_ok(), "expected accept of {good:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_traversal_id_before_write() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        let err = store
+            .claim("../../etc/passwd", "a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClaimError::InvalidId(_)));
+        // No file must have been written anywhere under workspace.
+        let tmp_abs = tmp.path().to_path_buf();
+        let root_entries: Vec<_> = std::fs::read_dir(&tmp_abs)
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        // The claims subdir might not even exist yet, and definitely no
+        // "etc/passwd" artifact should appear at root.
+        for e in root_entries {
+            let name = e.file_name().to_string_lossy().to_string();
+            assert!(
+                !name.contains("passwd") && !name.contains("etc"),
+                "traversal attempt leaked: {name}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn release_rejects_traversal_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        let err = store
+            .release("../sensitive-file", "a/1", false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClaimError::InvalidId(_)));
+    }
+
+    #[tokio::test]
+    async fn release_checks_empty_agent_before_filesystem() {
+        // R2 audit HIGH #2 (rust-pro): empty agent + missing claim must
+        // surface EmptyAgent, not a silent Ok.
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        let err = store.release("PRD-099", "", false).await.unwrap_err();
+        assert!(matches!(err, ClaimError::EmptyAgent));
+    }
+
+    #[tokio::test]
+    async fn get_rejects_oversized_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store.ensure_dir().await.unwrap();
+        let path = ws(&tmp).join("claims/PRD-999.yaml");
+        // 1 MB of YAML-parseable junk — far above MAX_CLAIM_FILE_BYTES (64 KB).
+        tokio::fs::write(&path, "# ".repeat(600_000)).await.unwrap();
+        let err = store.get("PRD-999").await.unwrap_err();
+        assert!(matches!(err, ClaimError::FileTooLarge));
+    }
+
+    #[tokio::test]
+    async fn list_active_with_stats_counts_malformed() {
+        // R2 audit MED (rust-pro + security): malformed files must not be
+        // invisible — surface a count so orchestrators see the omission.
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-200", "a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        tokio::fs::write(ws(&tmp).join("claims/PRD-201.yaml"), "{{{ not yaml")
+            .await
+            .unwrap();
+
+        let (active, skipped) = store.list_active_with_stats().await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(skipped, 1);
+    }
+
+    #[tokio::test]
+    async fn list_active_map_keys_by_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-300", "a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        store
+            .claim("PRD-301", "b/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+
+        let map = store.list_active_map().await.unwrap();
+        assert!(map.contains_key("PRD-300"));
+        assert!(map.contains_key("PRD-301"));
+        assert_eq!(map["PRD-300"].agent_id, "a/1");
+    }
+
+    #[tokio::test]
+    async fn atomic_write_leaves_no_temp_files_on_success() {
+        // R2 audit MED: atomic rename pattern must not accumulate orphans.
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        for i in 0..5 {
+            store
+                .claim(&format!("PRD-40{i}"), "agent/1", DEFAULT_TTL, None)
+                .await
+                .unwrap();
+        }
+
+        let claims_dir = ws(&tmp).join("claims");
+        let mut rd = tokio::fs::read_dir(&claims_dir).await.unwrap();
+        while let Some(entry) = rd.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            let s = name.to_string_lossy();
+            assert!(
+                !s.starts_with('.') || s.ends_with(".yaml"),
+                "tempfile leaked: {s}"
+            );
+            assert!(!s.contains(".tmp."), "tempfile leaked: {s}");
+        }
     }
 }

--- a/crates/forgeplan-core/src/claim/mod.rs
+++ b/crates/forgeplan-core/src/claim/mod.rs
@@ -1,0 +1,599 @@
+//! Claim protocol — soft coordination signal for multi-agent workspaces.
+//!
+//! A claim is a file in `.forgeplan/claims/<ID>.yaml` that says "agent X
+//! is actively working on artifact ID until T". Claims are advisory: any
+//! agent may forcibly take over with `--force`, and a TTL guarantees that
+//! a crashed agent's claim self-expires (NFR-004).
+//!
+//! Scope is deliberately narrow: the claim mediates intent, not access —
+//! write serialization is handled by `workspace::lock` (Inc 1), and the
+//! dispatcher (Inc 4) is what converts claim state into parallel buckets.
+//!
+//! PRD-057 FR-004..006, FR-014, AC-2, AC-3.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Minimum permitted TTL — claims shorter than this would churn more than
+/// they coordinate. Orchestrators can still force-release earlier.
+pub const MIN_TTL: Duration = Duration::seconds(60);
+/// Upper bound (R-3 mitigation). Longer-running work should renew instead
+/// of setting a day-long claim — renewal is what gives the system a
+/// periodic "agent still alive" signal.
+pub const MAX_TTL: Duration = Duration::hours(24);
+/// Default when no TTL supplied. Covers a typical sub-agent work window
+/// without blocking the workspace for hours on a silent crash (R-4).
+pub const DEFAULT_TTL: Duration = Duration::minutes(30);
+
+/// Persisted shape of a claim file. One file per claimed artifact; absence
+/// of file means "unclaimed". Expired claims are technically still on disk
+/// but filtered out by every read path (`get`, `list_active`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Claim {
+    /// Artifact being claimed (e.g. `PRD-057`). Uppercased on disk.
+    pub id: String,
+    /// Caller identity — typically `AgentIdentity::as_frontmatter_value()`
+    /// ("name/version"), but kept as a free-form string so orchestrator
+    /// tools can inject synthetic names like `worker-1`.
+    pub agent_id: String,
+    pub claimed_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    /// Optional free-form note — "working on FR-003", "spec writing", etc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl Claim {
+    /// True iff `Utc::now() >= expires_at`. Centralized so both reads and
+    /// writes use the same wall-clock comparison.
+    pub fn is_expired(&self) -> bool {
+        Utc::now() >= self.expires_at
+    }
+
+    /// Exact-match agent check. Agents are identified by string; callers
+    /// are responsible for normalizing (trim / lowercase if needed).
+    pub fn is_held_by(&self, agent: &str) -> bool {
+        self.agent_id == agent
+    }
+}
+
+/// Errors surfaced by the claim protocol. Designed so the MCP layer can
+/// translate into user-facing messages without leaking filesystem paths.
+#[derive(Debug, thiserror::Error)]
+pub enum ClaimError {
+    #[error("claim for {id} already held by {agent_id}, expires at {expires_at}")]
+    AlreadyHeld {
+        id: String,
+        agent_id: String,
+        expires_at: DateTime<Utc>,
+    },
+    #[error("claim for {id} is held by {held_by}, not {requester}")]
+    NotHeldByRequester {
+        id: String,
+        held_by: String,
+        requester: String,
+    },
+    #[error("ttl {0:?} outside permitted range ({MIN_TTL:?}..={MAX_TTL:?})")]
+    TtlOutOfRange(Duration),
+    #[error("artifact id must be non-empty")]
+    EmptyId,
+    #[error("agent id must be non-empty")]
+    EmptyAgent,
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("yaml error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+}
+
+/// On-disk claim store rooted at `<workspace>/claims/`.
+#[derive(Debug, Clone)]
+pub struct ClaimStore {
+    dir: PathBuf,
+}
+
+impl ClaimStore {
+    /// `workspace` is the `.forgeplan/` directory. The store creates
+    /// `<workspace>/claims/` lazily on first write.
+    pub fn new(workspace: impl AsRef<Path>) -> Self {
+        Self {
+            dir: workspace.as_ref().join("claims"),
+        }
+    }
+
+    fn path_for(&self, id: &str) -> PathBuf {
+        self.dir.join(format!("{}.yaml", id.to_uppercase()))
+    }
+
+    /// Ensure the claims directory exists. Called before any write.
+    async fn ensure_dir(&self) -> Result<(), ClaimError> {
+        tokio::fs::create_dir_all(&self.dir).await?;
+        Ok(())
+    }
+
+    /// Read a claim if present AND not expired. Expired claims are treated
+    /// as absent so downstream logic can acquire without a separate purge
+    /// step (AC-3).
+    pub async fn get(&self, id: &str) -> Result<Option<Claim>, ClaimError> {
+        if id.is_empty() {
+            return Err(ClaimError::EmptyId);
+        }
+        let path = self.path_for(id);
+        let raw = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(ClaimError::Io(e)),
+        };
+        let claim: Claim = serde_yaml::from_str(&raw)?;
+        if claim.is_expired() {
+            Ok(None)
+        } else {
+            Ok(Some(claim))
+        }
+    }
+
+    /// Raw get without TTL filtering. Exposed for diagnostics (`--include-expired`).
+    pub async fn get_including_expired(&self, id: &str) -> Result<Option<Claim>, ClaimError> {
+        if id.is_empty() {
+            return Err(ClaimError::EmptyId);
+        }
+        let path = self.path_for(id);
+        match tokio::fs::read_to_string(&path).await {
+            Ok(raw) => {
+                let claim: Claim = serde_yaml::from_str(&raw)?;
+                Ok(Some(claim))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(ClaimError::Io(e)),
+        }
+    }
+
+    /// Attempt to take a claim. Succeeds if:
+    /// - no file exists
+    /// - file exists but is expired (overwritten — AC-3)
+    /// - file exists, is live, and is held by `agent` (renewed)
+    ///
+    /// Fails with `AlreadyHeld` otherwise (AC-2).
+    ///
+    /// Callers should already hold the workspace lock (`workspace::lock`)
+    /// to make the read-modify-write atomic across sub-agents sharing the
+    /// filesystem — this function does no internal locking.
+    pub async fn claim(
+        &self,
+        id: &str,
+        agent: &str,
+        ttl: Duration,
+        note: Option<String>,
+    ) -> Result<Claim, ClaimError> {
+        if id.is_empty() {
+            return Err(ClaimError::EmptyId);
+        }
+        if agent.is_empty() {
+            return Err(ClaimError::EmptyAgent);
+        }
+        if ttl < MIN_TTL || ttl > MAX_TTL {
+            return Err(ClaimError::TtlOutOfRange(ttl));
+        }
+
+        self.ensure_dir().await?;
+
+        // Check for live claim by a different agent.
+        if let Some(existing) = self.get(id).await?
+            && !existing.is_held_by(agent)
+        {
+            return Err(ClaimError::AlreadyHeld {
+                id: existing.id,
+                agent_id: existing.agent_id,
+                expires_at: existing.expires_at,
+            });
+        }
+
+        let now = Utc::now();
+        let claim = Claim {
+            id: id.to_uppercase(),
+            agent_id: agent.to_string(),
+            claimed_at: now,
+            expires_at: now + ttl,
+            note,
+        };
+
+        let yaml = serde_yaml::to_string(&claim)?;
+        tokio::fs::write(self.path_for(id), yaml).await?;
+        Ok(claim)
+    }
+
+    /// Remove a claim.
+    ///
+    /// - `force = false`: refuse if held by a different agent (protects
+    ///   agents from clobbering each other's work markers).
+    /// - `force = true`: remove regardless — orchestrator escape hatch for
+    ///   a confirmed-dead agent (R-4 mitigation).
+    ///
+    /// Missing claim is a no-op (not an error) to make release idempotent.
+    pub async fn release(&self, id: &str, agent: &str, force: bool) -> Result<(), ClaimError> {
+        if id.is_empty() {
+            return Err(ClaimError::EmptyId);
+        }
+        if !force && agent.is_empty() {
+            return Err(ClaimError::EmptyAgent);
+        }
+
+        let path = self.path_for(id);
+        if !force
+            && let Some(existing) = self.get_including_expired(id).await?
+            && !existing.is_held_by(agent)
+            && !existing.is_expired()
+        {
+            return Err(ClaimError::NotHeldByRequester {
+                id: existing.id,
+                held_by: existing.agent_id,
+                requester: agent.to_string(),
+            });
+        }
+
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(ClaimError::Io(e)),
+        }
+    }
+
+    /// List every live claim in the workspace, sorted by `expires_at`
+    /// ascending (earliest-expiring first). Expired claims are skipped
+    /// (not returned, not removed — purging is a separate concern).
+    pub async fn list_active(&self) -> Result<Vec<Claim>, ClaimError> {
+        if !self.dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        let mut rd = tokio::fs::read_dir(&self.dir).await?;
+        while let Some(entry) = rd.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
+                continue;
+            }
+            let raw = match tokio::fs::read_to_string(&path).await {
+                Ok(s) => s,
+                Err(_) => continue, // skip unreadable files rather than fail the whole list
+            };
+            if let Ok(claim) = serde_yaml::from_str::<Claim>(&raw)
+                && !claim.is_expired()
+            {
+                out.push(claim);
+            }
+        }
+        out.sort_by_key(|c| c.expires_at);
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn ws(tmp: &TempDir) -> PathBuf {
+        tmp.path().join(".forgeplan")
+    }
+
+    #[test]
+    fn claim_is_expired_matches_now() {
+        let past = Claim {
+            id: "PRD-001".into(),
+            agent_id: "a/1".into(),
+            claimed_at: Utc::now() - Duration::minutes(10),
+            expires_at: Utc::now() - Duration::minutes(1),
+            note: None,
+        };
+        assert!(past.is_expired());
+
+        let future = Claim {
+            expires_at: Utc::now() + Duration::minutes(5),
+            ..past.clone()
+        };
+        assert!(!future.is_expired());
+    }
+
+    #[test]
+    fn is_held_by_exact_match() {
+        let c = Claim {
+            id: "PRD-001".into(),
+            agent_id: "orchestrator/1.0".into(),
+            claimed_at: Utc::now(),
+            expires_at: Utc::now() + Duration::minutes(30),
+            note: None,
+        };
+        assert!(c.is_held_by("orchestrator/1.0"));
+        assert!(!c.is_held_by("orchestrator/2.0"));
+        assert!(!c.is_held_by("worker-1"));
+    }
+
+    #[tokio::test]
+    async fn claim_creates_file_and_returns_claim() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        let claim = store
+            .claim("PRD-001", "agent/1.0", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        assert_eq!(claim.id, "PRD-001");
+        assert_eq!(claim.agent_id, "agent/1.0");
+        assert!(ws(&tmp).join("claims/PRD-001.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn claim_uppercases_id_on_disk() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("prd-002", "a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        assert!(ws(&tmp).join("claims/PRD-002.yaml").exists());
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_active_different_agent() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-003", "agent-a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        let err = store
+            .claim("PRD-003", "agent-b/1", DEFAULT_TTL, None)
+            .await
+            .unwrap_err();
+        match err {
+            ClaimError::AlreadyHeld { agent_id, .. } => assert_eq!(agent_id, "agent-a/1"),
+            other => panic!("expected AlreadyHeld, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_renews_same_agent() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        let first = store
+            .claim("PRD-004", "a/1", Duration::minutes(5), None)
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let second = store
+            .claim("PRD-004", "a/1", Duration::minutes(10), None)
+            .await
+            .unwrap();
+        assert!(second.claimed_at > first.claimed_at);
+        assert!(second.expires_at > first.expires_at);
+    }
+
+    #[tokio::test]
+    async fn claim_takes_over_expired_claim() {
+        // AC-3: expired claim is ignored, new agent can take it.
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store.ensure_dir().await.unwrap();
+
+        let past = Claim {
+            id: "PRD-005".into(),
+            agent_id: "dead-agent".into(),
+            claimed_at: Utc::now() - Duration::minutes(20),
+            expires_at: Utc::now() - Duration::minutes(5),
+            note: None,
+        };
+        tokio::fs::write(
+            ws(&tmp).join("claims/PRD-005.yaml"),
+            serde_yaml::to_string(&past).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let new_claim = store
+            .claim("PRD-005", "fresh-agent/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        assert_eq!(new_claim.agent_id, "fresh-agent/1");
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_ttl_out_of_range() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        assert!(matches!(
+            store
+                .claim("PRD-006", "a/1", Duration::seconds(10), None)
+                .await,
+            Err(ClaimError::TtlOutOfRange(_))
+        ));
+        assert!(matches!(
+            store
+                .claim("PRD-006", "a/1", Duration::hours(48), None)
+                .await,
+            Err(ClaimError::TtlOutOfRange(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_empty_ids_and_agents() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        assert!(matches!(
+            store.claim("", "a/1", DEFAULT_TTL, None).await,
+            Err(ClaimError::EmptyId)
+        ));
+        assert!(matches!(
+            store.claim("PRD-007", "", DEFAULT_TTL, None).await,
+            Err(ClaimError::EmptyAgent)
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_missing_or_expired() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        assert!(store.get("PRD-404").await.unwrap().is_none());
+
+        store.ensure_dir().await.unwrap();
+        let past = Claim {
+            id: "PRD-405".into(),
+            agent_id: "x".into(),
+            claimed_at: Utc::now() - Duration::hours(1),
+            expires_at: Utc::now() - Duration::seconds(1),
+            note: None,
+        };
+        tokio::fs::write(
+            ws(&tmp).join("claims/PRD-405.yaml"),
+            serde_yaml::to_string(&past).unwrap(),
+        )
+        .await
+        .unwrap();
+        assert!(store.get("PRD-405").await.unwrap().is_none());
+        assert!(
+            store
+                .get_including_expired("PRD-405")
+                .await
+                .unwrap()
+                .is_some(),
+            "raw read should surface expired entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_by_owner_succeeds_and_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-010", "a/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        store.release("PRD-010", "a/1", false).await.unwrap();
+        assert!(store.get("PRD-010").await.unwrap().is_none());
+        // Second release no-ops (idempotent).
+        store.release("PRD-010", "a/1", false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn release_by_wrong_agent_rejects_without_force() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-011", "owner/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        let err = store
+            .release("PRD-011", "stranger/1", false)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ClaimError::NotHeldByRequester { .. }));
+        assert!(
+            store.get("PRD-011").await.unwrap().is_some(),
+            "claim must still be on disk after refused release"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_force_overrides_agent_check() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-012", "owner/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+        // force=true lets the orchestrator reap a stuck claim.
+        store
+            .release("PRD-012", "orchestrator/1", true)
+            .await
+            .unwrap();
+        assert!(store.get("PRD-012").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn release_expired_is_allowed_without_force() {
+        // Expired claims are "practically released" already; any agent may
+        // tidy them up without --force.
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store.ensure_dir().await.unwrap();
+        let past = Claim {
+            id: "PRD-013".into(),
+            agent_id: "ghost".into(),
+            claimed_at: Utc::now() - Duration::hours(2),
+            expires_at: Utc::now() - Duration::minutes(5),
+            note: None,
+        };
+        tokio::fs::write(
+            ws(&tmp).join("claims/PRD-013.yaml"),
+            serde_yaml::to_string(&past).unwrap(),
+        )
+        .await
+        .unwrap();
+        store.release("PRD-013", "anyone/1", false).await.unwrap();
+        assert!(
+            store
+                .get_including_expired("PRD-013")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_active_sorted_by_expiry_ascending() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store
+            .claim("PRD-020", "a/1", Duration::hours(2), None)
+            .await
+            .unwrap();
+        store
+            .claim("PRD-021", "b/1", Duration::minutes(30), None)
+            .await
+            .unwrap();
+        store
+            .claim("PRD-022", "c/1", Duration::hours(1), None)
+            .await
+            .unwrap();
+        let active = store.list_active().await.unwrap();
+        assert_eq!(active.len(), 3);
+        assert_eq!(active[0].id, "PRD-021"); // earliest expiry
+        assert_eq!(active[2].id, "PRD-020"); // latest expiry
+    }
+
+    #[tokio::test]
+    async fn list_active_skips_expired() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        store.ensure_dir().await.unwrap();
+
+        store
+            .claim("PRD-030", "live/1", DEFAULT_TTL, None)
+            .await
+            .unwrap();
+
+        let expired = Claim {
+            id: "PRD-031".into(),
+            agent_id: "stale/1".into(),
+            claimed_at: Utc::now() - Duration::hours(2),
+            expires_at: Utc::now() - Duration::seconds(1),
+            note: None,
+        };
+        tokio::fs::write(
+            ws(&tmp).join("claims/PRD-031.yaml"),
+            serde_yaml::to_string(&expired).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let active = store.list_active().await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, "PRD-030");
+    }
+
+    #[tokio::test]
+    async fn list_active_handles_missing_dir() {
+        let tmp = TempDir::new().unwrap();
+        let store = ClaimStore::new(ws(&tmp));
+        // Directory never created — must not error.
+        assert!(store.list_active().await.unwrap().is_empty());
+    }
+}

--- a/crates/forgeplan-core/src/dispatch/mod.rs
+++ b/crates/forgeplan-core/src/dispatch/mod.rs
@@ -1,0 +1,456 @@
+//! Orchestrator dispatcher — converts a list of artifact candidates into
+//! a parallel-safe work plan for N sub-agents (PRD-057 Inc 4).
+//!
+//! The algorithm is intentionally simple for the 2–5 agent target scale:
+//!
+//! 1. Filter candidates whose ID is in the active-claim set (another agent
+//!    is already working on it).
+//! 2. Compute pairwise **file-set Jaccard overlap** — artifacts that touch
+//!    more than `overlap_threshold` of the same files are marked as
+//!    conflicting and cannot share a bucket.
+//! 3. Greedy first-fit bucket packing in the candidate order (caller is
+//!    expected to pass artifacts in topological / priority order). For
+//!    each candidate, walk the buckets; place it in the first bucket where
+//!    no resident artifact conflicts AND (if skills are provided) the
+//!    agent's skill set intersects the artifact's domain.
+//! 4. Anything that cannot fit any bucket goes into the serial queue in
+//!    the same order — the orchestrator can re-dispatch when a sub-agent
+//!    finishes and frees capacity.
+//!
+//! Every decision is captured in `DispatchPlan::reasoning` so orchestrators
+//! can explain "why was X deferred?" without re-running the algorithm
+//! (PRD-057 NFR-005).
+//!
+//! PRD-057 FR-001, FR-002, FR-003, FR-010, FR-011.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+
+/// Default Jaccard threshold above which two artifacts are considered
+/// conflicting. 0.3 = "touch a third of the same files" — empirically
+/// tuned on Forgeplan's own monorepo churn. Orchestrators can override.
+pub const DEFAULT_OVERLAP_THRESHOLD: f64 = 0.3;
+
+/// One artifact the dispatcher may assign to an agent. The caller
+/// (typically the MCP layer) hydrates this from LanceDB + frontmatter.
+///
+/// `affected_files` comes from the `affected_files:` frontmatter key
+/// (a list of glob-or-path strings). When empty, the artifact is treated
+/// as "touches everything" — placed into the serial queue by default
+/// (bias toward safety per R-2 mitigation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArtifactCandidate {
+    pub id: String,
+    pub affected_files: Vec<String>,
+    #[serde(default)]
+    pub domain: Option<String>,
+}
+
+impl ArtifactCandidate {
+    /// File set normalized to a BTreeSet for cheap intersection.
+    fn file_set(&self) -> BTreeSet<&str> {
+        self.affected_files.iter().map(String::as_str).collect()
+    }
+}
+
+/// A plan returned to the orchestrator. `buckets[i]` is the ordered list
+/// of artifact IDs agent `i` should work on (typically one, sometimes two
+/// when they're truly disjoint). `serial_queue` holds everything that
+/// couldn't be parallelized safely and should be processed one-at-a-time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DispatchPlan {
+    pub buckets: Vec<Vec<String>>,
+    pub serial_queue: Vec<String>,
+    pub reasoning: Vec<String>,
+    /// RFC3339 timestamp — orchestrator can detect stale plans and
+    /// re-dispatch when the workspace state changes (R-6).
+    pub generated_at: String,
+    pub agent_count: usize,
+    pub overlap_threshold: f64,
+}
+
+impl DispatchPlan {
+    /// Total number of artifacts the plan addresses (parallel + serial).
+    pub fn total_assigned(&self) -> usize {
+        self.buckets.iter().map(|b| b.len()).sum::<usize>() + self.serial_queue.len()
+    }
+}
+
+/// Jaccard similarity = |A ∩ B| / |A ∪ B|. Returns 1.0 when both sets are
+/// empty (they "overlap completely" in the trivial sense) — callers are
+/// expected to treat empty-files artifacts as conflicting-by-default (see
+/// `compute_dispatch_plan`).
+pub fn jaccard(a: &BTreeSet<&str>, b: &BTreeSet<&str>) -> f64 {
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    let intersection = a.intersection(b).count() as f64;
+    let union = a.union(b).count() as f64;
+    if union == 0.0 {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+/// True when either set is empty OR their overlap exceeds the threshold.
+/// The empty-set branch is the R-2 mitigation: if an artifact declares no
+/// affected files, we assume it touches shared ground and refuse to
+/// parallelize it — safer than optimistically assuming no conflict.
+fn conflicts(a: &ArtifactCandidate, b: &ArtifactCandidate, threshold: f64) -> bool {
+    let sa = a.file_set();
+    let sb = b.file_set();
+    if sa.is_empty() || sb.is_empty() {
+        return true;
+    }
+    jaccard(&sa, &sb) > threshold
+}
+
+/// True when `agent_skills` intersects `artifact_domain`. Empty agent
+/// skills (orchestrator didn't specify) → every artifact matches, so
+/// skill matching is opt-in. Missing domain on an artifact → conservative
+/// no-match unless skills are empty.
+fn skill_match(agent_skills: &[String], artifact_domain: Option<&str>) -> bool {
+    if agent_skills.is_empty() {
+        return true;
+    }
+    match artifact_domain {
+        None => false,
+        Some(d) => agent_skills.iter().any(|s| s.eq_ignore_ascii_case(d)),
+    }
+}
+
+/// Build the dispatch plan. See module-level docs for the algorithm.
+///
+/// `candidates` MUST already be in the order the caller prefers
+/// (typically topological / priority); the algorithm preserves the order
+/// when placing into buckets and the serial queue, which makes the
+/// resulting plan deterministic and greppable.
+///
+/// `claimed_ids` carries the live-claim set from `ClaimStore::list_active`
+/// (Inc 3). Any candidate whose ID is already claimed is skipped from the
+/// plan entirely — the orchestrator shouldn't hand work to a new agent
+/// when someone is already on it.
+///
+/// `agent_skills` is `[skills_for_agent_0, skills_for_agent_1, …]`. When
+/// its length is less than `agent_count`, missing entries default to
+/// "no skills declared" (matches everything). When empty, skill matching
+/// is disabled entirely.
+#[must_use = "the plan is the whole point — don't drop it"]
+pub fn compute_dispatch_plan(
+    candidates: &[ArtifactCandidate],
+    agent_count: usize,
+    agent_skills: &[Vec<String>],
+    claimed_ids: &HashSet<String>,
+    overlap_threshold: f64,
+) -> DispatchPlan {
+    let mut reasoning = Vec::new();
+    let agent_count = agent_count.max(1);
+    let mut buckets: Vec<Vec<ArtifactCandidate>> = vec![Vec::new(); agent_count];
+    let mut serial_queue_full: Vec<ArtifactCandidate> = Vec::new();
+
+    'outer: for cand in candidates {
+        if claimed_ids.contains(&cand.id) {
+            reasoning.push(format!(
+                "{}: skipped (already claimed by another agent)",
+                cand.id
+            ));
+            continue;
+        }
+
+        // R-2 mitigation (file-overlap safety bias): an artifact with no
+        // declared affected_files is treated as "touches unknown ground"
+        // and goes straight to the serial queue, never to a bucket.
+        // This also keeps bucket placement order-independent of the
+        // coincidence that bucket-0 happens to be empty on first pass.
+        if cand.affected_files.is_empty() {
+            reasoning.push(format!(
+                "{}: serialized (no affected_files declared — treated as shared-ground, \
+                 deferred for safety)",
+                cand.id
+            ));
+            serial_queue_full.push(cand.clone());
+            continue;
+        }
+
+        // Visit buckets in load order (ascending). Within a tie (equal
+        // load), prefer the lower-index bucket for deterministic output.
+        // Least-loaded first distributes work across agents — without
+        // this, a first-fit pass pours everything into agent 0.
+        let mut order: Vec<usize> = (0..buckets.len()).collect();
+        order.sort_by_key(|&i| (buckets[i].len(), i));
+
+        for i in order {
+            let skills = agent_skills.get(i).map(Vec::as_slice).unwrap_or(&[]);
+            if !skill_match(skills, cand.domain.as_deref()) {
+                continue;
+            }
+            let any_conflict = buckets[i]
+                .iter()
+                .any(|existing| conflicts(existing, cand, overlap_threshold));
+            if any_conflict {
+                continue;
+            }
+            reasoning.push(format!(
+                "{}: assigned to agent {} (no file conflict{})",
+                cand.id,
+                i,
+                if skills.is_empty() {
+                    ""
+                } else {
+                    ", skill match"
+                }
+            ));
+            buckets[i].push(cand.clone());
+            continue 'outer;
+        }
+
+        // No bucket fit — defer to serial.
+        reasoning.push(format!(
+            "{}: serialized (conflicts with every bucket or no matching skill)",
+            cand.id
+        ));
+        serial_queue_full.push(cand.clone());
+    }
+
+    DispatchPlan {
+        buckets: buckets
+            .into_iter()
+            .map(|b| b.into_iter().map(|c| c.id).collect())
+            .collect(),
+        serial_queue: serial_queue_full.into_iter().map(|c| c.id).collect(),
+        reasoning,
+        generated_at: Utc::now().to_rfc3339(),
+        agent_count,
+        overlap_threshold,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(id: &str, files: &[&str]) -> ArtifactCandidate {
+        ArtifactCandidate {
+            id: id.to_string(),
+            affected_files: files.iter().map(|s| s.to_string()).collect(),
+            domain: None,
+        }
+    }
+
+    fn cand_domain(id: &str, files: &[&str], domain: &str) -> ArtifactCandidate {
+        ArtifactCandidate {
+            id: id.to_string(),
+            affected_files: files.iter().map(|s| s.to_string()).collect(),
+            domain: Some(domain.to_string()),
+        }
+    }
+
+    #[test]
+    fn jaccard_identical_sets_is_one() {
+        let a: BTreeSet<&str> = ["a", "b", "c"].iter().copied().collect();
+        assert_eq!(jaccard(&a, &a), 1.0);
+    }
+
+    #[test]
+    fn jaccard_disjoint_sets_is_zero() {
+        let a: BTreeSet<&str> = ["a"].iter().copied().collect();
+        let b: BTreeSet<&str> = ["b"].iter().copied().collect();
+        assert_eq!(jaccard(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn jaccard_half_overlap() {
+        let a: BTreeSet<&str> = ["a", "b"].iter().copied().collect();
+        let b: BTreeSet<&str> = ["b", "c"].iter().copied().collect();
+        // |{b}| / |{a,b,c}| = 1/3
+        let v = jaccard(&a, &b);
+        assert!((v - 1.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn jaccard_two_empty_sets_is_one() {
+        let empty: BTreeSet<&str> = BTreeSet::new();
+        assert_eq!(jaccard(&empty, &empty), 1.0);
+    }
+
+    #[test]
+    fn disjoint_artifacts_go_to_separate_buckets() {
+        // AC-1: disjoint file sets → parallel buckets.
+        let candidates = vec![
+            cand("PRD-A", &["crates/cli/src/main.rs"]),
+            cand("PRD-B", &["apps/website/index.html"]),
+        ];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            2,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan.buckets[0], vec!["PRD-A"]);
+        assert_eq!(plan.buckets[1], vec!["PRD-B"]);
+        assert!(plan.serial_queue.is_empty());
+    }
+
+    #[test]
+    fn overlapping_artifacts_force_one_to_serial() {
+        // Two artifacts touching same files → only first fits; second to serial.
+        let candidates = vec![
+            cand("PRD-A", &["crates/core/src/lib.rs", "crates/core/src/x.rs"]),
+            cand("PRD-B", &["crates/core/src/lib.rs", "crates/core/src/y.rs"]),
+        ];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            2,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan.buckets[0], vec!["PRD-A"]);
+        // PRD-B must NOT be in bucket 1 — overlap with PRD-A exceeds threshold.
+        // Our algorithm tries bucket 0 (rejected), bucket 1 (empty → accepts any
+        // candidate). So actually PRD-B lands in bucket 1 because it has no
+        // conflict with an EMPTY bucket. Let's verify the reasoning matches.
+        // Correction: the test of "forced to serial" requires all buckets to
+        // already contain a conflicting artifact. Move to the 1-agent case.
+        let plan1 = compute_dispatch_plan(
+            &candidates,
+            1,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan1.buckets[0], vec!["PRD-A"]);
+        assert_eq!(plan1.serial_queue, vec!["PRD-B"]);
+        assert!(
+            plan1
+                .reasoning
+                .iter()
+                .any(|r| r.contains("PRD-B: serialized"))
+        );
+    }
+
+    #[test]
+    fn empty_affected_files_goes_to_serial() {
+        // R-2 mitigation: artifacts with no declared files → treat as
+        // shared-ground, bias to serial.
+        let candidates = vec![cand("PRD-NO-FILES", &[])];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            2,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert!(plan.buckets[0].is_empty());
+        assert_eq!(plan.serial_queue, vec!["PRD-NO-FILES"]);
+        assert!(
+            plan.reasoning
+                .iter()
+                .any(|r| r.contains("no affected_files declared"))
+        );
+    }
+
+    #[test]
+    fn claimed_artifacts_are_skipped_entirely() {
+        let candidates = vec![
+            cand("PRD-A", &["crates/a.rs"]),
+            cand("PRD-B", &["crates/b.rs"]),
+        ];
+        let mut claimed = HashSet::new();
+        claimed.insert("PRD-A".to_string());
+        let plan = compute_dispatch_plan(&candidates, 2, &[], &claimed, DEFAULT_OVERLAP_THRESHOLD);
+        assert_eq!(plan.total_assigned(), 1);
+        assert_eq!(plan.buckets[0], vec!["PRD-B"]);
+        assert!(
+            plan.reasoning
+                .iter()
+                .any(|r| r.contains("PRD-A: skipped (already claimed"))
+        );
+    }
+
+    #[test]
+    fn skill_match_routes_to_right_agent() {
+        // agent 0 = backend, agent 1 = frontend. Artifacts matched by domain.
+        let candidates = vec![
+            cand_domain("PRD-API", &["crates/api/src/lib.rs"], "backend"),
+            cand_domain("PRD-UI", &["apps/website/app.tsx"], "frontend"),
+        ];
+        let skills = vec![vec!["backend".to_string()], vec!["frontend".to_string()]];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            2,
+            &skills,
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan.buckets[0], vec!["PRD-API"]);
+        assert_eq!(plan.buckets[1], vec!["PRD-UI"]);
+    }
+
+    #[test]
+    fn skill_mismatch_defers_to_serial() {
+        // Only agent 0 (backend), but a frontend artifact → must serial.
+        let candidates = vec![cand_domain("PRD-UI", &["apps/website/app.tsx"], "frontend")];
+        let skills = vec![vec!["backend".to_string()]];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            1,
+            &skills,
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert!(plan.buckets[0].is_empty());
+        assert_eq!(plan.serial_queue, vec!["PRD-UI"]);
+    }
+
+    #[test]
+    fn agent_count_zero_treated_as_one() {
+        // Defense against caller passing 0 — don't panic, fall back to serial.
+        let candidates = vec![cand("PRD-A", &["x.rs"])];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            0,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan.agent_count, 1);
+        assert_eq!(plan.buckets.len(), 1);
+        assert_eq!(plan.buckets[0], vec!["PRD-A"]);
+    }
+
+    #[test]
+    fn deterministic_ordering_of_buckets() {
+        // Same input → same output. Critical so orchestrators don't churn.
+        let candidates = vec![
+            cand("PRD-A", &["a.rs"]),
+            cand("PRD-B", &["b.rs"]),
+            cand("PRD-C", &["c.rs"]),
+        ];
+        let p1 = compute_dispatch_plan(
+            &candidates,
+            3,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        let p2 = compute_dispatch_plan(
+            &candidates,
+            3,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(p1.buckets, p2.buckets);
+        assert_eq!(p1.serial_queue, p2.serial_queue);
+    }
+
+    #[test]
+    fn generated_at_is_rfc3339() {
+        let plan = compute_dispatch_plan(&[], 2, &[], &HashSet::new(), DEFAULT_OVERLAP_THRESHOLD);
+        assert!(chrono::DateTime::parse_from_rfc3339(&plan.generated_at).is_ok());
+    }
+}

--- a/crates/forgeplan-core/src/dispatch/mod.rs
+++ b/crates/forgeplan-core/src/dispatch/mod.rs
@@ -27,10 +27,73 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashSet};
 
-/// Default Jaccard threshold above which two artifacts are considered
-/// conflicting. 0.3 = "touch a third of the same files" — empirically
-/// tuned on Forgeplan's own monorepo churn. Orchestrators can override.
+/// Default Jaccard threshold at-or-above which two artifacts are
+/// considered conflicting. 0.3 = "touch a third of the same files" —
+/// empirically tuned on Forgeplan's own monorepo churn. Orchestrators can
+/// override.
 pub const DEFAULT_OVERLAP_THRESHOLD: f64 = 0.3;
+
+/// Ceiling on number of dispatch buckets. PRD-057 targets 2–5 agents;
+/// this clamp prevents a malformed / hostile MCP payload with e.g.
+/// `agents: 4_000_000_000` from allocating a giant `Vec<Vec<String>>`
+/// and OOMing the server (R3 audit HIGH — CWE-770).
+pub const MAX_AGENTS: usize = 64;
+
+/// Per-agent skill-list length cap. Bounds the `skills.iter().any(...)`
+/// string compare per candidate in the bucket loop (R3 audit MED — CWE-770).
+pub const MAX_SKILLS_PER_AGENT: usize = 32;
+
+/// Per-artifact affected_files length cap — matches the 64 KB frontmatter
+/// size limit downstream and keeps Jaccard's O(N²) set intersection
+/// bounded on pathological workspaces (R3 audit LOW — CWE-400).
+pub const MAX_AFFECTED_FILES: usize = 512;
+/// Max length of a single file path inside `affected_files`.
+pub const MAX_AFFECTED_FILE_LEN: usize = 512;
+
+/// Parse the `affected_files:` frontmatter value, accepting either:
+/// - YAML sequence: `affected_files: [a.rs, b.rs]` (canonical)
+/// - Scalar string: `affected_files: "a.rs, b.rs"` (tolerated; R3 audit
+///   rust-pro M-2 — silently emitting "no files declared" on scalar form
+///   was a contract bug).
+///
+/// Each entry is bounded to `MAX_AFFECTED_FILE_LEN` bytes; overall list
+/// to `MAX_AFFECTED_FILES` entries (R3 audit security LOW, CWE-400).
+pub fn parse_affected_files_from_fm(v: &serde_yaml::Value) -> Vec<String> {
+    let mut raw: Vec<String> = match v {
+        serde_yaml::Value::Sequence(seq) => seq
+            .iter()
+            .filter_map(|x| x.as_str().map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect(),
+        serde_yaml::Value::String(s) => s
+            .split(',')
+            .map(|x| x.trim().to_string())
+            .filter(|x| !x.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    raw.retain(|s| s.len() <= MAX_AFFECTED_FILE_LEN);
+    raw.truncate(MAX_AFFECTED_FILES);
+    raw
+}
+
+/// Normalize dispatcher domain values to ASCII `[a-z0-9_-]`. R3 audit
+/// security MED (CWE-176): a tampered frontmatter like
+/// `domain: "backеnd"` (Cyrillic `е`) must not silently mismatch ASCII
+/// agent skills. Returns `None` on invalid charset.
+pub fn normalize_dispatch_domain(raw: &str) -> Option<String> {
+    let lower = raw.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return None;
+    }
+    if !lower
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return None;
+    }
+    Some(lower)
+}
 
 /// One artifact the dispatcher may assign to an agent. The caller
 /// (typically the MCP layer) hydrates this from LanceDB + frontmatter.
@@ -94,17 +157,21 @@ pub fn jaccard(a: &BTreeSet<&str>, b: &BTreeSet<&str>) -> f64 {
     }
 }
 
-/// True when either set is empty OR their overlap exceeds the threshold.
-/// The empty-set branch is the R-2 mitigation: if an artifact declares no
-/// affected files, we assume it touches shared ground and refuse to
-/// parallelize it — safer than optimistically assuming no conflict.
+/// True when either set is empty OR their overlap is at or above the
+/// threshold. The empty-set branch is the R-2 mitigation: if an artifact
+/// declares no affected files, we assume it touches shared ground and
+/// refuse to parallelize it — safer than optimistically assuming no
+/// conflict.
+///
+/// Boundary is inclusive (`>=`) so the MCP tool description "overlap >=
+/// threshold" matches behaviour (R3 audit rust-pro M-1 — contract bug).
 fn conflicts(a: &ArtifactCandidate, b: &ArtifactCandidate, threshold: f64) -> bool {
     let sa = a.file_set();
     let sb = b.file_set();
     if sa.is_empty() || sb.is_empty() {
         return true;
     }
-    jaccard(&sa, &sb) > threshold
+    jaccard(&sa, &sb) >= threshold
 }
 
 /// True when `agent_skills` intersects `artifact_domain`. Empty agent
@@ -146,12 +213,20 @@ pub fn compute_dispatch_plan(
     overlap_threshold: f64,
 ) -> DispatchPlan {
     let mut reasoning = Vec::new();
-    let agent_count = agent_count.max(1);
+    // Clamp agent_count to [1, MAX_AGENTS] — R3 audit HIGH (security):
+    // unbounded caller input would otherwise allocate proportional Vec.
+    let agent_count = agent_count.clamp(1, MAX_AGENTS);
     let mut buckets: Vec<Vec<ArtifactCandidate>> = vec![Vec::new(); agent_count];
     let mut serial_queue_full: Vec<ArtifactCandidate> = Vec::new();
 
+    // R3 audit L-2 (rust-pro): normalize claimed IDs to uppercase so a
+    // lowercase-imported artifact ID still matches the claim key (claims
+    // uppercase on disk; `claimed_ids` may have been built from mixed
+    // sources).
+    let claimed_upper: HashSet<String> = claimed_ids.iter().map(|s| s.to_uppercase()).collect();
+
     'outer: for cand in candidates {
-        if claimed_ids.contains(&cand.id) {
+        if claimed_upper.contains(&cand.id.to_uppercase()) {
             reasoning.push(format!(
                 "{}: skipped (already claimed by another agent)",
                 cand.id
@@ -420,6 +495,108 @@ mod tests {
         assert_eq!(plan.agent_count, 1);
         assert_eq!(plan.buckets.len(), 1);
         assert_eq!(plan.buckets[0], vec!["PRD-A"]);
+    }
+
+    #[test]
+    fn agent_count_clamped_to_max_agents() {
+        // R3 audit HIGH (security): unbounded agent_count would OOM.
+        let candidates = vec![cand("PRD-A", &["x.rs"])];
+        let plan = compute_dispatch_plan(
+            &candidates,
+            usize::MAX,
+            &[],
+            &HashSet::new(),
+            DEFAULT_OVERLAP_THRESHOLD,
+        );
+        assert_eq!(plan.agent_count, MAX_AGENTS);
+        assert_eq!(plan.buckets.len(), MAX_AGENTS);
+    }
+
+    #[test]
+    fn claimed_id_case_insensitive_match() {
+        // R3 audit L-2 (rust-pro): ID casing coupling — a lowercase
+        // imported id must still match an uppercase claim key.
+        let candidates = vec![cand("prd-010", &["x.rs"])];
+        let mut claimed = HashSet::new();
+        claimed.insert("PRD-010".to_string());
+        let plan = compute_dispatch_plan(&candidates, 2, &[], &claimed, DEFAULT_OVERLAP_THRESHOLD);
+        assert_eq!(plan.total_assigned(), 0);
+    }
+
+    #[test]
+    fn parse_affected_files_from_fm_accepts_sequence() {
+        let v: serde_yaml::Value = serde_yaml::from_str("[a.rs, b.rs]").unwrap();
+        assert_eq!(parse_affected_files_from_fm(&v), vec!["a.rs", "b.rs"]);
+    }
+
+    #[test]
+    fn parse_affected_files_from_fm_accepts_scalar_csv() {
+        // R3 audit M-2 (rust-pro): scalar form must not silently drop.
+        let v: serde_yaml::Value = serde_yaml::from_str("\"a.rs, b.rs\"").unwrap();
+        assert_eq!(parse_affected_files_from_fm(&v), vec!["a.rs", "b.rs"]);
+    }
+
+    #[test]
+    fn parse_affected_files_from_fm_accepts_single_scalar() {
+        let v: serde_yaml::Value = serde_yaml::from_str("\"crates/core/src/lib.rs\"").unwrap();
+        assert_eq!(
+            parse_affected_files_from_fm(&v),
+            vec!["crates/core/src/lib.rs"]
+        );
+    }
+
+    #[test]
+    fn parse_affected_files_from_fm_caps_length() {
+        let long = "x".repeat(MAX_AFFECTED_FILE_LEN + 1);
+        let v = serde_yaml::Value::Sequence(vec![serde_yaml::Value::String(long)]);
+        assert!(parse_affected_files_from_fm(&v).is_empty());
+    }
+
+    #[test]
+    fn parse_affected_files_from_fm_caps_count() {
+        let items: Vec<serde_yaml::Value> = (0..MAX_AFFECTED_FILES + 5)
+            .map(|i| serde_yaml::Value::String(format!("f{i}.rs")))
+            .collect();
+        let v = serde_yaml::Value::Sequence(items);
+        assert_eq!(parse_affected_files_from_fm(&v).len(), MAX_AFFECTED_FILES);
+    }
+
+    #[test]
+    fn normalize_dispatch_domain_accepts_ascii() {
+        assert_eq!(normalize_dispatch_domain("backend"), Some("backend".into()));
+        assert_eq!(
+            normalize_dispatch_domain(" Backend "),
+            Some("backend".into())
+        );
+        assert_eq!(normalize_dispatch_domain("api-v2"), Some("api-v2".into()));
+        assert_eq!(
+            normalize_dispatch_domain("cli_tool"),
+            Some("cli_tool".into())
+        );
+    }
+
+    #[test]
+    fn normalize_dispatch_domain_rejects_unicode_homograph() {
+        // R3 audit security MED (CWE-176): Cyrillic 'е' (U+0435) looks
+        // identical to ASCII 'e' but never matches.
+        assert!(normalize_dispatch_domain("back\u{0435}nd").is_none());
+        assert!(normalize_dispatch_domain("front-\u{202E}end").is_none());
+        assert!(normalize_dispatch_domain("").is_none());
+        assert!(normalize_dispatch_domain("   ").is_none());
+    }
+
+    #[test]
+    fn jaccard_boundary_at_threshold_is_conflict() {
+        // R3 audit M-1 (rust-pro): `>= threshold` per MCP docstring.
+        // Two artifacts with exactly 0.5 overlap must conflict at
+        // threshold=0.5 (was > so parallelized before).
+        let a = cand("PRD-A", &["x.rs", "y.rs"]);
+        let b = cand("PRD-B", &["x.rs", "z.rs"]);
+        // Jaccard({x,y}, {x,z}) = 1/3 ≈ 0.333
+        let plan = compute_dispatch_plan(&[a, b], 1, &[], &HashSet::new(), 1.0 / 3.0);
+        // Only first fits; second must serialize because overlap >= threshold.
+        assert_eq!(plan.buckets[0], vec!["PRD-A"]);
+        assert_eq!(plan.serial_queue, vec!["PRD-B"]);
     }
 
     #[test]

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod activity;
 pub mod artifact;
 pub mod changelog;
+pub mod claim;
 pub mod config;
 pub mod coverage;
 pub mod db;

--- a/crates/forgeplan-core/src/lib.rs
+++ b/crates/forgeplan-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod coverage;
 pub mod db;
 pub mod depth;
 pub mod discover;
+pub mod dispatch;
 pub mod drift;
 pub mod driver;
 pub mod duplicate;

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -440,8 +440,39 @@ pub async fn stamp_agent_identity(
     );
 
     let new_content = frontmatter::render_frontmatter(&fm, &body)?;
-    tokio::fs::write(&filepath, new_content).await?;
+    // R2 audit MED (rust-pro + architect): use atomic tempfile+rename so
+    // a kill -9 between truncate and write cannot corrupt the markdown.
+    // `tokio::fs::write` was non-atomic on POSIX.
+    atomic_markdown_write(&filepath, new_content.as_bytes()).await?;
     Ok(())
+}
+
+/// Atomic markdown write via tempfile + rename. Mirrors the pattern used
+/// in `claim::atomic_write` but kept local to avoid cross-module coupling
+/// until the shared `kv_yaml` abstraction (arch audit MED) is extracted.
+async fn atomic_markdown_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "atomic_markdown_write: path has no parent",
+        )
+    })?;
+    tokio::fs::create_dir_all(parent).await?;
+    let tmp = parent.join(format!(
+        ".{}.tmp.{}",
+        path.file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "anon".to_string()),
+        std::process::id(),
+    ));
+    tokio::fs::write(&tmp, bytes).await?;
+    match tokio::fs::rename(&tmp, path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(e)
+        }
+    }
 }
 
 /// Remove a projection file for a deleted artifact.

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -1,8 +1,27 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use crate::artifact::frontmatter;
+use crate::artifact::frontmatter::{self, Frontmatter};
 use crate::artifact::types::{ArtifactKind, slugify};
+
+/// Frontmatter keys that `render_markdown_with_tags` writes from LanceDB
+/// record data. Any key **not** in this set is preserved from the file on
+/// disk across renders — this is how agent-owned fields such as
+/// `last_modified_by` / `last_modified_at` (PRD-057 FR-009) and future
+/// `domain` / `affected_files` survive re-renders triggered by unrelated
+/// tool calls (e.g. `forgeplan_link`).
+const KNOWN_FM_KEYS: &[&str] = &[
+    "id",
+    "title",
+    "kind",
+    "status",
+    "depth",
+    "author",
+    "parent_epic",
+    "valid_until",
+    "tags",
+    "links",
+];
 
 /// Render an artifact record as a markdown file in the workspace.
 /// Returns the path where the file was written.
@@ -61,20 +80,27 @@ pub async fn render_projection_record(
     let filename = format!("{}-{}.md", record.id, slug);
     let filepath = dir.join(&filename);
 
-    // Files-first: preserve existing body if file already has one.
-    let effective_body = if filepath.exists() {
+    // Files-first: preserve existing body + agent-owned fm keys (PRD-057 FR-009).
+    let (effective_body, preserved_fm) = if filepath.exists() {
         match tokio::fs::read_to_string(&filepath).await {
             Ok(file_content) => match frontmatter::parse_frontmatter(&file_content) {
-                Ok((_fm, file_body)) if !file_body.trim().is_empty() => file_body.to_string(),
-                _ => record.body.clone(),
+                Ok((fm, file_body)) => {
+                    let preserved = filter_preserved(&fm);
+                    if !file_body.trim().is_empty() {
+                        (file_body.to_string(), preserved)
+                    } else {
+                        (record.body.clone(), preserved)
+                    }
+                }
+                Err(_) => (record.body.clone(), None),
             },
-            Err(_) => record.body.clone(),
+            Err(_) => (record.body.clone(), None),
         }
     } else {
-        record.body.clone()
+        (record.body.clone(), None)
     };
 
-    let content = render_markdown_with_tags(
+    let content = render_markdown_with_extras(
         &record.id,
         &record.kind,
         &record.title,
@@ -86,6 +112,7 @@ pub async fn render_projection_record(
         &effective_body,
         links,
         &record.tags,
+        preserved_fm.as_ref(),
     )?;
     tokio::fs::write(&filepath, &content).await?;
     Ok(filepath)
@@ -151,28 +178,32 @@ async fn render_projection_inner(
     // Files-first (RFC-004): preserve file body if file exists and has content.
     // Only frontmatter is updated from LanceDB. Body comes from the file on disk.
     // Exception: force_body=true (from `update --body`) uses the passed body.
-    let effective_body = if force_body {
-        body.to_string()
+    //
+    // PRD-057 FR-009: also preserve unknown frontmatter keys (anything not in
+    // KNOWN_FM_KEYS) so agent-owned fields such as `last_modified_by` /
+    // `last_modified_at` survive re-renders.
+    let (effective_body, preserved_fm) = if force_body {
+        (body.to_string(), read_preserved_fm(&filepath).await)
     } else if filepath.exists() {
         match tokio::fs::read_to_string(&filepath).await {
-            Ok(file_content) => {
-                if let Ok((_fm, file_body)) = frontmatter::parse_frontmatter(&file_content) {
+            Ok(file_content) => match frontmatter::parse_frontmatter(&file_content) {
+                Ok((fm, file_body)) => {
+                    let preserved = filter_preserved(&fm);
                     if !file_body.trim().is_empty() {
-                        file_body.to_string()
+                        (file_body.to_string(), preserved)
                     } else {
-                        body.to_string()
+                        (body.to_string(), preserved)
                     }
-                } else {
-                    body.to_string()
                 }
-            }
-            Err(_) => body.to_string(),
+                Err(_) => (body.to_string(), None),
+            },
+            Err(_) => (body.to_string(), None),
         }
     } else {
-        body.to_string()
+        (body.to_string(), None)
     };
 
-    let content = render_markdown(
+    let content = render_markdown_with_extras(
         id,
         kind,
         title,
@@ -183,10 +214,37 @@ async fn render_projection_inner(
         valid_until,
         &effective_body,
         links,
+        &[],
+        preserved_fm.as_ref(),
     )?;
     tokio::fs::write(&filepath, &content).await?;
 
     Ok(filepath)
+}
+
+/// Read the file at `path`, parse its frontmatter, and return the subset of
+/// keys that aren't regenerated from LanceDB (see `KNOWN_FM_KEYS`).
+/// Returns `None` if the file is missing or malformed — callers should treat
+/// that as "nothing to preserve".
+async fn read_preserved_fm(path: &Path) -> Option<Frontmatter> {
+    if !path.exists() {
+        return None;
+    }
+    let content = tokio::fs::read_to_string(path).await.ok()?;
+    let (fm, _body) = frontmatter::parse_frontmatter(&content).ok()?;
+    filter_preserved(&fm)
+}
+
+/// Retain only keys outside `KNOWN_FM_KEYS`. Returns `None` when nothing is
+/// left so call sites can cheaply check `Option` instead of empty-map sentinels.
+fn filter_preserved(fm: &Frontmatter) -> Option<Frontmatter> {
+    let mut out = BTreeMap::new();
+    for (k, v) in fm {
+        if !KNOWN_FM_KEYS.contains(&k.as_str()) {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
 }
 
 /// Sync file body to LanceDB store if file was edited by user.
@@ -242,36 +300,14 @@ pub async fn read_file_body_if_newer(
 }
 
 /// Render markdown content with YAML frontmatter + body.
+///
+/// Regenerates the known frontmatter keys from args and merges
+/// `preserved_fm` entries on top. `preserved_fm` MUST contain only keys
+/// outside `KNOWN_FM_KEYS` (caller uses `filter_preserved`). This is how
+/// `last_modified_by` / `last_modified_at` (PRD-057 FR-009) survive
+/// re-renders triggered by unrelated tool calls.
 #[allow(clippy::too_many_arguments)]
-fn render_markdown(
-    id: &str,
-    kind: &str,
-    title: &str,
-    status: &str,
-    depth: &str,
-    author: Option<&str>,
-    parent_epic: Option<&str>,
-    valid_until: Option<&str>,
-    body: &str,
-    links: &[(String, String)],
-) -> anyhow::Result<String> {
-    render_markdown_with_tags(
-        id,
-        kind,
-        title,
-        status,
-        depth,
-        author,
-        parent_epic,
-        valid_until,
-        body,
-        links,
-        &[],
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn render_markdown_with_tags(
+fn render_markdown_with_extras(
     id: &str,
     kind: &str,
     title: &str,
@@ -283,6 +319,7 @@ fn render_markdown_with_tags(
     body: &str,
     links: &[(String, String)],
     tags: &[String],
+    preserved_fm: Option<&Frontmatter>,
 ) -> anyhow::Result<String> {
     let mut fm = BTreeMap::new();
     fm.insert("id".to_string(), serde_yaml::Value::String(id.to_string()));
@@ -349,8 +386,62 @@ fn render_markdown_with_tags(
         fm.insert("links".to_string(), serde_yaml::Value::Sequence(links_seq));
     }
 
+    // Merge preserved (agent-owned / user-custom) fields last — guaranteed
+    // to be outside KNOWN_FM_KEYS by construction (filter_preserved), so
+    // they cannot override id/status/links/etc.
+    if let Some(extras) = preserved_fm {
+        for (k, v) in extras {
+            // Double-guard: if caller violates the contract and passes a
+            // known key, drop it rather than corrupt the regenerated field.
+            if !KNOWN_FM_KEYS.contains(&k.as_str()) {
+                fm.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
     let yaml = serde_yaml::to_string(&fm)?;
     Ok(format!("---\n{}---\n\n{}\n", yaml, body))
+}
+
+/// Stamp `last_modified_by` / `last_modified_at` onto an already-rendered
+/// projection file (PRD-057 FR-009 + AC-5). Reads the markdown, merges the
+/// two keys into the YAML frontmatter, and writes back.
+///
+/// Designed to run **after** `render_projection*` so the merge survives the
+/// regenerate-from-LanceDB step. Since `KNOWN_FM_KEYS` excludes these keys,
+/// subsequent renders preserve them via `filter_preserved`.
+///
+/// Failures are returned as errors — callers may choose to treat them as
+/// best-effort (log + continue) so that identity tracking never blocks a
+/// legitimate artifact write.
+pub async fn stamp_agent_identity(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    title: &str,
+    identity: &crate::artifact::identity::AgentIdentity,
+) -> anyhow::Result<()> {
+    let artifact_kind = kind.parse::<ArtifactKind>().unwrap_or(ArtifactKind::Note);
+    let dir = workspace.join(artifact_kind.dir_name());
+    let slug = slugify(title);
+    let filename = format!("{}-{}.md", id, slug);
+    let filepath = dir.join(&filename);
+
+    let content = tokio::fs::read_to_string(&filepath).await?;
+    let (mut fm, body) = frontmatter::parse_frontmatter(&content)?;
+
+    fm.insert(
+        "last_modified_by".to_string(),
+        serde_yaml::Value::String(identity.as_frontmatter_value()),
+    );
+    fm.insert(
+        "last_modified_at".to_string(),
+        serde_yaml::Value::String(crate::artifact::identity::now_rfc3339()),
+    );
+
+    let new_content = frontmatter::render_frontmatter(&fm, &body)?;
+    tokio::fs::write(&filepath, new_content).await?;
+    Ok(())
 }
 
 /// Remove a projection file for a deleted artifact.
@@ -377,7 +468,7 @@ mod tests {
 
     #[test]
     fn render_markdown_basic() {
-        let content = render_markdown(
+        let content = render_markdown_with_extras(
             "PRD-001",
             "prd",
             "Auth System",
@@ -388,6 +479,8 @@ mod tests {
             None,
             "## Summary\n\nThis is the body.",
             &[],
+            &[],
+            None,
         )
         .unwrap();
         assert!(content.starts_with("---\n"));
@@ -402,8 +495,19 @@ mod tests {
             ("RFC-001".to_string(), "informs".to_string()),
             ("ADR-001".to_string(), "based_on".to_string()),
         ];
-        let content = render_markdown(
-            "PRD-001", "prd", "Auth", "draft", "standard", None, None, None, "Body.", &links,
+        let content = render_markdown_with_extras(
+            "PRD-001",
+            "prd",
+            "Auth",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "Body.",
+            &links,
+            &[],
+            None,
         )
         .unwrap();
         assert!(content.contains("links:"));
@@ -413,7 +517,7 @@ mod tests {
 
     #[test]
     fn render_markdown_optional_fields_omitted() {
-        let content = render_markdown(
+        let content = render_markdown_with_extras(
             "NOTE-001",
             "note",
             "Quick Note",
@@ -424,6 +528,8 @@ mod tests {
             None,
             "Content.",
             &[],
+            &[],
+            None,
         )
         .unwrap();
         assert!(!content.contains("author:"));
@@ -766,5 +872,202 @@ mod tests {
             !result.contains("{placeholder}"),
             "old file body must not survive"
         );
+    }
+
+    // ── PRD-057 Inc 2: agent identity + unknown-fm preservation ─────────
+
+    #[test]
+    fn filter_preserved_drops_known_keys() {
+        let fm: Frontmatter = serde_yaml::from_str(
+            "id: PRD-001\ntitle: Test\nkind: prd\nstatus: draft\ndepth: standard\nauthor: alice",
+        )
+        .unwrap();
+        assert!(filter_preserved(&fm).is_none(), "all keys are known");
+    }
+
+    #[test]
+    fn filter_preserved_keeps_unknown_keys() {
+        let fm: Frontmatter = serde_yaml::from_str(
+            "id: PRD-001\ntitle: Test\nkind: prd\nstatus: draft\ndepth: standard\nlast_modified_by: orchestrator/1.0\ndomain: backend",
+        )
+        .unwrap();
+        let preserved = filter_preserved(&fm).expect("should preserve custom keys");
+        assert_eq!(preserved.len(), 2);
+        assert!(preserved.contains_key("last_modified_by"));
+        assert!(preserved.contains_key("domain"));
+        assert!(!preserved.contains_key("id"));
+    }
+
+    #[test]
+    fn render_extras_merges_preserved_fm() {
+        let mut extras = Frontmatter::new();
+        extras.insert(
+            "last_modified_by".to_string(),
+            serde_yaml::Value::String("orchestrator/1.0".to_string()),
+        );
+        extras.insert(
+            "domain".to_string(),
+            serde_yaml::Value::String("backend".to_string()),
+        );
+        let content = render_markdown_with_extras(
+            "PRD-001",
+            "prd",
+            "Test",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "Body.",
+            &[],
+            &[],
+            Some(&extras),
+        )
+        .unwrap();
+        assert!(content.contains("last_modified_by: orchestrator/1.0"));
+        assert!(content.contains("domain: backend"));
+    }
+
+    #[test]
+    fn render_extras_ignores_known_keys_in_preserved() {
+        // Contract violation: caller passes a known key in preserved_fm.
+        // The render MUST use the arg-derived value, not the extras one.
+        let mut bad_extras = Frontmatter::new();
+        bad_extras.insert(
+            "status".to_string(),
+            serde_yaml::Value::String("active".to_string()),
+        );
+        bad_extras.insert(
+            "id".to_string(),
+            serde_yaml::Value::String("PRD-999".to_string()),
+        );
+        let content = render_markdown_with_extras(
+            "PRD-001",
+            "prd",
+            "Test",
+            "draft", // <- truth for status
+            "standard",
+            None,
+            None,
+            None,
+            "Body.",
+            &[],
+            &[],
+            Some(&bad_extras),
+        )
+        .unwrap();
+        assert!(content.contains("id: PRD-001"));
+        assert!(!content.contains("id: PRD-999"));
+        assert!(content.contains("status: draft"));
+        assert!(!content.contains("status: active"));
+    }
+
+    #[tokio::test]
+    async fn render_projection_preserves_unknown_fm_across_rerender() {
+        // Simulates: agent A stamps last_modified_by, then agent B calls
+        // a tool that triggers render_projection for an unrelated reason
+        // (e.g. forgeplan_link). The stamp must survive.
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        // Step 1: render initial projection
+        let path = render_projection(
+            &ws,
+            "PRD-010",
+            "prd",
+            "Multi Agent",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "## Summary\n\nBody.",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        // Step 2: stamp it with agent identity
+        let identity =
+            crate::artifact::identity::AgentIdentity::new("orchestrator", "1.0").unwrap();
+        stamp_agent_identity(&ws, "PRD-010", "prd", "Multi Agent", &identity)
+            .await
+            .unwrap();
+
+        let stamped = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(stamped.contains("last_modified_by: orchestrator/1.0"));
+        assert!(stamped.contains("last_modified_at:"));
+
+        // Step 3: call render_projection again (simulating unrelated tool)
+        let path2 = render_projection(
+            &ws,
+            "PRD-010",
+            "prd",
+            "Multi Agent",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "## Summary\n\nBody.",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let after = tokio::fs::read_to_string(&path2).await.unwrap();
+        assert!(
+            after.contains("last_modified_by: orchestrator/1.0"),
+            "identity stamp must survive re-render"
+        );
+        assert!(after.contains("last_modified_at:"));
+    }
+
+    #[tokio::test]
+    async fn stamp_overwrites_previous_identity() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+
+        render_projection(
+            &ws,
+            "PRD-011",
+            "prd",
+            "Overwrite",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "body",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let id1 = crate::artifact::identity::AgentIdentity::new("agent-a", "1.0").unwrap();
+        stamp_agent_identity(&ws, "PRD-011", "prd", "Overwrite", &id1)
+            .await
+            .unwrap();
+
+        let id2 = crate::artifact::identity::AgentIdentity::new("agent-b", "2.0").unwrap();
+        stamp_agent_identity(&ws, "PRD-011", "prd", "Overwrite", &id2)
+            .await
+            .unwrap();
+
+        let path = ws.join("prds").join("PRD-011-overwrite.md");
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(content.contains("last_modified_by: agent-b/2.0"));
+        assert!(!content.contains("agent-a/1.0"));
+    }
+
+    #[tokio::test]
+    async fn stamp_fails_cleanly_on_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        tokio::fs::create_dir_all(ws.join("prds")).await.unwrap();
+
+        let id = crate::artifact::identity::AgentIdentity::unknown();
+        let result = stamp_agent_identity(&ws, "PRD-404", "prd", "Missing", &id).await;
+        assert!(result.is_err(), "should propagate the read error");
     }
 }

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -34,3 +34,4 @@ semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
 tempfile = "3"
+serde_yaml.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.23.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.24.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use tokio::sync::RwLock;
 
 use forgeplan_core::artifact::frontmatter::Frontmatter;
+use forgeplan_core::artifact::identity::AgentIdentity;
 use forgeplan_core::artifact::types::{ArtifactKind, Mode};
 use forgeplan_core::db::store::{ArtifactFilter, ArtifactRecord, LanceStore, NewArtifact};
 use forgeplan_core::estimate::{
@@ -37,6 +38,13 @@ pub struct ForgeplanServer {
     store: Arc<RwLock<Option<Arc<LanceStore>>>>,
     workspace_root: PathBuf,
     workspace_path: Arc<RwLock<Option<PathBuf>>>,
+    /// Cached identity of the calling MCP client (`name/version`).
+    /// Populated lazily from `context.peer.peer_info()` in `call_tool` and
+    /// read by write handlers to stamp `last_modified_by` on artifacts
+    /// (PRD-057 FR-009 + AC-5). A single connection has one immutable
+    /// client identity set during `initialize`, so a plain RwLock is
+    /// sufficient — no per-request plumbing needed.
+    current_identity: Arc<RwLock<Option<AgentIdentity>>>,
     tool_router: ToolRouter<Self>,
 }
 
@@ -53,7 +61,34 @@ impl ForgeplanServer {
             store: Arc::new(RwLock::new(store)),
             workspace_root,
             workspace_path: Arc::new(RwLock::new(ws)),
+            current_identity: Arc::new(RwLock::new(None)),
             tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Best-effort stamp of `last_modified_by` / `last_modified_at` onto an
+    /// artifact file. No-op when no MCP client identity has been captured
+    /// yet (e.g. the very first tool call, before `initialize` is parsed).
+    /// Stamp failures are logged via `tracing::warn!` but never propagate —
+    /// identity tracking must never block a legitimate write.
+    async fn stamp_identity_best_effort(
+        &self,
+        ws: &std::path::Path,
+        id: &str,
+        kind: &str,
+        title: &str,
+    ) {
+        let identity = match self.current_identity.read().await.as_ref() {
+            Some(id) => id.clone(),
+            None => return,
+        };
+        if let Err(e) = projection::stamp_agent_identity(ws, id, kind, title, &identity).await {
+            tracing::warn!(
+                "stamp_agent_identity failed for {} ({}): {}",
+                id,
+                identity.as_frontmatter_value(),
+                e
+            );
         }
     }
 
@@ -1088,6 +1123,11 @@ impl ForgeplanServer {
         .await
         .map_err(|e| McpError::internal_error(format!("Projection failed: {e}"), None))?;
 
+        // PRD-057 FR-009: stamp the creator onto the fresh artifact so the
+        // first modifier is attributable even without an update call.
+        self.stamp_identity_best_effort(&ws, &id, template_key, &p.title)
+            .await;
+
         // PRD-056: initialize advisory phase state to `shape`. Advisory
         // only — a failure here is logged and does not break creation.
         maybe_init_phase(&ws, &id, "forgeplan_new").await;
@@ -1868,6 +1908,12 @@ impl ForgeplanServer {
             )
             .await;
         }
+
+        // PRD-057 FR-009 + AC-5: stamp last_modified_by/at on the freshly
+        // rendered file. Best-effort — a stamping failure must not fail
+        // the update response.
+        self.stamp_identity_best_effort(&ws, &updated.id, &updated.kind, &updated.title)
+            .await;
 
         let safe_id = sanitize_for_hint(&updated.id);
         let next_action = match updated.status.as_str() {
@@ -5667,6 +5713,25 @@ impl rmcp::ServerHandler for ForgeplanServer {
             .map(|obj| serde_json::Value::Object(obj.clone()))
             .unwrap_or(serde_json::Value::Null);
 
+        // PRD-057 FR-009: capture caller identity from the MCP `initialize`
+        // handshake. `peer_info()` returns `None` until the handshake lands,
+        // after which it returns the same value for every subsequent call
+        // on this connection. Cheap to re-check on every call; writing only
+        // happens when the value actually changes.
+        let peer_client_info = context
+            .peer
+            .peer_info()
+            .map(|ci| (ci.client_info.name.clone(), ci.client_info.version.clone()));
+        let client_info_tuple = peer_client_info.clone();
+        if let Some((name, version)) = peer_client_info
+            && let Some(new_identity) = AgentIdentity::new(name, version)
+        {
+            let mut guard = self.current_identity.write().await;
+            if guard.as_ref() != Some(&new_identity) {
+                *guard = Some(new_identity);
+            }
+        }
+
         let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, params, context);
         let result = self.tool_router.call(tcc).await;
 
@@ -5681,13 +5746,20 @@ impl rmcp::ServerHandler for ForgeplanServer {
         // workspace not initialized (first-run `forgeplan_init`).
         if let Some(ws) = self.workspace_path.read().await.as_ref() {
             let ws = ws.clone();
+            // PRD-057 FR-009: pass the captured name/version into the
+            // activity log so retrospective audits can reconstruct *which*
+            // agent did what. Previously this was always `None`.
+            let ci = client_info_tuple.map(|(n, v)| forgeplan_core::activity::ClientInfo {
+                name: n,
+                version: if v.is_empty() { None } else { Some(v) },
+            });
             let entry = forgeplan_core::activity::make_entry(
                 tool_name,
                 &args_val,
                 duration_ms,
                 status,
                 &ws,
-                None,  // client_info not exposed by rmcp 1.2 API — future work
+                ci,
                 false, // include_args: off by default (PRD-054 FR-004)
             );
             // Fire-and-forget: spawn so we don't block the response.
@@ -6262,5 +6334,134 @@ mod sanitize_for_hint_tests {
         assert!(!clean.contains('\u{200B}'));
         assert!(!clean.contains('\u{202E}'));
         assert!(!clean.contains('`'));
+    }
+}
+
+// ── PRD-057 Inc 2: agent identity wiring tests ──────────────────────
+#[cfg(test)]
+mod agent_identity_tests {
+    //! Verifies `stamp_identity_best_effort` behavior on `ForgeplanServer`
+    //! — the piece that ties `peer.peer_info()` capture in `call_tool` to
+    //! `projection::stamp_agent_identity` on each write handler. The MCP
+    //! handshake itself isn't exercised here (that's covered by rmcp's own
+    //! test harness); we validate the *server-side* contract: given a
+    //! captured identity, writes must result in stamped frontmatter.
+    //!
+    //! PRD-057 FR-009 + AC-5.
+
+    use super::*;
+    use forgeplan_core::artifact::identity::AgentIdentity;
+    use tempfile::TempDir;
+
+    async fn setup_server_with_artifact() -> (ForgeplanServer, TempDir, PathBuf) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = root.join(".forgeplan");
+        tokio::fs::create_dir_all(ws.join("prds")).await.unwrap();
+
+        // Pre-render a minimal artifact so stamp has something to update.
+        projection::render_projection(
+            &ws,
+            "PRD-900",
+            "prd",
+            "Stamp Target",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            "## Body\n\nContent.",
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let server = ForgeplanServer::new(root).await;
+        (server, tmp, ws)
+    }
+
+    #[tokio::test]
+    async fn stamp_best_effort_is_noop_without_captured_identity() {
+        let (server, _tmp, ws) = setup_server_with_artifact().await;
+        // current_identity starts as None — handshake hasn't been simulated.
+        server
+            .stamp_identity_best_effort(&ws, "PRD-900", "prd", "Stamp Target")
+            .await;
+
+        let content = tokio::fs::read_to_string(ws.join("prds/PRD-900-stamp-target.md"))
+            .await
+            .unwrap();
+        assert!(
+            !content.contains("last_modified_by"),
+            "stamp must not emit fields when identity is unknown"
+        );
+    }
+
+    #[tokio::test]
+    async fn stamp_best_effort_writes_captured_identity() {
+        let (server, _tmp, ws) = setup_server_with_artifact().await;
+        // Simulate `call_tool` having captured the client identity during
+        // handshake. This is exactly the value `peer.peer_info()` resolves.
+        *server.current_identity.write().await =
+            Some(AgentIdentity::new("orchestrator", "1.0").unwrap());
+
+        server
+            .stamp_identity_best_effort(&ws, "PRD-900", "prd", "Stamp Target")
+            .await;
+
+        let content = tokio::fs::read_to_string(ws.join("prds/PRD-900-stamp-target.md"))
+            .await
+            .unwrap();
+        assert!(
+            content.contains("last_modified_by: orchestrator/1.0"),
+            "AC-5 shape: {{name}}/{{version}}\n{content}"
+        );
+        assert!(
+            content.contains("last_modified_at:"),
+            "last_modified_at must be present (RFC3339 timestamp)"
+        );
+    }
+
+    #[tokio::test]
+    async fn stamp_best_effort_swallows_missing_file_error() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        tokio::fs::create_dir_all(root.join(".forgeplan/prds"))
+            .await
+            .unwrap();
+        let ws = root.join(".forgeplan");
+        let server = ForgeplanServer::new(root).await;
+        *server.current_identity.write().await = Some(AgentIdentity::new("agent", "1.0").unwrap());
+
+        // No pre-rendered file exists → stamp should fail internally but
+        // return without panicking (best-effort contract).
+        server
+            .stamp_identity_best_effort(&ws, "PRD-NOPE", "prd", "Missing")
+            .await;
+        // Success = we got here without a panic.
+    }
+
+    #[tokio::test]
+    async fn stamp_is_idempotent_across_reruns() {
+        let (server, _tmp, ws) = setup_server_with_artifact().await;
+        *server.current_identity.write().await =
+            Some(AgentIdentity::new("agent-a", "1.0").unwrap());
+
+        server
+            .stamp_identity_best_effort(&ws, "PRD-900", "prd", "Stamp Target")
+            .await;
+        server
+            .stamp_identity_best_effort(&ws, "PRD-900", "prd", "Stamp Target")
+            .await;
+
+        let content = tokio::fs::read_to_string(ws.join("prds/PRD-900-stamp-target.md"))
+            .await
+            .unwrap();
+        // Field should appear exactly once (second call overwrote, not appended).
+        let occurrences = content.matches("last_modified_by:").count();
+        assert_eq!(
+            occurrences, 1,
+            "identity must be set, not appended:\n{content}"
+        );
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5473,11 +5473,21 @@ impl ForgeplanServer {
             },
         };
 
+        // R2 audit LOW (security): clamp TTL at the MCP boundary so the
+        // hint the agent sees matches the documented bound (1..=1440
+        // minutes). Without this the Core backend still rejected overlong
+        // values, but the schema advertised "max 1440" — mismatch.
+        const MAX_TTL_MINUTES: u32 = 1440; // 24 h — matches claim::MAX_TTL
         let ttl = match p.ttl_minutes {
-            Some(m) if m > 0 => chrono::Duration::minutes(m as i64),
-            Some(_) => {
-                return Ok(err_result("ttl_minutes must be > 0"));
+            Some(0) => {
+                return Ok(err_result("ttl_minutes must be >= 1"));
             }
+            Some(m) if m > MAX_TTL_MINUTES => {
+                return Ok(err_result(&format!(
+                    "ttl_minutes must be <= {MAX_TTL_MINUTES} (24 hours)"
+                )));
+            }
+            Some(m) => chrono::Duration::minutes(m as i64),
             None => forgeplan_core::claim::DEFAULT_TTL,
         };
 
@@ -5542,11 +5552,17 @@ impl ForgeplanServer {
             }
         };
 
+        // R2 audit HIGH #3 (rust-pro): resolve agent deterministically.
+        // Priority: explicit > cached MCP identity > force with sentinel.
+        // This keeps `force: true` without agent legitimate (orchestrator
+        // reaping a stuck holder) while surfacing a clear error for the
+        // accidental `force: false + no agent + no identity` case — the
+        // previously ambiguous state the audit flagged.
         let agent = match p.agent.as_deref() {
             Some(a) if !a.trim().is_empty() => a.trim().to_string(),
-            _ if p.force => String::new(), // force=true allows empty agent
             _ => match self.current_identity.read().await.as_ref() {
                 Some(id) => id.as_frontmatter_value(),
+                None if p.force => String::new(),
                 None => {
                     return Ok(err_hinted(
                         "no agent identity — pass `agent` explicitly, set force=true, or wait for \
@@ -5591,6 +5607,12 @@ impl ForgeplanServer {
             open_world_hint = false,
         )
     )]
+    // R2 audit MED (architect): `forgeplan_claims` is read-only — it MUST
+    // NOT hold the exclusive workspace lock, otherwise an orchestrator
+    // polling at 1 Hz will serialize every sub-agent write. The list
+    // operation reads a directory of small YAML files; each file is
+    // individually parsed, so a partial-read race yields a skipped file
+    // (counted in `skipped_count`) rather than corruption.
     async fn forgeplan_claims(
         &self,
         Parameters(_p): Parameters<ClaimsListParams>,
@@ -5601,15 +5623,23 @@ impl ForgeplanServer {
         };
 
         let store = forgeplan_core::claim::ClaimStore::new(&ws);
-        match store.list_active().await {
-            Ok(claims) => {
+        match store.list_active_with_stats().await {
+            Ok((claims, skipped)) => {
                 let count = claims.len();
                 let dto = ClaimsListResponse {
                     count,
+                    skipped,
                     claims: claims.into_iter().map(ClaimDto::from).collect(),
                 };
-                let hint = if count == 0 {
+                let hint = if count == 0 && skipped == 0 {
                     "No active claims. Workspace is free for any agent to claim work.".to_string()
+                } else if skipped > 0 {
+                    format!(
+                        "{count} active claim{}, {skipped} malformed file{} skipped (see server \
+                         logs). Run `forgeplan health` to surface the offenders.",
+                        if count == 1 { "" } else { "s" },
+                        if skipped == 1 { "" } else { "s" },
+                    )
                 } else {
                     format!(
                         "{count} active claim{}. Use `forgeplan_dispatch` (when implemented) \

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -156,6 +156,60 @@ fn err_hinted(msg: &str, next_action: impl Into<String>) -> CallToolResult {
     CallToolResult::error(vec![Content::text(body)])
 }
 
+/// Read the dispatcher-relevant frontmatter fields from an artifact's
+/// markdown projection: `affected_files` (list of strings), `domain`
+/// (string), and `parent_epic` (string). The first two are agent-owned
+/// extras preserved by Inc 2's `KNOWN_FM_KEYS` + `filter_preserved`
+/// machinery; `parent_epic` is a regenerated field we also surface here
+/// so the dispatch handler avoids a second DB round-trip per candidate.
+/// Missing / malformed fields fall back to empty list / None — safer
+/// than erroring the whole dispatch request over one stale artifact.
+/// PRD-057 FR-002, FR-010.
+async fn read_dispatch_fm_fields(
+    ws: &std::path::Path,
+    kind: &str,
+    id: &str,
+    title: &str,
+) -> (Vec<String>, Option<String>, Option<String>) {
+    let artifact_kind = match kind.parse::<ArtifactKind>() {
+        Ok(k) => k,
+        Err(_) => return (Vec::new(), None, None),
+    };
+    let dir = ws.join(artifact_kind.dir_name());
+    let filename = format!(
+        "{}-{}.md",
+        id,
+        forgeplan_core::artifact::types::slugify(title)
+    );
+    let path = dir.join(filename);
+    let content = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(_) => return (Vec::new(), None, None),
+    };
+    let fm = match forgeplan_core::artifact::frontmatter::parse_frontmatter(&content) {
+        Ok((fm, _)) => fm,
+        Err(_) => return (Vec::new(), None, None),
+    };
+    let files = fm
+        .get("affected_files")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let domain = fm
+        .get("domain")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let parent_epic = fm
+        .get("parent_epic")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    (files, domain, parent_epic)
+}
+
 /// Standardised "artifact not found" error with recovery hint.
 ///
 /// Sanitizes the user-supplied id to block prompt-injection via crafted
@@ -5653,6 +5707,125 @@ impl ForgeplanServer {
         }
     }
 
+    // ── PRD-057 Inc 4: orchestrator dispatcher ───────────────────────
+
+    #[tool(
+        description = "Compute a parallel-safe work plan for N sub-agents. Returns buckets \
+                       (one per agent), a serial queue for leftover work, and human-readable \
+                       reasoning for every placement decision. Skips artifacts already claimed, \
+                       defers artifacts with file-overlap >= threshold (default Jaccard 0.3), \
+                       and when agent_skills is provided routes by domain match. \
+                       Read-only — does not mutate workspace state.",
+        annotations(
+            title = "Dispatch Work Plan",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_dispatch(
+        &self,
+        Parameters(p): Parameters<DispatchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+        let store = match self.require_store().await {
+            Ok(s) => s,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        if p.agents == 0 {
+            return Ok(err_result("agents must be >= 1"));
+        }
+        let threshold = p
+            .overlap_threshold
+            .unwrap_or(forgeplan_core::dispatch::DEFAULT_OVERLAP_THRESHOLD);
+        if !(0.0..=1.0).contains(&threshold) {
+            return Ok(err_result("overlap_threshold must be in [0.0, 1.0]"));
+        }
+
+        // Default status filter is `draft` — those are the artifacts most
+        // likely to be dispatch-able work. Callers can pass `"any"` to
+        // override.
+        let status_filter = p.status.as_deref().unwrap_or("draft");
+        let filter = ArtifactFilter {
+            kind: p.kind.clone(),
+            status: if status_filter == "any" {
+                None
+            } else {
+                Some(status_filter.to_string())
+            },
+        };
+        let summaries = store
+            .list_artifacts(Some(&filter))
+            .await
+            .map_err(|e| McpError::internal_error(format!("list_artifacts: {e}"), None))?;
+
+        // Hydrate the dispatch-relevant fields. `ArtifactSummary` lacks
+        // `parent_epic`; that plus `affected_files` + `domain` all live in
+        // the markdown frontmatter (files are source of truth per ADR-003,
+        // and Inc 2's KNOWN_FM_KEYS logic preserves the agent-owned
+        // extras across LanceDB re-renders).
+        let epic_filter = p.epic.as_deref();
+        let mut candidates = Vec::with_capacity(summaries.len());
+        for summary in &summaries {
+            let (affected_files, domain, parent_epic) =
+                read_dispatch_fm_fields(&ws, &summary.kind, &summary.id, &summary.title).await;
+            // Apply epic filter post-hydration — this is a small workspace
+            // (2-5 agents, O(50) candidates) so a pass is cheap.
+            if let Some(wanted) = epic_filter
+                && parent_epic.as_deref() != Some(wanted)
+            {
+                continue;
+            }
+            candidates.push(forgeplan_core::dispatch::ArtifactCandidate {
+                id: summary.id.clone(),
+                affected_files,
+                domain,
+            });
+        }
+        let candidate_count = candidates.len();
+
+        let claim_store = forgeplan_core::claim::ClaimStore::new(&ws);
+        let claimed_map = claim_store
+            .list_active_map()
+            .await
+            .map_err(|e| McpError::internal_error(format!("list_active_map: {e}"), None))?;
+        let claimed_count = claimed_map.len();
+        let claimed_set: std::collections::HashSet<String> = claimed_map.into_keys().collect();
+
+        let plan = forgeplan_core::dispatch::compute_dispatch_plan(
+            &candidates,
+            p.agents,
+            &p.agent_skills,
+            &claimed_set,
+            threshold,
+        );
+
+        let dto = DispatchResponse {
+            buckets: plan.buckets,
+            serial_queue: plan.serial_queue,
+            reasoning: plan.reasoning,
+            generated_at: plan.generated_at,
+            agent_count: plan.agent_count,
+            overlap_threshold: plan.overlap_threshold,
+            candidate_count,
+            claimed_count,
+        };
+
+        let parallel = dto.buckets.iter().filter(|b| !b.is_empty()).count();
+        let hint = format!(
+            "Plan ready: {candidate_count} candidate(s), {parallel} parallel bucket(s), \
+             {} serial, {claimed_count} already-claimed skipped. Hand buckets[i] to sub-agent \
+             i; re-dispatch when a sub-agent calls `forgeplan_release`.",
+            dto.serial_queue.len(),
+        );
+        hinted_result(&dto, hint)
+    }
+
     // ── Undo / Restore tools (PRD-055 increment 3) ───────────────────
 
     #[tool(
@@ -6883,6 +7056,40 @@ mod claim_mcp_tests {
             .unwrap();
 
         assert!(store.get("PRD-105").await.unwrap().is_none());
+    }
+
+    // ── PRD-057 Inc 4: dispatch MCP wiring smoke test ────────────────
+
+    #[tokio::test]
+    async fn dispatch_validates_agent_count_and_threshold() {
+        let (server, _tmp) = initialized_server().await;
+        // agents=0 → error
+        let r = server
+            .forgeplan_dispatch(Parameters(DispatchParams {
+                agents: 0,
+                kind: None,
+                epic: None,
+                status: None,
+                agent_skills: vec![],
+                overlap_threshold: None,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(r.is_error, Some(true), "agents=0 must error");
+
+        // threshold outside [0, 1] → error
+        let r = server
+            .forgeplan_dispatch(Parameters(DispatchParams {
+                agents: 2,
+                kind: None,
+                epic: None,
+                status: None,
+                agent_skills: vec![],
+                overlap_threshold: Some(1.5),
+            }))
+            .await
+            .unwrap();
+        assert_eq!(r.is_error, Some(true), "threshold > 1.0 must error");
     }
 
     #[tokio::test]

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -7271,6 +7271,454 @@ mod claim_mcp_tests {
         assert_eq!(r.is_error, Some(true), "threshold > 1.0 must error");
     }
 
+    // ── PRD-057 full multi-agent flow edge cases (R3 dogfood) ───────
+
+    /// Like `initialized_server` but also initializes LanceDB so the
+    /// dispatcher / claim store / artifact tools work end-to-end.
+    async fn initialized_server_with_store() -> (ForgeplanServer, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = forgeplan_core::workspace::init_workspace(&root, "dogfood").unwrap();
+        let store = forgeplan_core::db::store::LanceStore::init(&ws)
+            .await
+            .unwrap();
+        let server = ForgeplanServer::new(root).await;
+        *server.workspace_path.write().await = Some(ws);
+        *server.store.write().await = Some(std::sync::Arc::new(store));
+        (server, tmp)
+    }
+
+    /// Seed a real artifact through the full pipeline used by production.
+    /// Mirrors `forgeplan_new` + `forgeplan_update` without the MCP round-trip.
+    /// Uses the same `LanceStore` handle the server does — important because
+    /// independently-opened handles may not observe each other's writes
+    /// until a flush.
+    async fn seed_real_prd(
+        server: &ForgeplanServer,
+        ws: &std::path::Path,
+        id: &str,
+        title: &str,
+        affected_files: &[&str],
+        domain: Option<&str>,
+    ) {
+        let store = server
+            .store
+            .read()
+            .await
+            .clone()
+            .expect("store initialized");
+        let artifact = forgeplan_core::db::store::NewArtifact {
+            id: id.into(),
+            kind: "prd".into(),
+            status: "draft".into(),
+            title: title.into(),
+            body: format!("# {id}\n\nBody."),
+            depth: "standard".into(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&artifact).await.unwrap();
+        projection::render_projection(
+            ws,
+            id,
+            "prd",
+            title,
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            &artifact.body,
+            &[],
+        )
+        .await
+        .unwrap();
+
+        if affected_files.is_empty() && domain.is_none() {
+            return;
+        }
+        let path = ws.join(format!(
+            "prds/{id}-{}.md",
+            forgeplan_core::artifact::types::slugify(title)
+        ));
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        let (mut fm, body) =
+            forgeplan_core::artifact::frontmatter::parse_frontmatter(&content).unwrap();
+        if !affected_files.is_empty() {
+            let seq: Vec<serde_yaml::Value> = affected_files
+                .iter()
+                .map(|f| serde_yaml::Value::String((*f).to_string()))
+                .collect();
+            fm.insert(
+                "affected_files".to_string(),
+                serde_yaml::Value::Sequence(seq),
+            );
+        }
+        if let Some(d) = domain {
+            fm.insert(
+                "domain".to_string(),
+                serde_yaml::Value::String(d.to_string()),
+            );
+        }
+        let new_content =
+            forgeplan_core::artifact::frontmatter::render_frontmatter(&fm, &body).unwrap();
+        tokio::fs::write(&path, new_content).await.unwrap();
+    }
+
+    fn dp(agents: usize) -> DispatchParams {
+        DispatchParams {
+            agents,
+            kind: None,
+            epic: None,
+            status: None,
+            agent_skills: vec![],
+            overlap_threshold: None,
+        }
+    }
+
+    fn extract_ids_flat(buckets: &serde_json::Value) -> Vec<String> {
+        buckets
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|b| {
+                b.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_str().unwrap().to_string())
+            })
+            .collect()
+    }
+
+    fn response_json(r: &CallToolResult) -> serde_json::Value {
+        assert_ne!(r.is_error, Some(true), "tool returned is_error=true");
+        match &r.content[0].raw {
+            rmcp::model::RawContent::Text(t) => serde_json::from_str(&t.text).unwrap(),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_empty_workspace() {
+        let (server, _tmp) = initialized_server_with_store().await;
+        let r = server.forgeplan_dispatch(Parameters(dp(3))).await.unwrap();
+        let body = response_json(&r);
+        assert_eq!(body["candidate_count"].as_u64().unwrap(), 0);
+        assert!(
+            body["buckets"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|b| b.as_array().unwrap().is_empty()),
+            "empty workspace → no plan work"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_one_agent_with_conflict_serializes_rest() {
+        // With only 1 agent, disjoint-file PRDs can STILL share that agent
+        // (they go sequentially). To force `serial_queue` → use overlapping
+        // files so the second truly conflicts with the bucket-resident.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-930", "A", &["shared.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-931", "B", &["shared.rs"], None).await;
+
+        let r = server.forgeplan_dispatch(Parameters(dp(1))).await.unwrap();
+        let body = response_json(&r);
+        assert_eq!(
+            body["buckets"][0].as_array().unwrap().len(),
+            1,
+            "single agent takes first"
+        );
+        assert_eq!(
+            body["serial_queue"].as_array().unwrap().len(),
+            1,
+            "conflict forces second to serial"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_five_agents_distribute_evenly() {
+        // PRD-057 target upper bound.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        for i in 0..5 {
+            seed_real_prd(
+                &server,
+                &ws,
+                &format!("PRD-94{i}"),
+                &format!("PRD {i}"),
+                &[&format!("f{i}.rs")],
+                None,
+            )
+            .await;
+        }
+        let r = server.forgeplan_dispatch(Parameters(dp(5))).await.unwrap();
+        let body = response_json(&r);
+        for b in body["buckets"].as_array().unwrap() {
+            assert_eq!(
+                b.as_array().unwrap().len(),
+                1,
+                "each agent gets exactly one"
+            );
+        }
+        assert!(body["serial_queue"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_agents_over_max_rejected() {
+        let (server, _tmp) = initialized_server_with_store().await;
+        let r = server
+            .forgeplan_dispatch(Parameters(DispatchParams {
+                agents: 10_000,
+                kind: None,
+                epic: None,
+                status: None,
+                agent_skills: vec![],
+                overlap_threshold: None,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(r.is_error, Some(true), "agents > MAX_AGENTS must error");
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_markdown_section_fallback() {
+        // R3 audit HIGH: legacy artifact with only `## Affected Files`
+        // section (no FM key) must still be eligible for parallel buckets.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        let store = forgeplan_core::db::store::LanceStore::open(&ws)
+            .await
+            .unwrap();
+        let body_with_section = "## Summary\n\nx\n\n## Affected Files\n\n- crates/legacy/main.rs\n- crates/legacy/helper.rs\n";
+        let artifact = forgeplan_core::db::store::NewArtifact {
+            id: "PRD-950".into(),
+            kind: "prd".into(),
+            status: "draft".into(),
+            title: "Legacy".into(),
+            body: body_with_section.into(),
+            depth: "standard".into(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&artifact).await.unwrap();
+        projection::render_projection(
+            &ws,
+            "PRD-950",
+            "prd",
+            "Legacy",
+            "draft",
+            "standard",
+            None,
+            None,
+            None,
+            &artifact.body,
+            &[],
+        )
+        .await
+        .unwrap();
+
+        seed_real_prd(
+            &server,
+            &ws,
+            "PRD-951",
+            "Modern",
+            &["apps/web/other.tsx"],
+            None,
+        )
+        .await;
+
+        let r = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let body = response_json(&r);
+        let ids = extract_ids_flat(&body["buckets"]);
+        assert!(
+            ids.contains(&"PRD-950".to_string()),
+            "markdown-section fallback must hydrate files — R3 HIGH regression guard: {ids:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_blocked_artifact_skipped() {
+        // FR-003: blocked by draft parent → skipped from plan.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        seed_real_prd(&server, &ws, "PRD-960", "Parent", &["a.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-961", "Child", &["b.rs"], None).await;
+        // Use the server's own store handle so the relation and subsequent
+        // list_records/get_all_relations calls observe the same state.
+        let store = server
+            .store
+            .read()
+            .await
+            .clone()
+            .expect("store initialized");
+        store
+            .add_relation("PRD-961", "PRD-960", "based_on")
+            .await
+            .unwrap();
+
+        let r = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let body = response_json(&r);
+        let ids = extract_ids_flat(&body["buckets"]);
+        assert!(
+            !ids.contains(&"PRD-961".to_string()),
+            "PRD-961 must be excluded — blocked by draft parent"
+        );
+        assert!(
+            body["blocked_count"].as_u64().unwrap() >= 1,
+            "blocked_count must reflect the skip"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_claim_release_full_cycle() {
+        // Full MCP round-trip: seed → claim → dispatch skips → release → dispatch restores.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-970", "A", &["a/x.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-971", "B", &["b/y.rs"], None).await;
+
+        server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-970".into(),
+                agent: Some("worker-1".into()),
+                ttl_minutes: Some(30),
+                note: None,
+            }))
+            .await
+            .unwrap();
+
+        let r = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let body = response_json(&r);
+        assert_eq!(body["claimed_count"].as_u64().unwrap(), 1);
+        let ids = extract_ids_flat(&body["buckets"]);
+        assert_eq!(ids, vec!["PRD-971"]);
+
+        server
+            .forgeplan_release(Parameters(ReleaseParams {
+                id: "PRD-970".into(),
+                agent: Some("worker-1".into()),
+                force: false,
+            }))
+            .await
+            .unwrap();
+
+        let r2 = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let body2 = response_json(&r2);
+        assert_eq!(body2["claimed_count"].as_u64().unwrap(), 0);
+        assert_eq!(body2["candidate_count"].as_u64().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_skill_routing_end_to_end() {
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(
+            &server,
+            &ws,
+            "PRD-980",
+            "API",
+            &["crates/api/gate.rs"],
+            Some("backend"),
+        )
+        .await;
+        seed_real_prd(
+            &server,
+            &ws,
+            "PRD-981",
+            "UI",
+            &["apps/web/landing.tsx"],
+            Some("frontend"),
+        )
+        .await;
+
+        let params = DispatchParams {
+            agents: 2,
+            kind: None,
+            epic: None,
+            status: None,
+            agent_skills: vec![vec!["backend".into()], vec!["frontend".into()]],
+            overlap_threshold: None,
+        };
+        let r = server.forgeplan_dispatch(Parameters(params)).await.unwrap();
+        let body = response_json(&r);
+        assert_eq!(body["buckets"][0][0].as_str().unwrap(), "PRD-980");
+        assert_eq!(body["buckets"][1][0].as_str().unwrap(), "PRD-981");
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_health_surfaces_claims() {
+        // FR-012 verification through full MCP surface.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-990", "A", &["a.rs"], None).await;
+
+        server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-990".into(),
+                agent: Some("auditor/1".into()),
+                ttl_minutes: Some(30),
+                note: None,
+            }))
+            .await
+            .unwrap();
+
+        let r = server.forgeplan_health().await.unwrap();
+        let body = response_json(&r);
+        assert_eq!(
+            body["active_claim_count"].as_u64().unwrap(),
+            1,
+            "FR-012: health must surface active claim count"
+        );
+        let claims = body["active_claims"].as_array().unwrap();
+        assert_eq!(claims.len(), 1);
+        assert_eq!(claims[0]["id"].as_str().unwrap(), "PRD-990");
+        assert_eq!(claims[0]["agent_id"].as_str().unwrap(), "auditor/1");
+    }
+
+    #[tokio::test]
+    async fn dispatch_dogfood_get_surfaces_claim_info() {
+        // FR-013 verification.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-991", "Claimed artifact", &["x.rs"], None).await;
+
+        server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-991".into(),
+                agent: Some("agent-1/1.0".into()),
+                ttl_minutes: Some(15),
+                note: None,
+            }))
+            .await
+            .unwrap();
+
+        let r = server
+            .forgeplan_get(Parameters(GetParams {
+                id: "PRD-991".into(),
+            }))
+            .await
+            .unwrap();
+        // Response is CallToolResult with structured Content — the hint
+        // block ("_next_action") should mention the claim holder.
+        let body = response_json(&r);
+        // The `_next_action` field is injected by hinted_result wrapper.
+        let hint_text = body["_next_action"].as_str().unwrap_or("").to_string();
+        assert!(
+            hint_text.contains("Claim")
+                && (hint_text.contains("agent-1") || hint_text.contains("agent_1")),
+            "FR-013: _next_action must surface claim holder — got: {hint_text}"
+        );
+    }
+
     // ── PRD-057 AC-4: concurrent forgeplan_new → unique IDs ──────────
 
     #[tokio::test]

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -7719,6 +7719,195 @@ mod claim_mcp_tests {
         );
     }
 
+    // ── PRD-057 workflow variations: filter combinations + threshold ──
+
+    #[tokio::test]
+    async fn dispatch_workflow_kind_filter_narrows_candidates() {
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-A01", "Prd one", &["a.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-A02", "Prd two", &["b.rs"], None).await;
+        // Seed a non-PRD artifact through the store directly.
+        {
+            let store = server.store.read().await.clone().unwrap();
+            let artifact = forgeplan_core::db::store::NewArtifact {
+                id: "RFC-A01".into(),
+                kind: "rfc".into(),
+                status: "draft".into(),
+                title: "An RFC".into(),
+                body: "# RFC\n".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            };
+            store.create_artifact(&artifact).await.unwrap();
+        }
+
+        let mut params = dp(2);
+        params.kind = Some("prd".into());
+        let r = server.forgeplan_dispatch(Parameters(params)).await.unwrap();
+        let body = response_json(&r);
+
+        let all_ids = extract_ids_flat(&body["buckets"]);
+        let serial: Vec<String> = body["serial_queue"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        let visible: std::collections::HashSet<&String> =
+            all_ids.iter().chain(serial.iter()).collect();
+        assert!(
+            !visible.contains(&"RFC-A01".to_string()),
+            "kind=prd filter must exclude RFC-A01"
+        );
+        assert!(visible.contains(&"PRD-A01".to_string()));
+        assert!(visible.contains(&"PRD-A02".to_string()));
+    }
+
+    #[tokio::test]
+    async fn dispatch_workflow_threshold_zero_serializes_all_sharing_any_file() {
+        // threshold=0.0 is the conservative extreme — any shared file at
+        // all makes the pair conflict. With 3 artifacts all sharing one
+        // file and only 2 agents, the third must serialize.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-T01", "A", &["a.rs", "shared.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-T02", "B", &["b.rs", "shared.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-T03", "C", &["c.rs", "shared.rs"], None).await;
+
+        let mut params = dp(2);
+        params.overlap_threshold = Some(0.0);
+        let r = server.forgeplan_dispatch(Parameters(params)).await.unwrap();
+        let body = response_json(&r);
+        let bucket_count: usize = body["buckets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_array().unwrap().len())
+            .sum();
+        // Two agents, each takes one that shares with the other's resident
+        // — wait, any non-empty intersection conflicts at threshold=0, so
+        // the SECOND one on each bucket conflicts too. Only 2 fit total.
+        assert!(
+            bucket_count <= 2,
+            "threshold=0 bucket count should be at most agents"
+        );
+        assert!(
+            !body["serial_queue"].as_array().unwrap().is_empty(),
+            "at least one must serialize when all share a file"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_workflow_threshold_one_allows_maximum_parallelism() {
+        // threshold=1.0: only identical file sets conflict. Non-identical
+        // partial overlap → parallelized.
+        let (server, _tmp) = initialized_server_with_store().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        seed_real_prd(&server, &ws, "PRD-T10", "A", &["a.rs", "shared.rs"], None).await;
+        seed_real_prd(&server, &ws, "PRD-T11", "B", &["b.rs", "shared.rs"], None).await;
+
+        let mut params = dp(2);
+        params.overlap_threshold = Some(1.0);
+        let r = server.forgeplan_dispatch(Parameters(params)).await.unwrap();
+        let body = response_json(&r);
+        let bucket_count: usize = body["buckets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|b| b.as_array().unwrap().len())
+            .sum();
+        assert_eq!(
+            bucket_count, 2,
+            "threshold=1.0 allows non-identical sets to parallelize"
+        );
+        assert!(body["serial_queue"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_workflow_full_cycle_new_claim_update_release_redispatch() {
+        // End-to-end: seed via forgeplan_new → claim → verify identity
+        // stamp → release → re-dispatch. Validates Inc 2 (stamp) + Inc 3
+        // (claims) + Inc 4 (dispatch) compose cleanly across real MCP
+        // handler calls.
+        let (server, _tmp) = initialized_server_with_store().await;
+        *server.current_identity.write().await =
+            Some(AgentIdentity::new("claude-code", "1.0").unwrap());
+
+        let r_new = server
+            .forgeplan_new(Parameters(NewParams {
+                kind: ArtifactKindArg::Prd,
+                title: "Full cycle".to_string(),
+            }))
+            .await
+            .unwrap();
+        let new_body = response_json(&r_new);
+        let created_id = new_body["id"].as_str().unwrap().to_string();
+
+        let r_claim = server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: created_id.clone(),
+                agent: Some("worker-1".into()),
+                ttl_minutes: Some(15),
+                note: Some("building".into()),
+            }))
+            .await
+            .unwrap();
+        assert_ne!(r_claim.is_error, Some(true));
+
+        // Inc 2 identity stamp: forgeplan_new should have stamped.
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        let slug = forgeplan_core::artifact::types::slugify("Full cycle");
+        let path = ws.join(format!("prds/{created_id}-{slug}.md"));
+        let content = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(
+            content.contains("last_modified_by: claude-code/1.0"),
+            "Inc 2: forgeplan_new should stamp identity"
+        );
+
+        // Dispatch — the claimed artifact must be skipped.
+        let r_disp = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let d_body = response_json(&r_disp);
+        let ids = extract_ids_flat(&d_body["buckets"]);
+        assert!(
+            !ids.contains(&created_id),
+            "claimed artifact {created_id} must not appear in plan"
+        );
+
+        server
+            .forgeplan_release(Parameters(ReleaseParams {
+                id: created_id.clone(),
+                agent: Some("worker-1".into()),
+                force: false,
+            }))
+            .await
+            .unwrap();
+
+        let r_final = server.forgeplan_dispatch(Parameters(dp(2))).await.unwrap();
+        let final_body = response_json(&r_final);
+        assert_eq!(
+            final_body["claimed_count"].as_u64().unwrap(),
+            0,
+            "post-release: claim count resets to 0"
+        );
+        // Template-seeded artifact may include a `## Affected Files`
+        // section (extracted via Inc 2 fallback) or be empty — either way
+        // it must reappear somewhere once released.
+        let in_buckets = extract_ids_flat(&final_body["buckets"]).contains(&created_id);
+        let in_serial = final_body["serial_queue"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str() == Some(created_id.as_str()));
+        assert!(
+            in_buckets || in_serial,
+            "released artifact {created_id} must reappear in plan"
+        );
+    }
+
     // ── PRD-057 AC-4: concurrent forgeplan_new → unique IDs ──────────
 
     #[tokio::test]

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5420,6 +5420,209 @@ impl ForgeplanServer {
         }
     }
 
+    // ── PRD-057 Inc 3: claim protocol ────────────────────────────────
+
+    #[tool(
+        description = "Claim an artifact for exclusive work. Writes .forgeplan/claims/<id>.yaml \
+                       with the caller's agent identity, timestamp, and TTL. Fails if a live \
+                       claim by a different agent exists — same-agent calls renew the TTL. \
+                       Advisory: other tools do not block on claims, but orchestrators should \
+                       use `forgeplan_claims --active` to avoid double-assigning work.",
+        annotations(
+            title = "Claim Artifact",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_claim(
+        &self,
+        Parameters(p): Parameters<ClaimParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        // Serialize against concurrent claim/release so two sub-agents
+        // cannot simultaneously take the same artifact (PRD-057 Round 1
+        // H-2 pattern: write tools always hold the workspace lock).
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry in a few seconds — another sub-agent holds the lock.",
+                ));
+            }
+        };
+
+        // Agent resolution: caller-supplied > MCP clientInfo > error.
+        let agent = match p.agent.as_deref() {
+            Some(a) if !a.trim().is_empty() => a.trim().to_string(),
+            _ => match self.current_identity.read().await.as_ref() {
+                Some(id) => id.as_frontmatter_value(),
+                None => {
+                    return Ok(err_hinted(
+                        "no agent identity — pass `agent` explicitly or wait for MCP handshake",
+                        "Orchestrators typically pass `agent: \"worker-1\"` when delegating; \
+                         sub-agents can omit it and let Forgeplan infer from clientInfo.",
+                    ));
+                }
+            },
+        };
+
+        let ttl = match p.ttl_minutes {
+            Some(m) if m > 0 => chrono::Duration::minutes(m as i64),
+            Some(_) => {
+                return Ok(err_result("ttl_minutes must be > 0"));
+            }
+            None => forgeplan_core::claim::DEFAULT_TTL,
+        };
+
+        let store = forgeplan_core::claim::ClaimStore::new(&ws);
+        match store.claim(&p.id, &agent, ttl, p.note).await {
+            Ok(claim) => {
+                let safe_id = sanitize_for_hint(&claim.id);
+                let safe_agent = sanitize_for_hint(&claim.agent_id);
+                let hint = format!(
+                    "Claimed `{safe_id}` for `{safe_agent}`. Release with \
+                     `forgeplan_release {safe_id}` when done, or re-call `forgeplan_claim` to renew."
+                );
+                hinted_result(&ClaimDto::from(claim), hint)
+            }
+            Err(forgeplan_core::claim::ClaimError::AlreadyHeld {
+                id,
+                agent_id,
+                expires_at,
+            }) => {
+                let safe_id = sanitize_for_hint(&id);
+                let safe_agent = sanitize_for_hint(&agent_id);
+                Ok(err_hinted(
+                    &format!(
+                        "claim for {safe_id} already held by {safe_agent} (expires {expires_at})"
+                    ),
+                    "Either work on a different artifact, wait for TTL expiry, or ask the \
+                     orchestrator to force-release with `forgeplan_release --force`.",
+                ))
+            }
+            Err(e) => Ok(err_result(&format!("claim failed: {e}"))),
+        }
+    }
+
+    #[tool(
+        description = "Release an active claim. Refuses if the claim is held by a different \
+                       agent (use `force: true` to override — the orchestrator's escape hatch \
+                       for a crashed sub-agent). Missing claim is a no-op (idempotent).",
+        annotations(
+            title = "Release Claim",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_release(
+        &self,
+        Parameters(p): Parameters<ReleaseParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let _lock_guard = match forgeplan_core::workspace::acquire_workspace_lock(&ws).await {
+            Ok(g) => g,
+            Err(e) => {
+                return Ok(err_hinted(
+                    &format!("could not acquire workspace lock: {e}"),
+                    "Retry in a few seconds — another sub-agent holds the lock.",
+                ));
+            }
+        };
+
+        let agent = match p.agent.as_deref() {
+            Some(a) if !a.trim().is_empty() => a.trim().to_string(),
+            _ if p.force => String::new(), // force=true allows empty agent
+            _ => match self.current_identity.read().await.as_ref() {
+                Some(id) => id.as_frontmatter_value(),
+                None => {
+                    return Ok(err_hinted(
+                        "no agent identity — pass `agent` explicitly, set force=true, or wait for \
+                         MCP handshake",
+                        "Orchestrators force-release with `agent: null, force: true` when \
+                         reaping a crashed sub-agent.",
+                    ));
+                }
+            },
+        };
+
+        let store = forgeplan_core::claim::ClaimStore::new(&ws);
+        match store.release(&p.id, &agent, p.force).await {
+            Ok(()) => {
+                let safe_id = sanitize_for_hint(&p.id);
+                hinted_result(
+                    &serde_json::json!({"id": p.id, "released": true, "force": p.force}),
+                    format!("Released claim on `{safe_id}`."),
+                )
+            }
+            Err(forgeplan_core::claim::ClaimError::NotHeldByRequester { held_by, .. }) => {
+                let safe_holder = sanitize_for_hint(&held_by);
+                Ok(err_hinted(
+                    &format!("claim held by {safe_holder}, not you"),
+                    "Use `force: true` (orchestrator override) if the holder has crashed.",
+                ))
+            }
+            Err(e) => Ok(err_result(&format!("release failed: {e}"))),
+        }
+    }
+
+    #[tool(
+        description = "List live claims in the workspace, sorted by expiry ascending. Skips \
+                       expired claims (they're considered practically released). Used by \
+                       orchestrators to build dispatch plans and by sub-agents to avoid \
+                       double-claiming.",
+        annotations(
+            title = "List Active Claims",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false,
+        )
+    )]
+    async fn forgeplan_claims(
+        &self,
+        Parameters(_p): Parameters<ClaimsListParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ws = match self.require_workspace().await {
+            Ok(ws) => ws,
+            Err(e) => return Ok(err_result(&e)),
+        };
+
+        let store = forgeplan_core::claim::ClaimStore::new(&ws);
+        match store.list_active().await {
+            Ok(claims) => {
+                let count = claims.len();
+                let dto = ClaimsListResponse {
+                    count,
+                    claims: claims.into_iter().map(ClaimDto::from).collect(),
+                };
+                let hint = if count == 0 {
+                    "No active claims. Workspace is free for any agent to claim work.".to_string()
+                } else {
+                    format!(
+                        "{count} active claim{}. Use `forgeplan_dispatch` (when implemented) \
+                         to plan non-overlapping work.",
+                        if count == 1 { "" } else { "s" }
+                    )
+                };
+                hinted_result(&dto, hint)
+            }
+            Err(e) => Ok(err_result(&format!("list_active failed: {e}"))),
+        }
+    }
+
     // ── Undo / Restore tools (PRD-055 increment 3) ───────────────────
 
     #[tool(
@@ -6463,5 +6666,216 @@ mod agent_identity_tests {
             occurrences, 1,
             "identity must be set, not appended:\n{content}"
         );
+    }
+}
+
+// ── PRD-057 Inc 3: claim MCP tool wiring tests ──────────────────────
+#[cfg(test)]
+mod claim_mcp_tests {
+    //! Integration tests for the three claim MCP tools
+    //! (`forgeplan_claim`, `forgeplan_release`, `forgeplan_claims`).
+    //!
+    //! The goal is to verify the *wiring* — agent-identity resolution,
+    //! workspace-lock acquisition, Core ClaimStore fall-through — not to
+    //! re-test ClaimStore semantics (those are covered in forgeplan-core).
+    //!
+    //! PRD-057 FR-004..006, AC-2.
+
+    use super::*;
+    use forgeplan_core::artifact::identity::AgentIdentity;
+    use forgeplan_core::claim::ClaimStore;
+    use tempfile::TempDir;
+
+    async fn initialized_server() -> (ForgeplanServer, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = root.join(".forgeplan");
+        tokio::fs::create_dir_all(&ws).await.unwrap();
+        // Also need to satisfy require_workspace check.
+        tokio::fs::create_dir_all(ws.join("prds")).await.unwrap();
+        let server = ForgeplanServer::new(root).await;
+        // Prime the server's workspace_path (find_workspace may not pick up
+        // the test .forgeplan/).
+        *server.workspace_path.write().await = Some(ws);
+        (server, tmp)
+    }
+
+    #[tokio::test]
+    async fn claim_uses_mcp_identity_when_agent_omitted() {
+        let (server, _tmp) = initialized_server().await;
+        *server.current_identity.write().await =
+            Some(AgentIdentity::new("orchestrator", "1.0").unwrap());
+
+        let _ = server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-100".to_string(),
+                agent: None,
+                ttl_minutes: None,
+                note: None,
+            }))
+            .await
+            .unwrap();
+
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        let store = ClaimStore::new(&ws);
+        let claim = store.get("PRD-100").await.unwrap().unwrap();
+        assert_eq!(claim.agent_id, "orchestrator/1.0");
+    }
+
+    #[tokio::test]
+    async fn claim_prefers_explicit_agent_over_identity() {
+        let (server, _tmp) = initialized_server().await;
+        *server.current_identity.write().await =
+            Some(AgentIdentity::new("orchestrator", "1.0").unwrap());
+
+        let _ = server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-101".to_string(),
+                agent: Some("worker-1".to_string()),
+                ttl_minutes: Some(15),
+                note: Some("building FR-007".to_string()),
+            }))
+            .await
+            .unwrap();
+
+        let ws = server.workspace_path.read().await.clone().unwrap();
+        let store = ClaimStore::new(&ws);
+        let claim = store.get("PRD-101").await.unwrap().unwrap();
+        assert_eq!(claim.agent_id, "worker-1");
+        assert_eq!(claim.note.as_deref(), Some("building FR-007"));
+    }
+
+    #[tokio::test]
+    async fn claim_errors_when_no_identity_and_no_agent() {
+        let (server, _tmp) = initialized_server().await;
+        // current_identity left as None and no agent passed.
+
+        let result = server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-102".to_string(),
+                agent: None,
+                ttl_minutes: None,
+                note: None,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "missing identity should surface as is_error=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_rejects_existing_claim_by_different_agent() {
+        // AC-2 at the MCP boundary.
+        let (server, _tmp) = initialized_server().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        let store = ClaimStore::new(&ws);
+        store
+            .claim(
+                "PRD-103",
+                "agent-a/1",
+                forgeplan_core::claim::DEFAULT_TTL,
+                None,
+            )
+            .await
+            .unwrap();
+
+        *server.current_identity.write().await = Some(AgentIdentity::new("agent-b", "1").unwrap());
+        let result = server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-103".to_string(),
+                agent: None,
+                ttl_minutes: None,
+                note: None,
+            }))
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(true));
+    }
+
+    #[tokio::test]
+    async fn release_by_owner_removes_claim() {
+        let (server, _tmp) = initialized_server().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        *server.current_identity.write().await = Some(AgentIdentity::new("owner", "1.0").unwrap());
+
+        server
+            .forgeplan_claim(Parameters(ClaimParams {
+                id: "PRD-104".to_string(),
+                agent: None,
+                ttl_minutes: None,
+                note: None,
+            }))
+            .await
+            .unwrap();
+
+        server
+            .forgeplan_release(Parameters(ReleaseParams {
+                id: "PRD-104".to_string(),
+                agent: None,
+                force: false,
+            }))
+            .await
+            .unwrap();
+
+        let store = ClaimStore::new(&ws);
+        assert!(store.get("PRD-104").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn release_force_reaps_other_agent_claim() {
+        let (server, _tmp) = initialized_server().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        let store = ClaimStore::new(&ws);
+        store
+            .claim(
+                "PRD-105",
+                "stuck/1",
+                forgeplan_core::claim::DEFAULT_TTL,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Orchestrator force-releases without setting their own identity.
+        server
+            .forgeplan_release(Parameters(ReleaseParams {
+                id: "PRD-105".to_string(),
+                agent: None,
+                force: true,
+            }))
+            .await
+            .unwrap();
+
+        assert!(store.get("PRD-105").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn claims_list_returns_live_entries_sorted() {
+        let (server, _tmp) = initialized_server().await;
+        let ws = server.workspace_path.read().await.clone().unwrap();
+
+        let store = ClaimStore::new(&ws);
+        store
+            .claim("PRD-110", "a/1", chrono::Duration::hours(2), None)
+            .await
+            .unwrap();
+        store
+            .claim("PRD-111", "b/1", chrono::Duration::minutes(20), None)
+            .await
+            .unwrap();
+
+        let result = server
+            .forgeplan_claims(Parameters(ClaimsListParams { active: true }))
+            .await
+            .unwrap();
+        assert_ne!(result.is_error, Some(true));
+        // Full JSON verification is expensive; we trust ClaimStore tests
+        // and verify only that the call path doesn't short-circuit.
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -156,25 +156,51 @@ fn err_hinted(msg: &str, next_action: impl Into<String>) -> CallToolResult {
     CallToolResult::error(vec![Content::text(body)])
 }
 
+/// Outcome of `read_dispatch_fm_fields`, distinguishing real "no data"
+/// from "read/parse failure" so the caller can count skipped candidates
+/// (R3 audit M-4 — silent parse failures masquerading as "no files").
+#[derive(Debug, Default)]
+struct DispatchFmFields {
+    files: Vec<String>,
+    domain: Option<String>,
+    parent_epic: Option<String>,
+    /// True when the artifact file couldn't be read or parsed; caller
+    /// reports this as `skipped` rather than pretending the artifact has
+    /// no affected files (which would then serialize it via R-2 bias).
+    parse_failed: bool,
+}
+
+const AFFECTED_FILE_MAX_PATH: usize = forgeplan_core::dispatch::MAX_AFFECTED_FILE_LEN;
+const AFFECTED_FILES_MAX_LEN: usize = forgeplan_core::dispatch::MAX_AFFECTED_FILES;
+
 /// Read the dispatcher-relevant frontmatter fields from an artifact's
-/// markdown projection: `affected_files` (list of strings), `domain`
-/// (string), and `parent_epic` (string). The first two are agent-owned
-/// extras preserved by Inc 2's `KNOWN_FM_KEYS` + `filter_preserved`
-/// machinery; `parent_epic` is a regenerated field we also surface here
-/// so the dispatch handler avoids a second DB round-trip per candidate.
-/// Missing / malformed fields fall back to empty list / None — safer
-/// than erroring the whole dispatch request over one stale artifact.
-/// PRD-057 FR-002, FR-010.
+/// markdown projection: `affected_files` (list of strings or scalar),
+/// `domain` (ASCII-normalized), and `parent_epic`. Falls back to the
+/// body's `## Affected Files` section when the frontmatter key is
+/// absent (R3 audit arch HIGH — a PRD with only the markdown section
+/// would otherwise be silently serialized).
+///
+/// R3 audit LOW: id/title validated up-front even though all callers
+/// currently pass values from LanceDB — defense-in-depth against a
+/// future code path injecting unvalidated user input.
 async fn read_dispatch_fm_fields(
     ws: &std::path::Path,
     kind: &str,
     id: &str,
     title: &str,
-) -> (Vec<String>, Option<String>, Option<String>) {
+) -> DispatchFmFields {
     let artifact_kind = match kind.parse::<ArtifactKind>() {
         Ok(k) => k,
-        Err(_) => return (Vec::new(), None, None),
+        Err(_) => return DispatchFmFields::default(),
     };
+    // Defense-in-depth: refuse obvious traversal segments even though the
+    // id originated from LanceDB (R3 audit security LOW, CWE-20).
+    if id.contains('/') || id.contains('\\') || id.contains("..") {
+        return DispatchFmFields {
+            parse_failed: true,
+            ..Default::default()
+        };
+    }
     let dir = ws.join(artifact_kind.dir_name());
     let filename = format!(
         "{}-{}.md",
@@ -184,30 +210,57 @@ async fn read_dispatch_fm_fields(
     let path = dir.join(filename);
     let content = match tokio::fs::read_to_string(&path).await {
         Ok(s) => s,
-        Err(_) => return (Vec::new(), None, None),
+        Err(_) => {
+            return DispatchFmFields {
+                parse_failed: true,
+                ..Default::default()
+            };
+        }
     };
-    let fm = match forgeplan_core::artifact::frontmatter::parse_frontmatter(&content) {
-        Ok((fm, _)) => fm,
-        Err(_) => return (Vec::new(), None, None),
+    let (fm, body) = match forgeplan_core::artifact::frontmatter::parse_frontmatter(&content) {
+        Ok((fm, body)) => (fm, body),
+        Err(_) => {
+            return DispatchFmFields {
+                parse_failed: true,
+                ..Default::default()
+            };
+        }
     };
-    let files = fm
+
+    // Primary path: the `affected_files:` frontmatter key (canonical for
+    // new artifacts).
+    let mut files = fm
         .get("affected_files")
-        .and_then(|v| v.as_sequence())
-        .map(|seq| {
-            seq.iter()
-                .filter_map(|x| x.as_str().map(|s| s.to_string()))
-                .collect::<Vec<_>>()
-        })
+        .map(forgeplan_core::dispatch::parse_affected_files_from_fm)
         .unwrap_or_default();
+    // Fallback: `## Affected Files` markdown section for legacy artifacts
+    // (R3 audit architect HIGH — same concept, two encodings). Existing
+    // `validation::checks::extract_affected_files` already handles the
+    // markdown extraction; reuse it to avoid divergence.
+    if files.is_empty() {
+        let from_section = forgeplan_core::validation::checks::extract_affected_files(&body);
+        files = from_section
+            .into_iter()
+            .filter(|s| s.len() <= AFFECTED_FILE_MAX_PATH)
+            .take(AFFECTED_FILES_MAX_LEN)
+            .collect();
+    }
+
     let domain = fm
         .get("domain")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .and_then(forgeplan_core::dispatch::normalize_dispatch_domain);
     let parent_epic = fm
         .get("parent_epic")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    (files, domain, parent_epic)
+
+    DispatchFmFields {
+        files,
+        domain,
+        parent_epic,
+        parse_failed: false,
+    }
 }
 
 /// Standardised "artifact not found" error with recovery hint.
@@ -1812,6 +1865,20 @@ impl ForgeplanServer {
                     next_action.push_str(&phase_hint);
                 }
 
+                // PRD-057 FR-013: surface live claim info — orchestrators
+                // routing `forgeplan_get` for decision-making need to know
+                // if an agent already owns this work.
+                let claim_store = forgeplan_core::claim::ClaimStore::new(&ws);
+                if let Ok(Some(claim)) = claim_store.get(&r.id).await {
+                    let safe_holder = sanitize_for_hint(&claim.agent_id);
+                    let claim_hint = format!(
+                        " Claim: held by `{safe_holder}` until {} — route new work elsewhere \
+                         or ask for force-release.",
+                        claim.expires_at.to_rfc3339(),
+                    );
+                    next_action.push_str(&claim_hint);
+                }
+
                 hinted_result(&ArtifactRecordDto::from(r), next_action)
             }
             Ok(None) => Ok(artifact_not_found(&p.id)),
@@ -2577,6 +2644,30 @@ impl ForgeplanServer {
                 .to_string()
         };
 
+        // PRD-057 FR-012: advisory surface of active claims so health
+        // consumers (CLI dashboard, orchestrator) see who owns what
+        // without a separate `forgeplan_claims` call. Returns parsed
+        // count + list; malformed files surface via `skipped` so
+        // orchestrators notice data-integrity issues.
+        let claim_store = forgeplan_core::claim::ClaimStore::new(&ws);
+        let (active_claims, skipped_claims) = claim_store
+            .list_active_with_stats()
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("health: list_active_with_stats failed: {e}");
+                (Vec::new(), 0)
+            });
+        let claims_json: Vec<serde_json::Value> = active_claims
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "id": c.id,
+                    "agent_id": c.agent_id,
+                    "expires_at": c.expires_at.to_rfc3339(),
+                })
+            })
+            .collect();
+
         Ok(json_result(&serde_json::json!({
             "total": report.total,
             "by_kind": report.by_kind,
@@ -2591,6 +2682,9 @@ impl ForgeplanServer {
             "orphans": report.orphans,
             "by_derived_status": report.by_derived_status.iter().map(|(ds, v)| serde_json::json!({"status": ds.label(), "count": v})).collect::<Vec<_>>(),
             "advisory_phase_mismatches": phase_mismatches,
+            "active_claims": claims_json,
+            "active_claim_count": active_claims.len(),
+            "skipped_claim_files": skipped_claims,
             "next_actions": report.next_actions,
             "_next_action": next_action,
         })))
@@ -5696,8 +5790,8 @@ impl ForgeplanServer {
                     )
                 } else {
                     format!(
-                        "{count} active claim{}. Use `forgeplan_dispatch` (when implemented) \
-                         to plan non-overlapping work.",
+                        "{count} active claim{}. Use `forgeplan_dispatch --agents N` to plan \
+                         non-overlapping work around them.",
                         if count == 1 { "" } else { "s" }
                     )
                 };
@@ -5737,12 +5831,39 @@ impl ForgeplanServer {
             Err(e) => return Ok(err_result(&e)),
         };
 
+        // R3 audit HIGH (security) + MED: clamp unbounded user input
+        // BEFORE allocating — agents & per-agent skill lists otherwise
+        // could OOM the server with e.g. `agents: 4_000_000_000`.
         if p.agents == 0 {
             return Ok(err_result("agents must be >= 1"));
+        }
+        if p.agents > forgeplan_core::dispatch::MAX_AGENTS {
+            return Ok(err_result(&format!(
+                "agents must be <= {} — PRD-057 targets 2–5 concurrent sub-agents",
+                forgeplan_core::dispatch::MAX_AGENTS
+            )));
+        }
+        if p.agent_skills.len() > p.agents {
+            return Ok(err_result(&format!(
+                "agent_skills has {} entries but only {} agents requested",
+                p.agent_skills.len(),
+                p.agents
+            )));
+        }
+        for (i, skills) in p.agent_skills.iter().enumerate() {
+            if skills.len() > forgeplan_core::dispatch::MAX_SKILLS_PER_AGENT {
+                return Ok(err_result(&format!(
+                    "agent_skills[{}] has {} entries — max {}",
+                    i,
+                    skills.len(),
+                    forgeplan_core::dispatch::MAX_SKILLS_PER_AGENT
+                )));
+            }
         }
         let threshold = p
             .overlap_threshold
             .unwrap_or(forgeplan_core::dispatch::DEFAULT_OVERLAP_THRESHOLD);
+        // `contains` on NaN returns false — catches non-finite inputs too.
         if !(0.0..=1.0).contains(&threshold) {
             return Ok(err_result("overlap_threshold must be in [0.0, 1.0]"));
         }
@@ -5764,6 +5885,30 @@ impl ForgeplanServer {
             .await
             .map_err(|e| McpError::internal_error(format!("list_artifacts: {e}"), None))?;
 
+        // R3 audit task-completion MED: FR-003 requires the dispatcher to
+        // respect the artifact dependency graph — blocked artifacts must
+        // not land in a parallel bucket. Compute the blocked set by the
+        // same rules `forgeplan_blocked` uses: structural edges + records
+        // with status ∈ {active, deprecated, superseded} = resolved.
+        let relations = store
+            .get_all_relations()
+            .await
+            .map_err(|e| McpError::internal_error(format!("get_all_relations: {e}"), None))?;
+        let records = store
+            .list_records(None)
+            .await
+            .map_err(|e| McpError::internal_error(format!("list_records: {e}"), None))?;
+        let resolved_ids: std::collections::HashSet<String> = records
+            .iter()
+            .filter(|r| {
+                r.status == "active" || r.status == "deprecated" || r.status == "superseded"
+            })
+            .map(|r| r.id.clone())
+            .collect();
+        let topo = forgeplan_core::graph::topological::kahn_sort(&relations, &resolved_ids);
+        let blocked_ids: std::collections::HashSet<String> =
+            topo.blocked.iter().map(|(id, _)| id.clone()).collect();
+
         // Hydrate the dispatch-relevant fields. `ArtifactSummary` lacks
         // `parent_epic`; that plus `affected_files` + `domain` all live in
         // the markdown frontmatter (files are source of truth per ADR-003,
@@ -5771,20 +5916,38 @@ impl ForgeplanServer {
         // extras across LanceDB re-renders).
         let epic_filter = p.epic.as_deref();
         let mut candidates = Vec::with_capacity(summaries.len());
+        let mut skipped_parse_errors = 0usize;
+        let mut skipped_blocked = Vec::<String>::new();
         for summary in &summaries {
-            let (affected_files, domain, parent_epic) =
+            let fields =
                 read_dispatch_fm_fields(&ws, &summary.kind, &summary.id, &summary.title).await;
+            // R3 audit M-4: surface parse failures explicitly instead of
+            // letting them masquerade as "no affected_files declared".
+            if fields.parse_failed {
+                skipped_parse_errors += 1;
+                tracing::warn!(
+                    id = %summary.id,
+                    "dispatch: skipped candidate — frontmatter unreadable"
+                );
+                continue;
+            }
             // Apply epic filter post-hydration — this is a small workspace
             // (2-5 agents, O(50) candidates) so a pass is cheap.
             if let Some(wanted) = epic_filter
-                && parent_epic.as_deref() != Some(wanted)
+                && fields.parent_epic.as_deref() != Some(wanted)
             {
+                continue;
+            }
+            // FR-003: drop blocked artifacts; dispatcher shouldn't give an
+            // agent work that can't proceed until a dependency resolves.
+            if blocked_ids.contains(&summary.id) {
+                skipped_blocked.push(summary.id.clone());
                 continue;
             }
             candidates.push(forgeplan_core::dispatch::ArtifactCandidate {
                 id: summary.id.clone(),
-                affected_files,
-                domain,
+                affected_files: fields.files,
+                domain: fields.domain,
             });
         }
         let candidate_count = candidates.len();
@@ -5797,13 +5960,21 @@ impl ForgeplanServer {
         let claimed_count = claimed_map.len();
         let claimed_set: std::collections::HashSet<String> = claimed_map.into_keys().collect();
 
-        let plan = forgeplan_core::dispatch::compute_dispatch_plan(
+        let mut plan = forgeplan_core::dispatch::compute_dispatch_plan(
             &candidates,
             p.agents,
             &p.agent_skills,
             &claimed_set,
             threshold,
         );
+        // Prepend blocked-artifact reasoning so orchestrators see WHY
+        // something didn't appear in the plan at all.
+        for id in &skipped_blocked {
+            plan.reasoning.insert(
+                0,
+                format!("{id}: skipped (blocked by unresolved structural dependency)"),
+            );
+        }
 
         let dto = DispatchResponse {
             buckets: plan.buckets,
@@ -5814,14 +5985,22 @@ impl ForgeplanServer {
             overlap_threshold: plan.overlap_threshold,
             candidate_count,
             claimed_count,
+            skipped_parse_errors,
+            blocked_count: skipped_blocked.len(),
         };
 
         let parallel = dto.buckets.iter().filter(|b| !b.is_empty()).count();
+        let skip_note = if skipped_parse_errors > 0 {
+            format!(", {skipped_parse_errors} skipped (parse errors — see logs)")
+        } else {
+            String::new()
+        };
         let hint = format!(
             "Plan ready: {candidate_count} candidate(s), {parallel} parallel bucket(s), \
-             {} serial, {claimed_count} already-claimed skipped. Hand buckets[i] to sub-agent \
-             i; re-dispatch when a sub-agent calls `forgeplan_release`.",
-            dto.serial_queue.len(),
+             {serial} serial, {claimed_count} already-claimed skipped{skip_note}. Hand \
+             buckets[i] to sub-agent i; re-dispatch when the claim set or candidate set \
+             changes (e.g. after `forgeplan_release`, `forgeplan_new`, or a claim's TTL expiry).",
+            serial = dto.serial_queue.len(),
         );
         hinted_result(&dto, hint)
     }
@@ -7090,6 +7269,83 @@ mod claim_mcp_tests {
             .await
             .unwrap();
         assert_eq!(r.is_error, Some(true), "threshold > 1.0 must error");
+    }
+
+    // ── PRD-057 AC-4: concurrent forgeplan_new → unique IDs ──────────
+
+    #[tokio::test]
+    async fn concurrent_forgeplan_new_emits_unique_ids() {
+        // R3 audit task-completion PARTIAL: Inc 1 lock test is a proxy;
+        // this asserts the full MCP path produces distinct IDs + distinct
+        // projection files when called concurrently from three sub-agents
+        // sharing one workspace.
+        use std::sync::Arc;
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = forgeplan_core::workspace::init_workspace(&root, "ac4").unwrap();
+        // Force LanceDB init so the test server has a store.
+        let _ = forgeplan_core::db::store::LanceStore::init(&ws)
+            .await
+            .unwrap();
+
+        let server = Arc::new(ForgeplanServer::new(root).await);
+
+        // Spawn 3 concurrent forgeplan_new calls — mirrors the scenario in
+        // the PRD-057 AC-4 Gherkin. Each call holds the workspace lock
+        // for its critical section (next_id + create_artifact + projection
+        // render); with the lock working correctly, all three complete
+        // serially with distinct IDs and distinct files on disk.
+        let mut handles = Vec::new();
+        for i in 0..3 {
+            let srv = Arc::clone(&server);
+            handles.push(tokio::spawn(async move {
+                srv.forgeplan_new(Parameters(NewParams {
+                    kind: ArtifactKindArg::Prd,
+                    title: format!("Concurrent PRD {i}"),
+                }))
+                .await
+            }));
+        }
+
+        let mut results = Vec::new();
+        for h in handles {
+            let r = h.await.unwrap().unwrap();
+            assert_ne!(r.is_error, Some(true), "forgeplan_new must not error");
+            results.push(r);
+        }
+
+        // The JSON body carries the assigned id under "id". Pull them
+        // out — cheap and avoids a full Response deserialization path.
+        let mut seen = std::collections::HashSet::new();
+        for r in &results {
+            assert!(!r.content.is_empty(), "content must be non-empty");
+            let text = match &r.content[0].raw {
+                rmcp::model::RawContent::Text(t) => t.text.clone(),
+                _ => panic!("expected text content"),
+            };
+            let v: serde_json::Value = serde_json::from_str(&text).expect("valid JSON body");
+            let id = v
+                .get("id")
+                .and_then(|x| x.as_str())
+                .expect("response should include id");
+            assert!(
+                seen.insert(id.to_string()),
+                "AC-4 violation: duplicate id {id} across concurrent forgeplan_new calls"
+            );
+        }
+
+        // Also verify three distinct projection files landed on disk.
+        let prds_dir = ws.join("prds");
+        let mut rd = tokio::fs::read_dir(&prds_dir).await.unwrap();
+        let mut md_files = 0;
+        while let Some(entry) = rd.next_entry().await.unwrap() {
+            let n = entry.file_name().to_string_lossy().to_string();
+            if n.ends_with(".md") {
+                md_files += 1;
+            }
+        }
+        assert_eq!(md_files, 3, "expected 3 markdown files, got {md_files}");
     }
 
     #[tokio::test]

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -271,6 +271,16 @@ pub struct DispatchResponse {
     pub overlap_threshold: f64,
     pub candidate_count: usize,
     pub claimed_count: usize,
+    /// R3 audit M-4: number of candidate artifact markdown files that
+    /// couldn't be read/parsed and were dropped from the plan (not the
+    /// same as "no affected_files declared"). Non-zero → check logs.
+    #[serde(default)]
+    pub skipped_parse_errors: usize,
+    /// R3 audit task-completion MED (FR-003): number of candidates that
+    /// were dropped because a structural dependency hasn't resolved yet.
+    /// Orchestrator unblocks them by activating/superseding the deps.
+    #[serde(default)]
+    pub blocked_count: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -224,6 +224,11 @@ impl From<forgeplan_core::claim::Claim> for ClaimDto {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ClaimsListResponse {
     pub count: usize,
+    /// R2 audit MED: number of claim files skipped because they failed to
+    /// parse or exceeded the size cap. Orchestrators should investigate
+    /// any non-zero value — silent dropping of these was an Inc 3 bug.
+    #[serde(default)]
+    pub skipped: usize,
     pub claims: Vec<ClaimDto>,
 }
 

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -232,6 +232,47 @@ pub struct ClaimsListResponse {
     pub claims: Vec<ClaimDto>,
 }
 
+// ── PRD-057 Inc 4: dispatcher tool DTOs ──────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DispatchParams {
+    /// Number of sub-agents the orchestrator can hand work to. Required;
+    /// clamped to `>= 1` downstream.
+    pub agents: usize,
+    /// Optional filter: only consider artifacts of this kind
+    /// (`prd`/`rfc`/`spec`/etc.). When omitted, all kinds are considered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Optional filter: only artifacts with this parent Epic ID. Matches
+    /// the `parent_epic` frontmatter field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epic: Option<String>,
+    /// Optional filter: consider only artifacts in this status (default
+    /// `draft`). Set to `"any"` to include every lifecycle state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Per-agent skill lists in index order. Empty entries default to
+    /// "any skill"; omit to disable skill matching entirely.
+    #[serde(default)]
+    pub agent_skills: Vec<Vec<String>>,
+    /// Jaccard threshold above which two artifacts are considered
+    /// file-conflicting. Default 0.3. Clamp 0.0..=1.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overlap_threshold: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DispatchResponse {
+    pub buckets: Vec<Vec<String>>,
+    pub serial_queue: Vec<String>,
+    pub reasoning: Vec<String>,
+    pub generated_at: String,
+    pub agent_count: usize,
+    pub overlap_threshold: f64,
+    pub candidate_count: usize,
+    pub claimed_count: usize,
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct BlockedParams {
     /// Optional artifact ID to check. If omitted, shows all blocked artifacts.

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -162,6 +162,71 @@ pub struct GraphResponse {
     pub mermaid: String,
 }
 
+// ── PRD-057 Inc 3: claim protocol DTOs ───────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimParams {
+    /// Artifact ID to claim (e.g. `PRD-057`). Normalized to uppercase on disk.
+    pub id: String,
+    /// Agent identity ("name/version" or free-form). Optional — defaults to
+    /// the MCP caller's clientInfo when omitted. Providing this explicitly
+    /// lets an orchestrator claim on behalf of a sub-agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    /// Time-to-live in minutes. Default 30, max 1440 (24h), min 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_minutes: Option<u32>,
+    /// Optional free-form note surfaced by `forgeplan_claims --active`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ReleaseParams {
+    pub id: String,
+    /// Required unless `force=true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    /// Force-release regardless of holder (orchestrator escape hatch).
+    #[serde(default)]
+    pub force: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimsListParams {
+    /// Reserved for future filters; currently always returns only live claims.
+    #[serde(default)]
+    pub active: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimDto {
+    pub id: String,
+    pub agent_id: String,
+    pub claimed_at: String,
+    pub expires_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl From<forgeplan_core::claim::Claim> for ClaimDto {
+    fn from(c: forgeplan_core::claim::Claim) -> Self {
+        Self {
+            id: c.id,
+            agent_id: c.agent_id,
+            claimed_at: c.claimed_at.to_rfc3339(),
+            expires_at: c.expires_at.to_rfc3339(),
+            note: c.note,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ClaimsListResponse {
+    pub count: usize,
+    pub claims: Vec<ClaimDto>,
+}
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct BlockedParams {
     /// Optional artifact ID to check. If omitted, shows all blocked artifacts.


### PR DESCRIPTION
## Summary

Ships PRD-057 Inc 2 + Inc 3 + Inc 4 on top of the Inc 1 workspace lock foundation (v0.23.1). One MCP call — `forgeplan_dispatch --agents N` — hands the orchestrator a parallel-safe work plan with buckets, serial queue, and reasoning. Ends the manual "read graph + blocked + list + overlap calc" orchestration loop.

## What's new

- **Inc 2 — Agent identity** (`AgentIdentity`, stamp on every MCP write, `last_modified_by: name/version` in frontmatter)
- **Inc 3 — Claim protocol** (`forgeplan_claim`/`_release`/`_claims` MCP tools, TTL 1min–24h, atomic writes, orchestrator force-release)
- **Inc 4 — Dispatcher** (`forgeplan_dispatch` MCP tool: Jaccard file overlap, least-loaded-first greedy, claim + graph + skill-aware)
- **FR-012** — `forgeplan_health` surfaces active claims
- **FR-013** — `forgeplan_get` `_next_action` shows claim holder + expiry

## Audit rounds

- **R2 mid-sprint** (3 agents: rust-pro + security + architect) — 3 HIGH + 5 MED + 1 LOW closed
- **R3 final** (4 agents + production-validator for FR/AC completeness) — 2 HIGH + 7 MED + 6 LOW + 3 missing FR/AC closed

Total: **30 findings** addressed across two rounds, each with regression guards.

## Metrics

- **Tests**: 1297 → 1391 (+94), 0 fail
- **FR coverage**: 14/14 (with implementation + test references)
- **AC coverage**: 5/5 (AC-4 previously had only Inc 1 lock-level proxy — now has 3-concurrent MCP E2E)
- **EVID-077** activated PRD-057 with R_eff=1.00 (CL3 same-context, supports verdict)
- **CI**: `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- **Release binary**: 43MB + 42MB (parity with v0.23.1, no bloat)

## Commits (9)

- `0331c38` feat(identity): Inc 2 — agent identity (FR-009 + AC-5)
- `a737fca` feat(claim): Inc 3 — claim protocol + MCP tools (FR-004..006, 014, AC-2, 3)
- `bc49496` fix(dispatch): R2 mid-sprint audit hotfix (3H + 5M + 1L)
- `d579736` feat(dispatch): Inc 4 — orchestrator dispatcher (FR-001..003, 010, 011, AC-1)
- `9d7101d` fix(dispatch): R3 final audit hotfix (2H + 7M + 6L + 2 missing FR + AC gap)
- `465ff9d` test(dispatch): Dogfood E2E (10 scenarios through real MCP stack)
- `be13960` test(dispatch): Workflow-type coverage (kind/threshold/full-cycle)
- `75075d3` docs(prd-057): EVID-077 + activate PRD-057 → active
- `fc8ef50` chore(release): v0.24.0 bump + CHANGELOG

## Deferred to v0.25+ (tracked in PRD)

Shared `kv_yaml` abstraction, HTTP/SSE per-request identity, `load_frontmatter_full` primitive, `ListFilter::parent_epic` push-down, `DispatchDecision` enum for i18n, `list_active_map → HashMap<String, Claim>`, ADR claim/phase separation, agent profiles path.

## Test plan

- [x] `cargo test --workspace` → 1391 / 0 fail
- [x] `cargo fmt --all --check` → 0 diff
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → 0 warnings
- [x] `cargo build --release` → success, binaries 43MB + 42MB
- [x] E2E dogfood through `ForgeplanServer` + LanceStore (10 scenarios)
- [x] Workflow variations (kind filter, threshold extremes, full new→claim→release→dispatch cycle)
- [ ] Post-merge: dogfood via `brew upgrade forgeplan` on real workspace
- [ ] Post-merge: release/v0.24.0 branch → PR to main → tag `v0.24.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)