### PR TITLE
[feat] Step.timeout_seconds wiring + sccache resilient CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,39 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Probe sccache backend
+        # Probe whether the GHA cache backend is healthy. If reachable,
+        # set RUSTC_WRAPPER for subsequent steps. If unreachable (Azure
+        # outage etc.), leave it unset so cargo uses direct rustc.
+        # This prevents a hard CI failure from third-party infrastructure
+        # outages — the trade-off is a slower run on probe failure, not
+        # a broken pipeline (lesson learned from PR #226 first attempt).
+        run: |
+          export SCCACHE_GHA_ENABLED=true
+          if timeout 30 sccache --start-server >/dev/null 2>&1; then
+            # Server started — try a tiny rustc invocation to confirm the
+            # backend is actually reachable for read/write operations.
+            echo 'fn main() {}' > /tmp/probe.rs
+            if timeout 30 sccache rustc \
+                --edition 2021 \
+                --crate-name probe \
+                --crate-type bin \
+                /tmp/probe.rs \
+                -o /tmp/probe 2>/dev/null; then
+              echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+              echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+              echo "✓ sccache probe passed — wrapper enabled"
+            else
+              sccache --stop-server >/dev/null 2>&1 || true
+              echo "✗ sccache probe failed (rustc invocation) — falling back to direct rustc"
+            fi
+          else
+            echo "✗ sccache probe failed (server start) — falling back to direct rustc"
+          fi
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -43,6 +76,10 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets
+
+      - name: sccache stats
+        if: always() && env.RUSTC_WRAPPER == 'sccache'
+        run: sccache --show-stats || true
 
   test:
     name: Tests
@@ -61,19 +98,41 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
+      - name: Probe sccache backend
+        # Same probe pattern as in the check job — see comment above.
+        run: |
+          export SCCACHE_GHA_ENABLED=true
+          if timeout 30 sccache --start-server >/dev/null 2>&1; then
+            echo 'fn main() {}' > /tmp/probe.rs
+            if timeout 30 sccache rustc \
+                --edition 2021 \
+                --crate-name probe \
+                --crate-type bin \
+                /tmp/probe.rs \
+                -o /tmp/probe 2>/dev/null; then
+              echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+              echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+              echo "✓ sccache probe passed — wrapper enabled"
+            else
+              sccache --stop-server >/dev/null 2>&1 || true
+              echo "✗ sccache probe failed (rustc invocation) — falling back to direct rustc"
+            fi
+          else
+            echo "✗ sccache probe failed (server start) — falling back to direct rustc"
+          fi
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-nextest
-        # Robust binary install — falls back to cargo install on cache miss.
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
 
       - name: cargo nextest run
-        # Parallel test runner — typically ~2x faster than `cargo test` on
-        # workspaces with many tests (we have 1400+). Better failure
-        # isolation: each test runs in its own process.
         run: cargo nextest run --workspace --all-targets
 
       - name: cargo test (doc-tests)
@@ -81,3 +140,7 @@ jobs:
         # (https://github.com/nextest-rs/nextest/issues/16). Run separately
         # to maintain coverage parity with the previous workflow.
         run: cargo test --workspace --doc
+
+      - name: sccache stats
+        if: always() && env.RUSTC_WRAPPER == 'sccache'
+        run: sccache --show-stats || true

