### PR TITLE
docs: v0.24.0 multi-agent dispatch guide (EN + RU) + release-docs rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,26 @@ Hooks в `.claude/hooks/` блокируют нарушения методоло
 
 Full guide: `docs/methodology/UNIFIED-WORKFLOW.ru.md`.
 
+## Multi-agent (v0.24.0+)
+
+При работе 2-5 суб-агентов в одном workspace используй MCP tools:
+- `forgeplan_dispatch --agents N` — получить план (buckets + serial queue)
+- `forgeplan_claim <id> --ttl 30` — «я беру этот артефакт»
+- `forgeplan_release <id>` — «закончил»
+- `forgeplan_claims` — кто сейчас что делает
+
+Guide: `docs/operations/MULTI-AGENT.ru.md`.
+
+## Docs — update on every release
+
+**Red line** для методологии: release, который добавляет user-facing MCP tool или CLI flag, **не мерджится в main** без:
+- раздела в `CHANGELOG.md`
+- соответствующего документа в `docs/operations/` или `docs/methodology/`
+- обновлённого индекса `docs/README.md` и `docs/README.ru.md`
+- упоминания новой фичи в этом CLAUDE.md (если меняет workflow)
+
+Иначе пользователи читают stale-docs, а фичи висят undocumented. Проверяй в последнем commit перед PR.
+
 ---
 
 ## Artifacts (10 types, 6 actively used)

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Setup, hooks, and repository protection.
 |---|---|
 | [AGENT-ENFORCEMENT.md](operations/AGENT-ENFORCEMENT.md) | Rules and guardrails for AI agents working in this project |
 | [AGENT-HOOKS.md](operations/AGENT-HOOKS.md) | PreToolUse / PostToolUse hooks (safety, formatting, tests) |
+| [MULTI-AGENT.md](operations/MULTI-AGENT.md) | **v0.24.0+ multi-agent dispatch** — `forgeplan_dispatch/claim/release/claims` MCP tools, file-overlap detection, skill routing |
 | [REPO-PROTECTION-GUIDE.md](operations/REPO-PROTECTION-GUIDE.md) | Branch protection, PR rules, destructive-action prevention |
 | [GIT-WORKFLOW.ru.md](operations/GIT-WORKFLOW.ru.md) | Full Git rules — branching lifecycle, PR pipeline, release process, worktrees |
 | [SOURCE-PORTING.ru.md](operations/SOURCE-PORTING.ru.md) | Reference Code map — what was ported from `sources/{quint-code,git-adr,BMAD,OpenSpec,ccpm}` to our crates |

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -44,6 +44,7 @@ docs/
 |---|---|
 | [AGENT-ENFORCEMENT.md](operations/AGENT-ENFORCEMENT.md) | Правила и ограничения для AI-агентов, работающих в проекте |
 | [AGENT-HOOKS.md](operations/AGENT-HOOKS.md) | Хуки PreToolUse / PostToolUse (безопасность, форматирование, тесты) |
+| [MULTI-AGENT.md](operations/MULTI-AGENT.md) | **v0.24.0+ multi-agent dispatch** — MCP-инструменты `forgeplan_dispatch/claim/release/claims`, file-overlap detection, skill routing |
 | [REPO-PROTECTION-GUIDE.md](operations/REPO-PROTECTION-GUIDE.md) | Защита веток, правила PR, предотвращение деструктивных действий |
 | [GIT-WORKFLOW.ru.md](operations/GIT-WORKFLOW.ru.md) | Полные Git-правила — lifecycle веток, PR pipeline, процесс релиза, worktrees |
 | [SOURCE-PORTING.ru.md](operations/SOURCE-PORTING.ru.md) | Reference Code map — что портировано из `sources/{quint-code,git-adr,BMAD,OpenSpec,ccpm}` в наши crates |

