### PR TITLE
docs(website): promote v0.25.0 changelog + Hint Contract page to main

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
           { label: 'Artifact Lifecycle', slug: 'docs/methodology/lifecycle', translations: { ru: 'Жизненный цикл' } },
           { label: 'Evidence & Scoring', slug: 'docs/methodology/evidence', translations: { ru: 'Доказательства и скоринг' } },
           { label: 'ADI Reasoning', slug: 'docs/methodology/adi', translations: { ru: 'ADI рассуждения' } },
+          { label: 'Hint Contract', slug: 'docs/methodology/agent-protocol', translations: { ru: 'Hint Contract' } },
         ],
       },
       {

--- a/website/src/content/docs/docs/changelog.md
+++ b/website/src/content/docs/docs/changelog.md
@@ -19,6 +19,46 @@ with pre-1.0 minor bumps for breaking changes.
 This file starts at v0.17.0. For prior releases, see git tags and the
 corresponding sprint evidence under `.forgeplan/evidence/`.
 
+## [0.25.0] — 2026-04-27 — Unified hint contract across CLI + MCP (PRD-071 complete)
+
+Forgeplan теперь говорит агентам что делать дальше. Каждый CLI и MCP вывод эмитит **один** контрактный маркер (`Next:` / `Or:` / `Wait:` / `Done.` / `Fix:`) — никаких больше «agent reads no-hint output → re-reads CLAUDE.md → guesses → loops». 5-rule контракт (PRESENCE / ACTIONABILITY / DETERMINISM / CONDITIONALITY / CONSISTENCY) реализован за 5 циклов multi-agent sprint, audit coverage 0% → **100% (70/70)**.
+
+### Added — 5-rule hint contract (PRD-071)
+
+- **`Next: <full command>`** — primary action with real IDs (no `<placeholder>`)
+- **`Or: <command>`** — alternate when primary blocks
+- **`Wait: <condition>`** — async/TTL retry signal
+- **`Done.`** — terminal success (workflow complete)
+- **`Fix: <command>`** — error remediation (paired with `Error:` line)
+- JSON output: `_next_action` field (string or null)
+- MCP responses: `_next_action` in success + error data
+
+### Added — Drift prevention infrastructure
+
+- **`crates/forgeplan-cli/tests/hint_contract.rs`** — 36 integration tests asserting every covered command emits contract marker AND no forbidden placeholders. New CLI/MCP command without hint **fails CI**.
+- **`scripts/audit-hints.sh`** — coverage metric (CI-ready), recognizes all 5 markers.
+- **`docs/methodology/agent-protocol.md`** — full contract spec with good/bad hint examples and agent reading protocol.
+- **`CLAUDE.md`** — Hint protocol section (5-line agent reference).
+
+### Changed — backward-compat preserved
+
+- `forgeplan list --json` and `forgeplan tree --json` retain bare-array stdout (`jq '.[]'` and existing scripts not broken). Hint moves to **stderr** in JSON mode.
+- All existing CLI text outputs preserved — hints are additive new lines at end.
+- MCP `_next_action` field was already present (just normalizing values).
+
+### Fixed — edge cases
+
+- 9 commands (get/delete/update/score/estimate/progress/calibrate/validate/link) now emit `Fix: forgeplan list` on "Artifact not found" errors. Previously only `Error:` line — failed PRESENCE rule for not-found path.
+- Audit script now recognizes `Fix:`/`Or:`/`Wait:`/`Done.` markers (was only `Next:` — produced false negatives).
+
+### Sprint metrics
+
+- 5 cycles × 3 parallel agents = 9 unique agents
+- 90 files changed (+3994, -539)
+- 1140 lib + 36 hint_contract + 104 cli_integration_test = **1280 tests passing**
+- 0 fmt diffs, 0 clippy warnings
+- EVID-086 linked to PRD-071, R_eff 0.70 (overall 0.80 A grade)
+
 ## [0.24.0] — 2026-04-19 — Orchestrator dispatcher for 2-5 sub-agents (PRD-057 complete)
 
 Forgeplan now dispatches work. One MCP call — `forgeplan_dispatch

--- a/website/src/content/docs/docs/methodology/agent-protocol.md
+++ b/website/src/content/docs/docs/methodology/agent-protocol.md
@@ -1,0 +1,198 @@
+---
+title: Hint Contract — Reading Forgeplan Output
+description: How agents read Forgeplan's deterministic next-action hints across CLI text, JSON, and MCP responses
+---
+
+> Status: **Active** since Forgeplan v0.25.0 (PRD-071, 2026-04-27)
+
+Forgeplan v0.25.0 introduced a **unified 5-rule hint contract** so any agent (Claude Code, Cursor, Windsurf, custom orchestrators) can read its output without re-discovering the methodology each time. This page is the canonical agent-facing reference.
+
+## Why This Matters
+
+Forgeplan is a methodology engine. Each command/tool call is one step in a longer workflow (Shape → Validate → Code → Evidence → Activate). When agents don't know what to do next, they:
+
+- Re-read CLAUDE.md to rediscover methodology
+- Guess and sometimes hallucinate
+- Loop on the same step
+
+Each costs tokens and risks correctness. The contract eliminates ambiguity by guaranteeing every output carries an explicit, deterministic next-action.
+
+## The 5-Rule Contract
+
+Every Forgeplan output, regardless of surface, satisfies these:
+
+1. **PRESENCE** — every response either emits a next-action OR is explicitly terminal. No silent gaps.
+2. **ACTIONABILITY** — the next-action is a full, copy-pasteable command with real IDs, never a fragment or placeholder.
+3. **DETERMINISM** — same input state always produces the same hint string. No randomness.
+4. **CONDITIONALITY** — hints appear only when actionable. Terminal states emit `Done.` rather than fake "all done!".
+5. **CONSISTENCY** — text and JSON renderings carry the same semantic content. CLI mirrors MCP semantics.
+
+## The 5 Hint Markers
+
+| Marker | When emitted | Agent action |
+|---|---|---|
+| `Next: <full command>` | Primary action — recommended next step | Execute exactly as written |
+| `Or: <command>` | Alternate when primary blocks (e.g. claim held) | Use only if primary fails |
+| `Wait: <condition>` | Async/TTL state | Retry after the condition |
+| `Done.` | Workflow complete (terminal) | Move on, do not loop |
+| `Fix: <command>` | Error remediation (paired with `Error:`) | Run the fix command immediately |
+
+## Where to Read the Hint
+
+| Surface | Location | Format |
+|---|---|---|
+| **CLI text (success)** | last lines of stdout | `Next: <full command>` plus optional rationale |
+| **CLI text (error)** | after `Error:` line | `Fix: <full command>` |
+| **CLI JSON** | top-level field | `{"_next_action": "<command>" \| null, ...}` |
+| **MCP success** | top-level field | `_next_action: "<command>" \| null` |
+| **MCP error** | error data field | `error.data._next_action: "<command>"` |
+
+**Special case**: `forgeplan list --json` and `forgeplan tree --json` preserve bare-array stdout (backward compat for `jq '.[]'` consumers). The hint is emitted to **stderr** in JSON mode.
+
+## Good Hints vs. Bad Hints
+
+### Good ✅
+
+```
+Next: forgeplan score PRD-001
+  R_eff is 0 — link evidence to enable activation
+```
+Specific, full command, real ID, rationale explains *why*.
+
+```
+Next: forgeplan dispatch --agents 3
+Or: forgeplan claim PRD-054 --agent worker-2 --ttl-minutes 30
+```
+One primary action, one explicit fallback.
+
+```
+Error: Direct status change to 'active' is not allowed.
+Fix: forgeplan activate PRD-001
+```
+Error has clear, executable remediation.
+
+### Bad ❌ (pre-v0.25.0 patterns — should never appear in v0.25.0+ output)
+
+```
+suggested next: adi
+```
+Bare word, not a command. Agent has to guess.
+
+```
+Try a longer window: --since-hours 720
+```
+Fragment, not full command.
+
+```
+Either work on a different artifact, wait for TTL expiry,
+or ask the orchestrator to force-release.
+```
+Three options, none chosen as primary. Paradox of choice.
+
+## Agent Reading Protocol
+
+When an agent receives any Forgeplan output:
+
+1. **Look for the next-action**.
+   - CLI text: scan for `Next:`, `Fix:`, `Wait:`, or `Done.` line
+   - CLI JSON: read `_next_action` field (or stderr `Next:` for list/tree)
+   - MCP: read `_next_action` field of response
+2. **Execute primary if present**.
+   - If `Next:` or `Fix:` — execute the command **exactly as written**
+   - Do not paraphrase, do not substitute placeholders
+   - Do not split into multiple commands
+3. **Use `Or:` only if primary blocks**.
+4. **On `Wait:`, retry after condition**.
+5. **On `Done.`, the workflow is complete** — move to next task, do not loop.
+6. **On no hint and not terminal — report a contract violation**. This is a bug in Forgeplan. Do not improvise.
+
+## What NOT to Do
+
+1. **Don't paraphrase the hint** — full command is given for a reason
+2. **Don't combine `Next:` + `Or:`** in same call — pick one
+3. **Don't ignore `Done.`** — explicit terminal signal
+4. **Don't substitute `EVID-NNN` placeholders** — first run `forgeplan_new evidence`, then use the real ID
+5. **Don't panic on `Wait:`** — async/TTL is normal; just retry
+
+## Practical Workflow Patterns
+
+### Pattern A: Shape → Validate → Activate
+
+```
+forgeplan_route("add OAuth login")
+  → Next: forgeplan new prd "<title>"
+
+forgeplan_new(kind: "prd", title: "OAuth login support")
+  → Next: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Next: forgeplan activate PRD-042   (if PASS)
+  → Fix: forgeplan validate PRD-042    (if errors)
+
+forgeplan_activate("PRD-042")
+  → Done.
+```
+
+### Pattern B: Recovery from Error
+
+```
+forgeplan_activate("PRD-042")
+  → Error: No evidence linked
+  → Fix: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Result: PASS
+  → Next: forgeplan score PRD-042
+```
+
+### Pattern C: Multi-Agent Dispatch
+
+```
+forgeplan_dispatch(--agents 3)
+  → Next: forgeplan claim PRD-054 --agent worker-1 --ttl 30
+  → Or:   forgeplan list --status draft
+
+forgeplan_claim("PRD-054")
+  → Error: Already held by worker-2
+  → Or: forgeplan release PRD-054 --force
+```
+
+## Drift Prevention
+
+The contract is enforced by:
+
+1. **Integration test** `crates/forgeplan-cli/tests/hint_contract.rs` — 36 tests, fails CI if any command lacks contract marker
+2. **Audit script** `scripts/audit-hints.sh` — coverage metric, target 100%, currently 100% (70/70 commands)
+
+## Quick Reference Card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  FORGEPLAN HINT CONTRACT (v0.25.0+)                     │
+├─────────────────────────────────────────────────────────┤
+│  Next:  <command>   → execute as-is                     │
+│  Or:    <command>   → fallback if primary blocks        │
+│  Wait:  <condition> → retry after condition             │
+│  Done.              → workflow complete, move on        │
+│  Fix:   <command>   → error remediation (with Error:)   │
+├─────────────────────────────────────────────────────────┤
+│  Read from: stdout (text), _next_action (JSON/MCP)      │
+│  Special:   list/tree --json → hint on stderr           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## For Plugin Users
+
+The marketplace plugin **`forgeplan-workflow` v1.5.0+** teaches Claude Code agents to read these markers automatically. After installing:
+
+```
+/plugin marketplace update ForgePlan-marketplace
+```
+
+Your agent will read `Next:`/`Fix:` hints across `/forge-cycle`, the `forge-advisor` agent, and the methodology skill — no manual configuration needed.
+
+## Related
+
+- **Forgeplan v0.25.0 release** — first version shipping the contract ([CHANGELOG](/docs/changelog/))
+- **Marketplace plugin forgeplan-workflow v1.5.0** — agent-side awareness layer
+- **Lifecycle model** ([read more](/docs/methodology/lifecycle/)) — hints integrate with status transitions (draft → active → terminal)

--- a/website/src/content/docs/ru/docs/methodology/agent-protocol.md
+++ b/website/src/content/docs/ru/docs/methodology/agent-protocol.md
@@ -1,0 +1,198 @@
+---
+title: Hint Contract — чтение вывода Forgeplan
+description: Как агенты читают детерминированные next-action подсказки Forgeplan в CLI text, JSON и MCP ответах
+---
+
+> Статус: **Active** с Forgeplan v0.25.0 (PRD-071, 2026-04-27)
+
+В Forgeplan v0.25.0 введён **унифицированный 5-правильный hint contract** — любой агент (Claude Code, Cursor, Windsurf, custom orchestrators) может читать вывод без повторного открытия методологии каждый раз. Эта страница — канонический агент-ориентированный референс.
+
+## Зачем это нужно
+
+Forgeplan — методологический движок. Каждая команда/MCP-вызов — один шаг в более длинном workflow (Shape → Validate → Code → Evidence → Activate). Когда агенты не знают что делать дальше, они:
+
+- Перечитывают CLAUDE.md чтобы заново открыть методологию
+- Гадают, иногда галлюцинируют
+- Зацикливаются на одном шаге
+
+Каждое из этого тратит токены и рискует корректностью. Контракт убирает неоднозначность — каждый вывод несёт явный детерминированный next-action.
+
+## Контракт из 5 правил
+
+Каждый вывод Forgeplan, независимо от surface, удовлетворяет:
+
+1. **PRESENCE** — каждый ответ либо emit'ит next-action, либо явно терминальный. Тихих gaps не бывает.
+2. **ACTIONABILITY** — next-action это полная copy-paste команда с реальными ID, никогда не фрагмент или placeholder.
+3. **DETERMINISM** — одно и то же состояние всегда производит одинаковую hint строку. Без рандома.
+4. **CONDITIONALITY** — подсказки появляются только когда actionable. Терминальные states emit'ят `Done.` вместо фиктивного "all done!".
+5. **CONSISTENCY** — text и JSON renderings несут одинаковый семантический контент. CLI отражает MCP semantics.
+
+## 5 hint маркеров
+
+| Маркер | Когда emit'ится | Действие агента |
+|---|---|---|
+| `Next: <full command>` | Основное действие — рекомендуемый следующий шаг | Выполнить exactly как написано |
+| `Or: <command>` | Альтернатива когда primary блокирован (например claim занят) | Использовать только если primary fails |
+| `Wait: <condition>` | Async/TTL state | Retry после condition |
+| `Done.` | Workflow завершён (terminal) | Перейти дальше, не зацикливаться |
+| `Fix: <command>` | Error remediation (paired с `Error:`) | Сразу выполнить fix команду |
+
+## Где читать hint
+
+| Surface | Местоположение | Формат |
+|---|---|---|
+| **CLI text (success)** | последние строки stdout | `Next: <full command>` плюс опциональный rationale |
+| **CLI text (error)** | после `Error:` строки | `Fix: <full command>` |
+| **CLI JSON** | top-level field | `{"_next_action": "<command>" \| null, ...}` |
+| **MCP success** | top-level field | `_next_action: "<command>" \| null` |
+| **MCP error** | error data field | `error.data._next_action: "<command>"` |
+
+**Особый случай**: `forgeplan list --json` и `forgeplan tree --json` сохраняют bare-array stdout (backward compat для `jq '.[]'` consumers). Hint emit'ится в **stderr** в JSON режиме.
+
+## Хорошие vs. плохие подсказки
+
+### Хорошо ✅
+
+```
+Next: forgeplan score PRD-001
+  R_eff is 0 — link evidence to enable activation
+```
+Specific, full command, реальный ID, rationale объясняет *почему*.
+
+```
+Next: forgeplan dispatch --agents 3
+Or: forgeplan claim PRD-054 --agent worker-2 --ttl-minutes 30
+```
+Одно primary действие, один явный fallback.
+
+```
+Error: Direct status change to 'active' is not allowed.
+Fix: forgeplan activate PRD-001
+```
+Error имеет clear, executable remediation.
+
+### Плохо ❌ (паттерны до v0.25.0 — не должны появляться в v0.25.0+ выводе)
+
+```
+suggested next: adi
+```
+Bare word, не команда. Агент должен догадаться.
+
+```
+Try a longer window: --since-hours 720
+```
+Фрагмент, не full command.
+
+```
+Either work on a different artifact, wait for TTL expiry,
+or ask the orchestrator to force-release.
+```
+Три опции, ни одна не выбрана как primary. Парадокс выбора.
+
+## Reading protocol для агента
+
+Когда агент получает любой Forgeplan вывод:
+
+1. **Найди next-action**.
+   - CLI text: scan для `Next:`, `Fix:`, `Wait:`, или `Done.` строки
+   - CLI JSON: read `_next_action` field (или stderr `Next:` для list/tree)
+   - MCP: read `_next_action` field response'а
+2. **Выполни primary если present**.
+   - Если `Next:` или `Fix:` — выполни команду **exactly как написано**
+   - Не парафразируй, не подставляй placeholders
+   - Не разбивай на несколько команд
+3. **Используй `Or:` только если primary blocks**.
+4. **На `Wait:`, retry после condition**.
+5. **На `Done.`, workflow complete** — переходи к следующей задаче, не зацикливайся.
+6. **На no hint и не terminal — сообщи о violation контракта**. Это bug в Forgeplan. Не импровизируй.
+
+## Чего НЕ делать
+
+1. **Не парафразируй hint** — full команда дана не просто так
+2. **Не комбинируй `Next:` + `Or:`** в одном call — выбери одно
+3. **Не игнорируй `Done.`** — явный terminal сигнал
+4. **Не подставляй `EVID-NNN` placeholders** — сначала запусти `forgeplan_new evidence`, потом используй real ID
+5. **Не паникуй на `Wait:`** — async/TTL это нормально; просто retry
+
+## Практические workflow паттерны
+
+### Pattern A: Shape → Validate → Activate
+
+```
+forgeplan_route("add OAuth login")
+  → Next: forgeplan new prd "<title>"
+
+forgeplan_new(kind: "prd", title: "OAuth login support")
+  → Next: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Next: forgeplan activate PRD-042   (если PASS)
+  → Fix: forgeplan validate PRD-042    (если errors)
+
+forgeplan_activate("PRD-042")
+  → Done.
+```
+
+### Pattern B: Recovery после error
+
+```
+forgeplan_activate("PRD-042")
+  → Error: No evidence linked
+  → Fix: forgeplan validate PRD-042
+
+forgeplan_validate("PRD-042")
+  → Result: PASS
+  → Next: forgeplan score PRD-042
+```
+
+### Pattern C: Multi-agent dispatch
+
+```
+forgeplan_dispatch(--agents 3)
+  → Next: forgeplan claim PRD-054 --agent worker-1 --ttl 30
+  → Or:   forgeplan list --status draft
+
+forgeplan_claim("PRD-054")
+  → Error: Already held by worker-2
+  → Or: forgeplan release PRD-054 --force
+```
+
+## Drift prevention
+
+Контракт enforced через:
+
+1. **Integration test** `crates/forgeplan-cli/tests/hint_contract.rs` — 36 тестов, fails CI если команда без contract marker
+2. **Audit script** `scripts/audit-hints.sh` — coverage метрика, target 100%, currently 100% (70/70 commands)
+
+## Quick reference card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  FORGEPLAN HINT CONTRACT (v0.25.0+)                     │
+├─────────────────────────────────────────────────────────┤
+│  Next:  <command>   → execute as-is                     │
+│  Or:    <command>   → fallback if primary blocks        │
+│  Wait:  <condition> → retry after condition             │
+│  Done.              → workflow complete, move on        │
+│  Fix:   <command>   → error remediation (with Error:)   │
+├─────────────────────────────────────────────────────────┤
+│  Read from: stdout (text), _next_action (JSON/MCP)      │
+│  Special:   list/tree --json → hint on stderr           │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Для пользователей плагина
+
+Marketplace плагин **`forgeplan-workflow` v1.5.0+** учит Claude Code агентов читать эти маркеры автоматически. После установки:
+
+```
+/plugin marketplace update ForgePlan-marketplace
+```
+
+Твой агент будет читать `Next:`/`Fix:` подсказки в `/forge-cycle`, `forge-advisor` агенте и methodology skill — без manual configuration.
+
+## Связанное
+
+- **Forgeplan v0.25.0 release** — первая версия с контрактом ([CHANGELOG](/ru/docs/changelog/))
+- **Marketplace плагин forgeplan-workflow v1.5.0** — agent-side awareness layer
+- **Lifecycle model** ([читать дальше](/ru/docs/methodology/lifecycle/)) — подсказки интегрируются с переходами status (draft → active → terminal)


### PR DESCRIPTION
forgeplan.dev deploys from \`main\` but PR #215 merged into \`dev\`. This PR cherry-picks the website changes onto main so Cloudflare Pages can deploy them.

## Why a separate PR

PR #215 (merged to dev) had website docs for v0.25.0. v0.25.0 binary release PR #213 was code/CHANGELOG only — website updates came after as separate sprint. forgeplan.dev didn't pick them up because CF Pages watches main, not dev.

This is a clean cherry-pick of \`a6b6318\` (the website commit on dev) onto main.

## What's included

- \`website/src/content/docs/docs/changelog.md\` — v0.25.0 entry synced from CHANGELOG
- \`website/src/content/docs/docs/methodology/agent-protocol.md\` — NEW EN page (Hint Contract reference, 198 lines)
- \`website/src/content/docs/ru/docs/methodology/agent-protocol.md\` — NEW RU mirror
- \`website/astro.config.mjs\` — sidebar entry "Hint Contract" under Methodology

## After merge

Cloudflare Pages auto-deploys from main → forgeplan.dev shows:
- Latest version v0.25.0 in /docs/changelog/
- /docs/methodology/agent-protocol/ (EN)
- /ru/docs/methodology/agent-protocol/ (RU)

## Test plan

- [x] Build verified locally (342 pages, 0 broken links, 0 content issues)
- [x] CI passed on PR #215 (same content)
- [ ] CF Pages deploys to main after merge
- [ ] Live verify v0.25.0 shows on forgeplan.dev/docs/changelog/

🤖 Generated with [Claude Code](https://claude.com/claude-code)