### PR TITLE
chore: sync main → dev after v0.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-05-06 — defensive sprint: security trio + cache self-healing + MCP transport parity + Wave 3 paper cuts
+
+**Highlights** (11 PROBs closed in single defensive sprint):
+
+- **Security**: PROB-053 shell-execution gate (CWE-78/94 default-deny + escape_debug warning), PROB-052 `which_in_path` TOCTOU/CWE-426 hardening (canonicalize + perm gate + symmetric override paths), PROB-054 `produces_at` prompt-injection-via-filesystem validator (CWE-94/OWASP A03)
+- **Trust calculus**: PROB-057 R_eff cache self-healing on link/unlink/activate (closes 4-consumer stale-state leak), PROB-058 (4/6 ACs) MCP transport parity для cache invalidation + score lock + concurrent-writer regression test
+- **Quality**: PROB-051 (4/7 items) phase-fold unification + perf scans + module rustdocs, PROB-056 `partial_verdict` field surfaces phase-fold contract в type system, PROB-032 search score breakdown coherent с total
+- **Paper cuts**: PROB-027/030/033 verified-already-closed via E2E + PROB-038 NEW validator strip pipeline (HTML comments + fenced code + inline backticks), PROB-028 reindex resilience против Phase-1 abort, **PROB-059** body↔links drift validate warning (strict `## Related Artifacts` parser)
+
+**Cross-surface symmetry pattern emerged 7×** в этом sprint — fixing security primitive on primary path while leaving symmetric override paths unguarded. Now baseline audit prompt asks "grep ALL consumers" before declaring closure.
+
+**Test count**: 1977 → **1489 lib + integration suites = ~1995 tests** (+ regression coverage по каждому PROB).
+
+**Quality gates**: `cargo fmt --check`, `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings`, `cargo test --workspace --features test-helpers` — all clean across all 38 suites, 0 failures.
+
+**Deferred to v0.31.0+**:
+- PROB-049 follow-up retry-loop (typed-error refactor через scoring path)
+- PROB-051 MEDIUM/LOW deferred items (L-M1/M2/M3, P-M1/M2, P-L5, D-LOW-2/4)
+- PROB-058 deferred ACs (driver-trait parity, r_eff_local perf bound)
+- PROB-059 follow-ups: `forgeplan reconcile` interactive command, workspace-wide drift cleanup
+
 ### Added (Validation — PROB-059 closure, body↔links drift warning)
 
 - **PROB-059 ✅ — `body-links-drift` validate warning** (SHOULD-level).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.29.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.29.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.30.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.30.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.29.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.30.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
@@ -33,6 +33,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.29.0", features = ["test-helpers"] }
+forgeplan-core = { path = "../forgeplan-core", version = "0.30.0", features = ["test-helpers"] }
 tempfile = "3"
 serde_yaml.workspace = true


### PR DESCRIPTION
## Summary

Per CLAUDE.md red line #9: every `release/v* → main` merge requires this sync-PR back к dev so dev's Cargo.toml workspace version stays current (no merge conflicts on next release prep).

This PR brings the v0.30.0 release commit + version bump (`0.29.0 → 0.30.0`) back into dev.

## What's included

- v0.30.0 release commit (`fa33898`) + chore commit (`1017ae9`) on top of dev
- `Cargo.toml` workspace version bump
- `crates/forgeplan-cli/Cargo.toml` + `crates/forgeplan-mcp/Cargo.toml` sub-crate version bumps
- `Cargo.lock` regeneration
- `CHANGELOG.md` `[0.30.0]` release block

## Validation

This is a "merge main into dev" sync-PR — no new code changes. All v0.30.0 changes already passed CI on PR #261 release-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)