### PR TITLE
chore(sync): main → dev after v0.32.1 hotfix

### DIFF
--- a/.github/workflows/assign-id.yml
+++ b/.github/workflows/assign-id.yml
@@ -37,7 +37,7 @@ jobs:
       DRY_RUN_MODE: ${{ github.event.inputs.dry-run-only || false }}
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
@@ -135,7 +135,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && failure() && env.DRY_RUN_MODE != 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.0.2
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || (github.base_ref == 'main' && !startsWith(github.head_ref, 'release/')))
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
         with:
           fetch-depth: 0  # Full history for git diff to work correctly
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Check Rust enum vs bash validator drift
         run: |
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Run validator audit on workspace
         run: |
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -194,7 +194,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (pinned)
@@ -234,7 +234,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9  # v2.33.60
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468  # v2.33.60
         with:
           tool: cargo-nextest
 
@@ -258,7 +258,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (pinned)
@@ -304,7 +304,7 @@ jobs:
 
       - name: Upload smoke logs on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: smoke-test-logs
           path: /tmp/forgeplan-smoke-*

--- a/.github/workflows/forgeplan-health.yml
+++ b/.github/workflows/forgeplan-health.yml
@@ -12,7 +12,7 @@ jobs:
     name: Forgeplan Health Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.1.7
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable (pinned)
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload bench output as artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: perf-output-${{ github.sha }}
           path: target/perf-output/bench.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -131,7 +131,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -166,7 +166,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -183,19 +183,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -213,7 +213,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           name: artifacts-build-global
           path: |
@@ -233,19 +233,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -258,14 +258,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.8.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.8.0
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           pattern: artifacts-*
           path: artifacts
@@ -298,14 +298,14 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: true
           repository: "ForgePlan/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.10.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4.10.0
         with:
           pattern: artifacts-*
           path: Formula/
@@ -345,7 +345,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
     # here; that suppresses the job exit and makes the security badge green
     # even when cargo-deny reports a real advisory failure.
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.0.0
       - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1  # v2.0.18
         with:
           command: check advisories licenses bans sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-05-21
+
+**Hotfix release.** v0.32.0 shipped with a Cargo.toml regression that prevented Windows binary publication via cargo-dist. macOS / Linux binaries also did not publish because cargo-dist exits the entire workflow when any target fails. No semantic / behaviour changes — purely a build-time dependency placement fix.
+
+### Fixed
+
+- **Windows build** — `tera` / `walkdir` / `globset` were accidentally placed inside the `[target.'cfg(unix)'.dependencies]` block (commit `a3b6ed3` audit-r3 closure on 2026-05-20 when adding `libc` for `O_NOFOLLOW`). The three crates are cross-platform and used unconditionally in `src/ingest/` and `src/projection/`. Moved back into the canonical `[dependencies]` block; only `libc = "0.2"` remains unix-gated. cargo-dist v0.32.0 Release workflow failed with 20 `error[E0432]/E0433]` "cannot find module or crate" errors on `x86_64-pc-windows-msvc`; v0.32.1 Release workflow re-triggers and publishes all four target binaries plus the homebrew-tap formula bump.
+
+### Internal
+
+- v0.32.0 GitHub release page has zero binary assets (visible blocker). v0.32.1 supersedes it for distribution; the v0.32.0 tag remains on `main` as the canonical commit but should not be referenced for installation. Users on Homebrew get the upgrade once cargo-dist updates `ForgePlan/homebrew-tap` Formula/forgeplan.rb (automated, no human intervention).
+- Catch-up doc updates from PR #317 (was on `dev` only): CLAUDE.md `Current status` refreshed to v0.32 banner; README dogfood table refreshed to current counts.
+
 ## [0.32.0] - 2026-05-20
 
 Sprint headline: **Epic #287 brownfield extraction surface + 3 pre-Epic issues (#286/#288/#289) + 6 dogfood-discovered issues, closed inline across multiple adversarial audit rounds.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,16 +86,20 @@ semantic search via BGE-M3, typed links, lifecycle with validation gates.
 
 ## Current status
 