--- a/docs/operations/MULTI-AGENT.md
+++ b/docs/operations/MULTI-AGENT.md
@@ -1,0 +1,236 @@
+[English](MULTI-AGENT.md) · [Русский](MULTI-AGENT.ru.md)
+
+# Multi-Agent Workflow (v0.24.0+)
+
+Since **v0.24.0** (PRD-057), Forgeplan can **dispatch work** between 2–5 sub-agents sharing a single workspace. One MCP call returns a ready-to-execute plan: who works on what, what runs in parallel, what waits in the serial queue, and why.
+
+## Why this exists
+
+Before v0.24.0 the orchestrator (you or an AI agent) had to **manually** keep in mind:
+- which of N agents is busy with what
+- which PRDs/RFCs touch shared files (or merge-hell follows)
+- who blocks whom via dependencies
+- which skill set fits which agent (backend/frontend/api/…)
+
+2–3 agents is manageable, 5 is not. Failure modes:
+- **Double work** — two agents grab the same PRD
+- **File conflict** — two agents edit the same crate → race / merge-hell
+- **Serial wasted** — A waits on B while C could have gone in parallel
+- **Forgotten blocker** — a PRD is activated while deps are still draft
+
+v0.24.0 closes this through four MCP tools.
+
+## The four MCP tools
+
+### `forgeplan_dispatch` — the main one
+
+**Purpose:** turn a list of artifacts + live claim set + dependency graph into a ready plan for N agents.
+
+**Contract:**
+```jsonc
+{
+  "name": "forgeplan_dispatch",
+  "arguments": {
+    "agents": 3,                                    // 1..=64
+    "kind": "prd",                                  // optional: filter by kind
+    "epic": "EPIC-005",                             // optional: filter by parent_epic
+    "status": "draft",                              // default "draft", "any" = all
+    "agent_skills": [["backend"], ["frontend"], []],// optional: per-agent skills
+    "overlap_threshold": 0.3                        // default 0.3 Jaccard
+  }
+}
+```
+
+**Returns:**
+```jsonc
+{
+  "buckets": [["PRD-901"], ["PRD-902"], ["PRD-903"]],  // one bucket per agent
+  "serial_queue": ["PRD-905"],                           // waits their turn
+  "reasoning": [                                          // NFR-005 — why each decision
+    "PRD-901: assigned to agent 0 (no file conflict, skill match)",
+    "PRD-905: serialized (conflicts with every bucket or no matching skill)"
+  ],
+  "candidate_count": 4,
+  "claimed_count": 0,
+  "blocked_count": 0,
+  "skipped_parse_errors": 0,
+  "agent_count": 3,
+  "overlap_threshold": 0.3,
+  "generated_at": "2026-04-19T15:44:56.219+00:00"
+}
+```
+
+**What the algorithm considers** (in order):
+
+1. **Claims** (`forgeplan_claim`) — already-claimed artifacts are excluded.
+2. **Structural dependencies** — blocked artifacts (via `graph::topological::kahn_sort`, the same Kahn sort used by `forgeplan_blocked`) are excluded with explanation.
+3. **File overlap** — Jaccard similarity on `affected_files`. Pairs with overlap ≥ threshold (default 0.3) are treated as conflicting. `affected_files` source: frontmatter key if present; otherwise the `## Affected Files` markdown section (fallback for legacy artifacts).
+4. **Domain/skill match** — if `agent_skills` is provided, an artifact goes only to an agent with a matching skill. Skill mismatch → serial queue.
+5. **Least-loaded-first greedy** — distributes work evenly; avoids dumping everything onto agent 0.
+
+**Read-only:** does not mutate the workspace, does not take `workspace_lock`. Safe to poll at 1 Hz — does not serialize writers.
+
+### `forgeplan_claim` — "I am taking this artifact"
+
+```jsonc
+{
+  "name": "forgeplan_claim",
+  "arguments": {
+    "id": "PRD-901",
+    "agent": "worker-1",          // optional: default = MCP clientInfo name/version
+    "ttl_minutes": 30,            // default 30, min 1, max 1440 (24h)
+    "note": "implementing FR-003" // optional
+  }
+}
+```
+
+Writes `.forgeplan/claims/PRD-901.yaml` (gitignored). If already held by a different agent — **refuses** with the holder's `agent_id` and `expires_at`. Same-agent calls **renew** the TTL. Expired claims are **transparently overwritten** (AC-3).
+
+**Atomic write** via tempfile + rename — SIGKILL mid-write cannot leave a corrupt YAML.
+
+### `forgeplan_release` — "done"
+
+```jsonc
+{
+  "name": "forgeplan_release",
+  "arguments": {
+    "id": "PRD-901",
+    "agent": "worker-1",  // required if force=false
+    "force": false         // true — orchestrator override for a crashed agent
+  }
+}
+```
+
+Without `force`: only the holding agent may release (prevents accidental clobber). Missing claim → no-op (idempotent).
+
+### `forgeplan_claims` — "who is doing what right now"
+
+```jsonc
+{
+  "name": "forgeplan_claims",
+  "arguments": { "active": true }
+}
+```
+
+Returns:
+```jsonc
+{
+  "count": 2,
+  "skipped": 0,  // malformed YAML files — check server logs
+  "claims": [
+    { "id": "PRD-901", "agent_id": "worker-1", "expires_at": "...", "note": "..." },
+    { "id": "PRD-902", "agent_id": "worker-2", "expires_at": "...", "note": null }
+  ]
+}
+```
+
+Sorted by `expires_at` ASC (earliest-expiring first). **Read-only** — does not take the lock.
+
+## Typical flow
+
+### Orchestrator dispatches work to 3 agents
+
+```
+1. orchestrator → forgeplan_dispatch --agents 3 --epic EPIC-005
+   ← { buckets: [[PRD-A], [PRD-B], [PRD-C]], serial: [PRD-D], ... }
+
+2. orchestrator → worker-1 "work on PRD-A"
+   orchestrator → worker-2 "work on PRD-B"
+   orchestrator → worker-3 "work on PRD-C"
+
+3. worker-1 → forgeplan_claim PRD-A --ttl 30
+   worker-2 → forgeplan_claim PRD-B --ttl 30
+   worker-3 → forgeplan_claim PRD-C --ttl 30
+
+4. Agents work in parallel. Every ~N minutes:
+   worker-1 → forgeplan_claim PRD-A (same agent, renews TTL)
+
+5. worker-1 done → forgeplan_release PRD-A
+   orchestrator → forgeplan_dispatch --agents 3 (re-plan — PRD-D may be parallelizable now)
+```
+
+### An agent crashed — orchestrator reaps the claim
+
+```
+worker-2 crashed; claim on PRD-B still valid for 20 more minutes.
+orchestrator → forgeplan_release PRD-B --force
+orchestrator → forgeplan_dispatch --agents 3 (PRD-B available again)
+```
+
+Alternative: just wait for TTL expiry — the claim will self-expire after 30 minutes.
+
+## What v0.24.0 does NOT ship
+
+(Deferred to v0.25+ per PRD-057 Growth Vision)
+
+- **CLI parity** — no `forgeplan dispatch/claim/release/claims` CLI commands; MCP only. To use from CLI, pipe to `forgeplan serve` stdio MCP.
+- **`agents/<id>.yaml` profiles** — skills are passed per-call, not persisted. Roadmapped for v0.27.
+- **HTTP/SSE transport** — identity capture works on stdio only (one client per connection). Multi-connection HTTP needs per-request identity extraction.
+- **Inter-bucket overlap check** — the dispatcher checks file conflicts within a bucket but not between agents. Two overlapping PRDs may land in different buckets (they will merge-conflict on the mainline — user-level mitigation: don't hand them out together). Tracked as a v0.25 follow-up.
+- **Richer claim context** — Claim stores only `id + agent + ttl + note`. Structured fields ("which FRs I am working on") are a v0.25 item.
+
+## Frontmatter fields for better dispatch
+
+Two fields the dispatcher reads (both **optional**, but dramatically improve scheduling):
+
+```yaml
+---
+id: PRD-042
+title: Auth rewrite
+kind: prd
+status: draft
+depth: standard
+# ← new for dispatch:
+affected_files:
+  - crates/auth/src/**
+  - crates/api/src/auth/
+domain: backend   # frontend | backend | api | infra | docs | testing | general
+---
+```
+
+- **Without `affected_files`:** the dispatcher applies the R-2 safety bias and sends the artifact to the serial queue (treat as shared ground).
+- **With `affected_files`:** the dispatcher computes Jaccard overlap against other candidates and decides if they are parallel-compatible.
+- **With `domain`:** when the orchestrator passes `agent_skills`, the artifact routes to the matching agent. `domain` is validated against ASCII `[a-z0-9_-]` — non-ASCII (Cyrillic, RTL, ZWJ) is **rejected** (security CWE-176).
+
+**Fallback for legacy artifacts** (no FM key): the dispatcher reads the `## Affected Files` markdown section in the body — backward-compatible.
+
+## Identity stamping (Inc 2)
+
+**Automatic** on every MCP write tool, provided the client passed `clientInfo` during `initialize`:
+
+```yaml
+# In .forgeplan/prds/PRD-042-title.md after forgeplan_update:
+---
+...
+last_modified_by: claude-code/1.0
+last_modified_at: 2026-04-19T15:44:56+00:00
+---
+```
+
+Used for:
+- Retro-audit ("who touched this last?")
+- Activity log (`.forgeplan/logs/tools-YYYY-MM-DD.jsonl` — every MCP invocation carries `client_info`)
+- `forgeplan_get` `_next_action` hint (when a claim and identity are known, the "held by ..." hint appears automatically)
+
+**Unicode protection:** control characters, bidi overrides, ZWJ, path separators are **rejected** in `AgentIdentity::new` — invisible characters cannot leak into markdown via `clientInfo`.
+
+## Input bounds (security)
+
+| Param | Cap | Reason |
+|---|---|---|
+| `agents` | 1..=64 | PRD target is 2–5; unbounded → OOM (CWE-770) |
+| `agent_skills[i].length` | ≤ 32 | O(N²) Jaccard hot path |
+| `affected_files.length` | ≤ 512 | same |
+| `affected_files[i].length` | ≤ 512 bytes | same |
+| Claim file size | ≤ 64 KB | billion-laughs, R1 parity |
+| Claim TTL | 1..=1440 min (24h) | shorter churns, longer risks stuck agent |
+
+Exceeding the cap → error at the MCP boundary with a clear message.
+
+## Further reading
+
+- **PRD-057** (`.forgeplan/prds/PRD-057-*.md`) — full FR/AC/NFR + Growth Vision roadmap
+- **EVID-077** (`.forgeplan/evidence/EVID-077-*.md`) — what was tested and how (R_eff=1.00, CL3)
+- **CHANGELOG.md** `[0.24.0]` — full release notes
+- [AGENT-HOOKS.md](AGENT-HOOKS.md) — how Forgeplan hooks (forge-safety, pre-commit-fmt) behave in a multi-agent setup
+- [UNIFIED-WORKFLOW.md](../methodology/UNIFIED-WORKFLOW.md) — how Forgeplan × Orchestra × Hindsight fit together

--- a/docs/operations/MULTI-AGENT.ru.md
+++ b/docs/operations/MULTI-AGENT.ru.md
@@ -1,0 +1,236 @@
+[English](MULTI-AGENT.md) · [Русский](MULTI-AGENT.ru.md)
+
+# Multi-Agent Workflow (v0.24.0+)
+
+С версии **v0.24.0** (PRD-057) Forgeplan умеет **диспетчеризовать работу** между 2–5 суб-агентами в одном workspace. Один MCP-вызов возвращает готовый план: кто над чем работает, что идёт параллельно, что ждёт в serial queue, и почему.
+
+## Зачем это нужно
+
+До v0.24.0 оркестратор (вы или AI-агент) должен был **вручную** держать в голове:
+- кто из N агентов чем занят
+- какие PRD/RFC трогают общие файлы (иначе merge-hell)
+- кто кого блокирует по зависимостям
+- кому какие скиллы подходят (backend/frontend/api/…)
+
+2–3 агента ещё управляемо, 5 — уже нет. Типичные провалы:
+- **Двойная работа** — два агента взяли один PRD
+- **File conflict** — два агента редактируют один crate → race / merge-hell
+- **Serial wasted** — A ждёт B, хотя могла бы идти параллельно с C
+- **Забытый блокер** — активировали PRD, deps ещё в draft
+
+v0.24.0 закрывает это через четыре MCP-инструмента.
+
+## Четыре MCP-инструмента
+
+### `forgeplan_dispatch` — главный
+
+**Назначение:** превратить список артефактов + live claim-set + граф зависимостей в готовый план на N агентов.
+
+**Контракт:**
+```jsonc
+{
+  "name": "forgeplan_dispatch",
+  "arguments": {
+    "agents": 3,                                    // 1..=64
+    "kind": "prd",                                  // optional: фильтр по kind
+    "epic": "EPIC-005",                             // optional: фильтр по parent_epic
+    "status": "draft",                              // default "draft", "any" = все
+    "agent_skills": [["backend"], ["frontend"], []],// optional: per-agent skills
+    "overlap_threshold": 0.3                        // default 0.3 Jaccard
+  }
+}
+```
+
+**Возвращает:**
+```jsonc
+{
+  "buckets": [["PRD-901"], ["PRD-902"], ["PRD-903"]],  // один bucket на агента
+  "serial_queue": ["PRD-905"],                           // ждут своей очереди
+  "reasoning": [                                          // NFR-005 — почему каждое решение
+    "PRD-901: assigned to agent 0 (no file conflict, skill match)",
+    "PRD-905: serialized (conflicts with every bucket or no matching skill)"
+  ],
+  "candidate_count": 4,
+  "claimed_count": 0,
+  "blocked_count": 0,
+  "skipped_parse_errors": 0,
+  "agent_count": 3,
+  "overlap_threshold": 0.3,
+  "generated_at": "2026-04-19T15:44:56.219+00:00"
+}
+```
+
+**Что алгоритм учитывает** (в порядке применения):
+
+1. **Claims** (`forgeplan_claim`) — уже занятые артефакты исключаются.
+2. **Структурные зависимости** — блокированные артефакты (через `graph::topological::kahn_sort`, тот же Kahn sort, что использует `forgeplan_blocked`) исключаются с explanation.
+3. **File overlap** — Jaccard similarity по `affected_files`. Пары с overlap ≥ threshold (default 0.3) считаются конфликтующими. Источник `affected_files`: frontmatter-ключ, если есть; иначе секция `## Affected Files` в теле (fallback для legacy-артефактов).
+4. **Domain/skill match** — если передан `agent_skills`, артефакт идёт только к агенту с совпадающим skill. Skill mismatch → serial queue.
+5. **Least-loaded-first greedy** — распределяет работу равномерно; не валит всё на agent 0.
+
+**Read-only:** не мутирует workspace, не берёт `workspace_lock`. Безопасно поллить с частотой 1 Hz — не блокирует writers.
+
+### `forgeplan_claim` — «я беру этот артефакт»
+
+```jsonc
+{
+  "name": "forgeplan_claim",
+  "arguments": {
+    "id": "PRD-901",
+    "agent": "worker-1",          // optional: default = MCP clientInfo name/version
+    "ttl_minutes": 30,            // default 30, min 1, max 1440 (24h)
+    "note": "implementing FR-003" // optional
+  }
+}
+```
+
+Пишет `.forgeplan/claims/PRD-901.yaml` (gitignored). Если уже держит другой агент — **отказ** с `agent_id` и `expires_at` держащего. Same-agent calls **продлевают** TTL. Истёкшие claims **transparent overwrite** (AC-3).
+
+**Атомарная запись** через tempfile + rename — SIGKILL mid-write не оставляет битый YAML.
+
+### `forgeplan_release` — «закончил»
+
+```jsonc
+{
+  "name": "forgeplan_release",
+  "arguments": {
+    "id": "PRD-901",
+    "agent": "worker-1",  // обязателен, если force=false
+    "force": false         // true — orchestrator override для упавшего агента
+  }
+}
+```
+
+Без `force`: только владелец может release'нуть (защита от случайного clobber'а). Missing claim → no-op (идемпотент).
+
+### `forgeplan_claims` — «кто сейчас что делает»
+
+```jsonc
+{
+  "name": "forgeplan_claims",
+  "arguments": { "active": true }
+}
+```
+
+Возвращает:
+```jsonc
+{
+  "count": 2,
+  "skipped": 0,  // malformed YAML файлы — см. server logs
+  "claims": [
+    { "id": "PRD-901", "agent_id": "worker-1", "expires_at": "...", "note": "..." },
+    { "id": "PRD-902", "agent_id": "worker-2", "expires_at": "...", "note": null }
+  ]
+}
+```
+
+Sorted by `expires_at` ASC (earliest-expiring first). **Read-only** — не берёт lock.
+
+## Типичный flow
+
+### Оркестратор распределяет работу между 3 агентами
+
+```
+1. orchestrator → forgeplan_dispatch --agents 3 --epic EPIC-005
+   ← { buckets: [[PRD-A], [PRD-B], [PRD-C]], serial: [PRD-D], ... }
+
+2. orchestrator → worker-1 "работай над PRD-A"
+   orchestrator → worker-2 "работай над PRD-B"
+   orchestrator → worker-3 "работай над PRD-C"
+
+3. worker-1 → forgeplan_claim PRD-A --ttl 30
+   worker-2 → forgeplan_claim PRD-B --ttl 30
+   worker-3 → forgeplan_claim PRD-C --ttl 30
+
+4. Агенты работают параллельно. Каждые ~N минут:
+   worker-1 → forgeplan_claim PRD-A (same agent, продлевает TTL)
+
+5. worker-1 done → forgeplan_release PRD-A
+   orchestrator → forgeplan_dispatch --agents 3 (re-plan — PRD-D может стать parallelizable)
+```
+
+### Агент упал — orchestrator reap'ит claim
+
+```
+worker-2 crashed; claim на PRD-B ещё валиден 20 минут.
+orchestrator → forgeplan_release PRD-B --force
+orchestrator → forgeplan_dispatch --agents 3 (PRD-B снова доступен)
+```
+
+Альтернатива: просто подождать TTL expiry — claim сам истечёт через 30 минут.
+
+## Что v0.24.0 НЕ включает
+
+(Deferred to v0.25+ per PRD-057 Growth Vision)
+
+- **CLI parity** — нет CLI-команд `forgeplan dispatch/claim/release/claims`; только MCP. Для использования из CLI — через `forgeplan serve` stdio MCP.
+- **Профили `agents/<id>.yaml`** — skills передаются per-call, не персистятся. Roadmapped на v0.27.
+- **HTTP/SSE transport** — identity capture работает только на stdio (один клиент на connection). Multi-connection HTTP требует per-request identity extraction.
+- **Inter-bucket overlap check** — dispatcher проверяет file-conflicts внутри bucket, но не между агентами. Два overlapping PRD могут попасть в разные buckets (они будут конфликтовать при merge на main — user-level mitigation: не давать их одновременно). Треккается как v0.25 follow-up.
+- **Richer claim context** — Claim хранит только `id + agent + ttl + note`. Структурированные поля («какие FR делаю сейчас») — v0.25.
+
+## Поля frontmatter для лучшего dispatch'а
+
+Два поля, которые dispatcher читает (оба **optional**, но сильно улучшают распределение):
+
+```yaml
+---
+id: PRD-042
+title: Auth rewrite
+kind: prd
+status: draft
+depth: standard
+# ← новое для dispatch:
+affected_files:
+  - crates/auth/src/**
+  - crates/api/src/auth/
+domain: backend   # frontend | backend | api | infra | docs | testing | general
+---
+```
+
+- **Без `affected_files`:** dispatcher применяет R-2 safety bias и отправляет в serial queue (consider shared-ground).
+- **С `affected_files`:** dispatcher считает Jaccard overlap с другими кандидатами и решает, совместимы ли они в параллель.
+- **С `domain`:** если orchestrator передал `agent_skills`, артефакт идёт к совпадающему агенту. `domain` валидируется на ASCII `[a-z0-9_-]` — non-ASCII (Cyrillic, RTL, ZWJ) **отклоняется** (security CWE-176).
+
+**Fallback для legacy-артефактов** (без FM-ключа): dispatcher читает секцию `## Affected Files` в теле — обратная совместимость.
+
+## Identity stamping (Inc 2)
+
+**Автоматически** на каждый MCP write-tool, если клиент передал `clientInfo` во время `initialize`:
+
+```yaml
+# В .forgeplan/prds/PRD-042-title.md после forgeplan_update:
+---
+...
+last_modified_by: claude-code/1.0
+last_modified_at: 2026-04-19T15:44:56+00:00
+---
+```
+
+Используется для:
+- Retro-audit («кто последний трогал это?»)
+- Activity log (`.forgeplan/logs/tools-YYYY-MM-DD.jsonl` — каждая MCP-инвокация несёт `client_info`)
+- `forgeplan_get` `_next_action` hint (если claim + identity известны, подсказка «held by ...» появляется автоматически)
+
+**Unicode-защита:** control characters, bidi override, ZWJ, path separators **отклоняются** в `AgentIdentity::new` — невидимые символы не могут попасть в markdown через `clientInfo`.
+
+## Ограничения на input (security)
+
+| Param | Cap | Причина |
+|---|---|---|
+| `agents` | 1..=64 | PRD target 2–5; unbounded → OOM (CWE-770) |
+| `agent_skills[i].length` | ≤ 32 | O(N²) Jaccard hot path |
+| `affected_files.length` | ≤ 512 | same |
+| `affected_files[i].length` | ≤ 512 bytes | same |
+| Claim file size | ≤ 64 KB | billion-laughs, R1 parity |
+| Claim TTL | 1..=1440 min (24h) | короче — churn, длиннее — stuck-agent risk |
+
+Превышение → error at MCP boundary с понятным сообщением.
+
+## Читать дальше
+
+- **PRD-057** (`.forgeplan/prds/PRD-057-*.md`) — полные FR/AC/NFR + Growth Vision roadmap
+- **EVID-077** (`.forgeplan/evidence/EVID-077-*.md`) — что и как было протестировано (R_eff=1.00, CL3)
+- **CHANGELOG.md** `[0.24.0]` — полные release notes
+- [AGENT-HOOKS.ru.md](AGENT-HOOKS.ru.md) — как Forgeplan hooks (forge-safety, pre-commit-fmt) работают в multi-agent setup
+- [UNIFIED-WORKFLOW.ru.md](../methodology/UNIFIED-WORKFLOW.ru.md) — как Forgeplan × Orchestra × Hindsight живут вместе


