### PR TITLE
chore(security): bump devalue 5.6.4 → 5.8.1 (GHSA-77vg-94rm-hx3p)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4420,9 +4420,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {


### PR DESCRIPTION
## Summary

Closes Dependabot alert **#33** (HIGH severity, GHSA-77vg-94rm-hx3p):
`devalue` 5.6.3..=5.8.0 has a DoS via sparse-array deserialization.
Patched in 5.8.1.

`npm update devalue` bumps the lockfile cleanly from 5.6.4 → 5.8.1
without touching `package.json` semver ranges. Post-update `npm audit`
reports 0 vulnerabilities.

## Impact

`devalue` is pulled in by `website/` (Astro/React) — NOT by the
forgeplan CLI/MCP binaries:

```
website/
├─ @astrojs/react@5.0.2 → devalue@^5.6.3
└─ astro@6.1.10 → devalue@^5.6.3
```

The exploit surface is limited to:
- build-time crash on malicious input (we control all inputs)
- client-side crash on payloads we serialize (same — we control them)

There is no exposed network endpoint that deserializes untrusted user
input via devalue in our deployment.

## Test plan
- [x] `npm update devalue` succeeds, lockfile cleanly diffs
- [x] `npm audit` post-update: 0 vulnerabilities
- [ ] CI green on this branch
- [ ] Website builds (Astro CI)

## Bypass justification
`FORGEPLAN_SKIP_EVIDENCE=1` — this is a dependency bump per RED-LINE #10
(Dependabot triage at release time), not a feature with linked artifact.
Tracked in the v0.32.0 release Dependabot triage write-up (see release
PR body when opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)