### PR TITLE
fix: 6 dogfood issues (#290-#295) + audit-r-dogfood + v0.32.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,67 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-05-20
+
+Sprint headline: **Epic #287 brownfield extraction surface + 6 dogfood-discovered issues, closed inline across 4 adversarial audit rounds (r4/r5/r6/r7) + audit-r-dogfood.**
+
+Two parallel sprints landed into one release:
+
+### A. Epic #287 — brownfield extraction surface
+
+6 new `ArtifactKind` variants (`use_case`, `glossary`, `invariant`, `scenario`, `hypothesis`, `domain_model`) with Factum/Intent two-tier validation, 7 new MCP tools (`forgeplan_hypothesis_status` / `_promote` / `_coverage_business` / `_contradictions` / `_orphans` / `_interview_packet_draft` / `_ingest`), brownfield graph rendering (`forgeplan_graph --brownfield-only`), and a Hypothesis lifecycle state machine (parked → inferred → strong-inferred → verified → refuted with terminal absorbing states).
+
+5 adversarial audit rounds — r4 (13 findings closed), r5 (8 deferred items closed inline), r6 (ARCH-H1 consolidation + PROB-069), r7 (full-branch review, 13 more findings), plus E2E coverage. **ADR-014** added for AnomalyKind catalog evolution policy.
+
+Phase E (`forgeplan_render_canonical` + `forgeplan_export_rag`) split into [`marketplace#79`](https://github.com/ForgePlan/marketplace/issues/79) — those tools live in plugin layer (wrap brownfield-pack skills C10/C12), not core.
+
+### B. 6 dogfood-discovered issues (#290..#295)
+
+Collected from real-world workspace usage in `marketplace` repo, filed upstream, fixed in this release:
+
+- **#290 `forgeplan_release_notes` split-repo discovery** — new `find_git_root` with 3-tier discovery (start → walk up bounded by `.forgeplan/` marker or 8 hops → walk down one level with symlink rejection and deterministic ordering). Fixes "not a git repository" failure when `.forgeplan/` and `.git/` are in different directories.
+- **#291 `forgeplan_restore` target_status override** — new `apply_restore_with_target` accepts explicit `target_status` (`draft`/`active`/`deprecated`). Lifecycle FSM validates the transition before mutation. Response surfaces `restored_status` + `restored_status_source` so operators see exactly which state was applied.
+- **#292 `forgeplan_discover_*` status field disambiguation** — added `session_status` (explicit session state) and `artifact_status` (always `draft` for newly-created findings) to all three discover tools. Legacy `status` field kept for backward compat (zero breakage on existing consumers). `_field_warnings` deprecation channel announces upcoming removal of legacy `status`.
+- **#293 `forgeplan_drift` markdown-table parser** — `extract_path_from_line` now handles backtick-quoted paths, pipe-delimited table cells, and `(planned)`/`(done)` annotations. Closes silent false-negative where drift detector returned `changed_files: []` for artifacts with table-formatted `## Affected Files`. Control chars / ANSI escapes also rejected (closes downstream-display injection vector).
+- **#294 `forgeplan_activate` error UX** — "No evidence linked" error now teaches the canonical 5-step fix order verbatim in the error message (`forgeplan_new evidence → update → link informs → activate EVID → activate parent`). Operators no longer reach for `--force` as a shortcut.
+- **#295 `forgeplan_new(kind=evidence, parent_id=...)` auto-link** — optional `parent_id` parameter creates the `informs` link in one call. Closes the 3-step boilerplate (new → update → link) observed in 100% of measured EVIDs across 12 sprints. Auto-link uses `add_link_with_projection` (file-first per ADR-003); response carries `auto_linked` + `auto_link_warnings` fields.
+
+### C. Audit-r-dogfood — 8 findings closed inline before release
+
+3 parallel adversarial agents (security/code-quality/architecture) reviewed the 6 dogfood fixes. 24 findings total (after dedup). Closed inline:
+
+- **SEC-1 HIGH** — `find_git_root` rejects symlinks via `symlink_metadata`, bounds walk-up by `.forgeplan/` marker, sorts walk-down candidates alphabetically. Closes: attacker plants `subdir/.git -> /other-user-repo/.git` → release_notes leaks their commits.
+- **CODE-1 HIGH** — `restored_status_source` compares actual values (after trim+lowercase) instead of just `target_status.is_some()`. Previously reported `explicit_override` even on no-op overrides.
+- **SEC-2 MED** — `target_status` FSM transition validation. Forbidden transitions (e.g. `deprecated → draft`) rejected before any mutation.
+- **SEC-3 MED** — control chars + Unicode line separators (`U+0085/2028/2029`) rejected in `extract_path_from_line` results. Closes ANSI-escape injection in MCP `DriftedFile.path`.
+- **SEC-4 MED** — `auto_link_warnings` route errors through `sanitize_error_chain`. Wave 9 SEC-H3 regression closed — raw `{e}` HOME paths no longer leak.
+- **CODE-2 MED** — `_field_warnings` deprecation channel added to `_start` and `_complete` (was only in `_finding`). All three discover tools now consistent.
+- **CODE-4 / ARCH-2 MED** — `NewArtifactResponse` gets proper `auto_linked` + `auto_link_warnings` DTO fields (`#[serde(skip_serializing_if)]`). Replaces post-hoc `serde_json::Value` mutation that broke JsonSchema codegen for TS clients.
+- **CODE-7 LOW** — `target_status` trimmed before validation so `Some("  active  ")` no longer falls through with inscrutable error.
+
+### D. New methodology documentation
+
+- **`docs/methodology/CROSS-REPO-WORKFLOW.ru.md`** — protocol for coordinating issues / fixes / feature requests across the multi-repo ForgePlan org (`forgeplan` core ↔ `marketplace` ↔ `forgeplan-hud` ↔ ...). Codifies the 5 typical failure modes when 1→5 repos org grows without conventions, label taxonomy proposal, session-start inbox sweep protocol for AI agents, 4-phase implementation roadmap.
+
+### Deferred to v0.33.0 (tracked as GitHub issues)
+
+- **[#296](https://github.com/ForgePlan/forgeplan/issues/296)** — Architectural debt cluster (ARCH-1/3/4/5/6/7): ADR for status deprecation, explicit `git_root` param, invert restore as shim, undo::restore projection exemption, methodology doc location, shared evidence_recipe helper.
+- **[#297](https://github.com/ForgePlan/forgeplan/issues/297)** — Security follow-ups (SEC-5/6): TOCTOU window in find_git_root, sanitize_for_hint on activate error path.
+- **[#298](https://github.com/ForgePlan/forgeplan/issues/298)** — Code quality edge cases (CODE-5/6/8/9/10/11): paths with `(parens)` in name, tab-indented bullets, walk_artifact_changes integration test, backticks-in-path edge.
+
+### Cross-repo follow-ups
+
+- **[marketplace#86](https://github.com/ForgePlan/marketplace/issues/86)** — docs update for `discover_finding` workaround references (now obsolete after #292 closure).
+- **[marketplace#79](https://github.com/ForgePlan/marketplace/issues/79)** — Phase E split: `forgeplan_render_canonical` + `forgeplan_export_rag` in `forgeplan-brownfield-pack` plugin.
+
+### Tests, pipeline, scope
+
+- **3034 tests PASS** on Epic #287 branch (`feat/issues-286-288-289`)
+- **2751 tests PASS** on dogfood branch (`fix/issues-290-295-dogfood-findings`)
+- cargo clippy clean on both, cargo fmt clean, scripts/smoke-test.sh PASS (14 kinds including 6 brownfield)
+- **5 audit rounds** total across both sprints
+- **ADR-014** new methodology artefact
+
 ## [0.31.0] - 2026-05-13
 
 Sprint headline: **Wave 9 polish + 5-agent adversarial audit closure.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.31.0"
+version = "0.32.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -18,8 +18,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.31.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.31.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/src/lifecycle/mod.rs
+++ b/crates/forgeplan-core/src/lifecycle/mod.rs
@@ -282,7 +282,28 @@ pub async fn activate(
         for e in &errs {
             msg.push_str(&format!("\n  - {e}"));
         }
-        msg.push_str("\n\nUse --force to override.");
+
+        // Issue #294: teach the canonical fix order in the error message
+        // itself so operators don't reach for --force as a shortcut. The
+        // "no evidence" case has a well-known 5-step recipe; surface it
+        // verbatim when that gate failed. Other gate failures still get
+        // the generic --force hint (they're per-artifact problems with
+        // no universal recipe — short body, stub markers, etc.).
+        let evidence_gate_failed = errs.iter().any(|e| e.contains("No evidence linked"));
+        if evidence_gate_failed {
+            msg.push_str(&format!(
+                "\n\nCanonical fix order (no evidence yet):\n  \
+                 1. forgeplan_new(kind=\"evidence\", title=\"<verification title>\")\n  \
+                 2. forgeplan_update(id=<EVID-ID>, body=\"<verdict + congruence_level + evidence_type>\")\n  \
+                 3. forgeplan_link(source=<EVID-ID>, target={artifact_id}, relation=\"informs\")\n  \
+                 4. forgeplan_activate(id=<EVID-ID>)\n  \
+                 5. forgeplan_activate(id={artifact_id})  # now succeeds\n\
+                 \n\
+                 Or use --force to bypass (not recommended — leaves R_eff=0)."
+            ));
+        } else {
+            msg.push_str("\n\nUse --force to override (not recommended).");
+        }
         anyhow::bail!("{msg}");
     }
 
@@ -992,6 +1013,117 @@ mod tests {
             err.contains("methodology gates failed"),
             "should cite shared gate error, got: {err}"
         );
+    }
+
+    /// Issue #294: when activation fails due to "No evidence linked",
+    /// the error must teach the canonical 5-step fix order so operators
+    /// don't reach for --force as a shortcut.
+    #[tokio::test]
+    async fn activate_no_evidence_error_teaches_canonical_fix_order() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        // Body that passes length + stub gates but has no evidence linked.
+        let body = "## Problem\n\nLong enough body to pass the 100-char gate \
+                    so the only methodology failure is the missing evidence link. \
+                    This text needs more padding to clear the length threshold \
+                    for the activation gate check.\n\n## Goals\n\nClear.\n";
+        let prd = NewArtifact {
+            id: "PRD-294".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Issue 294 test PRD".to_string(),
+            body: body.to_string(),
+            depth: "standard".to_string(),
+            author: Some("test".to_string()),
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&prd).await.unwrap();
+
+        let result = activate(&store, "PRD-294", false).await;
+        let err = result
+            .expect_err("must fail — no evidence linked")
+            .to_string();
+
+        // The 5-step canonical fix recipe must appear verbatim in the message.
+        assert!(
+            err.contains("No evidence linked"),
+            "must cite gate cause: {err}"
+        );
+        assert!(
+            err.contains("Canonical fix order"),
+            "must teach fix order: {err}"
+        );
+        assert!(
+            err.contains("forgeplan_new(kind=\"evidence\"")
+                && err.contains("forgeplan_link")
+                && err.contains("informs")
+                && err.contains("forgeplan_activate"),
+            "must list the 5-step recipe: {err}"
+        );
+        assert!(
+            err.contains("--force") && err.contains("not recommended"),
+            "must still mention --force as last resort but discourage it: {err}"
+        );
+    }
+
+    /// Issue #294: non-evidence gate failures (e.g. body too short) do
+    /// NOT get the evidence-specific recipe — only the generic --force
+    /// hint. Realistic scenario: short body PRD WITH an evidence already
+    /// linked (so the only remaining gate failure is body length).
+    #[tokio::test]
+    async fn activate_short_body_error_does_not_show_evidence_recipe() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+
+        // Body short enough to fail the length gate.
+        let prd = NewArtifact {
+            id: "PRD-294B".to_string(),
+            kind: "prd".to_string(),
+            status: "draft".to_string(),
+            title: "Short".to_string(),
+            body: "tiny".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&prd).await.unwrap();
+        // Link an EVID so the evidence gate passes — only body-length fails.
+        let evid = NewArtifact {
+            id: "EVID-294B".to_string(),
+            kind: "evidence".to_string(),
+            status: "active".to_string(),
+            title: "Evidence for 294B".to_string(),
+            body: "verdict: supports\ncongruence_level: 3\nevidence_type: measurement".to_string(),
+            depth: "tactical".to_string(),
+            author: None,
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        };
+        store.create_artifact(&evid).await.unwrap();
+        store
+            .add_relation_for_test("EVID-294B", "PRD-294B", "informs")
+            .await
+            .unwrap();
+
+        let err = activate(&store, "PRD-294B", false)
+            .await
+            .expect_err("must fail — body too short")
+            .to_string();
+        assert!(
+            !err.contains("No evidence linked"),
+            "evidence gate must pass — only length fails: {err}"
+        );
+        assert!(
+            !err.contains("Canonical fix order"),
+            "evidence-specific recipe must NOT appear for non-evidence failures: {err}"
+        );
+        assert!(err.contains("--force"), "generic hint still present: {err}");
     }
 
     #[tokio::test]

--- a/crates/forgeplan-core/src/release_notes.rs
+++ b/crates/forgeplan-core/src/release_notes.rs
@@ -303,14 +303,57 @@ pub fn format_json(notes: &ReleaseNotes) -> serde_json::Value {
     })
 }
 
+/// Issue #290: locate the nearest git repository for changelog generation.
+///
+/// Some workspaces split `.forgeplan/` and `.git/` into different
+/// directories (the marketplace pattern: `.forgeplan/` at parent,
+/// `.git/` in a child submodule-style repo). Without discovery,
+/// `git log` runs from the workspace root and reports
+/// "not a git repository".
+///
+/// Strategy:
+/// 1. If `start/.git` exists → use `start` (standard layout).
+/// 2. Walk **up** from `start` looking for the nearest ancestor with
+///    `.git/` (standard monorepo / subdirectory case).
+/// 3. Walk **down** one level into immediate subdirectories of `start`
+///    looking for `.git/` (split-repo case from issue #290).
+/// 4. Fall back to `start` (preserves legacy behaviour — caller still
+///    gets the original "not a git repository" error if no `.git` is
+///    found anywhere).
+///
+/// Returns the directory to use as `current_dir` for git invocations.
+pub fn find_git_root(start: &Path) -> std::path::PathBuf {
+    // 1 + 2. Walk up.
+    let mut current: Option<&Path> = Some(start);
+    while let Some(dir) = current {
+        if dir.join(".git").exists() {
+            return dir.to_path_buf();
+        }
+        current = dir.parent();
+    }
+    // 3. Walk down one level — covers `.forgeplan/` sibling-of-git layout.
+    if let Ok(entries) = std::fs::read_dir(start) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() && path.join(".git").exists() {
+                return path;
+            }
+        }
+    }
+    // 4. Fallback (legacy behaviour).
+    start.to_path_buf()
+}
+
 /// Try `git describe --tags --abbrev=0` to find the latest tag. Returns
 /// `None` if there are no tags or git fails — the caller decides on a
 /// fallback (currently `HEAD~50` so something still gets emitted on a
 /// fresh repo with no tags).
 pub fn latest_tag(repo_root: &Path) -> Option<String> {
+    // Issue #290: resolve to nearest .git before invoking git.
+    let git_root = find_git_root(repo_root);
     let output = Command::new("git")
         .args(["describe", "--tags", "--abbrev=0"])
-        .current_dir(repo_root)
+        .current_dir(&git_root)
         .output()
         .ok()?;
     if !output.status.success() {
@@ -355,9 +398,11 @@ pub fn walk_artifact_changes(repo_root: &Path, since: &str, until: &str) -> Resu
         args.push((*d).to_string());
     }
 
+    // Issue #290: resolve to nearest .git before invoking git.
+    let git_root = find_git_root(repo_root);
     let output = Command::new("git")
         .args(&args)
-        .current_dir(repo_root)
+        .current_dir(&git_root)
         .output()
         .with_context(|| "running `git log` — is git installed?")?;
 
@@ -819,5 +864,75 @@ mod tests {
         assert!(!t.contains("##"));
         assert!(!t.contains("###"));
         assert!(t.contains("Added:"));
+    }
+
+    // ─── Issue #290: find_git_root discovery ──────────────────────────────
+
+    use tempfile::TempDir;
+
+    /// Standard layout: `.git/` directly inside the start directory.
+    #[test]
+    fn find_git_root_standard_layout() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        assert_eq!(find_git_root(tmp.path()), tmp.path().to_path_buf());
+    }
+
+    /// Walk-up: `.git/` in a parent directory, start in a subdir.
+    #[test]
+    fn find_git_root_walks_up_to_parent() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        assert_eq!(find_git_root(&sub), tmp.path().to_path_buf());
+    }
+
+    /// Issue #290 reproduction: `.git/` in a CHILD subdirectory, NOT in
+    /// any parent. Start dir is the workspace root containing `.forgeplan/`.
+    /// The discovery must walk DOWN one level to find the repo.
+    #[test]
+    fn find_git_root_walks_down_for_split_repo() {
+        let tmp = TempDir::new().unwrap();
+        // .forgeplan/ at root (no .git here)
+        std::fs::create_dir(tmp.path().join(".forgeplan")).unwrap();
+        // .git/ in child repo subdir
+        let repo = tmp.path().join("forgeplan-marketplace");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::create_dir(repo.join(".git")).unwrap();
+
+        let resolved = find_git_root(tmp.path());
+        assert_eq!(
+            resolved, repo,
+            "issue #290: .git/ in child subdir must be discovered (not fallback to start)"
+        );
+    }
+
+    /// No git anywhere → falls back to start (legacy behaviour, caller
+    /// gets the same "not a git repository" error as before).
+    #[test]
+    fn find_git_root_fallback_when_no_git() {
+        let tmp = TempDir::new().unwrap();
+        let resolved = find_git_root(tmp.path());
+        // tmp.path() may walk up to a real .git/ on dev machines (cargo
+        // workspace root); assert resolved is either start OR an ancestor.
+        assert!(
+            resolved == tmp.path() || tmp.path().starts_with(&resolved),
+            "fallback or walked up to ancestor .git/: {resolved:?}"
+        );
+    }
+
+    /// Prefer walk-up over walk-down: if both ancestor AND child have
+    /// `.git/`, the ancestor (standard) wins because step 2 runs before
+    /// step 3.
+    #[test]
+    fn find_git_root_prefers_ancestor_over_child() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        let child = tmp.path().join("child");
+        std::fs::create_dir(&child).unwrap();
+        std::fs::create_dir(child.join(".git")).unwrap();
+        // Start = tmp.path() itself — should return tmp.path() (has .git).
+        assert_eq!(find_git_root(tmp.path()), tmp.path().to_path_buf());
     }
 }

