### PR TITLE
[PROB-032] forgeplan search score breakdown coherent с total (Wave 3 paper cut)

### DIFF
--- a/.forgeplan/evidence/EVID-111-prob-032-closure-search-score-breakdown-shows-max-bm25-kw-precision-bumped.md
+++ b/.forgeplan/evidence/EVID-111-prob-032-closure-search-score-breakdown-shows-max-bm25-kw-precision-bumped.md
@@ -1,0 +1,99 @@
+---
+depth: standard
+id: EVID-111
+kind: evidence
+links:
+- target: PROB-032
+  relation: informs
+status: active
+title: PROB-032 closure search score breakdown shows max(bm25, kw) precision bumped
+---
+
+# EVID-111: PROB-032 closure — search score breakdown coherent с total
+
+## Summary
+
+Closes PROB-032 — `forgeplan search` displayed `kw=0.0 sem=0.0 r=0.0 g=0.0` while total score was non-zero (e.g. 0.57), violating "sum ≈ total" expectation и lying к user about ranking composition. Two-part fix в `crates/forgeplan-cli/src/commands/search.rs:393-405`: (a) display `max(bm25_score, keyword_score)` instead of `keyword_score` (substring) since `combined_score()` actually uses the max; (b) bump precision `{:.1}` → `{:.2}` so contributions of 0.02–0.09 no longer round-down к 0.0.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Evidence
+
+### Root cause
+
+`SmartSearchResult` carries TWO keyword channels:
+- `keyword_score` — substring match score (raw `record.body.contains(query)` etc.)
+- `bm25_score` — normalized BM25 token-match score (PRD-039 Smart Search v2)
+
+`combined_score()` в `crates/forgeplan-core/src/search/smart.rs:153` uses
+`keyword_channel = bm25_norm.max(keyword_score)` as the base. When match is
+via BM25 tokenization (e.g. "auth" matches "authentication" via stemming
+but not as substring), `keyword_score` = 0 but `bm25_score` > 0. CLI
+display только showed `keyword_score`, hence `kw=0.0` despite non-zero
+total.
+
+### Fix
+
+```rust
+let kw_channel = r.bm25_score.max(r.keyword_score);
+let signals = format!(
+    "kw={:.2} sem={:.2} r={:.2} g={:.2}",
+    kw_channel, r.semantic_score, r.r_eff, r.graph_centrality
+);
+```
+
+### Real E2E (target/release/forgeplan, fresh tempdir)
+
+```
+$ forgeplan init -y
+$ forgeplan new prd "Error handling for API endpoints"
+$ forgeplan new prd "Authentication system"
+$ forgeplan search "api error"
+
+Found 1 result(s) for "api error" (smart search):
+
+  0.36  PRD-001 [prd|draft] "Error handling for API endpoints"
+        kw=0.36 sem=0.00 r=0.00 g=0.00
+```
+
+Pre-fix: `kw=0.0 sem=0.0 r=0.0 g=0.0` (lying — total 0.36 без visible contributor).
+Post-fix: `kw=0.36 sem=0.00 r=0.00 g=0.00` (truthful — kw is the contributor; total = kw × boost).
+
+Math: `combined_score = max(kw, sem) × (1.0 + r×0.2 + active×0.1 + graph×0.1)`. With kw=0.36, sem=0, r=0, draft (no active boost), graph=0: `0.36 × 1.0 = 0.36` ✓.
+
+### AC tracking
+
+- AC-1 ✅ kw component shows non-zero value when contributing (was lying as 0.0)
+- AC-2 ✅ sum of components ≈ total (within rounding via {:.2} precision)
+- AC-3 N/A (sensible breakdown DOES exist — fix preserved breakdown line)
+- AC-4 ✅ existing search tests still pass (0 failures across 38 suites)
+
+### Quality gates
+
+```
+cargo fmt --check                                                  clean
+cargo clippy --workspace --all-targets --features test-helpers
+  -- -D warnings                                                   clean
+cargo test --workspace --features test-helpers                     0 failures (38 suites)
+```
+
+## Hindsight
+
+Bug-class lesson: **multi-channel scoring exposes display/computation drift**. When `combined_score` uses `max(A, B)` but display shows only `A`, users see incoherent breakdowns. Audit prompt template: «when scoring formula uses `max()` / `mean()` / `weighted_sum()` over multiple channels, display MUST show the actually-contributing channel(s), not arbitrary subset».
+
+Mirrors PROB-029 verdict aggregator pattern: hidden fold logic + display path that lies about the fold = same shape, different surface (search vs health).
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PROB-032 | informs (this evidence demonstrates closure) |
+| PRD-039 | informs (Sprint 13.2 BM25 introduced the breakdown duality) |
+| PROB-030 | informs (sibling BM25 search regression — same audit batch) |
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+### Fixed (Search UX — PROB-032 closure, score breakdown lies)
+
+- **PROB-032 ✅ — `forgeplan search` score breakdown coherent с total**.
+  Pre-PROB-032 the display showed `kw=0.0 sem=0.0 r=0.0 g=0.0` while
+  total score was non-zero (e.g. 0.57) — violating "sum ≈ total"
+  expectation и lying к user about ranking composition.
+
+  **Root cause**: `SmartSearchResult` carries TWO keyword channels
+  (`keyword_score` substring + `bm25_score` BM25). `combined_score()`
+  uses `max(bm25, keyword_score)` as base, but CLI display showed только
+  `keyword_score`. When match was via BM25 tokenization (e.g. "auth"
+  matches "authentication" via stemming но not as substring),
+  `keyword_score` = 0 hence misleading `kw=0.0` display.
+
+  **Two-part fix** в `crates/forgeplan-cli/src/commands/search.rs`:
+  - Display `max(bm25_score, keyword_score)` so the visible value
+    reflects the actually-contributing channel (matches what
+    `combined_score()` consumes)
+  - Bump precision `{:.1}` → `{:.2}` so contributions of 0.02–0.09 no
+    longer round-down к 0.0
+
+  **Real E2E verified**: query "api error" against fresh workspace now
+  shows `kw=0.36 sem=0.00 r=0.00 g=0.00` matching total 0.36 (was
+  pre-fix `kw=0.0 ... total 0.36`).
+
+  Architectural pattern same as PROB-029 verdict aggregator: hidden
+  fold logic + display path that lies about the fold. When scoring
+  formula uses `max()` / `mean()` / `weighted_sum()` over multiple
+  channels, display MUST show the actually-contributing channel(s).
+
 ### Fixed (Reindex — PROB-028 closure, reindex resilience)
 
 - **PROB-028 ✅ — `forgeplan reindex` resilience против Phase-1 abort**.

