### PR TITLE
[feat] ADR-003 Phase 1+2 — file-first wrappers + 4 MCP handlers migrated

### DIFF
--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -247,6 +247,48 @@ fn filter_preserved(fm: &Frontmatter) -> Option<Frontmatter> {
     if out.is_empty() { None } else { Some(out) }
 }
 
+/// Sync file → store BEFORE mutation. Preserves any user edits to the
+/// markdown body that haven't been picked up yet.
+///
+/// Convenience wrapper around `sync_file_to_store` that handles the
+/// `get_record + Option` boilerplate in the common case where caller
+/// only has the artifact ID. PROB-048 / ADR-003 enforcement helper —
+/// use as the first step of every mutating handler in `commands/` and
+/// `server.rs`.
+///
+/// No-op if the artifact does not exist (e.g., create flow).
+pub async fn sync_before_mutation(
+    workspace: &Path,
+    store: &crate::db::store::LanceStore,
+    id: &str,
+) -> anyhow::Result<()> {
+    if let Some(record) = store.get_record(id).await? {
+        sync_file_to_store(store, workspace, &record).await?;
+    }
+    Ok(())
+}
+
+/// Render store → file AFTER mutation. Reads the current artifact state
+/// from LanceDB and writes the markdown projection.
+///
+/// Convenience wrapper around `render_projection_record` that fetches
+/// the record + relations. PROB-048 / ADR-003 enforcement helper — use
+/// as the last step of every mutating handler.
+///
+/// No-op if the artifact does not exist (e.g., delete flow already
+/// removed both file and record).
+pub async fn render_after_mutation(
+    workspace: &Path,
+    store: &crate::db::store::LanceStore,
+    id: &str,
+) -> anyhow::Result<()> {
+    if let Some(record) = store.get_record(id).await? {
+        let links = store.get_relations(id).await.unwrap_or_default();
+        render_projection_record(workspace, &record, &links).await?;
+    }
+    Ok(())
+}
+
 /// Sync file body to LanceDB store if file was edited by user.
 /// Call this before render_projection to ensure LanceDB has the latest body.
 /// Returns true if sync happened (file was newer).
