### PR TITLE
[PROB-060] fix smoke test stdout pollution с --verbose (PR #272 CI fix)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -44,9 +44,13 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-# Utility functions
+# Utility functions.
+# All log functions write к stderr so callers using `$(create_artifact ...)`
+# capture only the ID line (which goes to stdout via final `echo "$id"`).
+# CI bug fix: `log_info` previously printed к stdout, which contaminated
+# `$(...)` capture with `ℹ Created prd: PRD-001` prefix when --verbose is on.
 log_step() {
-    echo -e "${GREEN}✓${NC} $1"
+    echo -e "${GREEN}✓${NC} $1" >&2
 }
 
 log_error() {
@@ -55,7 +59,7 @@ log_error() {
 
 log_info() {
     if [ "$VERBOSE" = "--verbose" ]; then
-        echo -e "${YELLOW}ℹ${NC} $1"
+        echo -e "${YELLOW}ℹ${NC} $1" >&2
     fi
 }
 


### PR DESCRIPTION
## Summary

PR #272 CI smoke-e2e failed at 5m51s. Local PASS, CI FAIL — `--verbose` flag triggered `log_info` printing к stdout, contaminating `$(create_artifact ...)` capture.

## Bug

```bash
log_info() {
    if [ "$VERBOSE" = "--verbose" ]; then
        echo -e "${YELLOW}ℹ${NC} $1"   # ← stdout, contaminates $(...)
    fi
}

create_artifact() {
    # ...
    log_info "Created $kind: $id"
    echo "$id"
}

PRD_ID=$(create_artifact "prd" "Smoke test PRD")
# Captured: "ℹ Created prd: PRD-001\nPRD-001"
# forgeplan validate "$PRD_ID" → not found
```

CI runs `bash scripts/smoke-test.sh --verbose` → triggers contamination.
Local runs без --verbose → log_info no-op → tests pass.

## Fix

Redirect `log_step` + `log_info` к stderr (`>&2`). Capture stays clean.

## Verified

- `bash scripts/smoke-test.sh --verbose` → exit 0 PASS (was fail at first validate)
- All 13+ operations succeed

## After this merges

PR #272 CI re-runs smoke-e2e. Expected: ALL gates green.

Refs: PROB-060 Phase 2.4, PR #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)