-- **v0.31.0** (2026-05-13) — Wave 9 polish: 19-finding adversarial audit
-  closure. SEC-C1+C2 input gate (`validate_title` lifted to core, gated at all
-  4 mutation paths — CLI new/update + MCP new/update). SEC-H1 output gate
-  (`sanitize_for_hint` on 8 CLI command print sites, completes LOG-001 from
-  v0.30). SEC-H2 HOME sanitiser bare-string masking. SEC-H3 MCP error chain
-  sanitisation across 40+ `McpError::internal_error` sites. ARCH-C1
-  `health_report_to_json` helper extract — single source of truth for
-  CLI/MCP wire shape. PROB-051 closed end-to-end (R_eff=0.80 grade B).
-- **76 CLI commands**, **73 MCP tools**, **3009 tests**, **0 warnings** on both feature configs
-- **EPIC-001/002/003 ✅**. Phase 5 (Desktop Tauri) — backlog
+- **v0.32.1** (2026-05-21) — hotfix: Windows binary build (tera/walkdir/globset
+  moved out of cfg(unix)). v0.32.0 shipped on 2026-05-21 with Epic #287
+  brownfield extraction surface (6 new ArtifactKinds: use_case/glossary/
+  invariant/scenario/hypothesis/domain_model, 7 new MCP tools, hypothesis
+  state machine, ADR-014 catalog evolution policy) + 3 pre-Epic methodology
+  issues (#286 forgeplan_unlink, #288 auto-activate evidence + stale_drafts
+  health surface, #289 forgeplan_anomalies + v1 catalog of 9 anomaly kinds)
+  + 6 dogfood findings (#290-#295) + post-merge hardening (PROB-074 MCP
+  stale lance handle: lazy refresh + retry budget + rate-limit + lancedb
+  downcast hint; docs drift #306 81→73 MCP tools; PROB-075 F-2/F-3/F-4
+  audit follow-ups). Dependabot: devalue HIGH addressed (5.6.4→5.8.1),
+  lru LOW accepted-with-justification.
+- **76 CLI commands**, **73 MCP tools**, **3084 tests**, **0 warnings** on both feature configs
+- **EPIC-001/002/003 ✅**, **Epic #287 ✅** (brownfield). Phase 5 (Desktop Tauri) — backlog
 - FPF KB semantic search via BGE-M3 (feature-gated, graceful fallback)
 
 Details: `TODO.md` (priorities), `CHANGELOG.md` (history), `docs/ROADMAP.md` (gap analysis).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -5130,9 +5130,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.11.1",
  "getopts",
@@ -5608,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5631,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -6751,9 +6751,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
  "petgraph",
  "proptest",
  "pulldown-cmark",
- "rand 0.8.6",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ Three entry points — pick the one that matches what you need right now.
 
 <table>
 <tr>
-<td align="center"><b>327</b><br>tracked artifacts</td>
-<td align="center"><b>2724</b><br>tests passing</td>
+<td align="center"><b>341</b><br>tracked artifacts</td>
+<td align="center"><b>3084</b><br>tests passing</td>
 <td align="center"><b>76</b><br>CLI commands</td>
-<td align="center"><b>72</b><br>MCP tools</td>
+<td align="center"><b>73</b><br>MCP tools</td>
 </tr>
 </table>
 

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -18,8 +18,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.1" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -30,7 +30,7 @@ fastembed = { version = "5", optional = true }
 bm25 = { version = "2.3.2", features = ["language_detection"] }
 sha2 = "0.10"
 tracing = "0.1"
-rand = "0.8"
+rand = "0.9"
 fs2.workspace = true
 schemars.workspace = true
 semver.workspace = true

--- a/crates/forgeplan-core/Cargo.toml
+++ b/crates/forgeplan-core/Cargo.toml
@@ -34,14 +34,20 @@ rand = "0.9"
 fs2.workspace = true
 schemars.workspace = true
 semver.workspace = true
-# Audit-r3 M4 closure — O_NOFOLLOW flag for the anomalies-journal
-# tempfile open so a pre-created symlink with workspace-write access
-# cannot redirect our write to a sibling target.
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
 tera.workspace = true
 walkdir.workspace = true
 globset.workspace = true
+
+# Audit-r3 M4 closure — O_NOFOLLOW flag for the anomalies-journal
+# tempfile open so a pre-created symlink with workspace-write access
+# cannot redirect our write to a sibling target.
+# v0.32.1 hotfix: ONLY libc is unix-gated. Previously (commit a3b6ed3)
+# `tera` / `walkdir` / `globset` were accidentally placed inside this
+# block, breaking Windows compilation (cargo-dist v0.32.0 Release
+# workflow exited with 20 E0432/E0433 errors). They are cross-platform
+# crates used unconditionally in `src/ingest/` and `src/projection/`.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [features]
 default = []

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [dependencies]
 forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
-rmcp = { version = "1.2", features = ["server", "transport-io"] }
+rmcp = { version = "1.7", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
 serde_json.workspace = true
@@ -41,7 +41,7 @@ serde_yaml.workspace = true
 # call_tool) over `tokio::io::duplex`. The runtime crate keeps only the
 # server feature; this dev-only addition gives `()` the `Service<RoleClient>`
 # impl needed by `ServiceExt::serve(transport)`.
-rmcp = { version = "1.2", features = ["server", "transport-io", "client"] }
+rmcp = { version = "1.7", features = ["server", "transport-io", "client"] }
 # CR-H6 (audit closure): tag every test that mutates HOME (or PATH) with
 # `#[serial_test::serial(env_home)]` so they cannot run in parallel within
 # this test binary. NB: serial_test locks are in-process — they do NOT

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
 rmcp = { version = "1.7", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.0", features = ["test-helpers"] }
+forgeplan-core = { path = "../forgeplan-core", version = "0.32.1", features = ["test-helpers"] }
 tempfile = "3"
 serde_yaml.workspace = true
 # Phase 2.4: enable the rmcp `client` role for E2E integration tests so we


### PR DESCRIPTION
## Summary

Routine post-release sync per RED-LINE #9. Brings v0.32.1 hotfix (PR #323 `e933da8`) into dev so the next feature branch starts from the bumped version.

## Commits

- `d0a33e6` merge of PR #323 (fix/v032-1-windows-build → main)
- `e933da8` release: v0.32.1 hotfix Windows build (tera/walkdir/globset cfg(unix) regression)

## Why

- Cargo.toml workspace.version on dev was 0.32.0; without this sync, next feature PR diverges + creates Cargo.lock conflict at next release
- CHANGELOG [0.32.1] entry needs to be visible on dev for future release-notes tooling
- CLAUDE.md / README updates carried in v0.32.1 hotfix should reach dev

## Test plan

- [ ] CI green
- [ ] User merges

## Bypass justification

`FORGEPLAN_SKIP_EVIDENCE=1` — pure history transit, no new artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)