### PR DESCRIPTION
## Summary

Closes the docs-lag gap for v0.24.0. Adds bilingual `MULTI-AGENT.md` covering the four new MCP tools (`forgeplan_dispatch`, `forgeplan_claim`, `forgeplan_release`, `forgeplan_claims`), with:

- Tool contracts and response shapes
- Dispatch algorithm breakdown (claim-aware → graph-blocked → Jaccard → skill match → least-loaded-first)
- Orchestrator flow + crashed-agent reap recipe
- Frontmatter hints (`affected_files`, `domain`) with the markdown-section fallback
- Input bounds with security rationale (CWE-770, CWE-176)
- What's deferred to v0.25+ (inter-bucket overlap check, CLI parity, HTTP/SSE identity, claim context)

## CLAUDE.md additions

1. `## Multi-agent (v0.24.0+)` — short pointer block listing the four tools.
2. `## Docs — update on every release` — red-line rule preventing docs lag on future releases. Kept CLAUDE.md at 393 lines (≤ 400 hygiene rule).

## Style parity

- Language switcher first line: `[English](X.md) · [Русский](X.ru.md)` — matches existing AGENT-HOOKS.md / AGENT-ENFORCEMENT.md / REPO-PROTECTION-GUIDE.md
- EN primary, RU translation with identical structure and code blocks
- Both indexed in `docs/README.md` and `docs/README.ru.md`

## Test plan

- [x] `docs/README.md` + `.ru.md` link through to MULTI-AGENT.md correctly
- [x] CLAUDE.md line count ≤ 400 (393)
- [x] Tool contracts match actual types.rs DTO shapes + v0.24.0 dogfood responses
- [x] Frontmatter examples match Inc 2 KNOWN_FM_KEYS preservation behavior
- [ ] Human review for phrasing consistency with existing docs/operations/*

🤖 Generated with [Claude Code](https://claude.com/claude-code)