### PR TITLE
[chore] Post-Phase 6 cleanup + PROB-047 mitigation 1 (scan-import path blacklist)

### DIFF
--- a/.forgeplan/evidence/EVID-092-prob-047-mitigation-1-scan-import-path-blacklist-verified.md
+++ b/.forgeplan/evidence/EVID-092-prob-047-mitigation-1-scan-import-path-blacklist-verified.md
@@ -1,0 +1,122 @@
+---
+depth: tactical
+id: EVID-092
+kind: evidence
+links:
+- target: PROB-047
+  relation: informs
+status: active
+title: PROB-047 mitigation 1 — scan-import path blacklist verified
+---
+
+# EVID-092: PROB-047 mitigation 1 — scan-import path blacklist verified
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-04-28 |
+| Valid Until | 2027-04-28 |
+| Target | PROB-047 (`scan-import false-positive — classifies docs/guides/instructions as PRDs`) |
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Measurement
+
+**Code change**: `crates/forgeplan-core/src/scan/detect.rs` + `import.rs`
+(commit `aa2ed25` on branch `chore/post-phase6-cleanup-prob047-mitigation`).
+
+New API:
+- `is_doc_path(relative_path: &Path) -> bool` — blacklist for `docs/`,
+  `marketplace/`, и root-level meta files (CLAUDE.md, AGENTS.md, README.md,
+  CHANGELOG.md, CONTRIBUTING.md, TODO.md, ROADMAP.md, plus `.ru.md` localized
+  variants).
+- `detect_kind_with_path(filename, relative_path, content)` — path-aware
+  variant that suppresses Tier 3 (content heuristic) only. Tier 1
+  (frontmatter `kind:` field) и Tier 2 (filename pattern PRD-XXX/RFC-XXX/…)
+  остаются authoritative — explicit signals всегда побеждают.
+- `scan::import::scan_and_import_inner` switched to path-aware variant.
+
+**Verification matrix** (in `scan::detect::tests`):
+
+| Scenario | Expected | Actual | Tier used |
+|----------|----------|--------|-----------|
+| `docs/methodology/FORGEPLAN-GUIDE.md` + Goals/Problem headings, no frontmatter | None (no false-positive) | None | suppressed |
+| `CLAUDE.md` + Problem heading, no frontmatter | None | None | suppressed |
+| `docs/PRD-099-arch.md` + filename pattern, no frontmatter | PRD (filename precedence) | PRD | Filename |
+| `docs/architecture.md` + `kind: prd` frontmatter | PRD (explicit opt-in) | PRD | Frontmatter |
+| `.forgeplan/prds/PRD-099.md` + filename + content | PRD (real artifact location) | PRD | Filename |
+
+**Backward compatibility**:
+- `detect_kind(filename, content)` retained as wrapper passing `None` for
+  path — все 15 existing tests pass без изменений.
+- `is_doc_path` blacklist conservative: sub-crate `crates/foo/CHANGELOG.md`
+  НЕ blacklisted (only root-level), `notes.md` без specific stem НЕ
+  blacklisted (false-positive risk minimised).
+
+## Result
+
+**Test counts**:
+- `scan::detect` module tests: was 15, now 26 (added 11 tests for
+  is_doc_path coverage + path-aware Tier 3 suppression + Tier 1/2
+  precedence under docs).
+- Workspace-wide lib tests: 1400 passed, 0 failed (was 1389 на dev
+  pre-commit aa2ed25, +11 new tests).
+- Workspace gate: `cargo fmt -- --check` clean, `cargo check` 0 warnings,
+  `cargo clippy --workspace --all-targets -- -D warnings` 0 errors.
+
+**Test command**:
+
+```bash
+cargo test --package forgeplan-core --lib detect:: 2>&1 | tail -30
+# 26 tests, all OK, 1302 filtered (other modules)
+
+cargo test --workspace --lib 2>&1 | grep "^test result"
+# every binary OK, total 1400 passed, 0 failed
+```
+
+## Interpretation
+
+**Mitigation 1 closes 100% of the original PROB-047 trigger pattern**.
+The 5 false-positive sources listed in PROB-047 body — `FORGEPLAN-GUIDE.md`,
+`FORGEPLAN-GUIDE.ru.md`, `BROWNFIELD-ORCHESTRATOR-HANDOFF-2026-04-21.ru.md`,
+`CLAUDE.md`, `SPEC-SCHEMA.md` — все classified ИСКЛЮЧИТЕЛЬНО через Tier 3
+(content heuristic). После guard'а Tier 3 suppress'ится для всех paths
+which match blacklist; результат — None (artifact not created).
+
+**Что НЕ закрыто (4 mitigations remain in PROB-047 backlog)**:
+1. ✅ Mitigation 1 — filename + path hybrid heuristic (THIS evidence).
+2. ⏳ Mitigation 2 — `kind:` frontmatter precedence (already implemented
+   in current code as Tier 1, just not formalized in PROB-047 wording).
+3. ⏳ Mitigation 3 — scan-import default `--dry-run` + report, opt-in
+   `--apply` flag (UX change, separate PRD).
+4. ⏳ Mitigation 4 — content_hash-based idempotency (повторный run с тем
+   же source updates existing instead of duplicating).
+5. ⏳ Mitigation 5 — brownfield test fixtures (typical guides → assert
+   scan-import создаёт 0 PRDs).
+
+Mitigation 1 alone is sufficient для closure главных recurring symptoms,
+but PROB-047 stays `active` until 4 remaining mitigations are addressed
+in Phase 7+ sprint.
+
+## Congruence Level Justification
+
+**CL3 (same-context measurement)**. The evidence измеряет именно тот код
+что упомянут в PROB-047 root cause hypothesis ("scan-import классификатор
+смотрит на: filename pattern, markdown headings, YAML frontmatter `kind:`
+field"). Tests are unit tests в том же module (`scan::detect`) что и
+implementation. Workspace gate ran on the same commit. No simulation, no
+proxy, no extrapolation — direct measurement of fix effectiveness.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| PROB-047 | supports (mitigation 1 reduces false-positive rate to 0% for original 5 trigger patterns) |
+| PRD-058 | informs (scan-import is the affected feature) |
+| ADR-003 | informs (markdown source of truth — fix preserves invariant) |
+
+

--- a/.forgeplan/problems/PROB-046-output-hint-contract-not-enforced-agents-waste-tokens-guessing-next-action-across-5-surfaces-cli-text-json-mcp-success-error-cli-error.md
+++ b/.forgeplan/problems/PROB-046-output-hint-contract-not-enforced-agents-waste-tokens-guessing-next-action-across-5-surfaces-cli-text-json-mcp-success-error-cli-error.md
@@ -5,7 +5,8 @@ kind: problem
 links:
 - target: PRD-070
   relation: informs
-status: active
+status: deprecated
+deprecated_reason: Resolved via PRD-071 hint contract implementation shipped in v0.25.0. Hint coverage now 100% across CLI text/JSON + MCP success/error. EVID-086 closes the loop.
 title: Output hint contract not enforced — agents waste tokens guessing next-action across 5 surfaces (CLI text/JSON, MCP success/error, CLI error)
 ---
 

--- a/.forgeplan/problems/PROB-047-scan-import-false-positive-classifies-docs-guides-instructions-as-prds.md
+++ b/.forgeplan/problems/PROB-047-scan-import-false-positive-classifies-docs-guides-instructions-as-prds.md
@@ -11,7 +11,9 @@ links:
   relation: informs
 - target: ADR-003
   relation: informs
-status: draft
+- target: EVID-092
+  relation: based_on
+status: active
 title: scan-import false-positive — classifies docs/guides/instructions as PRDs
 ---
 
@@ -20,7 +22,7 @@ created: 2026-04-28
 id: PROB-047
 kind: problem
 title: scan-import false-positive — classifies docs/guides/instructions as PRDs
-status: draft
+status: active
 ---
 
 # PROB-047: scan-import false-positive — classifies docs/guides/instructions as PRDs

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ W1-L2-CLAUDE-additional-sources.zip
 
 # Workspace advisory lock file (PRD-057) — fs2 flock on .forgeplan/.lock
 .forgeplan/.lock
+
+# Playbook execution journal (PRD-065) — per-run JSONL of step results,
+# workspace-local runtime state, not version-controlled.
+.forgeplan/journal/

--- a/crates/forgeplan-core/src/scan/detect.rs
+++ b/crates/forgeplan-core/src/scan/detect.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use crate::artifact::frontmatter::parse_frontmatter;
 use crate::artifact::types::ArtifactKind;
 
@@ -28,18 +30,91 @@ pub struct DetectionResult {
 ///
 /// Returns `None` if no tier can determine the type.
 pub fn detect_kind(filename: &str, content: &str) -> Option<DetectionResult> {
-    // Tier 1: Frontmatter
+    detect_kind_with_path(filename, None, content)
+}
+
+/// Path-aware variant of `detect_kind`. When `relative_path` matches a known
+/// documentation location (PROB-047 mitigation 1), Tier 3 (content heuristic)
+/// detection is suppressed — frontmatter and filename patterns remain
+/// authoritative because they are explicit signals.
+///
+/// This prevents misclassification of guides, instruction files, and config
+/// docs (e.g. `docs/methodology/FORGEPLAN-GUIDE.md` containing `## Goals`,
+/// `CLAUDE.md` containing `## Problem`) as PRDs.
+pub fn detect_kind_with_path(
+    filename: &str,
+    relative_path: Option<&Path>,
+    content: &str,
+) -> Option<DetectionResult> {
+    // Tier 1: Frontmatter — explicit, always authoritative.
     if let Some(result) = detect_from_frontmatter(content) {
         return Some(result);
     }
 
-    // Tier 2: Filename pattern
+    // Tier 2: Filename pattern (PRD-001, RFC-002…) — explicit naming convention.
     if let Some(result) = detect_from_filename(filename) {
         return Some(result);
     }
 
-    // Tier 3: Content heuristics
+    // Tier 3: Content heuristics — suppressed for known documentation paths
+    // because guides describing artifact structure naturally contain the
+    // same headings as the artifacts themselves (PROB-047).
+    if let Some(path) = relative_path
+        && is_doc_path(path)
+    {
+        return None;
+    }
     detect_from_content(content)
+}
+
+/// Returns `true` if `relative_path` points to a documentation file or
+/// project meta-file that should NOT be auto-classified by content
+/// heuristics (PROB-047 mitigation 1). Explicit frontmatter or filename
+/// patterns still win — this guard only suppresses Tier 3.
+///
+/// Blacklist:
+/// - any file under `docs/` or `marketplace/` (recursive)
+/// - root-level project meta-files: `CLAUDE.md`, `AGENTS.md`, `README.md`,
+///   `CONTRIBUTING.md`, `CHANGELOG.md`, `TODO.md`, `ROADMAP.md`,
+///   `LICENSE.md`, `SECURITY.md`, plus their `.ru.md` localized variants
+pub fn is_doc_path(relative_path: &Path) -> bool {
+    let path_str = relative_path.to_string_lossy();
+    let normalized = path_str.replace('\\', "/");
+    let normalized = normalized.trim_start_matches("./");
+
+    if normalized.starts_with("docs/") || normalized.starts_with("marketplace/") {
+        return true;
+    }
+
+    // Root-level meta-files (no path separators after normalization).
+    if !normalized.contains('/') {
+        const ROOT_DOC_FILES: &[&str] = &[
+            "CLAUDE.md",
+            "CLAUDE.ru.md",
+            "AGENTS.md",
+            "AGENTS.ru.md",
+            "README.md",
+            "README.ru.md",
+            "CONTRIBUTING.md",
+            "CONTRIBUTING.ru.md",
+            "CHANGELOG.md",
+            "CHANGELOG.ru.md",
+            "TODO.md",
+            "TODO.ru.md",
+            "ROADMAP.md",
+            "ROADMAP.ru.md",
+            "LICENSE.md",
+            "SECURITY.md",
+        ];
+        if ROOT_DOC_FILES
+            .iter()
+            .any(|f| f.eq_ignore_ascii_case(normalized))
+        {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Tier 1: Parse YAML frontmatter for `kind` field.
@@ -329,5 +404,124 @@ mod tests {
     fn binary_looking_content_returns_none() {
         let content = "\0\0\0binary garbage\x01\x02";
         assert!(detect_kind("binary.md", content).is_none());
+    }
+
+    // ============================================================
+    // PROB-047 mitigation 1: filename/path blacklist for docs
+    // ============================================================
+
+    #[test]
+    fn is_doc_path_under_docs_directory() {
+        assert!(is_doc_path(Path::new(
+            "docs/methodology/FORGEPLAN-GUIDE.md"
+        )));
+        assert!(is_doc_path(Path::new("docs/foo.md")));
+        assert!(is_doc_path(Path::new("./docs/foo.md")));
+    }
+
+    #[test]
+    fn is_doc_path_under_marketplace_directory() {
+        assert!(is_doc_path(Path::new("marketplace/playbooks/foo.md")));
+        assert!(is_doc_path(Path::new("./marketplace/foo.md")));
+    }
+
+    #[test]
+    fn is_doc_path_root_level_meta_files() {
+        assert!(is_doc_path(Path::new("CLAUDE.md")));
+        assert!(is_doc_path(Path::new("AGENTS.md")));
+        assert!(is_doc_path(Path::new("README.md")));
+        assert!(is_doc_path(Path::new("README.ru.md")));
+        assert!(is_doc_path(Path::new("CHANGELOG.md")));
+        assert!(is_doc_path(Path::new("CONTRIBUTING.md")));
+        assert!(is_doc_path(Path::new("TODO.md")));
+        assert!(is_doc_path(Path::new("ROADMAP.md")));
+    }
+
+    #[test]
+    fn is_doc_path_meta_files_case_insensitive() {
+        assert!(is_doc_path(Path::new("claude.md")));
+        assert!(is_doc_path(Path::new("Readme.md")));
+    }
+
+    #[test]
+    fn is_doc_path_not_blacklisted() {
+        // Real artifact locations
+        assert!(!is_doc_path(Path::new(".forgeplan/prds/PRD-001-real.md")));
+        assert!(!is_doc_path(Path::new(".forgeplan/adrs/ADR-001.md")));
+        // Sub-crate CHANGELOG isn't blacklisted — keeps classifier conservative
+        assert!(!is_doc_path(Path::new("crates/foo/CHANGELOG.md")));
+        // Random root .md files are NOT blacklisted (only specific stems)
+        assert!(!is_doc_path(Path::new("PRD-001-design.md")));
+        assert!(!is_doc_path(Path::new("notes.md")));
+    }
+
+    #[test]
+    fn path_aware_suppresses_content_tier_under_docs() {
+        // FORGEPLAN-GUIDE has `## Problem` and `## Goals` — Tier 3 would
+        // classify it as PRD without the path guard.
+        let content = "# Forgeplan Guide\n\n## Problem\nDescribed.\n\n## Goals\nListed.";
+        let path = Path::new("docs/methodology/FORGEPLAN-GUIDE.md");
+
+        // Without path: Tier 3 classifies as PRD (the bug).
+        assert_eq!(
+            detect_kind("FORGEPLAN-GUIDE.md", content).map(|r| r.tier),
+            Some(DetectionTier::Content)
+        );
+
+        // With path: Tier 3 suppressed — guide stays unclassified.
+        assert!(detect_kind_with_path("FORGEPLAN-GUIDE.md", Some(path), content).is_none());
+    }
+
+    #[test]
+    fn path_aware_suppresses_content_tier_for_root_claude_md() {
+        // CLAUDE.md contains `## Problem` (in red lines section) and
+        // would otherwise hit PRD content heuristic.
+        let content = "# CLAUDE.md\n\n## Problem\nFoo.\n\n## Goals\nBar.";
+        let path = Path::new("CLAUDE.md");
+
+        assert!(detect_kind_with_path("CLAUDE.md", Some(path), content).is_none());
+    }
+
+    #[test]
+    fn path_aware_honors_explicit_frontmatter_under_docs() {
+        // Explicit `kind: prd` frontmatter is authoritative even under docs/
+        // — user opted in deliberately.
+        let content = "---\nkind: prd\nid: PRD-099\n---\n# Real PRD in docs/\n\n## Problem\nX.";
+        let path = Path::new("docs/PRD-099-architecture.md");
+
+        let result = detect_kind_with_path("PRD-099-architecture.md", Some(path), content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Prd);
+        assert_eq!(result.tier, DetectionTier::Frontmatter);
+    }
+
+    #[test]
+    fn path_aware_honors_filename_pattern_under_docs() {
+        // Filename pattern PRD-001 is also explicit — keep classifying it.
+        let content = "# Real PRD in docs\n\nNo frontmatter, but filename is explicit.";
+        let path = Path::new("docs/PRD-099-arch.md");
+
+        let result = detect_kind_with_path("PRD-099-arch.md", Some(path), content).unwrap();
+        assert_eq!(result.kind, ArtifactKind::Prd);
+        assert_eq!(result.tier, DetectionTier::Filename);
+    }
+
+    #[test]
+    fn path_aware_passthrough_for_non_blacklisted_paths() {
+        // Files under .forgeplan/ or random locations are unaffected.
+        let content = "# Foo\n\n## Problem\nX.\n\n## Goals\nY.";
+        let path = Path::new(".forgeplan/prds/PRD-099.md");
+
+        let result = detect_kind_with_path("PRD-099.md", Some(path), content).unwrap();
+        // Filename tier wins here, but if we strip filename pattern...
+        assert_eq!(result.kind, ArtifactKind::Prd);
+    }
+
+    #[test]
+    fn path_aware_no_path_falls_back_to_old_behavior() {
+        // detect_kind_with_path(.., None, ..) === detect_kind
+        let content = "# Foo\n\n## Problem\nX.\n\n## Goals\nY.";
+        let r1 = detect_kind("foo.md", content);
+        let r2 = detect_kind_with_path("foo.md", None, content);
+        assert_eq!(r1.map(|r| r.kind), r2.map(|r| r.kind));
     }
 }

--- a/crates/forgeplan-core/src/scan/import.rs
+++ b/crates/forgeplan-core/src/scan/import.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::artifact::types::ArtifactKind;
 use crate::db::store::{LanceStore, NewArtifact};
-use crate::scan::detect::{DetectionResult, DetectionTier, detect_kind};
+use crate::scan::detect::{DetectionResult, DetectionTier, detect_kind_with_path};
 use crate::scan::discovery::{DiscoveredFile, discover_markdown_files};
 use crate::scan::status_map::map_external_status;
 
@@ -138,7 +138,7 @@ async fn scan_and_import_inner(
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
 
-        let detection = detect_kind(filename, &file.content);
+        let detection = detect_kind_with_path(filename, Some(&file.relative_path), &file.content);
 
         let entry = match detection {
             Some(det) => {


### PR DESCRIPTION
## Summary

Workspace hygiene + root-cause fix for the recurring PROB-047 false-positive pattern that triggered PR #218 cleanup. Five atomic commits:

| Commit | Subject |
|---|---|
| `97c935d` | gitignore `.forgeplan/journal/` (PRD-065 runtime state) |
| `756a93a` | deprecate PROB-046 (resolved by PRD-071 v0.25.0 hint contract) |
| `aa2ed25` | **fix(scan-import)**: suppress Tier 3 detection for `docs/`, `marketplace/`, root meta files |
| `c20f4d6` | EVID-092 — same-context measurement of mitigation 1 |
| `89c0f86` | sync PROB-047 frontmatter (status + EVID-092 link) |

## Why

After Phase 5+6 merged (PRs #217, #219, #220), `forgeplan health` reported:
- 9 orphan artifacts (PRD-001/021/027–032 + SPEC-001 — all `author: scan-import` false-positives, body matches `docs/methodology/FORGEPLAN-GUIDE.md` / `CLAUDE.md` / `SPEC-SCHEMA.md`)
- PROB-046 active+phase=shape (resolved via PRD-071 in v0.25.0 — wasn't deprecated)
- EPIC-007 active+phase=validate (children shipped — phase out of date)
- PROB-047 active without evidence (blind spot)

PR #218 cleanup was symptomatic: deleted 29 false-positives but didn't fix the classifier. They recurred. This PR closes the loop with a proper code-level mitigation.

## Root cause + fix (commit `aa2ed25`)

`crates/forgeplan-core/src/scan/detect.rs` had a 3-tier classifier (frontmatter → filename → content). All 5 false-positive trigger files (`FORGEPLAN-GUIDE.md`, `FORGEPLAN-GUIDE.ru.md`, `BROWNFIELD-…HANDOFF.md`, `CLAUDE.md`, `SPEC-SCHEMA.md`) matched **Tier 3** (content heuristics) because they describe artifact structure and naturally contain `## Goals`, `## Problem`, `## Decision` etc.

**Mitigation 1 (PROB-047 mitigation list)** — new `is_doc_path(relative_path)` blacklist for documentation paths + `detect_kind_with_path()` path-aware variant that suppresses Tier 3 only. Tier 1 (frontmatter `kind:` field) and Tier 2 (filename pattern PRD-001/RFC-002) remain authoritative — explicit signals always win.

Blacklist scope:
- recursive: `docs/`, `marketplace/`
- root-level meta files: `CLAUDE.md`, `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `TODO.md`, `ROADMAP.md` (+ `.ru.md` localized variants), `LICENSE.md`, `SECURITY.md`

## Tests

- 11 new unit tests in `scan::detect::tests` covering `is_doc_path` matrix + path-aware Tier 3 suppression + Tier 1/Tier 2 precedence under docs.
- All 15 existing `scan::detect` tests unchanged (backward compat via `detect_kind` wrapper).
- Workspace-wide: **1400 lib tests pass, 0 fail** (was 1389 on dev).
- Workspace gate clean: `cargo fmt --check` ✓, `cargo check` 0 warnings, `cargo clippy --workspace --all-targets -- -D warnings` 0 errors.

## Health diff (CLI `forgeplan health`)

| Metric | Before | After |
|---|---|---|
| Total artifacts | 266 | 258 |
| Orphans | 9 | 0 |
| Blind spots | 1 (PROB-047) | 0 |
| Advisory phase mismatches | 2 (PROB-046 shape, EPIC-007 validate) | 0 |
| Duplicate pairs | 4 | 0 |
| PROB-047 R_eff | 0.0 | 0.71 (B) |
| Status | "1 blind spot…" | **"Project looks healthy"** |

## Deferred

PROB-047 stays active (mitigation 1 closes 100% of original 5 trigger patterns, but 4 mitigations remain backlog for Phase 7+ sprint):
2. Frontmatter precedence formalization (already de-facto Tier 1)
3. scan-import default `--dry-run` + opt-in `--apply`
4. content_hash-based idempotency (re-run updates instead of duplicating)
5. Brownfield test fixtures asserting 0 PRDs from typical guides

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check --workspace` 0 warnings
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 0 errors
- [x] `cargo test --workspace` 1400+ tests pass
- [x] `forgeplan health` → "Project looks healthy"
- [x] `forgeplan score PROB-047` → R_eff 0.71 (B)
- [x] EVID-092 validate PASS, activated, structured fields complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)