--- a/crates/forgeplan-cli/src/commands/playbook.rs
+++ b/crates/forgeplan-cli/src/commands/playbook.rs
@@ -1023,6 +1023,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/agent_dispatcher.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/agent_dispatcher.rs
@@ -144,13 +144,19 @@ impl Dispatcher for AgentDispatcher {
 
         // 5. Build subprocess spec. cwd = workspace_root so produces_at
         //    relative paths land where the executor expects them.
+        // Per-step timeout (PRD-072 FR-8): step.timeout_seconds overrides
+        // the dispatcher default when set; otherwise default applies.
+        let timeout = step
+            .timeout_seconds
+            .map(|s| Duration::from_secs(u64::from(s)))
+            .unwrap_or(self.default_timeout);
         let program_str = program.to_string_lossy().into_owned();
         let spec = SubprocessSpec {
             program: &program_str,
             args: &args,
             env: &env,
             cwd: Some(&self.workspace_root),
-            timeout: self.default_timeout,
+            timeout,
             stdin_data: None,
         };
 
@@ -211,6 +217,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/command_dispatcher.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/command_dispatcher.rs
@@ -146,12 +146,18 @@ impl Dispatcher for CommandDispatcher {
 
         // 4. Build subprocess spec. cwd = workspace_root so relative paths in
         //    the command resolve where the user expects.
+        // Per-step timeout (PRD-072 FR-8): step.timeout_seconds overrides
+        // the dispatcher default when set; otherwise default applies.
+        let timeout = step
+            .timeout_seconds
+            .map(|s| Duration::from_secs(u64::from(s)))
+            .unwrap_or(self.default_timeout);
         let spec = SubprocessSpec {
             program: &program,
             args: &args,
             env: &env,
             cwd: Some(&self.workspace_root),
-            timeout: self.default_timeout,
+            timeout,
             // No stdin_data — helper applies Stdio::null() (security invariant).
             stdin_data: None,
         };
@@ -199,6 +205,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/forgeplan_core_dispatcher.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/forgeplan_core_dispatcher.rs
@@ -782,6 +782,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 
@@ -815,6 +816,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         };
         let err = d.dispatch(&step).await.expect_err("must reject");
         match err {

--- a/crates/forgeplan-core/src/playbook/dispatch/mod.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/mod.rs
@@ -382,6 +382,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 
@@ -397,6 +398,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/plugin_dispatcher.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/plugin_dispatcher.rs
@@ -158,8 +158,8 @@ impl Dispatcher for PluginDispatcher {
         let env = build_env_allowlist(&[], &base_env);
 
         let timeout = step
-            .timeout_seconds()
-            .map(Duration::from_secs)
+            .timeout_seconds
+            .map(|s| Duration::from_secs(u64::from(s)))
             .unwrap_or(self.default_timeout);
 
         let spec = SubprocessSpec {
@@ -208,26 +208,6 @@ fn which_in_path(program: &str) -> Option<PathBuf> {
         }
     }
     None
-}
-
-// =====================================================================
-// Step::timeout_seconds shim
-// =====================================================================
-//
-// PRD-072 FR-8 plans to add `timeout_seconds: Option<u32>` to `Step` once
-// SPEC-003 minor-bumps to 1.1. Until that ships, expose a trait-style
-// extension method that returns `None` so the dispatcher integrates
-// cleanly when the field lands without code churn here.
-trait StepTimeoutExt {
-    fn timeout_seconds(&self) -> Option<u64>;
-}
-
-impl StepTimeoutExt for Step {
-    fn timeout_seconds(&self) -> Option<u64> {
-        // FR-8 not yet wired into the type. When the field lands:
-        //   self.timeout_seconds.map(u64::from)
-        None
-    }
 }
 
 // =====================================================================
@@ -282,6 +262,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 
@@ -297,6 +278,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/routing.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/routing.rs
@@ -87,6 +87,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/dispatch/skill_dispatcher.rs
+++ b/crates/forgeplan-core/src/playbook/dispatch/skill_dispatcher.rs
@@ -141,6 +141,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 
@@ -156,6 +157,7 @@ mod tests {
             requires: None,
             fallback_hint: None,
             on_error: OnError::Abort,
+            timeout_seconds: None,
         }
     }
 

--- a/crates/forgeplan-core/src/playbook/types.rs
+++ b/crates/forgeplan-core/src/playbook/types.rs
@@ -147,6 +147,13 @@ pub struct Step {
     /// Error handling policy — `abort` (default) or `continue`.
     #[serde(default)]
     pub on_error: OnError,
+    /// Per-step timeout override in seconds (PRD-072 FR-8 / SPEC-003 1.1).
+    /// When `None`, the dispatcher applies its delegate-type default
+    /// (300s general / 600s plugin / 180s command/skill). When `Some(n)`,
+    /// `n` overrides the default for this single step. Backward compat:
+    /// playbooks without this field load identically to schema 1.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_seconds: Option<u32>,
 }
 
 /// Delegation target — strict 5-variant enum from SPEC-003 §"delegate_to".


### PR DESCRIPTION
## Summary

A4 task — two independent ergonomic improvements bundled.

## (1) Step.timeout_seconds wiring (PRD-072 FR-8)

Phase 6 v0.27.0 bumped SPEC-003 schema 1.0 → 1.1 advertising per-step timeout, but the actual field on `Step` was deferred. This PR closes the gap.

| Change | Detail |
|---|---|
| `Step.timeout_seconds: Option<u32>` added | `#[serde(default, skip_serializing_if = "Option::is_none")]` — backward compat |
| Removed `StepTimeoutExt` shim | Was returning `None` always; field is real now |
| plugin / command / agent dispatchers | Read `step.timeout_seconds`, fall back to delegate-type default (600s / 180s / 300s) |
| ForgeplanCore / Skill | n/a (in-process or trace stub) |
| 8 Step constructors patched | `timeout_seconds: None` preserves prior behaviour |

## (2) sccache resilient CI

PR #226 first attempt added sccache + nextest. Sccache crashed hard on GHA cache backend outage (Azure 503 at 2026-04-28T22:26Z) — server failed to start, all rustc invocations failed.

This PR re-introduces sccache with a **probe step** that:
1. Tries `sccache --start-server` with 30s timeout
2. If server starts, runs a tiny `sccache rustc` on a probe source to confirm the backend is actually reachable
3. On success, exports `RUSTC_WRAPPER=sccache` + `SCCACHE_GHA_ENABLED=true` to `GITHUB_ENV`
4. On failure, leaves `RUSTC_WRAPPER` unset → cargo uses direct rustc

Third-party outages can no longer brick the workflow. Trade-off: slower run on probe failure, not a broken pipeline.

`sccache --show-stats` runs at end of each cargo job (`if: always() && env.RUSTC_WRAPPER == 'sccache'`) for visibility into hit rate.

## Test plan

- [x] `cargo fmt --check` 0 diffs
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 0 errors
- [x] `cargo test --workspace --lib` 1400 passed, 0 failed
- [ ] CI green on dev — verify probe step works as designed
- [ ] Verify CI passes even if sccache backend has outage (probe falls back gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)