--- a/crates/forgeplan-core/src/release_notes.rs
+++ b/crates/forgeplan-core/src/release_notes.rs
@@ -311,33 +311,79 @@ pub fn format_json(notes: &ReleaseNotes) -> serde_json::Value {
 /// `git log` runs from the workspace root and reports
 /// "not a git repository".
 ///
-/// Strategy:
+/// Strategy (audit-r-dogfood SEC-1 hardening):
 /// 1. If `start/.git` exists → use `start` (standard layout).
-/// 2. Walk **up** from `start` looking for the nearest ancestor with
-///    `.git/` (standard monorepo / subdirectory case).
+/// 2. Walk **up** from `start`, **bounded** by the nearest `.forgeplan/`
+///    ancestor (don't escape workspace) or 8 hops (whichever comes
+///    first) — prevents reaching `/Users/<other>/.git` on multi-user
+///    systems.
 /// 3. Walk **down** one level into immediate subdirectories of `start`
-///    looking for `.git/` (split-repo case from issue #290).
+///    looking for `.git/`. Symlinks are explicitly rejected via
+///    `symlink_metadata().is_dir()` (not the symlink-following
+///    `is_dir()`) so an attacker can't plant a symlink at e.g.
+///    `subdir/.git -> /private/var/.../other-user-repo/.git` to make
+///    `release_notes` emit other repos' commit messages.
+///    Deterministic order: entries sorted by path (issue #290 follow-up
+///    CODE-8 / SEC-1).
 /// 4. Fall back to `start` (preserves legacy behaviour — caller still
 ///    gets the original "not a git repository" error if no `.git` is
 ///    found anywhere).
 ///
 /// Returns the directory to use as `current_dir` for git invocations.
 pub fn find_git_root(start: &Path) -> std::path::PathBuf {
-    // 1 + 2. Walk up.
+    /// Probe `dir/.git` rejecting symlinks (SEC-1 fix).
+    /// `dir/.git` is allowed to be a regular file (git worktree, submodule
+    /// pointer) — only symlinks are rejected because they're the vector
+    /// for attacker-redirected repo discovery.
+    fn has_real_dot_git(dir: &Path) -> bool {
+        let dot_git = dir.join(".git");
+        match std::fs::symlink_metadata(&dot_git) {
+            Ok(md) => !md.file_type().is_symlink(),
+            Err(_) => false,
+        }
+    }
+
+    // 1 + 2. Walk up, bounded.
+    //
+    // Boundary: stop walking when we either (a) find a `.forgeplan/`
+    // ancestor (that's the workspace edge, and the operator's repo
+    // should be inside it or co-located), or (b) traverse > MAX_HOPS
+    // (defensive against pathological deep nesting / fs loops).
+    const MAX_HOPS: usize = 8;
     let mut current: Option<&Path> = Some(start);
+    let mut hops = 0;
     while let Some(dir) = current {
-        if dir.join(".git").exists() {
+        if has_real_dot_git(dir) {
             return dir.to_path_buf();
+        }
+        // Stop at the workspace boundary marker (`.forgeplan/`).
+        if dir.join(".forgeplan").exists() && dir != start {
+            break;
+        }
+        hops += 1;
+        if hops >= MAX_HOPS {
+            break;
         }
         current = dir.parent();
     }
-    // 3. Walk down one level — covers `.forgeplan/` sibling-of-git layout.
+    // 3. Walk down one level, symlink-safe, deterministic order.
     if let Ok(entries) = std::fs::read_dir(start) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() && path.join(".git").exists() {
-                return path;
-            }
+        let mut candidates: Vec<std::path::PathBuf> = entries
+            .flatten()
+            .filter_map(|e| {
+                let p = e.path();
+                // Reject symlinks even on the directory itself.
+                let md = std::fs::symlink_metadata(&p).ok()?;
+                if md.file_type().is_dir() && has_real_dot_git(&p) {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        candidates.sort();
+        if let Some(p) = candidates.into_iter().next() {
+            return p;
         }
     }
     // 4. Fallback (legacy behaviour).
@@ -934,5 +980,75 @@ mod tests {
         std::fs::create_dir(child.join(".git")).unwrap();
         // Start = tmp.path() itself — should return tmp.path() (has .git).
         assert_eq!(find_git_root(tmp.path()), tmp.path().to_path_buf());
+    }
+
+    /// Audit-r-dogfood SEC-1: walk-down MUST reject symlinks at the
+    /// `.git` entry. Without this, an attacker who can write a subdir
+    /// in the workspace can plant a symlinked `.git` pointing at another
+    /// user's repo, causing `forgeplan_release_notes` to emit commit
+    /// messages from that other repo.
+    #[cfg(unix)]
+    #[test]
+    fn find_git_root_rejects_symlinked_dot_git_in_subdir() {
+        use std::os::unix::fs::symlink;
+        let tmp = TempDir::new().unwrap();
+        // `.forgeplan/` at root marks workspace boundary so walk-up
+        // doesn't escape into the cargo workspace's `.git/`.
+        std::fs::create_dir(tmp.path().join(".forgeplan")).unwrap();
+        // Plant a real repo "somewhere else" — simulates another user's repo.
+        let other_repo = tmp.path().join("other-user-repo");
+        std::fs::create_dir(&other_repo).unwrap();
+        std::fs::create_dir(other_repo.join(".git")).unwrap();
+        // Attacker plants a child dir with a SYMLINKED `.git/` pointing
+        // at the other-user repo.
+        let child = tmp.path().join("evil-subdir");
+        std::fs::create_dir(&child).unwrap();
+        symlink(other_repo.join(".git"), child.join(".git")).unwrap();
+
+        let resolved = find_git_root(tmp.path());
+        assert_ne!(
+            resolved, child,
+            "SEC-1: symlinked .git must NOT be selected — got {resolved:?}"
+        );
+    }
+
+    /// Walk-up must stop at `.forgeplan/` boundary so it can't escape
+    /// the workspace and reach `/Users/<other>/.git` on multi-user host.
+    #[test]
+    fn find_git_root_walk_up_bounded_by_forgeplan_marker() {
+        let tmp = TempDir::new().unwrap();
+        // No .git at tmp, but .forgeplan/ here = workspace boundary.
+        std::fs::create_dir(tmp.path().join(".forgeplan")).unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        // Subdir has no .git either. find_git_root from sub must NOT
+        // walk past tmp.path() (which has .forgeplan) into cargo workspace's
+        // real .git on the dev machine.
+        let resolved = find_git_root(&sub);
+        // Should fall back to `start` (sub) since no .git found within bound.
+        // Critical: must NOT return some ancestor outside the workspace.
+        assert!(
+            resolved == sub || resolved == tmp.path(),
+            "walk-up must stay within workspace bound: got {resolved:?}"
+        );
+    }
+
+    /// Walk-down is deterministic when multiple subdirs have `.git/`
+    /// (issue #290 CODE-8 / SEC-1).
+    #[test]
+    fn find_git_root_walk_down_deterministic_order() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir(tmp.path().join(".forgeplan")).unwrap();
+        for name in ["zeta-repo", "alpha-repo", "middle-repo"] {
+            let dir = tmp.path().join(name);
+            std::fs::create_dir(&dir).unwrap();
+            std::fs::create_dir(dir.join(".git")).unwrap();
+        }
+        let resolved = find_git_root(tmp.path());
+        assert_eq!(
+            resolved.file_name().and_then(|n| n.to_str()),
+            Some("alpha-repo"),
+            "alphabetic order: 'alpha' must win, not fs::read_dir() insertion order — got {resolved:?}"
+        );
     }
 }

--- a/crates/forgeplan-core/src/undo/restore.rs
+++ b/crates/forgeplan-core/src/undo/restore.rs
@@ -66,22 +66,51 @@ pub async fn apply_restore_with_target(
 ) -> anyhow::Result<RestoreReport> {
     // Issue #291: validate override BEFORE any mutation so a bad value
     // doesn't half-apply a restore.
-    if let Some(t) = target_status {
-        let lower = t.to_lowercase();
-        if !matches!(lower.as_str(), "draft" | "active" | "deprecated") {
-            anyhow::bail!(
-                "Invalid target_status `{t}` — valid values: `draft`, `active`, `deprecated`."
-            );
-        }
+    //
+    // Audit-dogfood CODE-7 fix: trim whitespace before lowercase so
+    // `Some("  active  ")` doesn't fall through with an inscrutable
+    // "invalid `  Active  `" message.
+    let normalized_target: Option<String> = target_status.map(|t| t.trim().to_lowercase());
+    if let Some(ref lower) = normalized_target
+        && !matches!(lower.as_str(), "draft" | "active" | "deprecated")
+    {
+        anyhow::bail!(
+            "Invalid target_status `{}` — valid values: `draft`, `active`, `deprecated`.",
+            target_status.unwrap_or("")
+        );
+    }
+
+    // Audit-dogfood SEC-2: FSM transition validation. Restore goes
+    // through `update_artifact` which writes raw status — bypassing
+    // `transitions::validate_transition`. Without this gate the operator
+    // can drive ANY artifact to ANY of 3 target states regardless of
+    // its current state, no lifecycle bookkeeping. We refuse transitions
+    // that the canonical lifecycle would reject, EXCEPT when the
+    // artifact is no longer in the store (Delete-op restore) — in that
+    // case the row is being re-created from the snapshot, not
+    // transitioned.
+    if let Some(ref new_status) = normalized_target
+        && let Ok(Some(current)) = store.get_record(&receipt.snapshot.id).await
+        && let Err(e) =
+            super::super::lifecycle::transitions::validate_transition(&current.status, new_status)
+    {
+        anyhow::bail!(
+            "target_status override `{}` would violate lifecycle FSM \
+             from current status `{}`: {e}. Use the canonical lifecycle \
+             command (`forgeplan_activate` / `_deprecate` / `_supersede`) \
+             instead of overriding restore.",
+            new_status,
+            current.status
+        );
     }
 
     // Build an effective receipt with status overridden if requested.
     // The struct is cloned cheaply — strings only — so this doesn't
     // touch the persisted receipt on disk.
-    let effective_receipt = match target_status {
+    let effective_receipt = match normalized_target {
         Some(t) => {
             let mut r = receipt.clone();
-            r.snapshot.status = t.to_lowercase();
+            r.snapshot.status = t;
             r
         }
         None => receipt.clone(),
@@ -778,13 +807,58 @@ mod tests {
         assert_eq!(report.restored_status, "active");
     }
 
-    /// `apply_restore_with_target` explicit override wins over snapshot.
+    /// `apply_restore_with_target` explicit override wins over snapshot
+    /// when the override is FSM-valid from the current state.
+    ///
+    /// Audit-dogfood SEC-2: override now respects lifecycle FSM. This
+    /// test uses `draft → active` (a legal transition); the negative
+    /// case (forbidden transition) is pinned in
+    /// `restore_with_target_rejects_fsm_invalid_transition` below.
     #[tokio::test]
     async fn restore_with_target_override_applies_explicit_status() {
         let (_tmp, ws, store) = fresh_ws().await;
         store
             .create_artifact(&NewArtifact {
                 id: "PRD-291B".into(),
+                kind: "prd".into(),
+                status: "draft".into(),
+                title: "T".into(),
+                body: "b".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            })
+            .await
+            .unwrap();
+        // Receipt captured active (the prior_status before some earlier op);
+        // current row is draft (a valid `draft → active` transition).
+        let mut receipt = build_receipt("PRD-291B", DestructiveOp::Deprecate, "b");
+        receipt.snapshot.status = "draft".into();
+        write_receipt(&ws, &receipt).await.unwrap();
+
+        // Override to `active` — FSM-valid from `draft`.
+        let report = apply_restore_with_target(&ws, &store, &receipt, Some("active"))
+            .await
+            .unwrap();
+        assert_eq!(report.restored_status, "active", "override wins");
+
+        let r = store.get_record("PRD-291B").await.unwrap().unwrap();
+        assert_eq!(r.status, "active", "store reflects override");
+    }
+
+    /// Audit-dogfood SEC-2: target_status override that violates the
+    /// lifecycle FSM is rejected before any mutation. Example: trying
+    /// to restore a `deprecated` artifact to `draft` — that's not a
+    /// legal forward transition. Operator must use the canonical
+    /// lifecycle commands.
+    #[tokio::test]
+    async fn restore_with_target_rejects_fsm_invalid_transition() {
+        let (_tmp, ws, store) = fresh_ws().await;
+        store
+            .create_artifact(&NewArtifact {
+                id: "PRD-291E".into(),
                 kind: "prd".into(),
                 status: "active".into(),
                 title: "T".into(),
@@ -798,21 +872,24 @@ mod tests {
             .await
             .unwrap();
         store
-            .update_artifact("PRD-291B", Some("deprecated"), None)
+            .update_artifact("PRD-291E", Some("deprecated"), None)
             .await
             .unwrap();
-        // Receipt captured active, but operator wants to restore to draft.
-        let mut receipt = build_receipt("PRD-291B", DestructiveOp::Deprecate, "b");
+        let mut receipt = build_receipt("PRD-291E", DestructiveOp::Deprecate, "b");
         receipt.snapshot.status = "active".into();
         write_receipt(&ws, &receipt).await.unwrap();
 
-        let report = apply_restore_with_target(&ws, &store, &receipt, Some("draft"))
+        // `deprecated → draft` is FSM-invalid — must be rejected.
+        let err = apply_restore_with_target(&ws, &store, &receipt, Some("draft"))
             .await
-            .unwrap();
-        assert_eq!(report.restored_status, "draft", "override wins");
-
-        let r = store.get_record("PRD-291B").await.unwrap().unwrap();
-        assert_eq!(r.status, "draft", "store reflects override");
+            .expect_err("FSM should reject deprecated->draft override");
+        assert!(
+            err.to_string().contains("FSM"),
+            "rejection must cite FSM: {err}"
+        );
+        // Store still deprecated — no partial mutation.
+        let r = store.get_record("PRD-291E").await.unwrap().unwrap();
+        assert_eq!(r.status, "deprecated", "no partial mutation on FSM reject");
     }
 
     /// Invalid target_status value is rejected BEFORE mutation.

--- a/crates/forgeplan-core/src/undo/restore.rs
+++ b/crates/forgeplan-core/src/undo/restore.rs
@@ -34,11 +34,61 @@ pub struct RestoreReport {
     pub relations_skipped: Vec<String>, // target IDs no longer in store
     pub projection_restored: bool,
     pub warnings: Vec<String>,
+    /// Issue #291: the status value the artifact was restored to.
+    /// Mirrors `receipt.snapshot.status` (or the explicit override from
+    /// [`apply_restore_with_target`]). Surfaced in tool responses so the
+    /// operator can confirm which state was applied without having to
+    /// re-read the artifact.
+    pub restored_status: String,
 }
 
 /// Restore the artifact captured in `receipt`. Returns an error if the
 /// store still has a row with the same ID (collision), or if reading
 /// any receipt field fails at apply time.
+/// Issue #291: restore an artifact AND override the restored status.
+///
+/// Same as [`apply_restore`] but accepts a `target_status` override.
+/// When `target_status` is `Some(s)`, the artifact is restored to `s`
+/// regardless of what was captured in the receipt. When `None`, the
+/// captured `snapshot.status` is used (legacy behaviour).
+///
+/// Valid status values: `"draft"`, `"active"`, `"deprecated"`. Any other
+/// value is rejected with an error so the caller can fix the request.
+///
+/// The receipt's snapshot is NOT mutated — only the in-flight restore
+/// writes the override. Subsequent `forgeplan_activity` on this receipt
+/// will still show the original captured status.
+pub async fn apply_restore_with_target(
+    workspace: &Path,
+    store: &LanceStore,
+    receipt: &Receipt,
+    target_status: Option<&str>,
+) -> anyhow::Result<RestoreReport> {
+    // Issue #291: validate override BEFORE any mutation so a bad value
+    // doesn't half-apply a restore.
+    if let Some(t) = target_status {
+        let lower = t.to_lowercase();
+        if !matches!(lower.as_str(), "draft" | "active" | "deprecated") {
+            anyhow::bail!(
+                "Invalid target_status `{t}` — valid values: `draft`, `active`, `deprecated`."
+            );
+        }
+    }
+
+    // Build an effective receipt with status overridden if requested.
+    // The struct is cloned cheaply — strings only — so this doesn't
+    // touch the persisted receipt on disk.
+    let effective_receipt = match target_status {
+        Some(t) => {
+            let mut r = receipt.clone();
+            r.snapshot.status = t.to_lowercase();
+            r
+        }
+        None => receipt.clone(),
+    };
+    apply_restore(workspace, store, &effective_receipt).await
+}
+
 pub async fn apply_restore(
     workspace: &Path,
     store: &LanceStore,
@@ -238,6 +288,8 @@ pub async fn apply_restore(
         relations_skipped,
         projection_restored,
         warnings,
+        // Issue #291: surface the status the artifact was restored to.
+        restored_status: receipt.snapshot.status.clone(),
     })
 }
 
@@ -690,5 +742,147 @@ mod tests {
         let current = store.get_record("PRD-CONFLICT").await.unwrap().unwrap();
         assert_eq!(current.kind, "prd", "existing row must be untouched");
         assert_eq!(current.title, "Current");
+    }
+
+    // ─── Issue #291: target_status override + restored_status surface ─────
+
+    /// Default behaviour (no override): restored_status equals captured
+    /// snapshot.status. RestoreReport surfaces it.
+    #[tokio::test]
+    async fn restore_report_surfaces_captured_status() {
+        let (_tmp, ws, store) = fresh_ws().await;
+        store
+            .create_artifact(&NewArtifact {
+                id: "PRD-291A".into(),
+                kind: "prd".into(),
+                status: "active".into(),
+                title: "T".into(),
+                body: "b".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            })
+            .await
+            .unwrap();
+        store
+            .update_artifact("PRD-291A", Some("deprecated"), None)
+            .await
+            .unwrap();
+        let mut receipt = build_receipt("PRD-291A", DestructiveOp::Deprecate, "b");
+        receipt.snapshot.status = "active".into();
+        write_receipt(&ws, &receipt).await.unwrap();
+
+        let report = apply_restore(&ws, &store, &receipt).await.unwrap();
+        assert_eq!(report.restored_status, "active");
+    }
+
+    /// `apply_restore_with_target` explicit override wins over snapshot.
+    #[tokio::test]
+    async fn restore_with_target_override_applies_explicit_status() {
+        let (_tmp, ws, store) = fresh_ws().await;
+        store
+            .create_artifact(&NewArtifact {
+                id: "PRD-291B".into(),
+                kind: "prd".into(),
+                status: "active".into(),
+                title: "T".into(),
+                body: "b".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            })
+            .await
+            .unwrap();
+        store
+            .update_artifact("PRD-291B", Some("deprecated"), None)
+            .await
+            .unwrap();
+        // Receipt captured active, but operator wants to restore to draft.
+        let mut receipt = build_receipt("PRD-291B", DestructiveOp::Deprecate, "b");
+        receipt.snapshot.status = "active".into();
+        write_receipt(&ws, &receipt).await.unwrap();
+
+        let report = apply_restore_with_target(&ws, &store, &receipt, Some("draft"))
+            .await
+            .unwrap();
+        assert_eq!(report.restored_status, "draft", "override wins");
+
+        let r = store.get_record("PRD-291B").await.unwrap().unwrap();
+        assert_eq!(r.status, "draft", "store reflects override");
+    }
+
+    /// Invalid target_status value is rejected BEFORE mutation.
+    #[tokio::test]
+    async fn restore_with_target_rejects_invalid_status() {
+        let (_tmp, ws, store) = fresh_ws().await;
+        store
+            .create_artifact(&NewArtifact {
+                id: "PRD-291C".into(),
+                kind: "prd".into(),
+                status: "deprecated".into(),
+                title: "T".into(),
+                body: "b".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            })
+            .await
+            .unwrap();
+        let mut receipt = build_receipt("PRD-291C", DestructiveOp::Deprecate, "b");
+        receipt.snapshot.status = "active".into();
+        write_receipt(&ws, &receipt).await.unwrap();
+
+        let err = apply_restore_with_target(&ws, &store, &receipt, Some("bogus"))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid target_status"),
+            "bad override must error: {err}"
+        );
+        // Store unchanged — error happened before mutation.
+        let r = store.get_record("PRD-291C").await.unwrap().unwrap();
+        assert_eq!(r.status, "deprecated", "no partial restore on bad input");
+    }
+
+    /// `None` override = legacy behaviour identical to `apply_restore`.
+    #[tokio::test]
+    async fn restore_with_target_none_matches_legacy() {
+        let (_tmp, ws, store) = fresh_ws().await;
+        store
+            .create_artifact(&NewArtifact {
+                id: "PRD-291D".into(),
+                kind: "prd".into(),
+                status: "active".into(),
+                title: "T".into(),
+                body: "b".into(),
+                depth: "standard".into(),
+                author: None,
+                parent_epic: None,
+                valid_until: None,
+                tags: Vec::new(),
+            })
+            .await
+            .unwrap();
+        store
+            .update_artifact("PRD-291D", Some("deprecated"), None)
+            .await
+            .unwrap();
+        let mut receipt = build_receipt("PRD-291D", DestructiveOp::Deprecate, "b");
+        receipt.snapshot.status = "active".into();
+        write_receipt(&ws, &receipt).await.unwrap();
+
+        let report = apply_restore_with_target(&ws, &store, &receipt, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            report.restored_status, "active",
+            "None override uses captured snapshot.status"
+        );
     }
 }

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -670,24 +670,97 @@ pub fn extract_affected_files(body: &str) -> Vec<String> {
         None => vec![],
         Some(text) => text
             .lines()
-            .map(|l| {
-                l.trim()
-                    .trim_start_matches("- ")
-                    .trim_start_matches("* ")
-                    .trim_start_matches("| ")
-                    .trim()
-            })
-            .filter(|l| {
-                !l.is_empty()
-                    && (l.contains('/')
-                        || l.contains('*')
-                        || l.ends_with(".rs")
-                        || l.ends_with(".ts")
-                        || l.ends_with(".md"))
-            })
-            .map(|l| l.to_string())
+            .filter_map(|l| extract_path_from_line(l))
+            .filter(|p| looks_like_file_path(p))
             .collect(),
     }
+}
+
+/// Extract a path candidate from a single body line.
+///
+/// Issue #293: prior implementation handled only bullet-list / single-pipe
+/// forms and missed markdown-table rows with backtick-quoted paths
+/// (`` | `path/to/file.md` | description | ``). That caused
+/// `forgeplan_drift` to silently return `changed_files: []` for artifacts
+/// whose `## Affected Files` section was a markdown table — a classic
+/// false-negative because the path still contained `/` so the legacy
+/// length-only filter accepted the garbled string, but `git log` rejected
+/// it as a pattern (no such file).
+///
+/// New logic:
+/// 1. Strip leading bullet markers (`- `, `* `, `| `).
+/// 2. If line still contains `|` (markdown table row): take the FIRST
+///    non-empty pipe-delimited column as the path candidate. Header rows
+///    (`| File | Status |`) and separator rows (`|------|`) are filtered
+///    out by the downstream `looks_like_file_path` check.
+/// 3. Strip surrounding backticks (\` … \`).
+/// 4. Strip a trailing parenthetical annotation (` (planned)`, `(done)`,
+///    `(in progress)` etc.) — operators frequently use these to mark
+///    file status without polluting the path.
+/// 5. Trim whitespace.
+///
+/// Returns `None` if the line, after trimming, is empty or has nothing
+/// resembling a path.
+fn extract_path_from_line(line: &str) -> Option<String> {
+    let mut s = line
+        .trim()
+        .trim_start_matches("- ")
+        .trim_start_matches("* ")
+        .trim_start_matches("| ")
+        .trim()
+        .to_string();
+
+    // Markdown table row — keep only first non-empty column.
+    if s.contains('|') {
+        s = s
+            .split('|')
+            .map(str::trim)
+            .find(|col| !col.is_empty())
+            .unwrap_or("")
+            .to_string();
+    }
+
+    // Strip surrounding backticks (`path/to/file.md`).
+    s = s
+        .trim_start_matches('`')
+        .trim_end_matches('`')
+        .trim()
+        .to_string();
+
+    // Strip trailing parenthetical annotation: "path/to/file (planned)".
+    if let Some(open) = s.rfind(" (")
+        && s.ends_with(')')
+    {
+        s.truncate(open);
+        s = s.trim().to_string();
+    }
+
+    // Re-strip backticks in case the annotation was inside them:
+    // `` `path` (planned) `` → after annotation strip: `` `path` `` → strip ``.
+    s = s
+        .trim_start_matches('`')
+        .trim_end_matches('`')
+        .trim()
+        .to_string();
+
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Heuristic: does this string look like a file path (vs table header,
+/// separator, or unrelated body text)?
+fn looks_like_file_path(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    // Markdown table separator: `------`, `---|---`, etc.
+    if s.chars().all(|c| c == '-' || c == ':' || c == ' ') {
+        return false;
+    }
+    s.contains('/')
+        || s.contains('*')
+        || s.ends_with(".rs")
+        || s.ends_with(".ts")
+        || s.ends_with(".md")
 }
 
 /// BMAD Step 5: Subjective adjectives that need metrics.
@@ -1177,5 +1250,141 @@ links:
         let fm: Frontmatter = serde_yaml::from_str(yaml).unwrap();
         let targets = extract_frontmatter_link_targets(&fm);
         assert!(targets.is_empty());
+    }
+
+    // ─── Issue #293: extract_affected_files — markdown-table support ──────
+
+    /// Bullet-list form (legacy — must still work).
+    #[test]
+    fn extract_affected_files_bullet_list() {
+        let body = "\
+## Affected Files
+
+- src/main.rs
+- src/lib.rs
+- docs/README.md
+";
+        let files = extract_affected_files(body);
+        assert_eq!(
+            files,
+            vec![
+                "src/main.rs".to_string(),
+                "src/lib.rs".to_string(),
+                "docs/README.md".to_string(),
+            ]
+        );
+    }
+
+    /// Issue #293 reproduction — markdown-table with backtick-quoted paths
+    /// + `(planned)` annotations. Previously returned malformed entries
+    /// (with backticks + annotations + trailing pipe content), causing
+    /// `forgeplan_drift` to silently miss changes.
+    #[test]
+    fn extract_affected_files_markdown_table_with_backticks_and_annotations() {
+        let body = "\
+## Affected Files
+
+| File | Status |
+|------|--------|
+| `plugins/fpl-skills/skills/autorun/SKILL.md` | (planned) |
+| `plugins/fpl-skills/.claude-plugin/plugin.json` | (planned) |
+| `.claude-plugin/marketplace.json` | (planned) |
+";
+        let files = extract_affected_files(body);
+        assert_eq!(
+            files,
+            vec![
+                "plugins/fpl-skills/skills/autorun/SKILL.md".to_string(),
+                "plugins/fpl-skills/.claude-plugin/plugin.json".to_string(),
+                ".claude-plugin/marketplace.json".to_string(),
+            ],
+            "issue #293: backticks stripped + trailing pipe column stripped"
+        );
+    }
+
+    /// Table separator rows MUST NOT be returned as paths.
+    #[test]
+    fn extract_affected_files_skips_table_separator_rows() {
+        let body = "\
+## Affected Files
+
+| File | Status |
+|------|--------|
+| `src/main.rs` | done |
+| -------- | -------- |
+";
+        let files = extract_affected_files(body);
+        assert_eq!(
+            files,
+            vec!["src/main.rs".to_string()],
+            "separator rows (`------`) must be filtered out"
+        );
+    }
+
+    /// Mixed format — bullet list AND table row in same section.
+    #[test]
+    fn extract_affected_files_mixed_bullet_and_table() {
+        let body = "\
+## Affected Files
+
+- src/legacy.rs
+| `src/new.rs` | (planned) |
+";
+        let files = extract_affected_files(body);
+        assert_eq!(
+            files,
+            vec!["src/legacy.rs".to_string(), "src/new.rs".to_string()]
+        );
+    }
+
+    /// Path WITHOUT backticks in a table row still parses correctly.
+    #[test]
+    fn extract_affected_files_table_without_backticks() {
+        let body = "\
+## Affected Files
+
+| File | Status |
+|------|--------|
+| src/raw.rs | done |
+";
+        let files = extract_affected_files(body);
+        assert_eq!(files, vec!["src/raw.rs".to_string()]);
+    }
+
+    /// Empty section returns empty vec.
+    #[test]
+    fn extract_affected_files_empty_section() {
+        let body = "## Affected Files\n\n";
+        let files = extract_affected_files(body);
+        assert!(files.is_empty());
+    }
+
+    /// Missing section returns empty vec.
+    #[test]
+    fn extract_affected_files_no_section() {
+        let body = "## Other Section\n\n- foo.rs\n";
+        let files = extract_affected_files(body);
+        assert!(files.is_empty());
+    }
+
+    /// Trailing `(done)` / `(deprecated)` / multi-word annotations.
+    #[test]
+    fn extract_affected_files_strips_various_annotations() {
+        let body = "\
+## Affected Files
+
+- src/a.rs (done)
+- src/b.rs (in progress)
+- src/c.rs (deprecated as of v2)
+";
+        let files = extract_affected_files(body);
+        assert_eq!(
+            files,
+            vec![
+                "src/a.rs".to_string(),
+                "src/b.rs".to_string(),
+                "src/c.rs".to_string(),
+            ]
+        );
     }
 }

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -670,7 +670,7 @@ pub fn extract_affected_files(body: &str) -> Vec<String> {
         None => vec![],
         Some(text) => text
             .lines()
-            .filter_map(|l| extract_path_from_line(l))
+            .filter_map(extract_path_from_line)
             .filter(|p| looks_like_file_path(p))
             .collect(),
     }
@@ -1276,9 +1276,9 @@ links:
     }
 
     /// Issue #293 reproduction — markdown-table with backtick-quoted paths
-    /// + `(planned)` annotations. Previously returned malformed entries
-    /// (with backticks + annotations + trailing pipe content), causing
-    /// `forgeplan_drift` to silently miss changes.
+    /// and `(planned)` annotations. Previously returned malformed entries
+    /// (backticks plus annotations plus trailing pipe content),
+    /// causing `forgeplan_drift` to silently miss changes.
     #[test]
     fn extract_affected_files_markdown_table_with_backticks_and_annotations() {
         let body = "\

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -748,8 +748,22 @@ fn extract_path_from_line(line: &str) -> Option<String> {
 
 /// Heuristic: does this string look like a file path (vs table header,
 /// separator, or unrelated body text)?
+///
+/// Audit-dogfood SEC-3 hardening: also reject control characters / ANSI
+/// escape sequences. Without this, a malicious PRD body with table-cell
+/// content like `` `legit/file.rs\x1b[31mEVIL` `` would survive parser
+/// extraction (still contains `/`, ends with `.rs`) and land in MCP
+/// `DriftedFile.path` — terminal renderers display the ANSI overlay and
+/// the operator sees fabricated content (log spoofing / agent confusion).
 fn looks_like_file_path(s: &str) -> bool {
     if s.is_empty() {
+        return false;
+    }
+    // SEC-3: reject control chars (covers `\n`/`\r`/`\t`/`\x1b` and C1
+    // controls) plus Unicode line separators U+0085/2028/2029.
+    if s.chars()
+        .any(|c| c.is_control() || matches!(c, '\u{0085}' | '\u{2028}' | '\u{2029}'))
+    {
         return false;
     }
     // Markdown table separator: `------`, `---|---`, etc.

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.31.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
 rmcp = { version = "1.2", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.31.0", features = ["test-helpers"] }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.0", features = ["test-helpers"] }
 tempfile = "3"
 serde_yaml.workspace = true
 # Phase 2.4: enable the rmcp `client` role for E2E integration tests so we

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -9506,6 +9506,7 @@ mod claim_mcp_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Full cycle".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -9605,6 +9606,7 @@ mod claim_mcp_tests {
                 srv.forgeplan_new(Parameters(NewParams {
                     kind: ArtifactKindArg::Prd,
                     title: format!("Concurrent PRD {i}"),
+                    parent_id: None,
                 }))
                 .await
             }));
@@ -9725,6 +9727,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Auth System".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -9782,6 +9785,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Payment Gateway".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -9827,6 +9831,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Rfc,
                 title: "Identity Resolver".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -9874,6 +9879,7 @@ mod prob060_response_shape_tests {
                 .forgeplan_new(Parameters(NewParams {
                     kind: ArtifactKindArg::Prd,
                     title: title.to_string(),
+                    parent_id: None,
                 }))
                 .await
                 .unwrap();
@@ -9931,6 +9937,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Quantum Cache".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -10124,6 +10131,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Mcp Hint Pre Merge".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -10166,6 +10174,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Mcp Hint Post Merge".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();
@@ -10204,6 +10213,7 @@ mod prob060_response_shape_tests {
             .forgeplan_new(Parameters(NewParams {
                 kind: ArtifactKindArg::Prd,
                 title: "Mcp Update Hint Pre Merge".to_string(),
+                parent_id: None,
             }))
             .await
             .unwrap();

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5378,7 +5378,11 @@ impl ForgeplanServer {
         Ok(json_result(&serde_json::json!({
             "session_id": session.id,
             "project_name": session.project_name,
+            // Issue #292: `status` ambiguity — refers to SESSION state,
+            // not artifact state. Old field kept for backward compat;
+            // new `session_status` is the unambiguous name.
             "status": session.status,
+            "session_status": session.status,
             "current_phase": session.current_phase,
             "protocol": protocol,
             "_next_action": format!(
@@ -5516,13 +5520,26 @@ impl ForgeplanServer {
             "phase": phase.name(),
             "tier": p.tier,
             "total_findings": session.findings.len(),
+            // Issue #292 closure — disambiguate `status`:
+            //   * `status` (legacy, deprecated): SESSION state. Kept for
+            //     backward compat — but readers should switch to the
+            //     two new fields below.
+            //   * `session_status`: explicitly the session's state
+            //     ("active" while recording, "completed" after _complete).
+            //   * `artifact_status`: the status of the artifact JUST
+            //     CREATED by this call. Always "draft" — operators must
+            //     `forgeplan_activate <artifact_id>` before relying on
+            //     it (or `forgeplan_deprecate` if it was a mis-finding).
+            // Operators were confusing the first field for the third.
             "status": session.status,
+            "session_status": session.status,
+            "artifact_status": "draft",
             // PRD-071: single primary action — finalize the session. If
             // more findings exist the agent simply re-calls _finding; the
             // hint reflects the canonical path forward.
             "_next_action": format!(
-                "Finding recorded. Complete session when phases done: \
-                 `forgeplan_discover_complete session_id=\"{}\"`.",
+                "Finding recorded (artifact in draft). Complete session when \
+                 phases done: `forgeplan_discover_complete session_id=\"{}\"`.",
                 session.id
             ),
         })))
@@ -5564,7 +5581,13 @@ impl ForgeplanServer {
         Ok(json_result(&serde_json::json!({
             "session_id": session.id,
             "project_name": session.project_name,
+            // Issue #292: `status` here refers to SESSION lifecycle
+            // (always "completed" at this point — _complete just set it).
+            // Backward-compat preserved; new `session_status` is the
+            // unambiguous name. NB: `artifacts_created` lists the
+            // finding artifacts — those are in `draft` until activated.
             "status": session.status,
+            "session_status": session.status,
             "total_findings": session.findings.len(),
             "phase_counts": phase_counts.iter().map(|(p, c)| (p.name(), c)).collect::<std::collections::HashMap<_, _>>(),
             "tier_counts": tier_counts,
@@ -5572,7 +5595,9 @@ impl ForgeplanServer {
             "completed_at": session.completed_at,
             // PRD-071: single primary action — health check is the
             // canonical post-discovery step.
-            "_next_action": "Validate the discovery output: `forgeplan_health`.",
+            "_next_action": "Validate the discovery output: `forgeplan_health`. \
+                            Finding artifacts created by this session are in `draft` — \
+                            run `forgeplan_activate <id>` on the ones to keep.",
         })))
     }
 

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -648,6 +648,17 @@ struct ActivityStatsParams {
 struct RestoreParams {
     /// Artifact ID to recover from the most recent non-consumed receipt.
     id: String,
+    /// Issue #291: optional explicit override of the restored status.
+    /// Default behaviour reads `prior_status` from the receipt snapshot
+    /// (which captures the artifact's status at the moment of `_delete`
+    /// / `_deprecate` / `_supersede`). Pass `target_status: "active"` to
+    /// force a specific status — useful when the operator wants to
+    /// restore to a different state than was captured.
+    ///
+    /// Valid values: `"draft"`, `"active"`, `"deprecated"`.
+    /// Unknown values are rejected with a structured error.
+    #[serde(default)]
+    target_status: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -6456,7 +6467,15 @@ impl ForgeplanServer {
             }
         };
 
-        match forgeplan_core::undo::restore::apply_restore(&ws, &store, &receipt).await {
+        // Issue #291: forward optional target_status override.
+        match forgeplan_core::undo::restore::apply_restore_with_target(
+            &ws,
+            &store,
+            &receipt,
+            p.target_status.as_deref(),
+        )
+        .await
+        {
             Ok(report) => {
                 let safe_id = sanitize_for_hint(&report.artifact_id);
                 let op_str = match report.op {
@@ -6494,6 +6513,16 @@ impl ForgeplanServer {
                         report.relations_restored
                     )
                 };
+                // Issue #291: surface the restored status explicitly so the
+                // operator can verify which state the artifact was returned
+                // to. `restored_status_source` says whether the value came
+                // from the receipt's captured prior_status or from the
+                // explicit `target_status` override.
+                let restored_status_source = if p.target_status.is_some() {
+                    "explicit_override"
+                } else {
+                    "receipt_snapshot"
+                };
                 hinted_result(
                     &serde_json::json!({
                         "restored": report.artifact_id,
@@ -6501,6 +6530,8 @@ impl ForgeplanServer {
                         "relations_restored": report.relations_restored,
                         "relations_skipped": safe_skipped,
                         "projection_restored": report.projection_restored,
+                        "restored_status": report.restored_status,
+                        "restored_status_source": restored_status_source,
                         "warnings": safe_warnings,
                     }),
                     next_action,

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -675,6 +675,17 @@ struct NewParams {
     kind: ArtifactKindArg,
     /// Artifact title
     title: String,
+    /// Issue #295: optional parent artifact ID for auto-link.
+    /// When supplied AND kind=evidence, an `informs` link is created
+    /// from the new EVID to the named parent in the same call.
+    /// Reduces the 3-step EVID flow (new → update → link) to 2 steps
+    /// (new+autolink → update).
+    /// Accepts display id (`PRD-074`) or slug (`prd-auth-system`).
+    /// For kinds other than `evidence` the parameter is rejected with
+    /// a structured error (other auto-link patterns are intentionally
+    /// out of scope for v1 — see issue #295).
+    #[serde(default)]
+    parent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -1183,6 +1194,16 @@ impl ForgeplanServer {
 
         let template_key = artifact_kind.template_key();
 
+        // Issue #295: `parent_id` is opt-in shorthand for EVID flow only.
+        // Reject early if combined with a non-evidence kind so the caller
+        // gets clear semantics instead of silent ignoring.
+        if p.parent_id.is_some() && template_key != "evidence" {
+            return Ok(err_hinted(
+                &format!("parent_id is only valid for kind=evidence (got kind={template_key})"),
+                "Fix: omit parent_id, or use forgeplan_link after creation for other kinds.",
+            ));
+        }
+
         // Duplicate detection (FR-004 of PRD-043) — non-blocking warnings.
         // MCP is non-interactive, so the artifact is still created and warnings
         // are returned for the AI agent to react to.
@@ -1291,6 +1312,54 @@ impl ForgeplanServer {
         // only — a failure here is logged and does not break creation.
         maybe_init_phase(&ws, &id, "forgeplan_new").await;
 
+        // Issue #295: auto-link evidence → parent via `informs` when
+        // `parent_id` supplied. Closes the 3-step EVID flow (new →
+        // update → link) into 2 steps (new+autolink → update).
+        // Resolve via `store.resolve_id` so both display id (`PRD-074`)
+        // and slug (`prd-auth-system`) work. If the parent doesn't
+        // exist we DO NOT roll back the creation — the artifact is
+        // still useful, the link is the missing piece. Caller gets
+        // a structured warning surfaced in response `warnings`.
+        let mut auto_link_warnings: Vec<String> = Vec::new();
+        let mut auto_link_target: Option<String> = None;
+        if let Some(ref raw_parent) = p.parent_id {
+            let safe = sanitize_for_hint(raw_parent);
+            match store.resolve_id(raw_parent).await {
+                Ok(Some(canonical_parent)) => {
+                    // Parent exists — write the link via the projection
+                    // helper so the markdown frontmatter `links:` array
+                    // stays in sync (file-first per ADR-003).
+                    match projection::add_link_with_projection(
+                        &projection::MutationContext::new(&ws, &store),
+                        &id,
+                        &canonical_parent,
+                        "informs",
+                    )
+                    .await
+                    {
+                        Ok(_) => {
+                            auto_link_target = Some(canonical_parent);
+                        }
+                        Err(e) => {
+                            auto_link_warnings.push(format!(
+                                "Auto-link {id} -> {safe} (informs) failed: {e}. \
+                                 Use `forgeplan_link` to retry."
+                            ));
+                        }
+                    }
+                }
+                Ok(None) => {
+                    auto_link_warnings.push(format!(
+                        "parent_id `{safe}` does not exist in workspace — \
+                         auto-link skipped. Artifact {id} created in draft."
+                    ));
+                }
+                Err(e) => {
+                    auto_link_warnings.push(format!("Auto-link skipped (resolve_id failed): {e}"));
+                }
+            }
+        }
+
         // PROB-060 Phase 2 Wave 1 — combine W1.A response shape (CD-2) +
         // W1.B slug-aware hint (CD-5).
         //
@@ -1334,7 +1403,13 @@ impl ForgeplanServer {
         // frontmatter and rendered the display id); wrapping in `Some(..)`
         // here keeps the JSON identical for current callers while letting
         // the schema match `ArtifactSummaryDto` / `ArtifactRecordDto`.
-        Ok(json_result(&NewArtifactResponse {
+        //
+        // Issue #295: surface auto-link result. NewArtifactResponse doesn't
+        // have `auto_linked` / `auto_link_warnings` fields — wrap the
+        // serialised DTO into a json Value and append them post-hoc so
+        // old consumers see the same shape; new consumers read the
+        // additional fields. Avoids a breaking DTO change.
+        let base = NewArtifactResponse {
             id,
             kind: template_key.into(),
             title: p.title,
@@ -1347,7 +1422,29 @@ impl ForgeplanServer {
             id_canonical,
             id_display,
             hint: identity_hint,
-        }))
+        };
+        if auto_link_target.is_some() || !auto_link_warnings.is_empty() {
+            let mut v = serde_json::to_value(&base).unwrap_or_default();
+            if let Some(obj) = v.as_object_mut() {
+                if let Some(linked) = auto_link_target {
+                    obj.insert("auto_linked".to_string(), serde_json::Value::String(linked));
+                }
+                if !auto_link_warnings.is_empty() {
+                    obj.insert(
+                        "auto_link_warnings".to_string(),
+                        serde_json::Value::Array(
+                            auto_link_warnings
+                                .into_iter()
+                                .map(serde_json::Value::String)
+                                .collect(),
+                        ),
+                    );
+                }
+            }
+            Ok(json_result(&v))
+        } else {
+            Ok(json_result(&base))
+        }
     }
 
     #[tool(

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -5631,6 +5631,17 @@ impl ForgeplanServer {
             "status": session.status,
             "session_status": session.status,
             "artifact_status": "draft",
+            // Option E (issue #292 follow-up audit): expose the semantic
+            // mismatch through a structured warning channel agents can
+            // parse. Old consumers ignore unknown fields, new consumers
+            // see the upcoming deprecation of `status` and migrate.
+            "_field_warnings": [
+                {
+                    "field": "status",
+                    "severity": "deprecation_notice",
+                    "message": "`status` refers to SESSION state. The created artifact is always in `draft`. Read `artifact_status` (this finding's artifact) and `session_status` (this session) instead. `status` will be removed in a future major release."
+                }
+            ],
             // PRD-071: single primary action — finalize the session. If
             // more findings exist the agent simply re-calls _finding; the
             // hint reflects the canonical path forward.

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -1324,6 +1324,15 @@ impl ForgeplanServer {
         let mut auto_link_target: Option<String> = None;
         if let Some(ref raw_parent) = p.parent_id {
             let safe = sanitize_for_hint(raw_parent);
+            // Audit-dogfood SEC-4: Wave 9 SEC-H3 closed ~40 sites that
+            // leaked raw `{e}` (HOME paths, CARGO_TARGET_DIR, etc.) into
+            // MCP responses. Auto-link warnings re-introduce the same
+            // leak vector. Route every error display through
+            // `sanitize_error_chain` so this code preserves the SEC-H3
+            // posture instead of regressing it.
+            let safe_err = |e: anyhow::Error| -> String {
+                forgeplan_core::projection::sanitize_error_chain(&e)
+            };
             match store.resolve_id(raw_parent).await {
                 Ok(Some(canonical_parent)) => {
                     // Parent exists — write the link via the projection
@@ -1342,8 +1351,9 @@ impl ForgeplanServer {
                         }
                         Err(e) => {
                             auto_link_warnings.push(format!(
-                                "Auto-link {id} -> {safe} (informs) failed: {e}. \
-                                 Use `forgeplan_link` to retry."
+                                "Auto-link {id} -> {safe} (informs) failed: {}. \
+                                 Use `forgeplan_link` to retry.",
+                                safe_err(anyhow::anyhow!("{e}"))
                             ));
                         }
                     }
@@ -1355,7 +1365,10 @@ impl ForgeplanServer {
                     ));
                 }
                 Err(e) => {
-                    auto_link_warnings.push(format!("Auto-link skipped (resolve_id failed): {e}"));
+                    auto_link_warnings.push(format!(
+                        "Auto-link skipped (resolve_id failed): {}",
+                        safe_err(e)
+                    ));
                 }
             }
         }
@@ -1404,12 +1417,13 @@ impl ForgeplanServer {
         // here keeps the JSON identical for current callers while letting
         // the schema match `ArtifactSummaryDto` / `ArtifactRecordDto`.
         //
-        // Issue #295: surface auto-link result. NewArtifactResponse doesn't
-        // have `auto_linked` / `auto_link_warnings` fields — wrap the
-        // serialised DTO into a json Value and append them post-hoc so
-        // old consumers see the same shape; new consumers read the
-        // additional fields. Avoids a breaking DTO change.
-        let base = NewArtifactResponse {
+        // Issue #295 (audit-dogfood CODE-4 / ARCH-2 fix): `auto_linked` +
+        // `auto_link_warnings` are now proper DTO fields (with
+        // `skip_serializing_if`) — preserves JsonSchema contract for
+        // typed clients (TS codegen). Old consumers ignore unknown
+        // fields; new consumers read them. Replaces post-hoc Value
+        // mutation that broke schema codegen.
+        Ok(json_result(&NewArtifactResponse {
             id,
             kind: template_key.into(),
             title: p.title,
@@ -1422,29 +1436,9 @@ impl ForgeplanServer {
             id_canonical,
             id_display,
             hint: identity_hint,
-        };
-        if auto_link_target.is_some() || !auto_link_warnings.is_empty() {
-            let mut v = serde_json::to_value(&base).unwrap_or_default();
-            if let Some(obj) = v.as_object_mut() {
-                if let Some(linked) = auto_link_target {
-                    obj.insert("auto_linked".to_string(), serde_json::Value::String(linked));
-                }
-                if !auto_link_warnings.is_empty() {
-                    obj.insert(
-                        "auto_link_warnings".to_string(),
-                        serde_json::Value::Array(
-                            auto_link_warnings
-                                .into_iter()
-                                .map(serde_json::Value::String)
-                                .collect(),
-                        ),
-                    );
-                }
-            }
-            Ok(json_result(&v))
-        } else {
-            Ok(json_result(&base))
-        }
+            auto_linked: auto_link_target,
+            auto_link_warnings,
+        }))
     }
 
     #[tool(
@@ -5480,6 +5474,16 @@ impl ForgeplanServer {
             // new `session_status` is the unambiguous name.
             "status": session.status,
             "session_status": session.status,
+            // Audit-dogfood CODE-2 fix: parallel `_field_warnings` channel
+            // (same one used in _finding) so schema-aware clients see the
+            // deprecation consistently across all 3 discover_* tools.
+            "_field_warnings": [
+                {
+                    "field": "status",
+                    "severity": "deprecation_notice",
+                    "message": "`status` refers to SESSION state. Read `session_status` instead. `status` will be removed in a future major release."
+                }
+            ],
             "current_phase": session.current_phase,
             "protocol": protocol,
             "_next_action": format!(
@@ -5696,6 +5700,16 @@ impl ForgeplanServer {
             // finding artifacts — those are in `draft` until activated.
             "status": session.status,
             "session_status": session.status,
+            // Audit-dogfood CODE-2 fix: parallel `_field_warnings` channel
+            // (same one used in _start / _finding) for consistency across
+            // all 3 discover_* tools.
+            "_field_warnings": [
+                {
+                    "field": "status",
+                    "severity": "deprecation_notice",
+                    "message": "`status` refers to SESSION state. Read `session_status` instead. `status` will be removed in a future major release."
+                }
+            ],
             "total_findings": session.findings.len(),
             "phase_counts": phase_counts.iter().map(|(p, c)| (p.name(), c)).collect::<std::collections::HashMap<_, _>>(),
             "tier_counts": tier_counts,
@@ -6651,10 +6665,18 @@ impl ForgeplanServer {
                 // to. `restored_status_source` says whether the value came
                 // from the receipt's captured prior_status or from the
                 // explicit `target_status` override.
-                let restored_status_source = if p.target_status.is_some() {
-                    "explicit_override"
-                } else {
-                    "receipt_snapshot"
+                //
+                // Audit-dogfood CODE-1 HIGH fix: compare *values*, not
+                // presence. If operator passes `target_status` equal to
+                // what the snapshot already had, the source is still
+                // `receipt_snapshot` semantically (override matched the
+                // default — no override effect). Previously this reported
+                // "explicit_override" misleadingly even on no-op overrides.
+                let restored_status_source = match p.target_status.as_deref() {
+                    Some(t) if t.trim().to_lowercase() != report.restored_status => {
+                        "explicit_override"
+                    }
+                    _ => "receipt_snapshot",
                 };
                 hinted_result(
                     &serde_json::json!({

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -171,6 +171,24 @@ pub struct NewArtifactResponse {
     /// Distinct from `_next_action`, which is the workflow chaining hint.
     #[serde(default)]
     pub hint: String,
+    /// Issue #295 (audit-dogfood CODE-4 / ARCH-2 fix): when
+    /// `forgeplan_new(kind=evidence, parent_id=...)` succeeds, this
+    /// field carries the canonical parent id that was auto-linked via
+    /// `informs`. None when no parent_id was supplied OR auto-link
+    /// failed (see `auto_link_warnings`).
+    ///
+    /// Previously surfaced as post-hoc `serde_json::Value` mutation,
+    /// which broke JsonSchema codegen for typed clients (TypeScript /
+    /// codegen-aware SDKs). Now a proper optional DTO field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_linked: Option<String>,
+    /// Issue #295: warnings about the auto-link step (parent missing,
+    /// resolve_id transient error, etc.). Empty when no parent_id
+    /// supplied or auto-link succeeded. Error chains routed through
+    /// `sanitize_error_chain` so HOME paths don't leak (audit-dogfood
+    /// SEC-4 fix preserving Wave 9 SEC-H3 posture).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub auto_link_warnings: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/forgeplan-mcp/tests/integration_e2e.rs
+++ b/crates/forgeplan-mcp/tests/integration_e2e.rs
@@ -793,3 +793,132 @@ async fn fixture_workspace_is_initialized() {
         "config.yaml landed in fresh workspace"
     );
 }
+
+// ── T14: Issue #295 — forgeplan_new evidence parent_id auto-link ──────
+
+/// Happy path: `forgeplan_new(kind=evidence, parent_id=<PRD>)` creates
+/// the evidence AND writes an `informs` link in one call. Response
+/// carries `auto_linked` with the canonical parent id.
+#[tokio::test]
+async fn t14_forgeplan_new_evidence_with_parent_id_auto_links() {
+    let fx = McpFixture::new().await;
+
+    // Seed a PRD to link against.
+    fx.call_tool_json(
+        "forgeplan_new",
+        json!({"kind": "prd", "title": "Parent PRD"}),
+    )
+    .await
+    .assert_ok();
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_new",
+            json!({
+                "kind": "evidence",
+                "title": "Auto-linked evidence",
+                "parent_id": "PRD-001",
+            }),
+        )
+        .await;
+    let resp = env.assert_ok();
+    assert_eq!(resp["kind"], "evidence");
+    assert_eq!(
+        resp["auto_linked"], "PRD-001",
+        "response must surface the linked parent: {resp}"
+    );
+
+    // Verify graph: EVID-001 should have an outgoing `informs` link to PRD-001.
+    let graph_env = fx.call_tool_json("forgeplan_graph", json!({})).await;
+    let graph_resp = graph_env.assert_ok();
+    let mermaid = graph_resp["mermaid"].as_str().unwrap_or("");
+    assert!(
+        mermaid.contains("EVID-001") && mermaid.contains("PRD-001") && mermaid.contains("informs"),
+        "graph must include the auto-link edge: {mermaid}"
+    );
+}
+
+/// Slug-form parent_id also works (resolver accepts both display id and slug).
+#[tokio::test]
+async fn t14b_forgeplan_new_evidence_with_slug_parent_resolves() {
+    let fx = McpFixture::new().await;
+
+    fx.call_tool_json(
+        "forgeplan_new",
+        json!({"kind": "prd", "title": "Auth System"}),
+    )
+    .await
+    .assert_ok();
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_new",
+            json!({
+                "kind": "evidence",
+                "title": "evidence via slug",
+                "parent_id": "prd-auth-system",
+            }),
+        )
+        .await;
+    let resp = env.assert_ok();
+    assert!(
+        resp["auto_linked"]
+            .as_str()
+            .unwrap_or("")
+            .contains("PRD-001"),
+        "slug parent_id must resolve to canonical id: {resp}"
+    );
+}
+
+/// Non-existent parent_id: artifact still created, warning surfaced,
+/// no `auto_linked` field. Caller can retry with `forgeplan_link`.
+#[tokio::test]
+async fn t14c_forgeplan_new_evidence_with_missing_parent_warns_but_creates() {
+    let fx = McpFixture::new().await;
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_new",
+            json!({
+                "kind": "evidence",
+                "title": "orphan evidence",
+                "parent_id": "PRD-NONEXISTENT-9999",
+            }),
+        )
+        .await;
+    let resp = env.assert_ok();
+    assert_eq!(resp["kind"], "evidence", "artifact still created");
+    assert!(
+        resp["auto_linked"].is_null() || resp.get("auto_linked").is_none(),
+        "no auto_linked field when target missing: {resp}"
+    );
+    let warnings = resp["auto_link_warnings"]
+        .as_array()
+        .expect("auto_link_warnings array when target missing");
+    assert!(!warnings.is_empty(), "warning surfaced: {warnings:?}");
+}
+
+/// parent_id with non-evidence kind is rejected with a clear error.
+#[tokio::test]
+async fn t14d_forgeplan_new_parent_id_rejected_for_non_evidence_kind() {
+    let fx = McpFixture::new().await;
+
+    fx.call_tool_json("forgeplan_new", json!({"kind": "prd", "title": "Parent"}))
+        .await
+        .assert_ok();
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_new",
+            json!({
+                "kind": "rfc",
+                "title": "RFC trying parent_id",
+                "parent_id": "PRD-001",
+            }),
+        )
+        .await;
+    assert!(
+        env.is_error,
+        "parent_id with non-evidence kind must be rejected: {env:?}"
+    );
+}

--- a/docs/methodology/CROSS-REPO-WORKFLOW.ru.md
+++ b/docs/methodology/CROSS-REPO-WORKFLOW.ru.md
@@ -1,0 +1,225 @@
+# Cross-repo workflow в ForgePlan org
+
+> Как координировать issues, fix'ы и feature requests между репозиториями
+> одной организации (`forgeplan` core ↔ `marketplace` ↔ `forgeplan-hud` ↔ ...)
+> чтобы знание не терялось и работа шла предсказуемо.
+
+## Проблема которую это решает
+
+Когда работаешь в одном repo и наткнулся на bug **другого** repo, есть 5 типичных провалов:
+
+1. **Bug фиксится локально workaround'ом**, репорт upstream забывают написать
+2. **Issue создаётся в неправильном repo** (там где обнаружено, не там где fix должен жить)
+3. **Связь между issues теряется** — fix в repo A не закрывает issue в repo B
+4. **Документация в downstream repo описывает workaround**, который перестал быть нужным после upstream fix — но никто не убирает
+5. **На session start не видишь** какие issues уже открыты — работаешь "вслепую", дублируешь работу
+
+Этот документ — стандарт как **не попадать** в эти провалы.
+
+## Tax onomy: label hierarchy (org-wide)
+
+Все repos в org должны иметь **одинаковый минимальный набор labels**. Внутренние per-repo labels (типа `prd`, `rfc` в marketplace) — поверх.
+
+### Core (обязательно во всех repos)
+
+**Type** (что это):
+- `bug` — что-то работает не так
+- `enhancement` — feature request
+- `documentation` — docs only
+- `refactor` — internal refactor без user-visible change
+- `question` — обсуждение, не actionable
+- `security` — vulnerability / hardening
+
+**Severity** (насколько срочно):
+- `severity:critical` — production-blocker
+- `severity:high` — серьёзный bug или важная feature
+- `severity:medium` — обычный workflow item
+- `severity:low` — nice-to-have
+
+**Origin** (откуда узнали):
+- `dogfood` — surfaced через реальную работу
+- `audit` — adversarial audit round
+- `community` — внешний reporter
+
+**Cross-repo coordination** (важнейшая категория для org):
+- `cross-repo` — issue затрагивает >1 repo, ищи Refs в body
+- `upstream:<repo>` — заблокировано фиксом в <repo>
+- `downstream:<repo>` — этот фикс разблокирует <repo>
+
+### Repo-specific (поверх core)
+
+В каждом repo разрешено добавлять свои labels для domain — например `forgeplan` в marketplace для tracking forgeplan artifacts. Не запрещено, но не должно дублировать core taxonomy.
+
+## Когда какой repo использовать (decision tree)
+
+### Bug surfaced при работе в repo X
+
+```
+Где источник bug'а?
+├── В repo X → создавай issue в X
+├── В upstream dependency (Y) → создавай issue в Y
+│   └── Если workaround есть в X → отдельный issue в X
+│       label: cross-repo + downstream:Y
+│       body: "Workaround for Y#NNN — remove when upstream fixes"
+└── Не понятно где → создавай в X, label: triage
+```
+
+### Feature request на boundary между двумя repos
+
+```
+1. Создай issue в repo где БУДЕТ FIX
+2. Если требует изменений в втором repo:
+   - Issue #1 в repo A (main fix)
+     label: cross-repo + downstream:B
+     body: содержит ссылку на #2
+   - Issue #2 в repo B (follow-up)
+     label: cross-repo + upstream:A
+     body: "Depends on A#NNN"
+3. PR в repo A merge'ит #1 + crossrefs #2 ("see also B#MMM")
+4. PR в repo B merge'ит #2 + closes "Closes A#NNN B#MMM"
+```
+
+### Documentation update в downstream repo после upstream fix
+
+Это случай **forgeplan#292 → marketplace#86**:
+- Core repo: code fix (forgeplan#292 closed by PR)
+- Marketplace repo: docs update issue (marketplace#86, references upstream)
+- Marketplace docs PR closes #86 после release upstream
+
+Pattern: документация **никогда не сидит в одном repo если она описывает кросс-repo поведение**.
+
+## Issue body conventions
+
+Каждый cross-repo issue должен иметь в body минимум:
+
+```markdown
+## Summary
+<one paragraph>
+
+## Affected files (or surface)
+- `path/to/file.rs` — что там не так
+- Cross-repo: `OtherRepo:path/to/file.md` — что обновить там
+
+## Upstream / Downstream
+
+- Upstream blocker: ForgePlan/repoY#NNN
+- Downstream impact: ForgePlan/repoZ#MMM
+- Related: see also ForgePlan/repoW#KKK
+
+## Acceptance criteria
+- [ ] что нужно done в этом repo
+- [ ] что нужно done в кросс-repo (с прямой ссылкой)
+```
+
+## Commit / PR conventions для cross-repo
+
+### Closing issues across repos
+
+GitHub поддерживает синтаксис:
+```
+Closes ForgePlan/marketplace#86
+```
+В PR body для cross-repo closure. Используй это вместо `Closes #86` если PR в другом repo.
+
+### Referencing without closing
+
+```
+Refs ForgePlan/forgeplan#292
+```
+Создаёт обратную ссылку без auto-close.
+
+### PR title (cross-repo PR)
+
+Префиксуй scope именем второго repo:
+```
+[+marketplace] fix(discover): add session_status alias (closes #292, refs marketplace#86)
+```
+
+## Session start protocol (для AI agents)
+
+### Что должен делать агент при старте session
+
+1. **Read project memory** (CLAUDE.md, MEMORY.md)
+2. **Read git state** (branch, recent commits)
+3. **Inbox sweep** для всех repos в org:
+   ```bash
+   for repo in $(gh repo list ForgePlan --json name -q '.[].name'); do
+     gh issue list --repo ForgePlan/$repo --state open --label "cross-repo,severity:high,severity:critical" --json number,title,labels
+   done
+   ```
+4. **Triage to user**: показать summary `N open issues across M repos (X critical, Y cross-repo)`. Спросить:
+   - "Хочешь review каждый?"
+   - "Сразу build sprint plan из них?"
+   - "Skip — продолжать что начинал?"
+5. Если user выбирает review → итерация по issues с decision'ами:
+   - **Close as obsolete** — устарел
+   - **Add to current sprint** — берёшь в работу сейчас
+   - **Plan for later** — оставить open, schedule
+   - **Cross-repo** — открыть partner issue в другом repo
+
+### Конкретная реализация (предложение)
+
+- **Hook**: `SessionStart` hook в `.claude/hooks/` который calls `gh issue list` для всех org repos
+- **Skill**: `cross-repo-inbox` skill activates когда user открывает session и spawn'ит triage prompt
+- **MCP tool**: `forgeplan_inbox` или `orchestra_inbox` — единая точка sweep
+
+## Best practices summary
+
+1. **Один issue — один repo** (где будет fix), даже если bug surfaced в другом
+2. **Cross-repo dependencies явно labeled** — `cross-repo` + `upstream:<repo>` / `downstream:<repo>`
+3. **Body ВСЕГДА содержит cross-refs** на partner issues
+4. **PR closes issues across repos** через `Closes Org/repo#NNN` синтаксис
+5. **Documentation cleanup** в downstream repo — отдельный issue с reference на upstream fix
+6. **Session start = inbox sweep** перед началом работы, не после
+7. **Labels org-wide consistent** — taxonomy одинакова для всех repos в org
+
+## Что НЕ делать
+
+❌ **Не вносить cross-repo fix в один PR одного repo** — это hides dependency и breaks audit trail
+❌ **Не reuse `status` label / `type` label с разными значениями в разных repos** — путает agents и людей
+❌ **Не закрывать upstream issue PR'ом в downstream repo** — `Closes` сработает (GitHub permits) но смысл потерян
+❌ **Не дублировать issue в каждом repo** — choose primary repo, cross-ref остальные
+
+## Implementation roadmap (org-wide rollout)
+
+### Phase 0: foundation (this doc)
+- [x] Methodology written down
+- [ ] User review + approve
+
+### Phase 1: label sync
+- [ ] Script: sync core label taxonomy across all org repos
+- [ ] Apply core labels (`severity:*`, `origin:*`, `cross-repo`, `upstream:*`, `downstream:*`)
+- [ ] CI workflow: enforce labels on new issues
+
+### Phase 2: issue templates
+- [ ] `.github/ISSUE_TEMPLATE/bug.yml` в org `.github` repo (наследуется всеми)
+- [ ] `.github/ISSUE_TEMPLATE/feature.yml`
+- [ ] `.github/ISSUE_TEMPLATE/cross-repo.yml` — structured cross-repo dep
+
+### Phase 3: session start automation
+- [ ] Hook `.claude/hooks/session-start-issue-inbox.sh` — sweep open issues across org
+- [ ] Skill `cross-repo-inbox` — triage flow with user interaction
+- [ ] Optional MCP tool `forgeplan_inbox` для integration
+
+### Phase 4: dashboard
+- [ ] GitHub Project (v2) org-wide — view across all repos
+- [ ] Custom fields: severity, status, origin
+- [ ] Saved views: "cross-repo open", "my critical", "this week"
+
+## Connection to existing tooling
+
+- **Orchestra MCP** — уже track'ает tasks, может стать **org-wide inbox UI**
+- **Hindsight MCP** — может сохранить decisions ("выбрали Option E для #292") как long-term memory
+- **Forgeplan** — может tracking issues как Notes/Problems артефактами с linked external refs
+
+## References
+
+- GitHub docs: [linking PR to issue across repos](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+- GitHub docs: [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)
+- GitHub Projects (v2): [cross-repo views](https://docs.github.com/en/issues/planning-and-tracking-with-projects)
+
+---
+
+**Last updated**: 2026-05-20. Audit-r7 + dogfood-findings sprint surfaced the
+need explicitly when 6 marketplace-discovered bugs got filed in forgeplan core
+without a clear protocol — this doc is the protocol.


### PR DESCRIPTION
## Summary

Closes 6 issues filed from real-world dogfood usage in the `marketplace` workspace (#290..#295), plus an adversarial audit round (`audit-r-dogfood`) that closed 8 more findings inline before this PR. New methodology doc on cross-repo coordination.

This branch is part of the v0.32.0 release alongside `feat/issues-286-288-289` (Epic #287 brownfield extraction). Both must merge before the release tag.

## Closes

- Closes #290 — `forgeplan_release_notes` split-repo `.git/` discovery
- Closes #291 — `forgeplan_restore` `target_status` override + `restored_status` surface
- Closes #292 — `forgeplan_discover_*` `status` field disambiguation
- Closes #293 — `forgeplan_drift` markdown-table `affected_files` parser
- Closes #294 — `forgeplan_activate` error UX teaches canonical EVID fix recipe
- Closes #295 — `forgeplan_new(kind=evidence, parent_id=...)` auto-link

## What landed

### 6 dogfood fixes (one commit each)
- `2a8408a` #293 drift markdown-table parser + 8 regression tests
- `56bbc7e` #290 `find_git_root` 3-tier discovery + 5 tests
- `e8473d1` #291 `apply_restore_with_target` + 4 tests
- `ea37318` #292 `session_status` + `artifact_status` + `_field_warnings` (backward-compat)
- `1644136` #294 5-step recipe in activate error + 2 tests
- `7af3576` #295 `parent_id` auto-link + T14/T14b/T14c/T14d (4 integration tests)

### Hardening from audit-r-dogfood
- `c87e2ce` #292 Option E (`_field_warnings` deprecation channel)
- `42d8cf3` clippy hygiene
- `2cb36e8` **8 audit findings closed inline** before this PR:
  - **SEC-1 HIGH**: `find_git_root` reject symlinks + bound walk-up + deterministic ordering (closes attacker-redirect vector to `/other-user-repo/.git`)
  - **CODE-1 HIGH**: `restored_status_source` compares values not presence
  - **SEC-2 MED**: FSM transition validation in `apply_restore_with_target`
  - **SEC-3 MED**: control chars / Unicode line separators rejected in `extract_path_from_line`
  - **SEC-4 MED**: `sanitize_error_chain` in `auto_link_warnings` (Wave 9 SEC-H3 regression closed)
  - **CODE-2 MED**: `_field_warnings` consistency across all 3 `discover_*` tools
  - **CODE-4 / ARCH-2 MED**: proper DTO fields for `auto_linked` / `auto_link_warnings` (JsonSchema contract restored)
  - **CODE-7 LOW**: `target_status` trim + lowercase normalization

### New methodology doc
- `dfdc7a3` `docs/methodology/CROSS-REPO-WORKFLOW.ru.md` — protocol for coordinating issues/fixes across the ForgePlan multi-repo org

### Release prep
- `9d1b1d1` v0.32.0 version bump + CHANGELOG entry

## Deferred to v0.33 (tracked as GitHub issues)

- #296 — Architectural debt (ARCH-1/3/4/5/6/7)
- #297 — Security follow-ups (SEC-5/6 LOW)
- #298 — Code quality edge cases (CODE-5/6/8/9/10/11)

## Cross-repo follow-ups

- ForgePlan/marketplace#86 — docs cleanup after #292 closure

## Backward compatibility

- All 4 backward-compat audits passed: #291 (legacy `apply_restore` unchanged), #292 (legacy `status` field kept), #293 (parser handles both old bullet-list and new table form), #295 (DTO fields use `skip_serializing_if`, existing consumers see same shape)
- `c45_forgeplan_discover_finding_smoke` + `c46_forgeplan_discover_complete_smoke` (existing tests reading `resp["status"]`) — both PASS

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets --features test-helpers -- -D warnings` — clean
- [x] `cargo test --workspace --features test-helpers --no-fail-fast` — **2751 PASS / 0 FAIL**
- [x] `scripts/smoke-test.sh` on release binary — PASS (real-CLI E2E)
- [x] Manual CLI dogfood of #294 activate redirect — PASS
- [x] Integration tests T14×4 for #295 auto-link — PASS

## Pipeline

```
2751 tests PASS / 0 FAIL
cargo clippy: clean
cargo fmt: clean
real-CLI smoke: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
