### PR TITLE
[EPIC-006] Narrow scope — consumer of EPIC-007, deprecate PRD-059/060/062

### DIFF
--- a/.forgeplan/epics/EPIC-006-brownfield-migration-pipeline-self-description-platform.md
+++ b/.forgeplan/epics/EPIC-006-brownfield-migration-pipeline-self-description-platform.md
@@ -13,6 +13,30 @@ title: Brownfield Migration Pipeline + Self-description Platform
 
 # EPIC-006: Brownfield Migration Pipeline + Self-description Platform
 
+## ⚠ Scope Narrowed 2026-04-20 (ADR-009 orchestrator pivot)
+
+После spike-1 C4 measurement (EVID-081 CL3) и ADR-009 «Forgeplan as orchestrator» — scope этого Epic **существенно сужен**. Ранее планировалось 6 child PRDs (PRD-059..064), из них:
+
+- **Superseded by EPIC-007** (orchestrator runtime делает это лучше):
+  - PRD-059 (discover + migrate core) → EPIC-007 PRD-065 (playbook runtime) + PRD-066 (ingest engine)
+  - PRD-060 (self-description + agent-manifest) → EPIC-007 PRD-067 (plugin detection + hints)
+  - PRD-062 (init + skill installer) → EPIC-007 PRD-067 + PRD-069 (orchestrator agents)
+
+- **Retained, narrowed to brownfield-docs-pack**:
+  - PRD-061 — становится `marketplace/brownfield-docs-pack/` (playbook + madr-to-forge mapping + forge-classify skill). Consumer of EPIC-007 runtime.
+
+- **Retained, forge-core work independent from orchestration**:
+  - PRD-063 (state machine `completed`/`archived` + bidirectional supersede) — intrinsic forge lifecycle feature, orthogonal к orchestration
+  - PRD-064 (new kinds kb/runbook/postmortem/retrospective/meeting + new links) — forge kind system extension, orthogonal
+
+**Result**: EPIC-006 Phase 1 scope reduced from ~6 PRDs (~3000 LOC estimated) to ~3 PRDs (~1000 LOC estimated). ~60% effort released to EPIC-007 foundation.
+
+Всё нижеследующее — **original shape** iter 1 (для исторического контекста). Actual execution следует narrowed scope выше.
+
+---
+
+
+
 ## Vision
 
 Сделать Forgeplan first-class инструментом для brownfield-проектов любого масштаба — из Obsidian, MADR, ADR-tools, log4brains, ad-hoc `requirements/` и смешанных структур в структурированный forge-граф без потерь данных и без ручной работы. Одновременно перевернуть модель: **инструмент сам ведёт агента**, не наоборот. Поддержка не только Claude Code, но и 6+ других harness'ов (Cursor, Windsurf, Cline, Roo, Copilot, agentskills.io generic).
@@ -130,6 +154,7 @@ TOTAL                                          0/?  (  0%)
 | PRD-058 | PRD | based_on (closed scan-import core bugs) |
 | ADR-003 | ADR | informs (markdown = source of truth invariant) |
 | RFC-003 | RFC | informs (layered architecture — new crate через trait pattern) |
+
 
 
 


### PR DESCRIPTION
Follow-up to PR #202 (EPIC-007 merged). EPIC-006 scope reduced from 6 PRDs to 3.

## Scope change

After ADR-009 orchestrator pivot + spike-1 CL3 evidence (EVID-081) that validated mapping concept on real c4-context output:

**Superseded by EPIC-007** (more powerful via Playbook/Mapping):
- PRD-059 (discover+migrate core) → PRD-065 + PRD-066
- PRD-060 (self-description + agent-manifest) → PRD-067
- PRD-062 (init + skill installer) → PRD-067 + PRD-069

**Retained, refocused**:
- PRD-061 → becomes `marketplace/brownfield-docs-pack/` consuming EPIC-007 runtime
- PRD-063 (state machine + bidir supersede) — orthogonal forge-core work
- PRD-064 (new kinds kb/runbook/postmortem) — orthogonal forge-core work

**Result**: ~60% effort released (~2000 LOC est.), redirected to EPIC-007 foundation.

## Close out

Closes #200 (original EPIC-006 brownfield shape PR — superseded by narrower scope here).

Refs: EPIC-006, ADR-009, EPIC-007, EVID-081

🤖 Generated with [Claude Code](https://claude.com/claude-code)