@@ -1100,5 +1142,94 @@ mod tests {
         let id = crate::artifact::identity::AgentIdentity::unknown();
         let result = stamp_agent_identity(&ws, "PRD-404", "prd", "Missing", &id).await;
         assert!(result.is_err(), "should propagate the read error");
+    }
+
+    // ============================================================
+    // PROB-048 / ADR-003 helpers — sync_before_mutation +
+    // render_after_mutation
+    // ============================================================
+
+    #[tokio::test]
+    async fn sync_before_mutation_is_noop_for_missing_artifact() {
+        let temp = TempDir::new().unwrap();
+        let ws = temp.path().to_path_buf();
+        let store = crate::db::store::LanceStore::init(&ws).await.unwrap();
+
+        // Artifact does not exist — helper must not error.
+        let result = sync_before_mutation(&ws, &store, "PRD-NEVER-CREATED").await;
+        assert!(
+            result.is_ok(),
+            "sync_before_mutation should be no-op for missing artifact, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_after_mutation_is_noop_for_missing_artifact() {
+        let temp = TempDir::new().unwrap();
+        let ws = temp.path().to_path_buf();
+        let store = crate::db::store::LanceStore::init(&ws).await.unwrap();
+
+        let result = render_after_mutation(&ws, &store, "PRD-NEVER-CREATED").await;
+        assert!(
+            result.is_ok(),
+            "render_after_mutation should be no-op for missing artifact, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_after_mutation_writes_file_with_status_from_store() {
+        // The PROB-048 deprecate bug pattern, in miniature:
+        //   1. create artifact (status = draft) — file gets status: draft
+        //   2. mutate store directly (status → deprecated)
+        //   3. call render_after_mutation
+        //   4. file should now reflect status: deprecated
+        let temp = TempDir::new().unwrap();
+        let ws = temp.path().to_path_buf();
+        tokio::fs::create_dir_all(ws.join("prds")).await.unwrap();
+        let store = crate::db::store::LanceStore::init(&ws).await.unwrap();
+
+        let new_artifact = crate::db::store::NewArtifact {
+            id: "PRD-901".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Test artifact".to_string(),
+            body: "## Summary\n\nA test PRD.".to_string(),
+            depth: "standard".to_string(),
+            author: Some("test".to_string()),
+            parent_epic: None,
+            valid_until: None,
+            tags: vec![],
+        };
+        store.create_artifact(&new_artifact).await.unwrap();
+
+        // Initial render — file has status: draft
+        render_after_mutation(&ws, &store, "PRD-901").await.unwrap();
+        let file_path = ws.join("prds/PRD-901-test-artifact.md");
+        let initial = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert!(
+            initial.contains("status: draft"),
+            "initial file should have status: draft, got:\n{initial}"
+        );
+
+        // Mutate store: simulate lifecycle::activate behaviour bypassing
+        // the projection. This is the bug pattern — store updated, file
+        // stale.
+        store
+            .update_artifact("PRD-901", Some("active"), None)
+            .await
+            .unwrap();
+
+        // The bug: without render_after_mutation, file would still say draft.
+        // With our helper: file gets refreshed.
+        render_after_mutation(&ws, &store, "PRD-901").await.unwrap();
+        let after = tokio::fs::read_to_string(&file_path).await.unwrap();
+        assert!(
+            after.contains("status: active"),
+            "post-mutation file should have status: active, got:\n{after}"
+        );
+        assert!(
+            !after.contains("status: draft"),
+            "post-mutation file should NOT have status: draft, got:\n{after}"
+        );
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1727,6 +1727,20 @@ impl ForgeplanServer {
             _ => {}
         }
 
+        // ADR-003 / PROB-048 file-first: pre-mutation file→store sync for
+        // both source AND target (either may have user-side edits we don't
+        // want to clobber).
+        if let Err(e) = projection::sync_before_mutation(&ws, &store, &p.source).await {
+            return Ok(err_result(&format!(
+                "pre-mutation file→store sync (source) failed: {e}"
+            )));
+        }
+        if let Err(e) = projection::sync_before_mutation(&ws, &store, &p.target).await {
+            // Target sync failure is non-fatal — target may not exist locally
+            // (e.g., cross-workspace reference). Log and proceed.
+            tracing::warn!("pre-mutation sync (target {}) failed: {e}", p.target);
+        }
+
         if let Err(e) = store.add_relation(&p.source, &p.target, &relation).await {
             let safe_src = sanitize_for_hint(&p.source);
             let safe_tgt = sanitize_for_hint(&p.target);
@@ -1739,37 +1753,17 @@ impl ForgeplanServer {
             ));
         }
 
-        // Sync file→LanceDB (preserve user edits), then re-render projection
-        if let Ok(Some(record)) = store.get_record(&p.source).await {
-            let _ = projection::sync_file_to_store(&store, &ws, &record).await;
-            // Re-read after sync. Possible states:
-            //   Ok(Some(r)) — use the refreshed record
-            //   Ok(None)    — artifact deleted concurrently (race) — fall
-            //                 back to the original record so we don't panic
-            //   Err(_)      — store error — same fallback
-            // Previous code used `.unwrap_or(Some(record)).unwrap()` which
-            // panics on Ok(None). Fixed per Round 3 deep QA.
-            let record = store
-                .get_record(&p.source)
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or(record);
-            let links = store.get_relations(&p.source).await.unwrap_or_default();
-            let _ = projection::render_projection(
-                &ws,
-                &record.id,
-                &record.kind,
-                &record.title,
-                &record.status,
-                &record.depth,
-                record.author.as_deref(),
-                record.parent_epic.as_deref(),
-                record.valid_until.as_deref(),
-                &record.body,
-                &links,
-            )
-            .await;
+        // ADR-003 / PROB-048 file-first: render BOTH source and target
+        // projections. Source's frontmatter gets the new outgoing link;
+        // target's frontmatter is rebuilt from store so any existing
+        // incoming-link metadata in the file body stays consistent.
+        // PROB-048 observed bug — link rendered only for source — closed.
+        if let Err(e) = projection::render_after_mutation(&ws, &store, &p.source).await {
+            tracing::warn!("post-mutation render (source {}) failed: {e}", p.source);
+        }
+        if let Err(e) = projection::render_after_mutation(&ws, &store, &p.target).await {
+            // Target may not have a markdown projection in this workspace.
+            tracing::warn!("post-mutation render (target {}) failed: {e}", p.target);
         }
 
         let safe_src = sanitize_for_hint(&p.source);
@@ -2285,12 +2279,36 @@ impl ForgeplanServer {
             Ok(s) => s,
             Err(e) => return Ok(err_result(&e)),
         };
+        let ws_opt = self.require_workspace().await.ok();
+
+        // ADR-003 / PROB-048 file-first: pre-mutation file→store sync.
+        if let Some(ws) = &ws_opt
+            && let Err(e) =
+                forgeplan_core::projection::sync_before_mutation(ws, &store, &p.id).await
+        {
+            return Ok(err_result(&format!(
+                "pre-mutation file→store sync failed: {e}"
+            )));
+        }
+
         match forgeplan_core::lifecycle::activate(&store, &p.id, p.force).await {
             Ok(result) => {
+                // ADR-003 / PROB-048 file-first: render store → file so the
+                // file's `status:` reflects active. Avoids file/lance skew.
+                if let Some(ws) = &ws_opt
+                    && let Err(e) =
+                        forgeplan_core::projection::render_after_mutation(ws, &store, &p.id).await
+                {
+                    tracing::warn!(
+                        "post-mutation render for {} failed: {e} — file projection stale",
+                        p.id
+                    );
+                }
+
                 // PRD-056: activation is terminal — advance phase to Done.
-                if let Ok(ws) = self.require_workspace().await {
+                if let Some(ws) = &ws_opt {
                     maybe_advance_phase(
-                        &ws,
+                        ws,
                         &p.id,
                         forgeplan_core::phase::Phase::Done,
                         "forgeplan_activate",
@@ -2398,8 +2416,28 @@ impl ForgeplanServer {
             }
         };
 
+        // ADR-003 / PROB-048 file-first: pre-mutation file→store sync.
+        if let Err(e) = forgeplan_core::projection::sync_before_mutation(&ws, &store, &p.id).await {
+            return Ok(err_result(&format!(
+                "pre-mutation file→store sync failed: {e}"
+            )));
+        }
+
         match forgeplan_core::lifecycle::supersede(&store, &p.id, &p.by).await {
             Ok(result) => {
+                // ADR-003 / PROB-048 file-first: render store → file. Both the
+                // superseded artifact (new status + supersede link) and the
+                // replacement (incoming reverse link) are written.
+                if let Err(e) =
+                    forgeplan_core::projection::render_after_mutation(&ws, &store, &p.id).await
+                {
+                    tracing::warn!("post-mutation render for superseded {} failed: {e}", p.id);
+                }
+                if let Err(e) =
+                    forgeplan_core::projection::render_after_mutation(&ws, &store, &p.by).await
+                {
+                    tracing::warn!("post-mutation render for replacement {} failed: {e}", p.by);
+                }
                 // PRD-056: supersede is terminal — advance phase to Done.
                 maybe_advance_phase(
                     &ws,
@@ -2515,8 +2553,30 @@ impl ForgeplanServer {
             }
         };
 
+        // ADR-003 / PROB-048 file-first: flush user file edits → store before
+        // lifecycle transition so they aren't lost.
+        if let Err(e) = forgeplan_core::projection::sync_before_mutation(&ws, &store, &p.id).await {
+            return Ok(err_result(&format!(
+                "pre-mutation file→store sync failed: {e}"
+            )));
+        }
+
         match forgeplan_core::lifecycle::deprecate(&store, &p.id, &p.reason).await {
             Ok(dependents) => {
+                // ADR-003 / PROB-048 file-first: render store → file so the
+                // markdown projection's `status:` frontmatter reflects the
+                // transition. Without this, a CLI re-deprecate would see a
+                // file `status: active` and a store `status: deprecated`.
+                if let Err(e) =
+                    forgeplan_core::projection::render_after_mutation(&ws, &store, &p.id).await
+                {
+                    tracing::warn!(
+                        "post-mutation render for {} failed: {e} — \
+                         LanceDB has the deprecation, file projection is stale",
+                        p.id
+                    );
+                }
+
                 // PRD-056: deprecation is terminal — advance phase to Done.
                 maybe_advance_phase(
                     &ws,


### PR DESCRIPTION
## Summary

PRD-073 Phase 1+2 — closes the three observed ADR-003 drift bugs from 2026-04-28 sprint via thin file-first wrappers + targeted MCP migration.

## New API (`forgeplan_core::projection`)

| Helper | Purpose |
|---|---|
| `sync_before_mutation(ws, store, id)` | Pre-mutation file→store sync — preserves user file edits |
| `render_after_mutation(ws, store, id)` | Post-mutation store→file render — closes file/lance skew |

CLI lifecycle commands (`deprecate.rs`, `activate.rs`, `supersede.rs`) were already doing this pattern inline — these helpers extract and reuse it.

## MCP migrations (closes observed bugs)

| Handler | Bug observed (sprint 2026-04-28) | Fix |
|---|---|---|
| `forgeplan_deprecate` | Updated LanceDB only — file `status:` stayed `draft` while store had `deprecated`; CLI rejected re-deprecate | Brackets with sync+render |
| `forgeplan_activate` | Same skew pattern | Same |
| `forgeplan_supersede` | Same + replacement projection wasn't refreshed | Brackets BOTH superseded artifact AND replacement |
| `forgeplan_link` | Rendered only source — target's projection never updated; health checker missed evidence links | **Bidirectional render** — source AND target both refreshed after `add_relation` |

## Tests

- 3 new unit tests in `projection::tests`:
  - `sync_before_mutation_is_noop_for_missing_artifact`
  - `render_after_mutation_is_noop_for_missing_artifact`
  - `render_after_mutation_writes_file_with_status_from_store` — exact PROB-048 deprecate bug pattern in miniature
- 1400 → 1403 lib tests, 0 failures.

## What this PR does NOT do

This is intentionally Phase 1+2 only. Phase 3 (bulk CLI migration) and Phase 4 (visibility lockdown) follow:

- Direct `LanceStore::*` calls in MCP and CLI commands still exist — they're now properly bracketed but not eliminated.
- `tests/adr_003_invariant.rs` baseline UNCHANGED (CLI=27, MCP=5). The test still locks regression but the calls count even when bracketed.

Phase 3 will replace direct calls with a single mutation helper, lowering both baselines toward 0. Phase 4 demotes `LanceStore::*` mutating methods to `pub(crate)`, achieving compile-time enforcement.

## Workspace gate

- [x] `cargo fmt --check` 0 diffs
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 0 errors
- [x] `cargo test --workspace --lib` 1403 passed, 0 failed
- [ ] CI green on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)