### PR TITLE
release: v0.32.1 — hotfix Windows build (tera/walkdir/globset cfg(unix) regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-05-21
+
+**Hotfix release.** v0.32.0 shipped with a Cargo.toml regression that prevented Windows binary publication via cargo-dist. macOS / Linux binaries also did not publish because cargo-dist exits the entire workflow when any target fails. No semantic / behaviour changes — purely a build-time dependency placement fix.
+
+### Fixed
+
+- **Windows build** — `tera` / `walkdir` / `globset` were accidentally placed inside the `[target.'cfg(unix)'.dependencies]` block (commit `a3b6ed3` audit-r3 closure on 2026-05-20 when adding `libc` for `O_NOFOLLOW`). The three crates are cross-platform and used unconditionally in `src/ingest/` and `src/projection/`. Moved back into the canonical `[dependencies]` block; only `libc = "0.2"` remains unix-gated. cargo-dist v0.32.0 Release workflow failed with 20 `error[E0432]/E0433]` "cannot find module or crate" errors on `x86_64-pc-windows-msvc`; v0.32.1 Release workflow re-triggers and publishes all four target binaries plus the homebrew-tap formula bump.
+
+### Internal
+
+- v0.32.0 GitHub release page has zero binary assets (visible blocker). v0.32.1 supersedes it for distribution; the v0.32.0 tag remains on `main` as the canonical commit but should not be referenced for installation. Users on Homebrew get the upgrade once cargo-dist updates `ForgePlan/homebrew-tap` Formula/forgeplan.rb (automated, no human intervention).
+- Catch-up doc updates from PR #317 (was on `dev` only): CLAUDE.md `Current status` refreshed to v0.32 banner; README dogfood table refreshed to current counts.
+
 ## [0.32.0] - 2026-05-20
 
 Sprint headline: **Epic #287 brownfield extraction surface + 3 pre-Epic issues (#286/#288/#289) + 6 dogfood-discovered issues, closed inline across multiple adversarial audit rounds.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,16 +86,20 @@ semantic search via BGE-M3, typed links, lifecycle with validation gates.
 
 ## Current status
 
-- **v0.31.0** (2026-05-13) — Wave 9 polish: 19-finding adversarial audit
-  closure. SEC-C1+C2 input gate (`validate_title` lifted to core, gated at all
-  4 mutation paths — CLI new/update + MCP new/update). SEC-H1 output gate
-  (`sanitize_for_hint` on 8 CLI command print sites, completes LOG-001 from
-  v0.30). SEC-H2 HOME sanitiser bare-string masking. SEC-H3 MCP error chain
-  sanitisation across 40+ `McpError::internal_error` sites. ARCH-C1
-  `health_report_to_json` helper extract — single source of truth for
-  CLI/MCP wire shape. PROB-051 closed end-to-end (R_eff=0.80 grade B).
-- **76 CLI commands**, **73 MCP tools**, **3009 tests**, **0 warnings** on both feature configs
-- **EPIC-001/002/003 ✅**. Phase 5 (Desktop Tauri) — backlog
+- **v0.32.1** (2026-05-21) — hotfix: Windows binary build (tera/walkdir/globset
+  moved out of cfg(unix)). v0.32.0 shipped on 2026-05-21 with Epic #287
+  brownfield extraction surface (6 new ArtifactKinds: use_case/glossary/
+  invariant/scenario/hypothesis/domain_model, 7 new MCP tools, hypothesis
+  state machine, ADR-014 catalog evolution policy) + 3 pre-Epic methodology
+  issues (#286 forgeplan_unlink, #288 auto-activate evidence + stale_drafts
+  health surface, #289 forgeplan_anomalies + v1 catalog of 9 anomaly kinds)
+  + 6 dogfood findings (#290-#295) + post-merge hardening (PROB-074 MCP
+  stale lance handle: lazy refresh + retry budget + rate-limit + lancedb
+  downcast hint; docs drift #306 81→73 MCP tools; PROB-075 F-2/F-3/F-4
+  audit follow-ups). Dependabot: devalue HIGH addressed (5.6.4→5.8.1),
+  lru LOW accepted-with-justification.
+- **76 CLI commands**, **73 MCP tools**, **3084 tests**, **0 warnings** on both feature configs
+- **EPIC-001/002/003 ✅**, **Epic #287 ✅** (brownfield). Phase 5 (Desktop Tauri) — backlog
 - FPF KB semantic search via BGE-M3 (feature-gated, graceful fallback)
 
 Details: `TODO.md` (priorities), `CHANGELOG.md` (history), `docs/ROADMAP.md` (gap analysis).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ Three entry points — pick the one that matches what you need right now.
 
 <table>
 <tr>
-<td align="center"><b>327</b><br>tracked artifacts</td>
-<td align="center"><b>2724</b><br>tests passing</td>
+<td align="center"><b>341</b><br>tracked artifacts</td>
+<td align="center"><b>3084</b><br>tests passing</td>
 <td align="center"><b>76</b><br>CLI commands</td>
-<td align="center"><b>72</b><br>MCP tools</td>
+<td align="center"><b>73</b><br>MCP tools</td>
 </tr>
 </table>
 

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -18,8 +18,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.1" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -34,14 +34,20 @@ rand = "0.9"
 fs2.workspace = true
 schemars.workspace = true
 semver.workspace = true
-# Audit-r3 M4 closure — O_NOFOLLOW flag for the anomalies-journal
-# tempfile open so a pre-created symlink with workspace-write access
-# cannot redirect our write to a sibling target.
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
 tera.workspace = true
 walkdir.workspace = true
 globset.workspace = true
+
+# Audit-r3 M4 closure — O_NOFOLLOW flag for the anomalies-journal
+# tempfile open so a pre-created symlink with workspace-write access
+# cannot redirect our write to a sibling target.
+# v0.32.1 hotfix: ONLY libc is unix-gated. Previously (commit a3b6ed3)
+# `tera` / `walkdir` / `globset` were accidentally placed inside this
+# block, breaking Windows compilation (cargo-dist v0.32.0 Release
+# workflow exited with 20 E0432/E0433 errors). They are cross-platform
+# crates used unconditionally in `src/ingest/` and `src/projection/`.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [features]
 default = []

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
 rmcp = { version = "1.7", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0", features = ["test-helpers"] }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1", features = ["test-helpers"] }
 tempfile = "3"
 serde_yaml.workspace = true
 # Phase 2.4: enable the rmcp `client` role for E2E integration tests so we


### PR DESCRIPTION
## Summary

v0.32.0 cargo-dist Release workflow failed on Windows (`x86_64-pc-windows-msvc`) with 20 compile errors. GitHub release page has 0 binary assets; homebrew-tap formula still references v0.31.0. This PR ships v0.32.1 hotfix.

**Root cause**: commit `a3b6ed3` (audit-r3 closure on 2026-05-20) introduced `[target.'cfg(unix)'.dependencies]` for `libc = "0.2"` (needed for `O_NOFOLLOW` in the anomalies-journal tempfile open — Audit-r3 M4). The block placement accidentally captured `tera` / `walkdir` / `globset`, which are cross-platform crates used unconditionally in `src/ingest/` and `src/projection/`. macOS / Linux runners passed locally because `cfg(unix)` evaluated true; Windows runner saw the deps as missing.

## Changes

| File | Change |
|---|---|
| `crates/forgeplan-core/Cargo.toml` | Move `tera` / `walkdir` / `globset` back to `[dependencies]`. Only `libc = "0.2"` stays `cfg(unix)`. Inline comment explains the regression so future contributors don't repeat. |
| `Cargo.toml` | `workspace.package.version` 0.32.0 → 0.32.1 |
| `crates/forgeplan-cli/Cargo.toml` | 2 intra-workspace path-version refs bumped |
| `crates/forgeplan-mcp/Cargo.toml` | 2 intra-workspace path-version refs bumped (dependencies + dev-dependencies) |
| `Cargo.lock` | Regenerated by `cargo check` |
| `CHANGELOG.md` | New `[0.32.1] - 2026-05-21` section explaining hotfix |
| `CLAUDE.md` | `Current status` refreshed (v0.31.0 → v0.32.1 banner with full v0.32.x summary, 3009 → 3084 tests) |
| `README.md` | Dogfood table refreshed (327 → 341 artifacts, 2724 → 3084 tests, 72 → 73 MCP tools) — catch-up from PR #317 which only landed on dev |

## Pipeline gate (local)

- `cargo check --workspace --all-targets`: PASS (0 warnings, 0.32.1 across all crates)
- No semantic / behaviour changes — purely Cargo.toml dependency placement
- 3084 existing tests unchanged

## Post-merge steps

1. Tag `v0.32.1` on the merge SHA
2. cargo-dist Release workflow re-runs all 4 targets (macOS aarch64+x86_64, Linux aarch64+x86_64, Windows x86_64)
3. GitHub release v0.32.1 created with binary assets
4. `ForgePlan/homebrew-tap` Formula updated to v0.32.1 (cargo-dist automated)
5. Sync PR `main → dev`

## Test plan

- [ ] CI green
- [ ] User approves merge
- [ ] cargo-dist Release workflow succeeds на all 4 targets
- [ ] GitHub release v0.32.1 has all artifacts
- [ ] `brew upgrade forgeplan` resolves to v0.32.1

## Bypass justification

`FORGEPLAN_SKIP_EVIDENCE=1` — release-flavoured hotfix PR. All referenced artifacts (PROB-074 / EVID-131 / EVID-132 / etc.) have evidence at their own files; this PR just fixes Cargo.toml + bumps versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)