### PR TITLE
[PROB-043] activity log: explicit flush to prevent empty-file race on CI

### DIFF
--- a/.forgeplan/problems/PROB-043-activity-log-flush-missing-ci-flaky-append-creates-file-and-directory-test.md
+++ b/.forgeplan/problems/PROB-043-activity-log-flush-missing-ci-flaky-append-creates-file-and-directory-test.md
@@ -1,0 +1,55 @@
+---
+created: 2026-04-20
+depth: tactical
+id: PROB-043
+kind: problem
+status: active
+title: Activity log flush missing — CI flaky append_creates_file_and_directory test
+updated: 2026-04-20
+---
+
+# PROB-043: Activity log missing explicit flush → CI flaky test
+
+## Problem Statement
+
+`crates/forgeplan-core/src/activity/mod.rs::append` пишет в файл через `tokio::fs::File::write_all` и возвращает `Ok(())` без explicit `file.flush().await`. `tokio::fs::File::drop` **не делает** async flush. На GitHub Actions runners (ubuntu-24.04, Linux overlayfs) test `activity::tests::append_creates_file_and_directory` intermittently видит пустой файл при чтении сразу после `append` returns — content.matches('\n').count() == 0 вместо expected 1.
+
+## Signal
+
+CI failure в PR #202 build `24661185656`:
+```
+thread 'activity::tests::append_creates_file_and_directory' panicked at
+  crates/forgeplan-core/src/activity/mod.rs:239:9:
+assertion `left == right` failed
+  left: 0
+  right: 1
+test result: FAILED. 1075 passed; 1 failed
+```
+
+Локально (macOS APFS) тест PASS — filesystem flushes быстрее. На CI (Linux overlayfs) buffer сидит дольше, test читает before OS flush.
+
+## Root Cause
+
+`tokio::fs::File` buffers writes. Explicit flush — ответственность caller. Наш PRD-054 (activity log) не flush'и́л для latency reasons (обосновано в комментарии "We do NOT fsync every write"). Но есть разница: **flush to OS buffer** (дешёвый) vs **fsync to disk** (дорогой). Нужен flush, не fsync.
+
+## Proposed Solution
+
+Добавить `file.flush().await?` перед `Ok(())`. Это только flush к OS buffer (не disk) — latency ~1μs, не влияет на performance. Durability (on crash) не меняется — OS всё равно буферизует.
+
+Комментарий обновлён — объясняет разницу flush vs fsync.
+
+## Acceptance Criteria
+
+- [x] `append` вызывает `file.flush().await?` перед return
+- [x] Комментарий обновлён: flush to OS buffer vs fsync to disk
+- [x] Локально `cargo test -p forgeplan-core --lib activity` PASS (18/18)
+- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] CI rerun — `append_creates_file_and_directory` PASS
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|----------|------|----------|
+| PRD-054 | PRD | informs (PRD that introduced activity log module) |
+
+

--- a/crates/forgeplan-core/src/activity/mod.rs
+++ b/crates/forgeplan-core/src/activity/mod.rs
@@ -134,10 +134,15 @@ pub async fn append(workspace: &Path, entry: &ActivityEntry) -> anyhow::Result<(
         .open(&path)
         .await?;
     file.write_all(line.as_bytes()).await?;
-    // We do NOT fsync every write — would dominate latency. The OS
-    // will flush on close or after a short interval; worst case on
-    // SIGKILL we lose <1 sec of entries. For durability-critical
-    // deployments, a future `activity.fsync: per_entry` flag can opt in.
+    // Explicit flush to buffer boundary. `tokio::fs::File::drop` does
+    // NOT perform an async flush; without this, CI filesystems (Linux
+    // overlayfs in GitHub Actions) intermittently show an empty file
+    // when a test reads right after `append` returns. We do NOT fsync
+    // to disk — would dominate latency. The OS still buffers; worst
+    // case on SIGKILL we lose <1 sec of entries. For durability-
+    // critical deployments, a future `activity.fsync: per_entry` flag
+    // can opt in.
+    file.flush().await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fix flaky CI test `activity::tests::append_creates_file_and_directory`. Pre-existing bug on dev baseline, caught на PR #202 CI run.

## Root cause

`tokio::fs::File::write_all` buffers writes. `tokio::fs::File::drop` **does not** async-flush. On GitHub Actions runners (Linux overlayfs), test occasionally reads file before OS buffer flushes — content is empty (0 newlines) when `append_creates_file_and_directory` expects 1.

Locally on macOS APFS this never reproduces — filesystem faster.

## Fix

Add `file.flush().await?` before `Ok(())` in `activity::append`. This flushes to **OS buffer** (~1μs), not fsync to disk (expensive). Durability unchanged — on SIGKILL we still lose <1 sec of entries buffered by OS.

Updated comment differentiates flush vs fsync.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p forgeplan-core --lib activity` → 18/18 PASS locally
- [ ] CI green

## Artifacts

- **PROB-043** (active) — problem statement + root cause + AC

Refs: PROB-043, PRD-054 (PRD that introduced activity log module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)