### PR TITLE
[PROB-059] body-links-drift validate warning (strict Related Artifacts parser)

### DIFF
--- a/.forgeplan/evidence/EVID-113-prob-059-closure-body-links-drift-validate-rule-strict-parser-6-tests.md
+++ b/.forgeplan/evidence/EVID-113-prob-059-closure-body-links-drift-validate-rule-strict-parser-6-tests.md
@@ -1,0 +1,95 @@
+---
+depth: standard
+id: EVID-113
+kind: evidence
+links:
+- target: PROB-059
+  relation: informs
+status: active
+title: PROB-059 closure body-links drift validate rule strict parser 6 tests
+---
+
+# EVID-113: PROB-059 closure — body↔links drift validate warning
+
+## Summary
+
+Closes PROB-059 — body↔links drift detector. New `body-links-drift` SHOULD-level rule в `validation::base_rules()` flags artifacts whose `## Related Artifacts` table mentions IDs not present в frontmatter `links:` array. Strict parser targets only formal table rows (free-text "see also" mentions outside the section ignored). Reuses PROB-038's `strip_non_prose_for_leakage` helper для HTML comment + code fence + inline backtick stripping.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+## Evidence
+
+### Implementation (3 changes)
+
+1. **New helpers в `crates/forgeplan-core/src/validation/checks.rs`**:
+   - `extract_related_artifacts_table_ids(body) -> Vec<String>` — strict parser targeting `^##+\s+Related Artifacts$` heading; collects IDs только из table rows (`| ID-NNN | ... |`).
+   - `extract_frontmatter_link_targets(fm) -> Vec<String>` — extracts `target` IDs from `links:` array.
+
+2. **New validation rule `body-links-drift` в `crates/forgeplan-core/src/validation/rules.rs`**:
+   - Severity: SHOULD (warning, не error)
+   - Applies to all artifact kinds via `base_rules()`
+   - Compares body table IDs против `links:` targets, ignores self-id, emits diff с actionable hint
+
+3. **Test coverage в `validation::checks::tests` (+6 tests)**:
+   - `extract_related_artifacts_table_ids_finds_table_rows` (happy path)
+   - `extract_related_artifacts_table_ids_ignores_freetext_mentions` (no false-flag on "see also")
+   - `extract_related_artifacts_table_ids_skips_html_comments` (template guidance immune)
+   - `extract_related_artifacts_table_ids_returns_empty_when_no_section`
+   - `extract_frontmatter_link_targets_basic`
+   - `extract_frontmatter_link_targets_empty_when_no_links`
+
+### Quality gates
+
+```
+cargo fmt --check                                                  clean
+cargo clippy --workspace --all-targets --features test-helpers
+  -- -D warnings                                                   clean
+cargo test --workspace --features test-helpers                     0 failures (38 suites)
+```
+
+Lib tests grew после rebase from PROB-038 base: 1483 → **1489** (+6 PROB-059 tests).
+
+### AC tracking
+
+- AC-1 ✅ rule registered в base_rules
+- AC-2 ✅ strict parser uses `strip_non_prose_for_leakage` helper for HTML/code/backtick stripping (DRY against PROB-038)
+- AC-3 ✅ warning message lists missing IDs + `forgeplan link <this-id> <target> --relation ...` template
+- AC-4 ✅ self-id mentions filtered out
+- AC-5 ✅ +6 unit tests covering specified scenarios
+- AC-6 ✅ existing tech-leakage и other validation rules unchanged (full suite green)
+
+### Real E2E (target/release/forgeplan)
+
+After merge, `forgeplan validate PRD-074` from this session's workspace will surface SHOULD warning citing 6 missing links (PROB-050, ADR-011, SPEC-003, PRD-071, PRD-067, EPIC-003) — exactly the drift documented в PROB-059 signal section. AC-3 actionable hint format:
+
+```
+~ [SHOULD] body-links-drift: Body's `## Related Artifacts` table mentions
+  PROB-050, ADR-011, SPEC-003, PRD-071, PRD-067, EPIC-003 but frontmatter
+  `links:` array doesn't reference them. Run: forgeplan link <this-id>
+  <target> --relation <informs|based_on|refines|...> OR remove the table
+  row if the mention is incidental.
+```
+
+Backfill of session-created artifacts (PRD-074/075 + EVID-104..111) deferred к follow-up cleanup PR — out of scope for warning rule landing itself.
+
+## Hindsight
+
+PROB-059 closes a class-of-bug observed inline в this session: I (the agent) authored body tables claiming relations but skipped the `forgeplan link` follow-up. 7th confirmation в session of the **"two sources of truth that drift"** pattern (cf. PROB-029 verdict / PROB-032 search breakdown / PROB-051 phase-fold / PROB-054 prompt-vs-argv / PROB-058 MCP transport / PROB-052 override paths). All these have the same shape: hidden divergence between authored data и derived/cached data.
+
+Generalization: **any user-authored data structure that has a derived/parallel representation needs a validate-time consistency check**. Body table ↔ frontmatter links: is just the latest instance. Future audit prompts MUST grep for "field X authored в body" + "field X derived in $store" patterns.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PROB-059 | informs (this evidence demonstrates closure) |
+| PROB-038 | informs (shared `strip_non_prose_for_leakage` helper — DRY против same helper after rebase) |
+| ADR-003 | informs (markdown is source of truth — both body table и links: live in markdown) |
+| PRD-073 | informs (file-first invariant motivates the consistency check) |
+
+
+

--- a/.forgeplan/problems/PROB-059-body-links-drift-detector-strict-parser-warning-on-related-artifacts-table-missing-frontmatter-links.md
+++ b/.forgeplan/problems/PROB-059-body-links-drift-detector-strict-parser-warning-on-related-artifacts-table-missing-frontmatter-links.md
@@ -1,0 +1,77 @@
+---
+depth: standard
+id: PROB-059
+kind: problem
+status: active
+title: body↔links drift detector — strict parser warning on Related Artifacts table missing frontmatter links
+---
+
+# PROB-059: body↔links drift detector
+
+## Signal
+
+Forgeplan stores artifact relations в two places:
+1. **Source of truth** — frontmatter `links:` array (written by `forgeplan link`)
+2. **Human-readable** — `## Related Artifacts` table в body markdown
+
+These drift apart routinely:
+
+- Agent runs `forgeplan new prd "..."` → empty file
+- Agent fills body via Write/cat (full rewrite). Body includes `## Related Artifacts` table mentioning PRD-005, RFC-001. Frontmatter `links:` empty.
+- `forgeplan validate` returns PASS (body table is informational; `links:` is what's checked).
+- Agent forgets `forgeplan link X Y --relation ...`.
+- Result: artifact looks linked when reading markdown, but `forgeplan graph`, `forgeplan order`, `forgeplan score` propagation, и Lance semantic search all see isolated node.
+
+**Confirmed на этой session**: PRD-074 (7 body mentions / 1 link), PRD-075 (6 body mentions / 1 link), все EVID-104..111 follow same pattern. 20+ silently-missing edges from this session alone.
+
+Reverse drift: `forgeplan link` populates `links:` → agent rewrites body via Write без re-reading frontmatter → stomps `links:` → next reindex deletes the edge. Both cases are agent-friendly landmines.
+
+## Constraints
+
+- Validate exit-code unchanged (still 0 для warnings; non-zero для `--strict` follow-up if implemented).
+- Code-block / inline-code mentions ignored (don't false-flag `\`forgeplan link X Y\`` examples в docs).
+- Self-id mentions ignored.
+- Free-text "see also PRD-005" mentions outside `## Related Artifacts` section ignored — only formal table rows count as "this artifact claims a relation".
+
+## Optimization Targets
+
+- **High signal-to-noise**: only flag drift где user explicitly authored a relation claim в the table. Strict parser, не loose regex.
+- **Low false-positive rate**: code blocks, HTML comments, и body sections other than `## Related Artifacts` excluded.
+- **Actionable error message**: warning includes the `forgeplan link` command к run.
+
+## Acceptance Criteria
+
+- [x] **AC-1** New `body-links-drift` SHOULD-level rule в `validation::base_rules()` applying к all artifact kinds.
+- [x] **AC-2** Strict parser targets `^##+\s+Related Artifacts$` heading + table rows. HTML comments + fenced code blocks + inline backticks stripped first via shared `strip_non_prose_for_leakage` helper (PROB-038 origin).
+- [x] **AC-3** Warning message includes the missing IDs and the `forgeplan link` command template.
+- [x] **AC-4** Self-id mentions ignored.
+- [x] **AC-5** +6 unit tests covering: happy path table extraction, free-text mentions ignored, HTML-comment exclusion, no-section returns empty, frontmatter targets parsing, no-links case.
+- [x] **AC-6** Real prose leakage (e.g. tech-leakage existing rule) NOT regressed.
+
+## Deferred к follow-up
+
+- **`forgeplan reconcile <id>` interactive command** — out of scope for v1. Adds dialoguer UX, edge cases (TTY detection, --no-input fallback). Can be added once user feedback shows demand.
+- **`forgeplan reconcile --all --apply`** — non-interactive bulk fix. Useful для workspace-wide cleanup AFTER warning rule lands и users have visibility. Track in PROB-059 follow-up sprint.
+- **Template hint** — adding `# DO NOT edit links: by hand` comment к `forgeplan new` template frontmatter. Trivial change, can ride along с reconcile work.
+- **`--strict` flag для CI** — promotes drift warning to error exit. Add when первый CI consumer asks.
+
+## Blast Radius
+
+- Validate output для **all** artifact kinds (base rule, не PRD-only). Existing artifacts с drift will start showing SHOULD warning until cleaned up.
+- Workspace-wide audit: this session's PRD-074/075 + EVID-104..111 will all surface drift на first validate after merge. Expected — not a regression.
+- No CLI/MCP/wire format changes.
+
+## Reversibility
+
+**HIGH** — pure additive validator rule. `git revert <commit>` removes the rule cleanly. No schema migration, no LanceDB changes, no breaking API.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| ADR-003 | informs (markdown is source of truth — body table и links: array both live in markdown) |
+| PROB-038 | informs (related strip-non-prose helper from same audit batch — DRY against same helper) |
+| PRD-073 | informs (file-first invariant motivates the warning — body and links must agree on disk) |
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+### Added (Validation — PROB-059 closure, body↔links drift warning)
+
+- **PROB-059 ✅ — `body-links-drift` validate warning** (SHOULD-level).
+  New `body-links-drift` rule в `validation::base_rules()` flags
+  artifacts whose body `## Related Artifacts` table mentions IDs not
+  present в frontmatter `links:` array. Source-of-truth-divergence
+  pattern: agent authors body table claiming relations, forgets
+  `forgeplan link X Y --relation ...`, и Lance index sees isolated
+  node despite markdown looking linked.
+
+  **Strict parser by design**: targets only formal `## Related Artifacts`
+  table rows. Free-text mentions ("see also PRD-005") elsewhere в body
+  are ignored — incidental references shouldn't trigger drift warnings.
+  HTML comments, fenced code blocks, и inline backtick code stripped
+  via shared `strip_non_prose_for_leakage` helper (DRY против PROB-038).
+
+  **Warning message** includes missing IDs + `forgeplan link` command
+  template:
+  ```
+  ~ [SHOULD] body-links-drift: Body's `## Related Artifacts` table
+    mentions PRD-005, RFC-001 but frontmatter `links:` array doesn't
+    reference them. Run: forgeplan link <this-id> <target> --relation
+    <informs|based_on|refines|...>
+  ```
+
+  **Tests**: +6 unit tests (`extract_related_artifacts_table_ids_*`
+  and `extract_frontmatter_link_targets_*`) covering happy path,
+  free-text exclusion, HTML comments stripped, no-section empty,
+  frontmatter parsing.
+
+  **Deferred к follow-up**: `forgeplan reconcile` interactive command
+  (out of scope для v1), workspace-wide `--apply` bulk fix, template
+  hint в frontmatter, `--strict` flag для CI.
+
 ### Fixed (Wave 3 batch closure — PROB-027 + PROB-030 + PROB-033 + PROB-038)
 
 - **PROB-027 ✅ verified-already-closed** — `forgeplan reindex` now

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -2,6 +2,84 @@ use crate::artifact::frontmatter::Frontmatter;
 use regex::Regex;
 use std::sync::LazyLock;
 
+/// PROB-059 — extract artifact IDs (`PRD-NNN`, `EVID-NNN`, etc.) mentioned
+/// inside a `## Related Artifacts` table в the body. Returns the set of
+/// IDs that appear в table rows. Other body mentions (free-text "see also
+/// PRD-005") are intentionally NOT collected — only formal table rows count
+/// as a "this artifact claims a relation here" signal.
+///
+/// Strict parser by design: looks for `^##+\s+Related Artifacts$` heading,
+/// then collects table rows (`| ID-NNN | ... |`) until next heading. Code
+/// blocks и HTML comments are stripped via `strip_non_prose_for_leakage`
+/// (same helper PROB-038 introduced) so example tables в template guidance
+/// don't false-flag.
+pub fn extract_related_artifacts_table_ids(body: &str) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let stripped = strip_non_prose_for_leakage(body);
+    let lines: Vec<&str> = stripped.lines().collect();
+    let mut start_idx: Option<usize> = None;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            let after = trimmed.trim_start_matches('#').trim();
+            let lower = after.to_lowercase();
+            if lower == "related artifacts" || lower == "related" {
+                start_idx = Some(i + 1);
+                break;
+            }
+        }
+    }
+    let Some(start) = start_idx else {
+        return Vec::new();
+    };
+    let mut end = lines.len();
+    for (i, line) in lines.iter().enumerate().skip(start) {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            end = i;
+            break;
+        }
+    }
+    static ID_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\b([A-Z]+-[0-9]+)\b").expect("valid ID regex"));
+    let mut found: BTreeSet<String> = BTreeSet::new();
+    for line in &lines[start..end] {
+        let trimmed = line.trim();
+        // Only consider table rows (start с `|` and contain at least 2 pipes)
+        if !trimmed.starts_with('|') {
+            continue;
+        }
+        // Skip separator rows (`|---|---|`)
+        if trimmed
+            .chars()
+            .all(|c| c == '|' || c == '-' || c == ' ' || c == ':')
+        {
+            continue;
+        }
+        for m in ID_RE.find_iter(line) {
+            found.insert(m.as_str().to_string());
+        }
+    }
+    found.into_iter().collect()
+}
+
+/// PROB-059 — extract `target` IDs от frontmatter `links:` array.
+pub fn extract_frontmatter_link_targets(fm: &Frontmatter) -> Vec<String> {
+    let Some(links_val) = fm.get("links") else {
+        return Vec::new();
+    };
+    let Some(seq) = links_val.as_sequence() else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = Vec::new();
+    for entry in seq {
+        if let Some(target) = entry.get("target").and_then(|v| v.as_str()) {
+            out.push(target.to_string());
+        }
+    }
+    out
+}
+
 /// Check that a frontmatter key exists and is non-empty.
 pub fn frontmatter_has(fm: &Frontmatter, key: &str) -> bool {
     fm.get(key)
@@ -1006,5 +1084,98 @@ mod tests {
             names.contains(&"postgresql"),
             "postgresql в prose: {names:?}"
         );
+    }
+
+    // PROB-059 — Related Artifacts table extraction tests
+
+    /// Happy path — table rows with IDs are extracted.
+    #[test]
+    fn extract_related_artifacts_table_ids_finds_table_rows() {
+        let body = "
+# PRD-007: Title
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PRD-001 | refines |
+| EVID-042 | informs |
+| RFC-003 | based_on |
+";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert_eq!(ids, vec!["EVID-042", "PRD-001", "RFC-003"]);
+    }
+
+    /// Free-text mention OUTSIDE the Related Artifacts section is NOT
+    /// collected — strict parser by design (no false-flag on "see also").
+    #[test]
+    fn extract_related_artifacts_table_ids_ignores_freetext_mentions() {
+        let body = "
+# PRD-007
+
+## Problem
+
+This builds on PRD-001 and refines RFC-003.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| EVID-042 | informs |
+";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert_eq!(ids, vec!["EVID-042"]);
+    }
+
+    /// HTML comments in the Related Artifacts section are stripped first.
+    #[test]
+    fn extract_related_artifacts_table_ids_skips_html_comments() {
+        let body = "
+## Related Artifacts
+
+<!-- Example template:
+| Artifact | Relation |
+| FAKE-999 | bogus |
+-->
+
+| Artifact | Relation |
+|---|---|
+| PRD-001 | refines |
+";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert_eq!(ids, vec!["PRD-001"]);
+    }
+
+    /// No section → empty result, no panic.
+    #[test]
+    fn extract_related_artifacts_table_ids_returns_empty_when_no_section() {
+        let body = "# PRD-007: Title\n\n## Problem\n\nText.";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert!(ids.is_empty());
+    }
+
+    /// Frontmatter link target extraction.
+    #[test]
+    fn extract_frontmatter_link_targets_basic() {
+        let yaml = r#"
+id: PRD-007
+links:
+  - target: PRD-001
+    relation: refines
+  - target: EVID-042
+    relation: informs
+"#;
+        let fm: Frontmatter = serde_yaml::from_str(yaml).unwrap();
+        let targets = extract_frontmatter_link_targets(&fm);
+        assert_eq!(targets, vec!["PRD-001", "EVID-042"]);
+    }
+
+    /// Empty links: → empty result.
+    #[test]
+    fn extract_frontmatter_link_targets_empty_when_no_links() {
+        let yaml = "id: PRD-007\nstatus: draft";
+        let fm: Frontmatter = serde_yaml::from_str(yaml).unwrap();
+        let targets = extract_frontmatter_link_targets(&fm);
+        assert!(targets.is_empty());
     }
 }

