### PR TITLE
[chore] CI ergonomics — cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
+  # sccache via GHA cache backend — free, scoped per-branch, ~50-70% speedup
+  # on rebuilds of incremental dep changes. Falls back to no-op if backend
+  # is unavailable, so workflow stays green even on cold cache.
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   check:
@@ -32,6 +37,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -43,6 +51,10 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
   test:
     name: Tests
@@ -61,8 +73,25 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
-      - name: cargo test
-        run: cargo test --workspace
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: cargo nextest run
+        run: cargo nextest run --workspace --all-targets
+
+      - name: cargo test (doc-tests)
+        # nextest does not run doc-tests yet (see nextest-rs/nextest#16).
+        # Run separately to maintain coverage parity.
+        run: cargo test --workspace --doc
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,6 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
-  # sccache via GHA cache backend — free, scoped per-branch, ~50-70% speedup
-  # on rebuilds of incremental dep changes. Falls back to no-op if backend
-  # is unavailable, so workflow stays green even on cold cache.
-  RUSTC_WRAPPER: sccache
-  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   check:
@@ -37,9 +32,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -51,10 +43,6 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets
-
-      - name: sccache stats
-        if: always()
-        run: sccache --show-stats || true
 
   test:
     name: Tests
@@ -73,25 +61,23 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-nextest
+        # Robust binary install — falls back to cargo install on cache miss.
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
       - name: cargo nextest run
+        # Parallel test runner — typically ~2x faster than `cargo test` on
+        # workspaces with many tests (we have 1400+). Better failure
+        # isolation: each test runs in its own process.
         run: cargo nextest run --workspace --all-targets
 
       - name: cargo test (doc-tests)
-        # nextest does not run doc-tests yet (see nextest-rs/nextest#16).
-        # Run separately to maintain coverage parity.
+        # nextest does not run doc-tests yet
+        # (https://github.com/nextest-rs/nextest/issues/16). Run separately
+        # to maintain coverage parity with the previous workflow.
         run: cargo test --workspace --doc
-
-      - name: sccache stats
-        if: always()
-        run: sccache --show-stats || true


### PR DESCRIPTION
## Summary

Replace `cargo test --workspace` с `cargo nextest run --workspace --all-targets` (+ `cargo test --doc` separately for doc-tests).

## What changed vs initial PR

Originally also added sccache + GHA cache backend wiring. First CI run uncovered that the GHA cache backend has occasional outages that crash sccache hard rather than gracefully falling back. Today's run (2026-04-28T22:26Z) failed with Azure Front Door 503 → sccache server failed to start → cargo failed to compile.

Risk too high to merge an "optimization" that occasionally bricks CI on third-party outage. Holding sccache for a separate PR that adds backend health probe + conditional `RUSTC_WRAPPER`. This PR ships nextest only — pure parallelism, no external dependencies.

## Expected speedup

`cargo nextest run` is a parallel test runner with better failure isolation. On workspaces with many tests (we have 1400+), typical speedup is ~2× wall-clock vs sequential `cargo test`.

## Test plan

- [x] Workflow YAML syntactically valid
- [x] No `github.event.*` in run blocks (clean per workflow injection guidelines)
- [ ] CI green on dev (re-run after sccache removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)