### PR TITLE
[PROB-040 C1] Rename Status::RefreshDue → Status::Stale

### DIFF
--- a/crates/forgeplan-core/src/artifact/types.rs
+++ b/crates/forgeplan-core/src/artifact/types.rs
@@ -126,6 +126,17 @@ pub fn slugify(title: &str) -> String {
         .join("-")
 }
 
+/// Artifact lifecycle status.
+///
+/// State machine (see CLAUDE.md + docs/methodology/):
+/// `draft → active → {superseded | deprecated | stale}`
+/// `stale → {active via renew | deprecated + new draft via reopen}`
+///
+/// PROB-040 C1 fix (2026-04-21): renamed `RefreshDue` → `Stale` to match
+/// documented state machine + existing string-based lifecycle checks
+/// (see `lifecycle::mod.rs` — compares against `"stale"` literal).
+/// Serialization is now `stale` (was: `refresh_due`). No artifacts
+/// in workspace serialized with the old value (verified via grep).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Status {
@@ -133,7 +144,7 @@ pub enum Status {
     Active,
     Superseded,
     Deprecated,
-    RefreshDue,
+    Stale,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Closes PROB-040 C1 — Status enum reality drift.

Docs + lifecycle code referenced `stale` as state; Rust enum had `RefreshDue` (dead variant, serialized as `refresh_due`). All existing lifecycle code compares against `"stale"` literal — never constructed the enum variant. Fix aligns enum with docs + code.

## Change

`crates/forgeplan-core/src/artifact/types.rs:131-137` — rename variant + documentation comment.

## Impact

- Zero breaking change for artifacts (no .md files contain `refresh_due`)
- Zero CLI API change
- Unblocks PRD-063 (state machine extension) which assumed `Stale` exists

## Test plan

- [x] cargo test --workspace → 1405/1405 PASS
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo fmt --check clean
- [x] grep for `refresh_due` in workspace `.forgeplan/` → no matches (no artifacts affected)

Refs: PROB-040 C1, PRD-063

🤖 Generated with [Claude Code](https://claude.com/claude-code)