### PR TITLE
fix(health): 3-level Verdict aggregator + advisory_phase_mismatches integration (PROB-029)

### DIFF
--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -278,12 +278,11 @@ pub async fn run(
         }
     }
 
-    // Overall health summary
-    let has_issues = !report.at_risk.is_empty()
-        || !report.blind_spots.is_empty()
-        || !report.orphans.is_empty()
-        || report.stale_count > 0;
-    if !has_issues && report.total > 0 {
+    // Overall health summary — drive off the verdict aggregator so the CLI
+    // banner cannot disagree with `next_actions` (PROB-029 closure: previously
+    // `has_issues` here missed `active_stubs` + `possible_duplicates` and
+    // could print "Project looks healthy!" right after a list of warnings).
+    if report.verdict == health::Verdict::Healthy && report.total > 0 {
         println!();
         println!("  {}", style("Project looks healthy!").green().bold());
     }

--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -65,6 +65,14 @@ pub async fn run(
     // No hints → workspace healthy → render `Done.` terminal indicator.
 
     if json {
+        // Round 5 audit closure HIGH-2 (Logic): match MCP `forgeplan_health`
+        // override for `total == 0` workspaces — same "uninitialized"
+        // text on both surfaces so jq filters work the same way.
+        let verdict_summary = if report.total == 0 {
+            "Workspace has no artifacts. Run `forgeplan new prd \"<title>\"` to start."
+        } else {
+            report.verdict.human_summary()
+        };
         let json_data = serde_json::json!({
             "project": config.project_name,
             "total": report.total,
@@ -75,7 +83,7 @@ pub async fn run(
             // had only raw counts and `next_actions` strings — re-implementing
             // the verdict aggregation downstream would silently drift.
             "verdict": report.verdict.as_str(),
-            "verdict_summary": report.verdict.human_summary(),
+            "verdict_summary": verdict_summary,
             "by_kind": report.by_kind.iter().map(|(k, v)| serde_json::json!({"kind": k, "count": v})).collect::<Vec<_>>(),
             "by_status": report.by_status.iter().map(|(s, v)| serde_json::json!({"status": s, "count": v})).collect::<Vec<_>>(),
             "at_risk": report.at_risk.iter().map(|a| serde_json::json!({"id": a.id, "title": a.title, "reason": a.reason})).collect::<Vec<_>>(),

--- a/crates/forgeplan-cli/src/commands/health.rs
+++ b/crates/forgeplan-cli/src/commands/health.rs
@@ -68,6 +68,14 @@ pub async fn run(
         let json_data = serde_json::json!({
             "project": config.project_name,
             "total": report.total,
+            // PROB-029 closure (Round 4 audit HIGH-1): expose the typed
+            // verdict + human-readable summary so programmatic consumers
+            // (CI scripts, agent-IDE plugins via `forgeplan health --json`)
+            // can branch on `verdict` directly. Without this, --json output
+            // had only raw counts and `next_actions` strings — re-implementing
+            // the verdict aggregation downstream would silently drift.
+            "verdict": report.verdict.as_str(),
+            "verdict_summary": report.verdict.human_summary(),
             "by_kind": report.by_kind.iter().map(|(k, v)| serde_json::json!({"kind": k, "count": v})).collect::<Vec<_>>(),
             "by_status": report.by_status.iter().map(|(s, v)| serde_json::json!({"status": s, "count": v})).collect::<Vec<_>>(),
             "at_risk": report.at_risk.iter().map(|a| serde_json::json!({"id": a.id, "title": a.title, "reason": a.reason})).collect::<Vec<_>>(),
@@ -282,9 +290,28 @@ pub async fn run(
     // banner cannot disagree with `next_actions` (PROB-029 closure: previously
     // `has_issues` here missed `active_stubs` + `possible_duplicates` and
     // could print "Project looks healthy!" right after a list of warnings).
-    if report.verdict == health::Verdict::Healthy && report.total > 0 {
+    //
+    // Round 4 audit closures:
+    // - MED-2: drive the literal off `Verdict::human_summary()` so the
+    //   text only lives in one place (no more banner-vs-summary drift).
+    // - LOW-4: render the summary for ALL three verdict levels (Healthy /
+    //   NeedsAttention / Unhealthy), not only Healthy. Pre-Round-4 the
+    //   banner disappeared entirely on non-Healthy workspaces — silent
+    //   regression vs the pre-PR-C banner that was at least always
+    //   present (just sometimes wrong). Now: gradient signalling per
+    //   PROB-029 AC-2 spirit.
+    if report.total > 0 {
+        let summary = report.verdict.human_summary();
+        let styled = match report.verdict {
+            health::Verdict::Healthy => style(summary).green().bold(),
+            health::Verdict::NeedsAttention => style(summary).yellow().bold(),
+            health::Verdict::Unhealthy => style(summary).red().bold(),
+            // `#[non_exhaustive]` future-proofing: render new verdicts as
+            // dim cyan placeholder — better than crashing or hiding them.
+            _ => style(summary).cyan().dim(),
+        };
         println!();
-        println!("  {}", style("Project looks healthy!").green().bold());
+        println!("  {}", styled);
     }
 
     // PRD-071 contract: terminal Next:/Done line.

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -39,7 +39,13 @@ pub const DEFAULT_UNHEALTHY_PHASE_MISMATCHES: usize = 5;
 /// align their gates with the verdict aggregator if desired. Backward
 /// compatible: existing CI gates continue to read the raw counts; this
 /// struct is purely additive.
+///
+/// `#[non_exhaustive]` (Round 4 audit HIGH-2) — adding new threshold
+/// classes is a SemVer-major break only for callers using struct literals.
+/// Construct via `VerdictThresholds::default()` then override individual
+/// fields, e.g. `VerdictThresholds { orphans: 10, ..Default::default() }`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct VerdictThresholds {
     pub orphans: usize,
     pub blind_spots: usize,
@@ -69,8 +75,14 @@ impl Default for VerdictThresholds {
 /// Serialized as snake_case strings (`"healthy"`, `"needs_attention"`,
 /// `"unhealthy"`) to match the wire format already used by other
 /// `forgeplan` JSON outputs.
+///
+/// `#[non_exhaustive]` (Round 4 audit HIGH-2) — additional verdict levels
+/// (e.g. `Degraded` for partial-outage signals) may be added in future
+/// releases. External `match` arms MUST use `_ =>` to remain
+/// forward-compatible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum Verdict {
     Healthy,
     NeedsAttention,
@@ -590,7 +602,12 @@ fn generate_next_actions(
         && stale_count == 0;
 
     if actions.is_empty() && total > 0 && zero_signals {
-        actions.push("Project looks healthy. Continue implementation.".into());
+        // Drive the literal off `Verdict::Healthy.human_summary()` so the
+        // string only lives in one place — Round 4 audit MED-3 closure.
+        actions.push(format!(
+            "{} Continue implementation.",
+            Verdict::Healthy.human_summary()
+        ));
     }
 
     // Cap at 3 most important actions

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -17,6 +17,88 @@ use crate::duplicate::{DUPLICATE_SIMILARITY_THRESHOLD, title_similarity};
 /// Maximum number of duplicate pairs to report.
 const DUPLICATE_PAIRS_LIMIT: usize = 10;
 
+/// Default thresholds at which a given warning class promotes the verdict
+/// to `Unhealthy`. Below the threshold (but > 0) → `NeedsAttention`.
+///
+/// PROB-029 AC-2: gradient verdict avoids the binary "healthy / unhealthy"
+/// trap that scared CI for a single stale evidence. Defaults are
+/// intentionally conservative so the upgrade path from pre-PRD-045
+/// workspaces does not flip every project to `Unhealthy` overnight.
+pub const DEFAULT_UNHEALTHY_ORPHANS: usize = 5;
+pub const DEFAULT_UNHEALTHY_BLIND_SPOTS: usize = 3;
+pub const DEFAULT_UNHEALTHY_ACTIVE_STUBS: usize = 3;
+pub const DEFAULT_UNHEALTHY_DUPLICATES: usize = 5;
+pub const DEFAULT_UNHEALTHY_PHASE_MISMATCHES: usize = 5;
+
+/// Tunable promotion thresholds for [`compute_verdict`]. When the count
+/// of a given warning class **strictly exceeds** the threshold, the
+/// verdict is promoted to `Unhealthy`. Counts in `1..=threshold` keep
+/// the verdict at `NeedsAttention` (gradient).
+///
+/// Exposed publicly so `--ci --fail-on` callers in the CLI layer can
+/// align their gates with the verdict aggregator if desired. Backward
+/// compatible: existing CI gates continue to read the raw counts; this
+/// struct is purely additive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VerdictThresholds {
+    pub orphans: usize,
+    pub blind_spots: usize,
+    pub active_stubs: usize,
+    pub duplicates: usize,
+    pub phase_mismatches: usize,
+}
+
+impl Default for VerdictThresholds {
+    fn default() -> Self {
+        Self {
+            orphans: DEFAULT_UNHEALTHY_ORPHANS,
+            blind_spots: DEFAULT_UNHEALTHY_BLIND_SPOTS,
+            active_stubs: DEFAULT_UNHEALTHY_ACTIVE_STUBS,
+            duplicates: DEFAULT_UNHEALTHY_DUPLICATES,
+            phase_mismatches: DEFAULT_UNHEALTHY_PHASE_MISMATCHES,
+        }
+    }
+}
+
+/// Three-level workspace verdict (PROB-029 AC-2).
+///
+/// - `Healthy`: zero warnings of any class.
+/// - `NeedsAttention`: at least one warning, none above CRITICAL threshold.
+/// - `Unhealthy`: at least one warning class above CRITICAL threshold.
+///
+/// Serialized as snake_case strings (`"healthy"`, `"needs_attention"`,
+/// `"unhealthy"`) to match the wire format already used by other
+/// `forgeplan` JSON outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    Healthy,
+    NeedsAttention,
+    Unhealthy,
+}
+
+impl Verdict {
+    /// Stable, agent-readable label. Matches the serde wire format.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Verdict::Healthy => "healthy",
+            Verdict::NeedsAttention => "needs_attention",
+            Verdict::Unhealthy => "unhealthy",
+        }
+    }
+
+    /// Human-friendly one-line summary for CLI rendering. Avoids the
+    /// pre-PROB-029 phrase "Project looks healthy" when the verdict is
+    /// not `Healthy` — that phrase was the original bug surface.
+    pub fn human_summary(self) -> &'static str {
+        match self {
+            Verdict::Healthy => "Project looks healthy.",
+            Verdict::NeedsAttention => "Project needs attention.",
+            Verdict::Unhealthy => "Project is unhealthy — multiple critical signals.",
+        }
+    }
+}
+
 /// Full health report for a Forgeplan workspace.
 #[derive(Debug, Clone)]
 pub struct HealthReport {
@@ -31,6 +113,35 @@ pub struct HealthReport {
     pub next_actions: Vec<String>,
     pub possible_duplicates: Vec<DuplicatePair>,
     pub active_stubs: Vec<ActiveStub>,
+    /// PROB-029 AC-2: aggregated verdict that reads ALL warning classes.
+    /// Pre-fix this didn't exist — `next_actions` was the only summary
+    /// and silently said "Project looks healthy" while stubs/dups were
+    /// printed above it (PRD-043 detection bypass).
+    pub verdict: Verdict,
+}
+
+impl HealthReport {
+    /// Compute the verdict using default thresholds. Reads `self`'s
+    /// signal counts; does not consult outside state. Pure function on
+    /// the report. Used internally by `health_report()` to populate
+    /// `self.verdict` and exposed publicly so callers that want to
+    /// re-evaluate after enriching the report (e.g. MCP server folding
+    /// in `advisory_phase_mismatches` from outside core) can do so.
+    pub fn compute_verdict(&self) -> Verdict {
+        compute_verdict(self, &VerdictThresholds::default(), 0)
+    }
+
+    /// Compute the verdict using explicit thresholds and an extra count
+    /// of phase mismatches injected by the caller. Returned value is
+    /// not stored; callers that want to mutate `self.verdict` must do
+    /// so explicitly. Keeps the report immutable except by intent.
+    pub fn compute_verdict_with(
+        &self,
+        thresholds: &VerdictThresholds,
+        phase_mismatches: usize,
+    ) -> Verdict {
+        compute_verdict(self, thresholds, phase_mismatches)
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -132,6 +243,21 @@ pub async fn health_report(store: &LanceStore) -> anyhow::Result<HealthReport> {
         &orphans,
         &possible_duplicates,
         &active_stubs,
+        &at_risk,
+    );
+
+    // PROB-029 AC-2: compute aggregated verdict from ALL warning
+    // classes. Done after detection but before returning, so callers
+    // (CLI render, MCP JSON, scripts) all see the same value.
+    let verdict = compute_verdict_from_signals(
+        orphans.len(),
+        blind_spots.len(),
+        active_stubs.len(),
+        possible_duplicates.len(),
+        stale_count,
+        at_risk.len(),
+        0, // phase_mismatches injected by upstream callers via compute_verdict_with()
+        &VerdictThresholds::default(),
     );
 
     Ok(HealthReport {
@@ -146,7 +272,75 @@ pub async fn health_report(store: &LanceStore) -> anyhow::Result<HealthReport> {
         next_actions,
         possible_duplicates,
         active_stubs,
+        verdict,
     })
+}
+
+/// Pure verdict computation. Reads counts only — no I/O, no allocation.
+///
+/// Precedence:
+/// 1. Any class strictly exceeding its threshold → `Unhealthy`.
+/// 2. Else any non-zero count → `NeedsAttention`.
+/// 3. Else → `Healthy`.
+///
+/// PROB-029 AC-1: this guarantees a workspace with active stubs ≥ 1,
+/// duplicate pairs ≥ 1, blind spots ≥ 1, OR orphans ≥ 1 will NOT come
+/// back as `Healthy` — closing the bug where the human-readable
+/// "Project looks healthy" verdict directly contradicted the warnings
+/// printed above it.
+pub fn compute_verdict(
+    report: &HealthReport,
+    thresholds: &VerdictThresholds,
+    phase_mismatches: usize,
+) -> Verdict {
+    compute_verdict_from_signals(
+        report.orphans.len(),
+        report.blind_spots.len(),
+        report.active_stubs.len(),
+        report.possible_duplicates.len(),
+        report.stale_count,
+        report.at_risk.len(),
+        phase_mismatches,
+        thresholds,
+    )
+}
+
+/// Internal: shared verdict logic over raw counts. Lets `health_report`
+/// compute the verdict during construction (when fields are scalars,
+/// not yet packed into the struct) without re-allocating.
+#[allow(clippy::too_many_arguments)]
+fn compute_verdict_from_signals(
+    orphans: usize,
+    blind_spots: usize,
+    active_stubs: usize,
+    duplicates: usize,
+    stale: usize,
+    at_risk: usize,
+    phase_mismatches: usize,
+    t: &VerdictThresholds,
+) -> Verdict {
+    // Critical: any single class above its threshold → Unhealthy.
+    if orphans > t.orphans
+        || blind_spots > t.blind_spots
+        || active_stubs > t.active_stubs
+        || duplicates > t.duplicates
+        || phase_mismatches > t.phase_mismatches
+    {
+        return Verdict::Unhealthy;
+    }
+    // Non-zero anywhere → NeedsAttention.
+    let has_any_warning = orphans > 0
+        || blind_spots > 0
+        || active_stubs > 0
+        || duplicates > 0
+        || stale > 0
+        || at_risk > 0
+        || phase_mismatches > 0;
+    if has_any_warning {
+        Verdict::NeedsAttention
+    } else {
+        Verdict::Healthy
+    }
 }
 
 /// Find active artifacts that look like stubs (template-only content).
@@ -308,6 +502,7 @@ fn find_at_risk(
     at_risk
 }
 
+#[allow(clippy::too_many_arguments)]
 fn generate_next_actions(
     total: usize,
     by_status: &BTreeMap<String, usize>,
@@ -316,6 +511,7 @@ fn generate_next_actions(
     orphans: &[String],
     possible_duplicates: &[DuplicatePair],
     active_stubs: &[ActiveStub],
+    at_risk: &[AtRiskArtifact],
 ) -> Vec<String> {
     let mut actions = Vec::new();
 
@@ -324,50 +520,76 @@ fn generate_next_actions(
         actions.push("All artifacts in Draft — review and activate ready ones".into());
     }
 
-    // PRD-045 FR-001: PRD-043 stub detection signal
-    if !active_stubs.is_empty() {
-        let first = &active_stubs[0];
+    // PRD-045 FR-001: PRD-043 stub detection signal.
+    // PROB-029 AC-3: include a concrete copy-pasteable command with a
+    // real id, not a placeholder, so agents can run it as-is.
+    if let Some(first) = active_stubs.first() {
         actions.push(format!(
-            "Fill or supersede {} active stub(s) — e.g. `forgeplan supersede {} --by <NEW>` or `forgeplan deprecate {} --reason \"abandoned\"`",
+            "Fill or supersede {} active stub(s) — `forgeplan supersede {} --by <NEW>` or `forgeplan deprecate {} --reason \"abandoned\"`",
             active_stubs.len(),
             first.id,
             first.id
         ));
     }
 
-    // PRD-045 FR-001: PRD-043 duplicate detection signal
-    if !possible_duplicates.is_empty() {
-        let first = &possible_duplicates[0];
+    // PRD-045 FR-001 + PROB-029 AC-3: concrete deprecate command for
+    // the first duplicate pair. Format matches what the PROB-029 body
+    // calls out as the desired remediation hint.
+    if let Some(first) = possible_duplicates.first() {
         actions.push(format!(
-            "Resolve {} duplicate pair(s) — e.g. `forgeplan deprecate {} --reason \"duplicate of {}\"`",
-            possible_duplicates.len(),
+            "Deprecate duplicate pair: `forgeplan deprecate {} --reason \"superseded by {}\"` ({} pair(s))",
             first.id_b,
-            first.id_a
+            first.id_a,
+            possible_duplicates.len()
         ));
     }
 
-    if !blind_spots.is_empty() {
+    // PROB-029 AC-3: include a concrete `forgeplan new evidence`
+    // suggestion targeting the first blind-spot id.
+    if let Some(first) = blind_spots.first() {
         actions.push(format!(
-            "Create evidence for {} artifact(s) without proof",
-            blind_spots.len()
+            "Create evidence for {} artifact(s) without proof — start with `forgeplan new evidence \"<title>\" --link {}`",
+            blind_spots.len(),
+            first.id,
         ));
     }
 
     if stale_count > 0 {
         actions.push(format!(
-            "Refresh {} stale evidence (expired valid_until)",
-            stale_count
+            "Refresh {stale_count} stale evidence (expired valid_until) — run `forgeplan stale` to list",
         ));
     }
 
-    if !orphans.is_empty() {
+    if let Some(first_orphan) = orphans.first() {
         actions.push(format!(
-            "Link {} orphan artifact(s) — isolated, no connections",
-            orphans.len()
+            "Link {} orphan artifact(s) — isolated, no connections — start with `forgeplan link {} based_on <other>`",
+            orphans.len(),
+            first_orphan,
         ));
     }
 
-    if actions.is_empty() && total > 0 {
+    // PROB-029 AC-3: surface at-risk decisions explicitly so agents
+    // see the R_eff problem, not just blind spots.
+    if let Some(first) = at_risk.first() {
+        actions.push(format!(
+            "{} at-risk artifact(s) (R_eff < threshold) — inspect `forgeplan score {}`",
+            at_risk.len(),
+            first.id,
+        ));
+    }
+
+    // PROB-029 AC-1: only emit the "looks healthy" line when EVERY
+    // warning class is empty. The previous implementation only checked
+    // the small subset (blind_spots, stale, orphans) and so silently
+    // lied with active stubs and duplicates printed above.
+    let zero_signals = active_stubs.is_empty()
+        && possible_duplicates.is_empty()
+        && blind_spots.is_empty()
+        && orphans.is_empty()
+        && at_risk.is_empty()
+        && stale_count == 0;
+
+    if actions.is_empty() && total > 0 && zero_signals {
         actions.push("Project looks healthy. Continue implementation.".into());
     }
 
@@ -798,8 +1020,17 @@ mod tests {
 
         let dups: Vec<DuplicatePair> = Vec::new();
         let stubs: Vec<ActiveStub> = Vec::new();
-        let actions =
-            generate_next_actions(5, &by_status, &blind_spots, 2, &orphans, &dups, &stubs);
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            2,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
         assert!(actions.len() <= 3);
     }
 
@@ -817,8 +1048,17 @@ mod tests {
             markers_found: 6,
             message: "stub".into(),
         }];
-        let actions =
-            generate_next_actions(10, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            10,
+            &by_status,
+            &blind_spots,
+            0,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
         assert!(
             actions.iter().any(|a| a.contains("PRD-008")),
             "expected PRD-008 stub mentioned, got {actions:?}"
@@ -844,8 +1084,17 @@ mod tests {
             kind: "evidence".into(),
         }];
         let stubs: Vec<ActiveStub> = Vec::new();
-        let actions =
-            generate_next_actions(10, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            10,
+            &by_status,
+            &blind_spots,
+            0,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
         assert!(
             actions.iter().any(|a| a.contains("EVID-003")),
             "expected EVID-003 duplicate mentioned, got {actions:?}"
@@ -853,6 +1102,15 @@ mod tests {
         assert!(
             !actions.iter().any(|a| a.contains("looks healthy")),
             "should NOT say healthy when duplicates present"
+        );
+        // PROB-029 AC-3: format should match the body's example
+        // (`forgeplan deprecate EVID-003 --reason "superseded by EVID-001"`).
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.contains("forgeplan deprecate EVID-003")
+                    && a.contains("superseded by EVID-001")),
+            "expected concrete deprecate command, got {actions:?}"
         );
     }
 
@@ -864,11 +1122,338 @@ mod tests {
         let orphans: Vec<String> = Vec::new();
         let dups: Vec<DuplicatePair> = Vec::new();
         let stubs: Vec<ActiveStub> = Vec::new();
-        let actions =
-            generate_next_actions(5, &by_status, &blind_spots, 0, &orphans, &dups, &stubs);
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            0,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
         assert!(
             actions.iter().any(|a| a.contains("looks healthy")),
             "expected healthy message, got {actions:?}"
+        );
+    }
+
+    // ── PROB-029 verdict aggregator regression suite ──────────────
+
+    fn empty_report(total: usize) -> HealthReport {
+        HealthReport {
+            total,
+            by_kind: Vec::new(),
+            by_status: Vec::new(),
+            at_risk: Vec::new(),
+            blind_spots: Vec::new(),
+            stale_count: 0,
+            orphans: Vec::new(),
+            by_derived_status: Vec::new(),
+            next_actions: Vec::new(),
+            possible_duplicates: Vec::new(),
+            active_stubs: Vec::new(),
+            verdict: Verdict::Healthy,
+        }
+    }
+
+    fn stub(id: &str) -> ActiveStub {
+        ActiveStub {
+            id: id.into(),
+            kind: "prd".into(),
+            title: "Stub".into(),
+            markers_found: 5,
+            message: "looks like a stub".into(),
+        }
+    }
+
+    fn dup(id_a: &str, id_b: &str) -> DuplicatePair {
+        DuplicatePair {
+            id_a: id_a.into(),
+            id_b: id_b.into(),
+            similarity: 1.0,
+            title_a: "X".into(),
+            title_b: "X".into(),
+            kind: "evidence".into(),
+        }
+    }
+
+    fn spot(id: &str) -> BlindSpot {
+        BlindSpot {
+            id: id.into(),
+            title: "X".into(),
+            issue: "no evidence".into(),
+        }
+    }
+
+    // PROB-029 AC-2: empty workspace → Healthy.
+    #[test]
+    fn verdict_empty_workspace_is_healthy() {
+        let r = empty_report(0);
+        assert_eq!(r.compute_verdict(), Verdict::Healthy);
+    }
+
+    // PROB-029 AC-1: 1 active stub → NOT Healthy. This is the primary
+    // bug from the dogfood audit (8 stubs printed → "looks healthy").
+    #[test]
+    fn verdict_one_active_stub_is_needs_attention() {
+        let mut r = empty_report(10);
+        r.active_stubs = vec![stub("PRD-008")];
+        assert_eq!(r.compute_verdict(), Verdict::NeedsAttention);
+        assert_ne!(r.compute_verdict(), Verdict::Healthy);
+    }
+
+    // PROB-029 AC-1: 1 duplicate pair → NOT Healthy.
+    #[test]
+    fn verdict_one_duplicate_pair_is_needs_attention() {
+        let mut r = empty_report(10);
+        r.possible_duplicates = vec![dup("EVID-001", "EVID-003")];
+        assert_eq!(r.compute_verdict(), Verdict::NeedsAttention);
+    }
+
+    // PROB-029 AC-1: 1 blind spot → NOT Healthy.
+    #[test]
+    fn verdict_one_blind_spot_is_needs_attention() {
+        let mut r = empty_report(10);
+        r.blind_spots = vec![spot("ADR-011")];
+        assert_eq!(r.compute_verdict(), Verdict::NeedsAttention);
+    }
+
+    // PROB-029 AC-1: 1 orphan → NOT Healthy.
+    #[test]
+    fn verdict_one_orphan_is_needs_attention() {
+        let mut r = empty_report(10);
+        r.orphans = vec!["NOTE-099".into()];
+        assert_eq!(r.compute_verdict(), Verdict::NeedsAttention);
+    }
+
+    // PROB-029 AC-2: stale evidence alone is a soft signal — needs
+    // attention but not unhealthy. (Stale doesn't count toward the
+    // "unhealthy" critical-class threshold, only toward the "any
+    // warning" floor.)
+    #[test]
+    fn verdict_stale_only_is_needs_attention() {
+        let mut r = empty_report(10);
+        r.stale_count = 7;
+        assert_eq!(r.compute_verdict(), Verdict::NeedsAttention);
+    }
+
+    // PROB-029 AC-2: many active stubs above threshold → Unhealthy.
+    #[test]
+    fn verdict_many_stubs_promotes_to_unhealthy() {
+        let mut r = empty_report(50);
+        r.active_stubs = (0..8).map(|i| stub(&format!("PRD-{i:03}"))).collect();
+        assert_eq!(r.compute_verdict(), Verdict::Unhealthy);
+    }
+
+    // PROB-029 AC-2: many duplicates above threshold → Unhealthy. This
+    // mirrors the dogfood snapshot in the PROB-029 body (5 pairs → at
+    // limit, NOT promoted) — adjust threshold via VerdictThresholds.
+    #[test]
+    fn verdict_many_duplicates_promotes_to_unhealthy() {
+        let mut r = empty_report(50);
+        r.possible_duplicates = (0..6)
+            .map(|i| dup(&format!("EVID-{i:03}"), &format!("EVID-{:03}", i + 100)))
+            .collect();
+        assert_eq!(r.compute_verdict(), Verdict::Unhealthy);
+    }
+
+    // PROB-029: phase mismatches counted via compute_verdict_with so
+    // the MCP server can fold them in without a core-side workspace
+    // path. Below threshold → NeedsAttention. Above → Unhealthy.
+    #[test]
+    fn verdict_phase_mismatches_below_threshold_is_needs_attention() {
+        let r = empty_report(10);
+        let v = r.compute_verdict_with(&VerdictThresholds::default(), 1);
+        assert_eq!(v, Verdict::NeedsAttention);
+    }
+
+    #[test]
+    fn verdict_phase_mismatches_above_threshold_is_unhealthy() {
+        let r = empty_report(10);
+        let v = r.compute_verdict_with(&VerdictThresholds::default(), 100);
+        assert_eq!(v, Verdict::Unhealthy);
+    }
+
+    // PROB-029 AC-2: respect custom thresholds. A team that wants
+    // unhealthy at 1+ duplicates must be able to set it.
+    #[test]
+    fn verdict_custom_thresholds_take_effect() {
+        let mut r = empty_report(10);
+        r.possible_duplicates = vec![dup("A", "B")];
+        let strict = VerdictThresholds {
+            duplicates: 0,
+            ..VerdictThresholds::default()
+        };
+        let v = r.compute_verdict_with(&strict, 0);
+        assert_eq!(v, Verdict::Unhealthy);
+    }
+
+    // PROB-029 AC-1 regression: the exact dogfood snapshot from the
+    // PROB-029 body — 5 dup pairs + 8 stubs + 0 blind spots + 0
+    // orphans — must NOT come back as "Healthy". With defaults
+    // (stubs threshold = 3, dups threshold = 5) it goes Unhealthy
+    // because stubs (8 > 3) exceeds critical.
+    #[test]
+    fn verdict_dogfood_snapshot_from_prob029_body() {
+        let mut r = empty_report(80);
+        r.possible_duplicates = (0..5)
+            .map(|i| dup(&format!("EVID-{i:03}"), &format!("EVID-{:03}", i + 100)))
+            .collect();
+        r.active_stubs = (0..8).map(|i| stub(&format!("PRD-{i:03}"))).collect();
+        let v = r.compute_verdict();
+        assert_ne!(v, Verdict::Healthy, "must not say healthy");
+        assert_eq!(v, Verdict::Unhealthy);
+    }
+
+    // PROB-029 AC-1 + AC-3: when verdict is not healthy, next_actions
+    // must NOT include the "looks healthy" line, and MUST include at
+    // least one concrete remediation command.
+    #[test]
+    fn next_actions_never_says_healthy_when_any_signal_present() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans: Vec<String> = Vec::new();
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+
+        // 1 stale, no other signals — pre-fix this would be ambiguous.
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            1,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
+        assert!(
+            !actions.iter().any(|a| a.contains("looks healthy")),
+            "stale > 0 must suppress healthy line, got {actions:?}"
+        );
+        assert!(!actions.is_empty(), "must surface a concrete next step");
+    }
+
+    // PROB-029 AC-3: blind-spot remediation hint contains a
+    // copy-pasteable `forgeplan new evidence --link <id>` command.
+    #[test]
+    fn next_actions_blind_spot_hint_is_concrete_command() {
+        let by_status = BTreeMap::new();
+        let blind_spots = vec![spot("ADR-011")];
+        let orphans: Vec<String> = Vec::new();
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            0,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.contains("forgeplan new evidence") && a.contains("ADR-011")),
+            "expected concrete evidence command for ADR-011, got {actions:?}"
+        );
+    }
+
+    // PROB-029 AC-3: orphan hint contains a `forgeplan link <id>` command.
+    #[test]
+    fn next_actions_orphan_hint_is_concrete_command() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans = vec!["NOTE-099".into()];
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let at_risk: Vec<AtRiskArtifact> = Vec::new();
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            0,
+            &orphans,
+            &dups,
+            &stubs,
+            &at_risk,
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.contains("forgeplan link NOTE-099")),
+            "expected concrete link command for NOTE-099, got {actions:?}"
+        );
+    }
+
+    // PROB-029 AC-3: at-risk surface gets its own action. Pre-fix
+    // at-risk artifacts were silent in next_actions.
+    #[test]
+    fn next_actions_at_risk_surfaced() {
+        let by_status = BTreeMap::new();
+        let blind_spots: Vec<BlindSpot> = Vec::new();
+        let orphans: Vec<String> = Vec::new();
+        let dups: Vec<DuplicatePair> = Vec::new();
+        let stubs: Vec<ActiveStub> = Vec::new();
+        let at_risk = vec![AtRiskArtifact {
+            id: "ADR-007".into(),
+            title: "Risky decision".into(),
+            reason: "R_eff = 0.10".into(),
+        }];
+        let actions = generate_next_actions(
+            5,
+            &by_status,
+            &blind_spots,
+            0,
+            &Vec::<String>::new(),
+            &dups,
+            &stubs,
+            &at_risk,
+        );
+        let _ = orphans;
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.contains("at-risk") && a.contains("ADR-007")),
+            "expected at-risk hint with ADR-007, got {actions:?}"
+        );
+    }
+
+    // PROB-029 sanity: Verdict::as_str matches the serde wire format.
+    #[test]
+    fn verdict_as_str_matches_serde_repr() {
+        for (v, s) in [
+            (Verdict::Healthy, "healthy"),
+            (Verdict::NeedsAttention, "needs_attention"),
+            (Verdict::Unhealthy, "unhealthy"),
+        ] {
+            assert_eq!(v.as_str(), s);
+            let json = serde_json::to_string(&v).unwrap();
+            assert_eq!(json, format!("\"{s}\""));
+        }
+    }
+
+    // PROB-029: human_summary never contains "Project looks healthy"
+    // for non-Healthy verdicts. Guards against accidental copy-paste
+    // of the legacy phrase that this whole task fixes.
+    #[test]
+    fn verdict_human_summary_never_lies() {
+        assert!(Verdict::Healthy.human_summary().contains("healthy"));
+        assert!(
+            !Verdict::NeedsAttention
+                .human_summary()
+                .contains("looks healthy"),
+            "NeedsAttention summary must not say 'looks healthy'"
+        );
+        assert!(
+            !Verdict::Unhealthy.human_summary().contains("looks healthy"),
+            "Unhealthy summary must not say 'looks healthy'"
         );
     }
 

--- a/crates/forgeplan-core/tests/health_verdict_test.rs
+++ b/crates/forgeplan-core/tests/health_verdict_test.rs
@@ -1,0 +1,194 @@
+//! Integration tests for PROB-029 health verdict aggregator.
+//!
+//! These exercise `health_report` end-to-end against a real LanceDB
+//! store seeded with a stub PRD, a duplicate evidence pair, and an
+//! orphan, then assert the aggregated `verdict` is *not* `Healthy` and
+//! that `next_actions` carries concrete remediation commands.
+//!
+//! Pre-fix the same workspace produced `verdict = Healthy` and a
+//! "Project looks healthy" line in `next_actions`, in direct
+//! contradiction of the warnings printed above.
+
+use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::health::{Verdict, health_report};
+use tempfile::TempDir;
+
+async fn make_store(tmp: &TempDir) -> LanceStore {
+    let ws = tmp.path().join(".forgeplan");
+    LanceStore::init(&ws).await.unwrap()
+}
+
+fn stub_body() -> String {
+    // Three-marker stub body that `validation::rules::check_stub`
+    // recognises. Mirrors the dogfood workspace's stub PRDs.
+    "## Vision\nWhat we are building and why\n\n## Users\n[Actor] can [capability]\n\n## Notes\nUse {placeholder} here\n".into()
+}
+
+fn new_prd_stub(id: &str) -> NewArtifact {
+    NewArtifact {
+        id: id.into(),
+        kind: "prd".into(),
+        status: "active".into(), // active stub — the PROB-029 surface
+        title: format!("Stub {id}"),
+        body: stub_body(),
+        depth: "standard".into(),
+        author: Some("tester".into()),
+        parent_epic: None,
+        valid_until: None,
+        tags: Vec::new(),
+    }
+}
+
+fn new_prd_clean(id: &str, title: &str) -> NewArtifact {
+    NewArtifact {
+        id: id.into(),
+        kind: "prd".into(),
+        status: "draft".into(),
+        title: title.into(),
+        body: "## Problem\n\nReal text that is not a stub.\n\n## Goals\n\nMore real text.\n".into(),
+        depth: "standard".into(),
+        author: Some("tester".into()),
+        parent_epic: None,
+        valid_until: None,
+        tags: Vec::new(),
+    }
+}
+
+// PROB-029 acceptance criterion #5: integration test creates a
+// workspace with 1 stub PRD, runs health, asserts verdict ≠ "healthy".
+#[tokio::test]
+async fn health_verdict_not_healthy_when_one_active_stub_present() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+
+    // Seed exactly one active stub PRD — the minimum reproducer.
+    store
+        .create_artifact_for_test(&new_prd_stub("PRD-100"))
+        .await
+        .expect("create_artifact_for_test");
+
+    let report = health_report(&store).await.expect("health_report");
+
+    // Smoke check — the stub detector saw it.
+    assert_eq!(
+        report.active_stubs.len(),
+        1,
+        "one active stub should be detected"
+    );
+
+    // PROB-029 AC-1: verdict is NOT Healthy.
+    assert_ne!(
+        report.verdict,
+        Verdict::Healthy,
+        "verdict must not be Healthy when 1 active stub is present, got {:?}",
+        report.verdict,
+    );
+    assert_eq!(
+        report.verdict,
+        Verdict::NeedsAttention,
+        "verdict should be NeedsAttention (1 stub is below Unhealthy threshold)",
+    );
+
+    // PROB-029 AC-3: next_actions is non-empty and includes a
+    // concrete remediation command.
+    assert!(
+        !report.next_actions.is_empty(),
+        "next_actions must not be empty"
+    );
+    assert!(
+        report.next_actions.iter().any(|a| a.contains("PRD-100")),
+        "next_actions must mention the stub id, got {:?}",
+        report.next_actions,
+    );
+    // PROB-029 AC-1 regression: no "Project looks healthy" line.
+    assert!(
+        !report
+            .next_actions
+            .iter()
+            .any(|a| a.contains("looks healthy")),
+        "next_actions must not say 'looks healthy', got {:?}",
+        report.next_actions,
+    );
+}
+
+// PROB-029: empty workspace stays Healthy. Anti-Goodhart: don't flip
+// every project to "unhealthy" the minute the verdict aggregator
+// learns more signals.
+#[tokio::test]
+async fn health_verdict_is_healthy_for_empty_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+
+    let report = health_report(&store).await.expect("health_report");
+
+    assert_eq!(report.total, 0);
+    assert_eq!(
+        report.verdict,
+        Verdict::Healthy,
+        "empty workspace must be Healthy",
+    );
+}
+
+// PROB-029: a workspace with a clean draft PRD (no stub markers, but
+// also no evidence yet) should be Healthy — drafts don't count toward
+// blind spots, and a single orphan draft alone is below all critical
+// thresholds. Acts as a guard against "every workspace is unhealthy"
+// false positives.
+#[tokio::test]
+async fn health_verdict_clean_draft_workspace_is_needs_attention_not_unhealthy() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+
+    store
+        .create_artifact_for_test(&new_prd_clean("PRD-200", "Clean PRD"))
+        .await
+        .expect("create_artifact_for_test");
+
+    let report = health_report(&store).await.expect("health_report");
+    // The lone draft PRD with no relations is an orphan → at most
+    // NeedsAttention with default thresholds.
+    assert_ne!(
+        report.verdict,
+        Verdict::Unhealthy,
+        "1 orphan draft must not promote to Unhealthy, got {:?}",
+        report.verdict,
+    );
+}
+
+// PROB-029 dogfood-style snapshot: 6 active stubs (above default
+// threshold of 3) → Unhealthy. This is the regression guard for the
+// scenario captured in the PROB-029 body.
+#[tokio::test]
+async fn health_verdict_many_active_stubs_promotes_to_unhealthy() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+
+    for i in 0..6 {
+        let id = format!("PRD-{:03}", 300 + i);
+        store
+            .create_artifact_for_test(&new_prd_stub(&id))
+            .await
+            .expect("create_artifact_for_test");
+    }
+
+    let report = health_report(&store).await.expect("health_report");
+    assert_eq!(
+        report.active_stubs.len(),
+        6,
+        "all 6 stubs should be detected"
+    );
+    assert_eq!(
+        report.verdict,
+        Verdict::Unhealthy,
+        "6 active stubs (> threshold 3) must promote verdict to Unhealthy, got {:?}",
+        report.verdict,
+    );
+    // No "looks healthy" line in any action.
+    assert!(
+        !report
+            .next_actions
+            .iter()
+            .any(|a| a.contains("looks healthy")),
+        "Unhealthy workspace must not emit 'looks healthy' line",
+    );
+}

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -2552,7 +2552,12 @@ impl ForgeplanServer {
     }
 
     #[tool(
-        description = "Show project health dashboard — gaps, risks, blind spots, orphans, stale evidence, and recommended next actions. No LLM needed.",
+        description = "Show project health dashboard — gaps, risks, blind spots, orphans, \
+                       stale evidence, and recommended next actions. Returns aggregate \
+                       `verdict` field (\"healthy\" | \"needs_attention\" | \"unhealthy\") \
+                       + `verdict_summary` for one-line human rendering. \
+                       Branch on `verdict` for CI gates and agent decision logic. \
+                       No LLM needed.",
         annotations(
             title = "Health Dashboard",
             read_only_hint = true,
@@ -2608,11 +2613,31 @@ impl ForgeplanServer {
         // PRD-071: deterministic single primary, real IDs (not <id>).
         // The first blind-spot/orphan/at-risk/stale gives the agent a
         // concrete starting target.
+        //
+        // Round 5 audit closure HIGH-1 (Logic): the ladder MUST also check
+        // active_stubs / possible_duplicates / phase_mismatches before
+        // emitting the "Project healthy" fallthrough — otherwise an MCP
+        // response can carry `verdict: "unhealthy"` AND `_next_action:
+        // "Project healthy ..."` simultaneously when the only signals are
+        // stubs / duplicates / phase mismatches. Same PROB-029 contradiction
+        // shape, just relocated to a different field.
         let next_action = if let Some(b) = report.blind_spots.first() {
             let id = sanitize_for_hint(&b.id);
             format!(
                 "{} blind spot(s). Inspect first: `forgeplan_score {id}`.",
                 report.blind_spots.len()
+            )
+        } else if let Some(s) = report.active_stubs.first() {
+            let id = sanitize_for_hint(&s.id);
+            format!(
+                "{} active stub(s) — fill or deprecate. First: `forgeplan_get {id}`.",
+                report.active_stubs.len()
+            )
+        } else if let Some(d) = report.possible_duplicates.first() {
+            let id = sanitize_for_hint(&d.id_a);
+            format!(
+                "{} possible duplicate pair(s). Review first: `forgeplan_get {id}`.",
+                report.possible_duplicates.len()
             )
         } else if let Some(o) = report.orphans.first() {
             let id = sanitize_for_hint(o);
@@ -2631,6 +2656,19 @@ impl ForgeplanServer {
                 "{} stale artifact(s). List them: `forgeplan_stale`.",
                 report.stale_count
             )
+        } else if let Some(p) = phase_mismatches.first() {
+            // Use sanitised id from the json! payload above (already sanitised).
+            let id = p
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(sanitize_for_hint)
+                .unwrap_or_else(|| "<id>".to_string());
+            format!(
+                "{} advisory phase mismatch(es). Inspect first: `forgeplan_get {id}`.",
+                phase_mismatches.len()
+            )
+        } else if report.total == 0 {
+            "Workspace has no artifacts. Start: `forgeplan_new kind=prd title=...`.".to_string()
         } else {
             "Project healthy. List pending drafts: `forgeplan_list status=draft`.".to_string()
         };
@@ -2671,12 +2709,26 @@ impl ForgeplanServer {
             phase_mismatches.len(),
         );
 
+        // Round 5 audit closure HIGH-2 (Logic): an uninitialized workspace
+        // (`total == 0`) was reporting `verdict_summary: "Project looks
+        // healthy."` — the literal pre-PROB-029 phrase the entire feature
+        // exists to eliminate. Override the summary text for the empty
+        // case while keeping the typed `verdict: healthy` (objectively
+        // there ARE no warnings — no false-positive promotion to
+        // NeedsAttention/Unhealthy). Adding `Verdict::Uninitialized` as a
+        // 4th enum variant deferred to v0.30.0 (API stability decision).
+        let verdict_summary = if report.total == 0 {
+            "Workspace has no artifacts. Run `forgeplan_new kind=prd title=...` to start."
+        } else {
+            verdict.human_summary()
+        };
+
         Ok(json_result(&serde_json::json!({
             "total": report.total,
             "by_kind": report.by_kind,
             "by_status": report.by_status,
             "verdict": verdict.as_str(),
-            "verdict_summary": verdict.human_summary(),
+            "verdict_summary": verdict_summary,
             "at_risk": report.at_risk.iter().map(|a| serde_json::json!({
                 "id": a.id, "title": a.title, "reason": a.reason
             })).collect::<Vec<_>>(),

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -2659,10 +2659,24 @@ impl ForgeplanServer {
             })
             .collect();
 
+        // PROB-029 closure: fold the MCP-side `advisory_phase_mismatches`
+        // count into the verdict so MCP consumers (Claude Desktop, agent
+        // IDE plugins) see a consistent `verdict` that reflects ALL signals,
+        // not just the ones the core `health_report` knows about. Without
+        // this, the JSON `verdict` field would say "healthy" while
+        // `advisory_phase_mismatches` printed warnings — the very contradiction
+        // PROB-029 was filed to prevent.
+        let verdict = report.compute_verdict_with(
+            &forgeplan_core::health::VerdictThresholds::default(),
+            phase_mismatches.len(),
+        );
+
         Ok(json_result(&serde_json::json!({
             "total": report.total,
             "by_kind": report.by_kind,
             "by_status": report.by_status,
+            "verdict": verdict.as_str(),
+            "verdict_summary": verdict.human_summary(),
             "at_risk": report.at_risk.iter().map(|a| serde_json::json!({
                 "id": a.id, "title": a.title, "reason": a.reason
             })).collect::<Vec<_>>(),


### PR DESCRIPTION
## Summary

Closes **PROB-029** — `forgeplan health` was reporting "Project looks healthy" even with active stubs / duplicate pairs / blind spots / orphans visible in the same output. The verdict aggregator was written before PRD-043 added new signals (Sprint 13.1) and never updated to fold them in.

### Fix

Typed `Verdict` enum (`Healthy / NeedsAttention / Unhealthy`) on `HealthReport` + pure `compute_verdict[_with]` functions. `compute_verdict_with(thresholds, phase_mismatches)` lets the MCP server fold its locally-computed `advisory_phase_mismatches` count without forcing a workspace-path arg into `health_report()`.

Default thresholds match anti-Goodhart constraint:
- orphans > 5, blind_spots > 3, active_stubs > 3
- duplicates > 5, phase_mismatches > 5 → **Unhealthy**
- Any non-zero signal below threshold → **NeedsAttention**
- All zero → **Healthy**

`generate_next_actions` rewritten to emit **concrete remediation commands** (`forgeplan deprecate EVID-003 --reason "superseded by EVID-001"` for duplicate pairs, `forgeplan new evidence --link <id>` for blind spots, etc.).

CLI banner at `commands/health.rs:282-289` also fixed (second commit) to drive off the verdict instead of the ad-hoc `has_issues` check that was missing `active_stubs` + `possible_duplicates` — single source of truth across JSON / banner / MCP.

### ADI

H1 (typed Verdict on HealthReport) chosen over H2 (free function only) and H3 (rewrite next_actions only) because verdict needs single source of truth across JSON, CLI banner, MCP `forgeplan_health`. Purely additive public API — `--ci` exit codes unchanged (AC-4).

### Acceptance criteria

- [x] AC-1: verdict ≠ Healthy when any signal present
- [x] AC-2: 3-level verdict (Healthy / NeedsAttention / Unhealthy)
- [x] AC-3: next_actions includes concrete remediation commands
- [x] AC-4: `--ci` exit codes preserved (additive API)
- [x] AC-5: integration test on real workspace + stub PRD asserts verdict ≠ healthy

## Test plan

- [x] `cargo fmt --check` — exit 0
- [x] `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` — 0 warnings
- [x] `cargo test --workspace --features test-helpers` — **1962 passed** (1940 baseline + 22 new health verdict tests; 18 unit + 4 integration)
- [x] CLI integration tests (`hint_contract`, `cli_integration_test`) — green

## Out of scope (follow-ups)

- MCP server at `crates/forgeplan-mcp/src/server.rs:2582-2606` should call `report.compute_verdict_with(&VerdictThresholds::default(), phase_mismatches.len())` to surface advisory_phase_mismatches in JSON. Defer to PROB-029 follow-up or PR-E pickup if scope allows. Internal API is ready (`compute_verdict_with` exposed `pub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)