### PR TITLE
[PROB-060] fix validator pipefail silent abort (CI Round 4)

### DIFF
--- a/.github/scripts/validate-forgeplan-frontmatter.sh
+++ b/.github/scripts/validate-forgeplan-frontmatter.sh
@@ -20,18 +20,29 @@ WARNINGS=0
 SLUG_REGEX="^(prd|rfc|adr|epic|spec|prob|sol|evid|note|ref|mem)-[a-z0-9]+(-[a-z0-9]+)*$"
 
 # Helper: extract frontmatter field value from markdown file
-# Returns the value or empty string if not found
+# Returns the value or empty string if not found.
+#
+# CI Round 4 fix: `set -euo pipefail` + grep no-match exits 1 (no field present),
+# pipefail propagates to subshell exit 1, which `set -e` then kills script
+# в next iteration when caller does `field=$(extract_field ...)`. The legacy
+# PROB-060 artifacts (ADR-012, PRD-076, RFC-009, SPEC-005, EVID-114, EVID-115,
+# PROB-060, PROB-061) lack `slug:` field в first frontmatter block (двойной
+# frontmatter from `forgeplan_new` template + manual edit) — they were created
+# pre-Phase-1.5 schema enforcement. Validator silently aborted on first
+# missing field.
+#
+# Fix: append `|| true` so grep no-match doesn't propagate pipefail.
 extract_field() {
     local file="$1"
     local field="$2"
 
     # Extract YAML frontmatter (between first --- and second ---)
-    # and grep for the field
-    sed -n '/^---$/,/^---$/p' "$file" | \
+    # and grep for the field. `|| true` neutralizes grep no-match.
+    { sed -n '/^---$/,/^---$/p' "$file" | \
         grep "^${field}:" | \
         head -1 | \
         sed "s/^${field}:[[:space:]]*//" | \
-        sed 's/^"\(.*\)"$/\1/'
+        sed 's/^"\(.*\)"$/\1/'; } || true
 }
 
 # Helper: check if a field exists and has a value


### PR DESCRIPTION
## Summary

PR #268 dev-sync CI exposed silent-failure bug в `extract_field` helper. Validator silently aborted с exit 1 на 8 legacy PROB-060 artifacts that lack `slug:` field в first frontmatter block.

## Root cause

`set -euo pipefail` + `grep "^${field}:"` no-match returns exit 1 → pipefail propagates to subshell exit 1 → next `slug=$(extract_field ...)` triggers `set -e` early termination. No error message — just silent exit.

Local smoke tests passed because used artifacts WITH slug field. CI hit 8 legacy artifacts (ADR-012, PRD-076, RFC-009, SPEC-005, EVID-114/115, PROB-060/061) created pre-Phase-1.5 schema enforcement с двойным frontmatter — first block from `forgeplan_new` template lacks slug.

## Fix

Wrap extract_field pipeline в `{ ... ; } || true`. grep no-match теперь returns empty string (intended semantics — "field absent") вместо propagating pipefail.

## Test plan

- [x] Validator on 8 legacy artifacts (no slug) → exit 0 PASS
- [x] Tamper test (assigned 73 → 999) → exit 1 FAIL (write-once enforced)
- [x] `cargo check --workspace` → 0 errors

## Why missed by 3 audit rounds

Each audit smoke-tested validator с artifacts что имели slug field. Legacy PROB-060 artifacts с partial frontmatter — edge case caught only by REAL CI run against feature branch.

## After this merges

PR #268 CI re-runs validator. Expected: validation gate PASS на all 8 PROB-060 artifacts.

Refs: PROB-060, PR #268