### PR TITLE
[chore] ADR-003 Stage 1 — regression guard + PROB-048/PRD-073 + 3 red lines

### DIFF
--- a/.forgeplan/prds/PRD-073-adr-003-file-first-migration-phase-out-direct-lancestore-mutations-from-commands-and-mcp-handlers.md
+++ b/.forgeplan/prds/PRD-073-adr-003-file-first-migration-phase-out-direct-lancestore-mutations-from-commands-and-mcp-handlers.md
@@ -1,0 +1,95 @@
+---
+depth: standard
+id: PRD-073
+kind: prd
+status: draft
+title: ADR-003 file-first migration — phase out direct LanceStore mutations from commands and MCP handlers
+links:
+- target: PROB-048
+  relation: based_on
+- target: ADR-003
+  relation: based_on
+---
+
+# PRD-073: ADR-003 file-first migration
+
+## Problem
+
+PROB-048 documents 32+ direct `LanceStore` mutating call sites in `crates/forgeplan-cli/src/commands/` (27) and `crates/forgeplan-mcp/src/server.rs` (5 production). Each is a potential ADR-003 invariant violation: writes go to LanceDB without first updating the markdown file. Three concrete drifts surfaced in the 2026-04-28 sprint (deprecate, link bidirectional, status).
+
+## Goals
+
+1. **Zero direct mutations**. All 32 call sites migrated to a single helper API that writes the markdown file first, then syncs LanceDB.
+2. **Compile-time enforcement**. After migration, demote `LanceStore::{create_artifact, update_*, delete_*, add_relation, delete_relation}` to `pub(crate)`. External consumers (commands, MCP handlers) cannot bypass.
+3. **Regression-proof**. The existing `tests/adr_003_invariant.rs` baseline reaches `CLI_BASELINE = 0` / `MCP_BASELINE = 0` and stays there. Visibility change makes any future bypass a compile error.
+4. **Reproducibility evidence**. EVID with `git clone → forgeplan reindex → assert workspace state identical to source` measurement.
+
+## Non-Goals
+
+- NOT a rewrite of `LanceStore` schema or query API — only mutation surface
+- NOT touching read-only methods (`get_*`, `list_*`, `search_*`) — they don't violate the invariant
+- NOT tackling `update_embedding` or `update_r_eff_score` — these are derived/cached values where LanceDB IS the authoritative store (covered in separate ADR clarification if needed)
+- NOT FPF or vector-search code paths — `insert_fpf_chunks` etc. operate on a separate LanceDB table without markdown projection
+
+## Target Users
+
+- **Forgeplan contributors** writing new commands or MCP handlers — get a single obvious helper, no decision paralysis
+- **Brownfield adopters** running scan-import on existing repos — clone reproducibility ensures their workspace state survives `git pull` without surprises
+- **AI agents** (Claude Code et al) using forgeplan tools — deterministic file state across sessions
+
+## Functional Requirements
+
+- **FR-001**: New helper `forgeplan_core::projection::write_artifact_mutation(workspace, id, mutation_kind, fields)` that:
+  - Reads current file
+  - Applies mutation to in-memory frontmatter / body
+  - Writes file atomically
+  - Calls `reindex_one(path)` to sync LanceDB
+- **FR-002**: Migrate CLI commands (27 call sites). Lower `CLI_BASELINE` in regression test to `0`.
+- **FR-003**: Migrate MCP handlers (5 call sites). Lower `MCP_BASELINE` to `0`.
+- **FR-004**: Visibility change — `LanceStore::create_artifact / update_* / delete_* / add_relation / delete_relation` → `pub(crate)`. External crates cannot call.
+- **FR-005**: Bidirectional link rendering — `forgeplan link` re-renders projections for source AND target so both files reflect the edge.
+- **FR-006**: EVID-XXX measurement — clean `git clone` of a repo with active artifacts, run `forgeplan reindex`, compare workspace state byte-for-byte to source.
+
+## Success Criteria
+
+1. `tests/adr_003_invariant.rs` passes with both baselines = 0
+2. `cargo build -p forgeplan-cli -p forgeplan-mcp` fails to compile if one re-introduces a direct mutation (because methods are `pub(crate)`)
+3. `cargo test --workspace` 0 failures (existing 1400+ lib tests + new helper tests)
+4. EVID demonstrates clone reproducibility with structured fields CL3
+5. CHANGELOG entry для release что shipnет migration
+
+## Phases
+
+### Phase 1 — Helper API design + first migration (1 PR, ~2-3h)
+- Design `write_artifact_mutation` signature with all mutation kinds (create, update_status, update_title, update_body, update_depth, update_valid_until, update_tags, add_link, delete_link, delete)
+- Implement in `core::projection`
+- Migrate 1-2 representative commands as canary (e.g., `tag.rs`)
+- Lower `CLI_BASELINE` accordingly
+
+### Phase 2 — MCP handlers + bidirectional links (1 PR, ~2h)
+- Migrate 5 MCP production sites
+- Implement bidirectional link rendering in helper
+- Lower `MCP_BASELINE` to 0
+
+### Phase 3 — Bulk CLI migration (1 PR, ~3-4h)
+- Migrate remaining ~25 CLI sites
+- Each migration is a focused diff
+- `CLI_BASELINE = 0`
+
+### Phase 4 — Visibility lockdown (1 PR, ~30min)
+- Demote LanceStore methods to `pub(crate)`
+- Compile errors confirm completeness
+- Remove regression guard test (compile-time enforcement supersedes it) OR keep as belt-and-suspenders
+
+### Phase 5 — Evidence + closure (1 PR, ~1h)
+- Create EVID-XXX with reproducibility measurement
+- Activate PROB-048 closure
+- Update CLAUDE.md to remove "in-progress migration" caveat
+
+Total: ~9-12h focused work across 5 PRs / 1 sprint.
+
+## Related Artifacts
+
+- PROB-048: documents the invariant violation (this PRD addresses)
+- ADR-003: invariant definition (this PRD enforces)
+- EVID-XXX: end-to-end reproducibility measurement (TBD)

