### PR TITLE
[PROB-056] HealthReport.partial_verdict — surface phase-fold contract в the type system (Round 6 audit MED-1)

### DIFF
--- a/.forgeplan/evidence/EVID-109-prob-056-closure-leaky-verdict-abstraction-partial-verdict-field-with-doc-contract.md
+++ b/.forgeplan/evidence/EVID-109-prob-056-closure-leaky-verdict-abstraction-partial-verdict-field-with-doc-contract.md
@@ -1,0 +1,92 @@
+---
+depth: standard
+id: EVID-109
+kind: evidence
+links:
+- target: PROB-056
+  relation: informs
+status: active
+title: PROB-056 closure leaky verdict abstraction partial_verdict field with doc contract
+---
+
+# EVID-109: PROB-056 closure — `HealthReport.partial_verdict` field surfaces phase-fold contract
+
+## Summary
+
+Closes PR-E Round 6 audit MED-1 — leaky verdict abstraction в `HealthReport`. Pre-PROB-056 the single `verdict` field silently switched semantic between callers: `health_report()` populated it as partial (phase_mismatches=0), `health_report_with_phase()` populated it as folded (PROB-051 closure). External library consumers calling `health_report` directly couldn't tell от the type signature что their `verdict` was partial. Post-PROB-056: new `partial_verdict: Verdict` field always carries the partial value; `verdict` continues to carry "best-known" value (folded когда available, partial otherwise).
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Evidence
+
+### Implementation
+
+New field on `HealthReport` struct в `crates/forgeplan-core/src/health/mod.rs`:
+
+```rust
+/// **Best-known verdict for user-facing display.**
+pub verdict: Verdict,
+
+/// PROB-056 closure — verdict computed using ONLY core warning classes
+/// (phase_mismatches=0). External library consumers tracking additional
+/// context MUST consume this as base for compute_verdict_with()
+/// recomputation rather than relying on `verdict` (which may be folded).
+pub partial_verdict: Verdict,
+```
+
+- `health_report` legacy path: writes BOTH fields с phase_mismatches=0 — they're equal.
+- `health_report_with_phase` post-fold path: writes `partial_verdict` с phase_mismatches=0, then OVERWRITES `verdict` с folded value.
+- Wire JSON format unchanged for `verdict`; new `partial_verdict` field appears optionally.
+
+### Tests (+2 unit tests)
+
+```
+test health::tests::health_report_partial_verdict_equals_verdict_when_no_phase ... ok
+test health::tests::health_report_with_phase_partial_verdict_invariant ... ok
+```
+
+Suite: lib 1475 → **1477** PASS.
+
+### AC tracking
+
+- AC-1 ✅ `partial_verdict` field added (rename was Option A — implemented as additive split which preserves wire format AND surfaces semantic without forcing CLI/MCP migration)
+- AC-2 ✅ Doc-comment on `partial_verdict` documents recomputation contract
+- AC-3 ✅ CLI/MCP code paths reviewed — both already route through `health_report_with_phase` (PROB-051 closure) so `verdict` is the right value to consume; no migration needed
+- AC-4 ✅ +2 tests demonstrating the invariants
+- AC-5 ✅ CHANGELOG entry under Refactor section
+
+### Quality gates
+
+```
+cargo fmt --check                                                  clean
+cargo clippy --workspace --all-targets --features test-helpers
+  -- -D warnings                                                   clean
+cargo test --workspace --features test-helpers                     0 failures (38 suites)
+```
+
+## Hindsight
+
+PROB-051 already closed the **specific MCP-override leaky abstraction** by routing both CLI and MCP through `health_report_with_phase` (which writes the folded verdict to the `verdict` field). PROB-056 is the **architectural completion** — surfacing the dual-semantic contract в the type system for external library consumers.
+
+Design choice: additive (`partial_verdict` as new field) vs hard rename (`verdict` → `partial_verdict`). Picked additive because:
+1. Hard rename forces all CLI/MCP/external code paths to migrate (LOC churn).
+2. Hard rename + serde rename keeps JSON wire OK but creates a different foot-gun: `verdict` JSON field carries different semantic than Rust `partial_verdict` field name suggests.
+3. Additive split lets `verdict` keep the user-facing "best known" semantic (which is what consumers actually want) and `partial_verdict` becomes the explicit access for advanced cases.
+
+This is the same architectural pattern as PROB-049 typed errors (introduce typed alternatives without removing the legacy surface) — incremental migration over breaking rename.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PROB-056 | informs (this evidence demonstrates closure) |
+| PROB-051 | informs (L-H3 closure already addressed the MCP-override specific instance; PROB-056 finishes the architectural cleanup) |
+| PROB-029 | informs (Verdict aggregator origin) |
+| EVID-107 | informs (PROB-051 closure context — health_report_with_phase introduced) |
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+### Refactor (Architecture — PROB-056 closure, leaky verdict abstraction)
+
+- **PROB-056 ✅ — `HealthReport.partial_verdict` field surfaces
+  phase-fold contract в the type system**. Pre-PROB-056 the single
+  `verdict` field silently switched semantic between callers:
+  `health_report()` populated it as partial (phase_mismatches=0),
+  `health_report_with_phase()` populated it as folded (PROB-051
+  closure). External library consumers calling `health_report`
+  directly couldn't tell от the type signature что their `verdict`
+  was partial.
+
+  **Fix**: new `partial_verdict: Verdict` field on `HealthReport` always
+  carries the value computed с phase_mismatches=0. `verdict` continues
+  carry the "best-known" value (folded когда available via
+  `health_report_with_phase`, partial otherwise). External library
+  consumers tracking additional context MUST consume `partial_verdict`
+  as base для their own `compute_verdict_with()` recomputation.
+
+  **Wire format**: `verdict` JSON field unchanged. New `partial_verdict`
+  appears in `--json` output (additive — non-breaking). CLI/MCP code
+  paths unchanged — both already route through `health_report_with_phase`
+  (PROB-051 closure) so `verdict` is the right value to consume.
+
+  **Tests**: +2 unit tests validating invariants:
+  - `health_report_partial_verdict_equals_verdict_when_no_phase` —
+    legacy path both fields equal
+  - `health_report_with_phase_partial_verdict_invariant` —
+    `partial_verdict` ALWAYS equals legacy `verdict` для same workspace,
+    even when post-fold `verdict` diverges
+
+  **Design choice**: additive (new field) vs hard rename (`verdict` →
+  `partial_verdict`). Picked additive — hard rename would force all
+  CLI/MCP/external code to migrate while still leaving the dual-semantic
+  foot-gun on the JSON wire field name. Additive split lets `verdict`
+  keep "best-known" user-facing semantic (= what consumers actually
+  want) и `partial_verdict` becomes explicit advanced-case access.
+  Mirror of PROB-049 typed-errors lineage (typed alternative alongside
+  legacy surface, incremental migration).
+
+  Suite: lib 1475 → **1477** PASS, 0 failures across 38 suites.
+
 ### Fixed (Security — PROB-054 closure, prompt-injection-via-filesystem)
 
 - **PROB-054 ✅ — `produces_at` prompt-injection validator** (CWE-94

--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -191,11 +191,33 @@ pub struct HealthReport {
     pub next_actions: Vec<String>,
     pub possible_duplicates: Vec<DuplicatePair>,
     pub active_stubs: Vec<ActiveStub>,
-    /// PROB-029 AC-2: aggregated verdict that reads ALL warning classes.
-    /// Pre-fix this didn't exist — `next_actions` was the only summary
-    /// and silently said "Project looks healthy" while stubs/dups were
-    /// printed above it (PRD-043 detection bypass).
+    /// **Best-known verdict for user-facing display.** Aggregates all
+    /// warning classes Forgeplan currently understands. Equals
+    /// [`HealthReport::partial_verdict`] when this report comes из
+    /// [`health_report`] (legacy / no phase context); equals the
+    /// post-fold value (включая `phase_mismatches.len()`) when this
+    /// report comes from [`health_report_with_phase`].
+    ///
+    /// PROB-029 AC-2 origin: aggregated verdict that reads ALL warning
+    /// classes. Pre-fix this didn't exist — `next_actions` was the only
+    /// summary и silently said "Project looks healthy" while stubs/dups
+    /// были printed above it (PRD-043 detection bypass).
     pub verdict: Verdict,
+    /// PROB-056 closure — verdict computed using ONLY the warning
+    /// classes the `forgeplan-core` crate tracks (phase_mismatches=0).
+    ///
+    /// External library consumers tracking additional context (extra
+    /// phase data, custom signals from a downstream crate) MUST consume
+    /// this field as the base for their own [`compute_verdict_with`]
+    /// recomputation rather than rely on [`HealthReport::verdict`] —
+    /// the latter equals `partial_verdict` only когда the report came
+    /// from [`health_report`]. After [`health_report_with_phase`] the
+    /// two diverge if any phase mismatches были detected.
+    ///
+    /// Pre-PROB-056 there was a single `verdict` field that silently
+    /// switched semantic between callers (Round 6 audit MED-1 — leaky
+    /// abstraction). The split surfaces the contract в the type system.
+    pub partial_verdict: Verdict,
 }
 
 impl HealthReport {
@@ -469,6 +491,11 @@ async fn health_report_inner(
         &VerdictThresholds::default(),
     );
 
+    // PROB-056 closure: from `health_report` (no phase context) the
+    // verdict equals partial_verdict — both are computed with
+    // phase_mismatches=0. They diverge only after `health_report_with_phase`
+    // overwrites `verdict` с the folded value. `partial_verdict` always
+    // reflects the "core knows about" subset.
     Ok(HealthReport {
         total,
         by_kind: by_kind.into_iter().collect(),
@@ -482,6 +509,7 @@ async fn health_report_inner(
         possible_duplicates,
         active_stubs,
         verdict,
+        partial_verdict: verdict,
     })
 }
 
@@ -1382,6 +1410,7 @@ mod tests {
             possible_duplicates: Vec::new(),
             active_stubs: Vec::new(),
             verdict: Verdict::Healthy,
+            partial_verdict: Verdict::Healthy,
         }
     }
 
@@ -1759,6 +1788,50 @@ mod tests {
         assert!(
             mismatches.is_empty(),
             "empty workspace has no active records → no phase mismatches possible"
+        );
+    }
+
+    /// PROB-056 closure — `partial_verdict` equals `verdict` for the
+    /// `health_report` legacy path (both computed с phase_mismatches=0).
+    /// Regression guard для the contract documented on the field.
+    #[tokio::test]
+    async fn health_report_partial_verdict_equals_verdict_when_no_phase() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let store = LanceStore::init(&ws).await.unwrap();
+
+        let report = health_report(&store).await.unwrap();
+        assert_eq!(
+            report.verdict, report.partial_verdict,
+            "PROB-056: legacy health_report has no phase context — verdict must == partial_verdict"
+        );
+    }
+
+    /// PROB-056 closure — `partial_verdict` and `verdict` may diverge
+    /// after `health_report_with_phase` if any phase mismatches were
+    /// folded. With zero mismatches they remain equal (regression guard
+    /// для the typical-case fast path).
+    #[tokio::test]
+    async fn health_report_with_phase_partial_verdict_invariant() {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path().join(".forgeplan");
+        let store = LanceStore::init(&ws).await.unwrap();
+
+        let (report, mismatches) = health_report_with_phase(&store, &ws).await.unwrap();
+        if mismatches.is_empty() {
+            assert_eq!(
+                report.verdict, report.partial_verdict,
+                "PROB-056: zero phase mismatches → verdict == partial_verdict"
+            );
+        }
+        // partial_verdict MUST always equal the legacy compute even when
+        // verdict диverges due to folded phase context.
+        let legacy = health_report(&store).await.unwrap();
+        assert_eq!(
+            report.partial_verdict, legacy.verdict,
+            "PROB-056: partial_verdict on with_phase == verdict on legacy (same input → same partial)"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes **PROB-056** (PR-E Round 6 audit MED-1) — leaky verdict abstraction. Pre-fix: single `verdict` field silently switched semantic between callers. Post-fix: new `partial_verdict` field always carries pre-fold value; `verdict` continues to carry "best-known" value (folded when available).

## Test plan

- [x] `cargo fmt --check` → clean
- [x] `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` → clean
- [x] `cargo test --workspace --features test-helpers` → 0 failures across 38 suites; lib 1475 → **1477** PASS

For reviewer:
- [ ] Verify CI green
- [ ] Confirm wire JSON unchanged (`verdict` field behavior preserved; `partial_verdict` is new additive field)
- [ ] Confirm CLI/MCP no migration needed (both consume `verdict` which still carries best-known value)

## Roadmap alignment

- ✅ **Tier 2 v0.30.0 Wave 2.2**: PROB-056 — closed на target estimate (S, 1d, shipped <1h)
- ⏳ Wave 2.3 next: PROB-049 follow-up retry-loop (M, 2-3d)
- ⏳ Wave 3: paper cuts batch (PROB-028/027/030/032/033/041/038, ~5d)

## Design choice

Additive (`partial_verdict` as new field) over hard rename. Hard rename forces all CLI/MCP/external code migration while leaving JSON wire foot-gun. Additive split keeps `verdict` user-facing best-known value, adds explicit advanced-case access via `partial_verdict`. Mirrors PROB-049 typed-errors lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)