--- a/crates/forgeplan-cli/src/commands/search.rs
+++ b/crates/forgeplan-cli/src/commands/search.rs
@@ -390,9 +390,20 @@ async fn run_smart(
             query
         );
         for r in &results {
+            // PROB-032 fix: pre-fix displayed `r.keyword_score` (substring
+            // match) but `combined_score` actually uses
+            // `max(bm25_score, keyword_score)`. When a query matched via BM25
+            // tokenization but had no substring presence (e.g. "auth" matches
+            // "authentication" via stemming but not substring), `kw=0.0` was
+            // shown despite the keyword channel contributing the entire base
+            // score — total > 0 with all displayed components 0.0. Display
+            // the MAX of both channels so the breakdown reflects the actual
+            // contributor. Precision bumped к {:.2} so small contributions
+            // (0.02–0.09) no longer round-down к 0.0.
+            let kw_channel = r.bm25_score.max(r.keyword_score);
             let signals = format!(
-                "kw={:.1} sem={:.1} r={:.1} g={:.1}",
-                r.keyword_score, r.semantic_score, r.r_eff, r.graph_centrality
+                "kw={:.2} sem={:.2} r={:.2} g={:.2}",
+                kw_channel, r.semantic_score, r.r_eff, r.graph_centrality
             );
             println!(
                 "  {:.2}  {} [{}|{}] \"{}\"",


### PR DESCRIPTION
Closes PROB-032. Display showed kw=0.0 while total > 0 because it used keyword_score (substring) but combined_score uses max(bm25, keyword_score). Fix: show max + bump precision to {:.2}. Real E2E verified.