--- a/.forgeplan/problems/PROB-048-adr-003-file-first-invariant-direct-lancestore-mutations-bypass-markdown-source-of-truth.md
+++ b/.forgeplan/problems/PROB-048-adr-003-file-first-invariant-direct-lancestore-mutations-bypass-markdown-source-of-truth.md
@@ -1,0 +1,72 @@
+---
+depth: standard
+id: PROB-048
+kind: problem
+status: active
+title: ADR-003 file-first invariant — direct LanceStore mutations bypass markdown source-of-truth
+links:
+- target: ADR-003
+  relation: based_on
+- target: PRD-073
+  relation: informs
+---
+
+# PROB-048: ADR-003 file-first invariant violated by direct LanceStore mutations
+
+## Context
+
+ADR-003 (active) declares: **markdown files в `.forgeplan/` — source of truth; LanceDB — derived, gitignored index**. Invariant в том что каждая мутация артефакта должна:
+
+1. Записать markdown файл FIRST (frontmatter + body)
+2. Sync результат в LanceDB через `forgeplan_core::projection::*`
+3. Никогда напрямую не вызывать `LanceStore::create_artifact / update_* / delete_* / add_relation / delete_relation` из command handler'а
+
+Practical consequence: fresh `git clone` + `forgeplan reindex` должен воспроизвести точно такое же workspace state как у автора. Если handler обновил LanceDB но не файл — следующий reindex на клоне молча расходится.
+
+## Observed symptoms (sprint 2026-04-28)
+
+Three independent skews surfaced в одной сессии:
+
+1. **MCP `forgeplan_deprecate` обновляет только LanceDB** — file's `status:` frontmatter оставался `draft` while LanceStore получил `deprecated`. CLI впоследствии отвергал re-deprecate как "deprecated → deprecated" (lance state) хотя файл утверждал что он draft.
+
+2. **CLI `forgeplan link EVID-092 PROB-047 --relation informs` рендерил projection только для source** (EVID-092). Target's (PROB-047) frontmatter никогда не получил соответствующий link. Health checker который ожидает наличие relation с любой стороны пометил PROB-047 как blind spot пока я не добавил explicit reverse link вручную.
+
+3. **PROB-047 file `status: draft` while LanceDB had `status: active`** — origin unclear, possibly an MCP-driven activate which bypassed projection. Workspace `forgeplan health` показал phantom blind spot пока файл не был отредактирован вручную.
+
+## Root cause hypothesis
+
+`crates/forgeplan-cli/src/commands/` и `crates/forgeplan-mcp/src/server.rs` содержат ~32 прямых call sites к мутирующим `LanceStore` методам (counted 2026-04-29: 27 в CLI, 5 в MCP production paths excluding `#[cfg(test)]`). Некоторые commands оборачивают их с `projection::sync_file_to_store` + `render_projection` (CLI lifecycle commands like `deprecate.rs` — корректные examples), другие — нет (большинство MCP handlers, несколько CLI commands like `tag.rs`, `update.rs` partial coverage, etc.).
+
+Без единого enforced flow, каждый новый handler — coin-flip: запомнил ли автор отрендерить? Когда у 30+ handlers each имеет opportunity забыть, drift — статистическая certainty.
+
+## Impact
+
+- **Workspace skew**: clone reproduction broken — derived state на клоне отличается от author's machine
+- **Phantom health signals**: blind spots / orphans / phase mismatches которые look real но являются LanceDB drift artefacts. Тратит audit time.
+- **Silent data loss risk**: если LanceDB rebuilt from files через `reindex`, мутации которых нет в files — lost. Сегодня единственное что защищает users — это что они редко rebuild
+- **Methodology dilution**: ADR-003 документирует invariant; код нарушает. New contributors learn from code, not docs.
+
+## Mitigations (PRD-073 will execute)
+
+1. **Regression guard test** (DONE in PR closing PROB-048 stage 1) — `tests/adr_003_invariant.rs` caps direct mutation count at current baseline. New PRs must not regress.
+
+2. **Migrate MCP lifecycle handlers** — `forgeplan_deprecate` / `forgeplan_activate` / `forgeplan_supersede` / `forgeplan_renew` / `forgeplan_reopen` to use same `sync_file_to_store` + `render_projection` flow as CLI counterparts.
+
+3. **Bidirectional link rendering** — `forgeplan link` должен re-render projections для BOTH source и target чтобы оба файла отражали новый edge корректно.
+
+4. **Migrate remaining CLI commands** — `tag.rs`, `update.rs` body path, `score.rs`, `delete.rs`, etc. Каждая migration — measurable ratchet (lower the test baseline).
+
+5. **Long-term**: сделать mutating `LanceStore` methods `pub(crate)` так что external consumers не могут bypass helper. Это architectural endpoint — когда reachable, все violations становятся compile-time errors.
+
+## Acceptance Criteria for closure
+
+- [ ] `tests/adr_003_invariant.rs` baseline reaches `CLI_BASELINE = 0` и `MCP_BASELINE = 0`
+- [ ] New helper `forgeplan_core::projection::write_artifact(...)` exists, used by all mutations
+- [ ] `LanceStore::{create_artifact, update_*, delete_*, add_relation, delete_relation}` are `pub(crate)`
+- [ ] EVID with end-to-end measurement: clone → reindex produces identical workspace state to author's
+
+## Related Artifacts
+
+- ADR-003: source of truth invariant (this problem cites)
+- PRD-073: full migration plan (this problem informs)
+- EVID-XXX (TBD after PRD-073 completion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,9 @@ Instructions for Claude Code when working in this repository.
 5. **DO NOT create a PR before `Code → Audit → Fix → Test → Fmt → Lint → Verify`**. **Verify** означает: unit tests + **РЕАЛЬНЫЙ E2E каждой затронутой surface** (не один tool из 45 — все затронутые). Dogfood with actual user tooling (brew binary, real client). Silent failures (PROB-035, PROB-039) все от того что протестировали только happy path.
 6. **DO NOT leave PRD stubs** — `forgeplan new prd` → immediately fill in the MUST sections.
 7. **DO NOT activate an artifact without code and evidence** — R_eff must be > 0. **EvidencePack body MUST contain** `verdict:`, `congruence_level:`, `evidence_type:` — без этих structured fields parser тихо ставит CL0 (silent failure → R_eff = 0.1).
+8. **DO NOT call `LanceStore::create_artifact / update_* / delete_* / add_relation / delete_relation` directly from `commands/*.rs` или `server.rs`** — нарушает ADR-003 (markdown — source of truth). Используй `forgeplan_core::projection::sync_file_to_store` + `render_projection` flow (см. canonical `crates/forgeplan-cli/src/commands/deprecate.rs`). Regression guard: `tests/adr_003_invariant.rs` блокирует рост counts. Migration tracker: PROB-048 + PRD-073.
+9. **DO NOT skip the post-release sync step** — после каждого `release/v* → main` PR merge обязательно открывай sync-PR `chore/sync-main-to-dev-after-vX.Y.Z` (branch protection blocks direct push to dev). Без этого dev forever lags `Cargo.toml` version, и следующий release создаст merge conflicts. См. PR #223 как канонический пример flow.
+10. **DO NOT ignore Dependabot alerts at release time** — перед каждым `release/v* → main` PR проверь `gh api repos/.../dependabot/alerts` и в release notes пометь: addressed / scheduled / accepted-with-justification. Накопление alerts — отдельный architectural debt (PROB-XXX TBD при первом triage).
 
 Everything else in this file is guidelines, not red lines.
 

--- a/crates/forgeplan-cli/tests/adr_003_invariant.rs
+++ b/crates/forgeplan-cli/tests/adr_003_invariant.rs
@@ -1,0 +1,129 @@
+//! ADR-003 regression guard.
+//!
+//! ADR-003 invariant: markdown files in `.forgeplan/` are the source of truth;
+//! LanceDB is a derived, gitignored index. Every mutation must write to the
+//! markdown file FIRST, then sync to LanceDB via `forgeplan_core::projection`.
+//!
+//! Direct calls to `LanceStore::create_artifact` / `update_*` / `delete_*` /
+//! `add_relation` / `delete_relation` from `commands/*.rs` or `server.rs`
+//! bypass the file. Even when followed by `projection::render_projection`,
+//! the order is wrong — the file becomes stale until the next reindex.
+//!
+//! This test caps the number of such direct calls at the current baseline.
+//! New PRs MUST NOT add more. Migrating an existing call site to the
+//! file-first helper is a positive ratchet — when this test starts to fail
+//! because the count went DOWN, lower the constants accordingly.
+//!
+//! Tracking: PROB-048 (architectural debt), PRD-073 (full migration sprint).
+//! Helper API: `forgeplan_core::projection::sync_file_to_store` +
+//! `render_projection` (used by CLI lifecycle commands today).
+
+use std::fs;
+use std::path::Path;
+
+/// Mutating LanceStore methods that bypass file-first flow when called
+/// directly from a command handler. Read-only methods (`get_*`, `list_*`,
+/// `search_*`) are excluded — they don't violate the invariant.
+const FORBIDDEN_PATTERNS: &[&str] = &[
+    "store.create_artifact(",
+    "store.update_artifact(",
+    "store.update_valid_until(",
+    "store.update_depth(",
+    "store.update_body(",
+    "store.add_tags(",
+    "store.remove_tags(",
+    "store.delete_artifact(",
+    "store.add_relation(",
+    "store.delete_relation(",
+    "store.delete_relations_for_artifact(",
+];
+
+/// Current baseline. Bumping these UP requires explicit ADR amendment.
+/// Bumping them DOWN is the goal — every migrated handler reduces the count.
+///
+/// CLI baseline counted on 2026-04-29 across `crates/forgeplan-cli/src/commands/*.rs`.
+const CLI_BASELINE: usize = 27;
+
+/// MCP baseline counted on 2026-04-29 across `crates/forgeplan-mcp/src/server.rs`,
+/// production code paths only (test fixtures inside `#[cfg(test)]` are exempt
+/// because tests need raw store access for setup).
+const MCP_BASELINE: usize = 5;
+
+#[test]
+fn cli_commands_have_no_new_direct_lance_mutations() {
+    let count = count_violations_in_dir(Path::new("src/commands"));
+    assert!(
+        count <= CLI_BASELINE,
+        "ADR-003 regression: CLI commands/ has {count} direct LanceStore mutations \
+         (baseline = {CLI_BASELINE}). Either migrate the new call to the file-first \
+         flow (sync_file_to_store + lifecycle/link operation + render_projection — \
+         see crates/forgeplan-cli/src/commands/deprecate.rs for the canonical \
+         pattern) OR, if you migrated an existing site, lower CLI_BASELINE in \
+         this test."
+    );
+    if count < CLI_BASELINE {
+        panic!(
+            "ADR-003 ratchet: CLI count dropped from {CLI_BASELINE} to {count}. \
+             Update CLI_BASELINE = {count} in tests/adr_003_invariant.rs to lock in \
+             the improvement (otherwise a future regression up to {CLI_BASELINE} would \
+             pass silently)."
+        );
+    }
+}
+
+#[test]
+fn mcp_server_has_no_new_direct_lance_mutations() {
+    // MCP server is a single big file; we exclude test fixtures by ignoring
+    // anything inside `#[cfg(test)]` blocks (rough — counts whole-file).
+    // Production code is the part above the first `#[cfg(test)]` marker.
+    let path = Path::new("../forgeplan-mcp/src/server.rs");
+    let production_text = read_until_test_module(path);
+    let count = count_violations_in_text(&production_text);
+    assert!(
+        count <= MCP_BASELINE,
+        "ADR-003 regression: MCP server.rs has {count} direct LanceStore mutations \
+         in production code (baseline = {MCP_BASELINE}). Migrate to the file-first \
+         flow used by CLI commands — see deprecate.rs for the pattern."
+    );
+    if count < MCP_BASELINE {
+        panic!(
+            "ADR-003 ratchet: MCP count dropped from {MCP_BASELINE} to {count}. \
+             Update MCP_BASELINE = {count} in tests/adr_003_invariant.rs."
+        );
+    }
+}
+
+fn count_violations_in_dir(dir: &Path) -> usize {
+    let mut total = 0;
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            if let Ok(text) = fs::read_to_string(&path) {
+                total += count_violations_in_text(&text);
+            }
+        } else if path.is_dir() {
+            total += count_violations_in_dir(&path);
+        }
+    }
+    total
+}
+
+fn count_violations_in_text(text: &str) -> usize {
+    FORBIDDEN_PATTERNS
+        .iter()
+        .map(|pat| text.matches(pat).count())
+        .sum()
+}
+
+fn read_until_test_module(path: &Path) -> String {
+    let full = fs::read_to_string(path).expect("read MCP server.rs");
+    if let Some(idx) = full.find("#[cfg(test)]") {
+        full[..idx].to_string()
+    } else {
+        full
+    }
+}