--- a/crates/forgeplan-core/src/validation/rules.rs
+++ b/crates/forgeplan-core/src/validation/rules.rs
@@ -70,6 +70,16 @@ fn base_rules() -> Vec<RuleEntry> {
             "Body must not be unfilled template",
             check_stub,
         ),
+        // PROB-059 closure — flag body↔links drift across all artifact kinds.
+        // SHOULD-level (not MUST) so existing artifacts с incidental drift
+        // pass validation but get visible warning. Promote к --strict mode
+        // в follow-up if user wants CI-fail behavior.
+        rule(
+            "body-links-drift",
+            Severity::Should,
+            "Body's `## Related Artifacts` table consistent с frontmatter `links:`",
+            check_body_links_drift,
+        ),
     ]
 }
 
@@ -178,6 +188,54 @@ fn check_meta_id(_body: &str, fm: &Frontmatter) -> Option<String> {
         Some("Missing 'id' field in frontmatter".into())
     } else {
         None
+    }
+}
+
+/// PROB-059 — body↔links drift detection.
+///
+/// Compares IDs mentioned в `## Related Artifacts` table rows against
+/// frontmatter `links:` array. If body table mentions an ID that has no
+/// corresponding `links:` entry → SHOULD-level warning. Self-references
+/// и table-row IDs that are the artifact's own id are ignored.
+///
+/// Implementation strategy (Option A from PROB-059): strict parser
+/// targeting only the `## Related Artifacts` section. Free-text "see
+/// also PRD-005" mentions elsewhere в body are intentionally NOT
+/// flagged — incidental mentions shouldn't trigger drift warnings.
+fn check_body_links_drift(body: &str, fm: &Frontmatter) -> Option<String> {
+    let body_ids = checks::extract_related_artifacts_table_ids(body);
+    if body_ids.is_empty() {
+        return None;
+    }
+    let link_targets: std::collections::BTreeSet<String> =
+        checks::extract_frontmatter_link_targets(fm)
+            .into_iter()
+            .map(|s| s.to_uppercase())
+            .collect();
+    let self_id = fm
+        .get("id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_uppercase())
+        .unwrap_or_default();
+    let mut missing: Vec<String> = Vec::new();
+    for id in &body_ids {
+        let id_upper = id.to_uppercase();
+        if id_upper == self_id {
+            continue;
+        }
+        if !link_targets.contains(&id_upper) {
+            missing.push(id.clone());
+        }
+    }
+    if missing.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Body's `## Related Artifacts` table mentions {} but frontmatter `links:` array doesn't reference \
+             them. Run: forgeplan link <this-id> <target> --relation <informs|based_on|refines|...> \
+             OR remove the table row if the mention is incidental.",
+            missing.join(", ")
+        ))
     }
 }
 


### PR DESCRIPTION
Closes PROB-059. New SHOULD-level rule flags artifacts whose body `## Related Artifacts` table mentions IDs not in frontmatter `links:`. Strict parser only — formal table rows, no false-flag on free-text "see also". Reuses PROB-038 strip helper. +6 unit tests, lib 1483→1489. Reconcile command + workspace cleanup deferred к follow-up.