### PR TITLE
chore(post-v0.32): protocol followup — CLAUDE/README counts + Dependabot triage + EVID-132

### DIFF
--- a/.forgeplan/evidence/EVID-132-prob-074-adi-verdict-live-reproducer-phantom-hypothesis-refuted-retry-rate-limit-approach-confirmed.md
+++ b/.forgeplan/evidence/EVID-132-prob-074-adi-verdict-live-reproducer-phantom-hypothesis-refuted-retry-rate-limit-approach-confirmed.md
@@ -1,0 +1,89 @@
+---
+depth: tactical
+id: EVID-132
+kind: evidence
+links:
+- target: PROB-074
+  relation: informs
+status: active
+title: PROB-074 ADI verdict + live reproducer — phantom hypothesis refuted, retry+rate-limit approach confirmed
+---
+
+# EVID-132: PROB-074 ADI verdict + live reproducer — phantom hypothesis refuted, retry+rate-limit approach confirmed
+
+| Field | Value |
+|-------|-------|
+| Status | Draft |
+| Created | 2026-05-21 |
+| Valid Until | 2026-08-21 |
+| Target | PROB-074 (MCP stale lance handle), architect Concern #4 (phantom hypothesis) |
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: audit
+
+## Measurement
+
+During v0.32.0 hardening sprint adversarial audit (2026-05-21), the architect-reviewer raised Concern #4: "PROB-074 may not fire in production — LanceDB itself auto-recovers manifests on drop+reinit. Retry budget is exercised only by synthetic-error tests." The architect recommended running ADI on PROB-074 to validate "real vs phantom" before tagging v0.32.0.
+
+Two independent pieces of evidence resolve the question.
+
+### Live reproducer (during this very sprint)
+
+While preparing to invoke ADI via MCP (`mcp__forgeplan__forgeplan_reason PROB-074`), the call **failed with the exact PROB-074 signature**:
+
+```
+lance error: Not found:
+  Users/explosovebit/Work/ForgePlan/.forgeplan/lance/artifacts.lance/data/110100000011111100101011af7a4f4bc4819b87e84e835bd2.lance
+```
+
+The MCP server (started earlier in the session) held a Dataset handle pinned to a manifest fragment UUID `110100…` that no longer exists on disk — exactly the failure mode PROB-074 describes. CLI `forgeplan reason PROB-074` worked transparently (fresh connection per process), validating the ADR-003 file-first invariant rescued the workflow. The orchestrator was forced to fall back to CLI to complete the ADI cycle.
+
+This is not a synthetic reproducer. It happened to a 5-agent multi-worker sprint mid-run.
+
+### ADI cycle output (gemini/gemini-3-flash-preview)
+
+Three hypotheses generated; ADI synthesised a recommendation that **directly matches the W2 fix architecture**:
+
+| ADI element | W2 implementation |
+|-------------|-------------------|
+| H1: "Reactive Lazy Re-open — catch LanceDB 'NotFound' errors at storage driver level, invalidate cached handle, retry once" | `is_stale_manifest_error` + `with_retry_on_stale` retry loop |
+| H2: "Proactive Version Validation — lightweight version check before tool execution" | `refresh()` pre-flight `try_join!(version())` on all tables |
+| TTL debounce for performance (PROB-073 trade-off) | `last_refresh_ms: AtomicI64` + `REFRESH_DEBOUNCE_MS = 250ms` |
+| "If 'Not found' encountered, force hard re-open" | `MutationError::RetryExhausted` + N=3 attempts |
+
+ADI confidence: **High**. Recommendation quote: "Reactive Refresh strategy (Hybrid of H1 and H2). The StorageDriver should perform a version check (H2) but only if the cached handle is older than a specific TTL (e.g., 5 seconds) to satisfy PROB-073. Additionally, wrap all LanceDB calls in a recovery block (H1) that forces a hard re-open if a 'Not found' error is encountered."
+
+Our debounce is 250ms vs ADI's suggested 5s — direction correct, magnitude tighter (because our PROB-074 reproducer triggers under second-scale reindex churn, not 5s+ scenarios).
+
+## Result
+
+**Architect Concern #4 (phantom hypothesis) is refuted by two independent signals:**
+
+1. **Live in-session reproducer**: same MCP daemon, same UUID-missing failure, while the architect's hypothesis claimed this couldn't happen.
+2. **ADI verdict**: independent LLM reasoning over hypotheses arrives at exactly the H1+H2 hybrid we shipped, with high confidence.
+
+The "PROB-074 is phantom" claim was probably grounded in W2's note that the existing integration test `stale_handle_auto_recovers_after_external_reindex` passes without `is_stale_manifest_error` being called. That observation is real but its scope is narrower than the audit inferred: the integration test uses `rm -rf lance && LanceStore::init` (full directory destruction + recreate), which LanceDB does auto-recover. The real-world failure mode is more subtle — manifest version skew with fragments-on-disk-but-not-in-manifest — and that path is exactly what triggered the live reproducer above.
+
+## Interpretation
+
+Ship W2 as-is. The retry budget + rate-limit + downcast are not over-engineering — they're the architecturally validated answer to a verified production failure. The architect's secondary recommendation (add real-world reproducer to E2E) is captured as PROB-075 F-6 (test gap, manifest-version skew test without rm -rf) and deferred to v0.33.
+
+Architect Concerns #2 (Wait: hint placement) and #5 (RETRY_BACKOFF_MS contradiction) — also raised by the code-reviewer at line-level — were closed inline by the second coder pass on commit `1e04f22`.
+
+## Congruence Level Justification
+
+CL3 — same context (forgeplan MCP daemon, same workspace, same Lance backend, same v0.32 sprint), same observation (PROB-074 reproducer), same artifact subject (stale-manifest recovery). The signals are independent (live failure + LLM reasoning) but the context is identical.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|----------|----------|
+| PROB-074 | informs (this evidence supports the PROB-074 fix architecture) |
+| PROB-075 | informs (F-6 manifest-version-skew test gap deferred to v0.33) |
+| ADR-003 | informs (file-first invariant rescued the workflow during the live reproducer — CLI worked while MCP failed) |
+
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,16 +86,18 @@ semantic search via BGE-M3, typed links, lifecycle with validation gates.
 
 ## Current status
 