### PR DESCRIPTION
## Summary

Stage 1 of ADR-003 file-first migration. **No code migration in this PR** — that lands across follow-up PRs tracked by PRD-073. This PR delivers:

1. **Regression guard test** `tests/adr_003_invariant.rs` — caps direct `LanceStore::{create_artifact, update_*, delete_*, add_relation, delete_relation}` calls at current baseline (CLI=27, MCP=5). New PRs that add violations fail CI; migration PRs must lower the constant (positive ratchet).
2. **Tracking artifacts** — PROB-048 (architectural debt with 3 observed drift examples) + PRD-073 (5-phase migration plan, ~9-12h estimated).
3. **Three new RED LINES** in CLAUDE.md (rules 8-10): file-first invariant, post-release sync PR mandatory, dependabot triage at release time.

## Why Stage 1 instead of full migration in one PR

Full migration touches 32+ call sites across two crates plus visibility changes — too much surface for a single PR without high regression risk. Splitting into tracked phases is the prudent path. The regression guard ensures **no new violations slip in** while migration proceeds incrementally; the planning artifacts make the work scope visible to anyone reading `.forgeplan/`.

## Background — drifts observed during 2026-04-28 sprint

Three independent failures of the ADR-003 invariant surfaced in a single session:

1. **MCP `forgeplan_deprecate`** — updated LanceDB only; file `status:` frontmatter stayed `draft`. CLI subsequently rejected re-deprecate as "deprecated → deprecated".
2. **CLI `forgeplan link EVID-092 PROB-047`** — rendered projection only for source. Target's frontmatter never received the corresponding link. Health checker flagged a phantom blind spot until I added the reverse link manually.
3. **PROB-047 `status: draft` in file vs `active` in LanceDB** — phantom orphan that needed manual file edit + reindex.

Root cause: 32 direct LanceStore mutation call sites, no enforced single flow.

## Test plan

- [x] `tests/adr_003_invariant.rs` passes at current baseline (CLI=27, MCP=5)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 0 errors
- [x] `cargo test --workspace --lib` 1400 passed, 0 failed
- [x] Test fails if a new direct mutation is added (verified manually by adding spurious call — locks regression)
- [x] Test fails if count drops without baseline update (positive ratchet — forces explicit acknowledgement of improvement)
- [ ] CI green on dev base

## Migration roadmap (executes after this PR merges, tracked in PRD-073)

| Phase | Scope | Est | Outcome |
|---|---|---|---|
| 1 | Helper API design + canary migration | 2-3h | `write_artifact_mutation()` + 1-2 sites done |
| 2 | MCP handlers + bidirectional links | 2h | MCP_BASELINE=0 |
| 3 | Bulk CLI migration | 3-4h | CLI_BASELINE=0 |
| 4 | Visibility lockdown (`pub(crate)`) | 30min | Compile-time enforcement |
| 5 | Reproducibility EVID + closure | 1h | PROB-048 closed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)