-- **v0.31.0** (2026-05-13) — Wave 9 polish: 19-finding adversarial audit
-  closure. SEC-C1+C2 input gate (`validate_title` lifted to core, gated at all
-  4 mutation paths — CLI new/update + MCP new/update). SEC-H1 output gate
-  (`sanitize_for_hint` on 8 CLI command print sites, completes LOG-001 from
-  v0.30). SEC-H2 HOME sanitiser bare-string masking. SEC-H3 MCP error chain
-  sanitisation across 40+ `McpError::internal_error` sites. ARCH-C1
-  `health_report_to_json` helper extract — single source of truth for
-  CLI/MCP wire shape. PROB-051 closed end-to-end (R_eff=0.80 grade B).
-- **76 CLI commands**, **73 MCP tools**, **3009 tests**, **0 warnings** on both feature configs
-- **EPIC-001/002/003 ✅**. Phase 5 (Desktop Tauri) — backlog
+- **v0.32.0** (2026-05-21) — Epic #287 brownfield extraction surface (6 new
+  ArtifactKinds: use_case/glossary/invariant/scenario/hypothesis/domain_model,
+  7 new MCP tools, hypothesis state machine, ADR-014 catalog evolution policy)
+  + 3 pre-Epic methodology issues (#286 forgeplan_unlink, #288 auto-activate
+  evidence + stale_drafts health surface, #289 forgeplan_anomalies + v1 catalog
+  of 9 anomaly kinds) + 6 dogfood findings (#290-#295) + post-merge hardening
+  (PROB-074 MCP stale lance handle: lazy refresh + retry budget + rate-limit
+  + lancedb downcast hint, fixed in PR #309; docs drift #306 81→73 MCP tools;
+  PROB-075 F-2/F-3/F-4 audit follow-ups). Dependabot triage: devalue HIGH
+  addressed (5.6.4→5.8.1), lru LOW accepted-with-justification.
+- **76 CLI commands**, **73 MCP tools**, **3084 tests**, **0 warnings** on both feature configs
+- **EPIC-001/002/003 ✅**, **Epic #287 ✅** (brownfield). Phase 5 (Desktop Tauri) — backlog
 - FPF KB semantic search via BGE-M3 (feature-gated, graceful fallback)
 
 Details: `TODO.md` (priorities), `CHANGELOG.md` (history), `docs/ROADMAP.md` (gap analysis).

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ Three entry points — pick the one that matches what you need right now.
 
 <table>
 <tr>
-<td align="center"><b>327</b><br>tracked artifacts</td>
-<td align="center"><b>2724</b><br>tests passing</td>
+<td align="center"><b>341</b><br>tracked artifacts</td>
+<td align="center"><b>3084</b><br>tests passing</td>
 <td align="center"><b>76</b><br>CLI commands</td>
-<td align="center"><b>72</b><br>MCP tools</td>
+<td align="center"><b>73</b><br>MCP tools</td>
 </tr>
 </table>
 

--- a/docs/operations/dependabot-triage-2026-05-21.md
+++ b/docs/operations/dependabot-triage-2026-05-21.md
@@ -1,0 +1,68 @@
+# Dependabot triage — 2026-05-21 (v0.32.0 release window)
+
+Per RED-LINE #10 (CLAUDE.md): each release tags every open Dependabot alert as **addressed** / **scheduled** / **accepted-with-justification**. Following the `docs/operations/RELEASE-PROTOCOL.ru.md` step-4 contract.
+
+## Snapshot at release time
+
+`gh api repos/ForgePlan/forgeplan/dependabot/alerts --jq '[.[] | select(.state == "open")]'`
+
+| # | Severity | Package | Ecosystem | GHSA | Range |
+|---|----------|---------|-----------|------|-------|
+| 33 | HIGH | `devalue` | npm | GHSA-77vg-94rm-hx3p | 5.6.3..=5.8.0 → 5.8.1 |
+| 3  | LOW  | `lru`     | rust | GHSA-rhfx-m35p-ff5j | < 0.16.3 |
+
+## Per-alert verdict
+
+### #33 — `devalue` (HIGH) — **addressed**
+
+GHSA-77vg-94rm-hx3p — Svelte `devalue` DoS via sparse-array deserialization.
+
+**Action**: bumped `devalue` 5.6.4 → 5.8.1 via lockfile-only update on PR #302 (commit `82d4634`, merged 2026-05-21 04:43 UTC).
+
+**Verification**:
+```bash
+cd website
+npm ls devalue
+# → @astrojs/react@5.0.2 → devalue@5.8.1
+# → astro@6.1.10 → devalue@5.8.1
+npm audit
+# → 0 vulnerabilities
+```
+
+**Impact assessment** (why not BLOCKER for production binaries):
+- `devalue` is a transitive of Astro (`@astrojs/react`, `astro`). Lives only in `website/` — the static documentation portal.
+- The Rust CLI/MCP binaries do not include any JavaScript runtime — `devalue` is not in the production binary's dependency tree.
+- The exploit surface is limited to: (a) build-time crash on malicious input (we control all build inputs), and (b) client-side crash on payloads we serialize (same — we control them).
+- No exposed network endpoint deserializes untrusted user input via `devalue` in our deployment.
+
+**Severity rating HIGH** reflects the upstream advisory; in our deployment context the practical impact is LOW. The bump is shipped regardless because the patched version is freely available and the lockfile bump is risk-free.
+
+**Auto-close timeline**: GitHub Dependabot will auto-close alert #33 once it re-scans `main` (post-PR-#310 merge, post-PR-#311 sync). Typically within 1-4 hours of `main` HEAD movement.
+
+### #3 — `lru` (LOW) — **accepted-with-justification**
+
+GHSA-rhfx-m35p-ff5j — `IterMut` violates Stacked Borrows by invalidating internal pointer. Affects `lru < 0.16.3`.
+
+**Action**: deferred to v0.33+, same posture as documented in v0.28.0 / v0.29.0 / v0.30.0 / v0.31.0 release notes.
+
+**Transitive chain**:
+```
+forgeplan-core → lancedb 0.27.2 → lance 4.0.0 → tantivy 0.24.2 → lru 0.12.5
+```
+
+`cargo update -p lru` is a no-op: tantivy 0.24.2 pins `lru = "^0.12"`. Direct upgrade to 0.16.3 requires bumping tantivy major, which cascades into Lance / LanceDB upgrades — out of scope for a v0.32.x patch release.
+
+**Impact in our context is LOW**:
+- Stacked Borrows violations surface as undefined behaviour only under strict aliasing analysis (Miri / asan), not in normal optimized builds.
+- The vulnerable code path (`IterMut` on LRU cache) is internal to tantivy's caching layer — never reached by forgeplan user input.
+- No remote-trigger surface: forgeplan is local-first CLI/MCP, no untrusted-input network endpoint.
+
+**Tracking**: tied to LanceDB upgrade work for v0.33 (when transitive can be bumped to a tantivy version that pins `lru = "^0.16"`).
+
+## Cross-reference
+
+- CHANGELOG.md v0.32.0 `### Security (RED-LINE #10 compliance)` section
+- PR #302 commit `82d4634` — devalue bump
+- PR #310 — v0.32.0 release
+- `docs/operations/RELEASE-PROTOCOL.ru.md` § Common pitfalls → "Dependabot alerts on release time"
+- Prior triages: `dependabot-triage-2026-05-02.md`, `-05-03.md`, `-05-05.md`


### PR DESCRIPTION
## Summary

Three post-release hygiene items caught against canonical `docs/operations/RELEASE-PROTOCOL.ru.md` after v0.32.0 shipped:

1. **CLAUDE.md `Current status`** — refreshed from stale v0.31.0 banner to v0.32.0 (test count 3009 → 3084)
2. **README.md dogfood table** — artefacts 327→341, tests 2724→3084, MCP tools 72→73
3. **`docs/operations/dependabot-triage-2026-05-21.md`** — required per RED-LINE #10 (prior triages exist for -05-02, -05-03, -05-05)
4. **EVID-132** — created via CLI during PROB-074 sprint, untracked in working tree until now

## Protocol audit findings (next release)

Two compliance gaps caught:
- **Missed Step 3**: didn't run `forgeplan release-notes --since v0.31.0` to seed CHANGELOG. Next release: always start from tool output.
- **Missed Step 9 verification**: didn't verify cargo-dist Release workflow trigger before opening sync-PR. Next release: `gh run list --workflow=Release --event=push` first.

## Bypass justification

`FORGEPLAN_SKIP_EVIDENCE=1` — doc-only PR (markdown + 1 evidence file that was the evidence). All artifact references resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)