### PR TITLE
chore(website): remove GSC + CF Analytics TODOs (handled out-of-band)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -106,14 +106,7 @@ export default defineConfig({
           href: 'https://forgeplan.dev/docs/',
         },
       },
-      // 4. GSC verification placeholder — replace TODO with code from Google Search Console
-      {
-        tag: 'meta',
-        attrs: {
-          name: 'google-site-verification',
-          content: 'TODO_PASTE_GSC_VERIFICATION_CODE_HERE',
-        },
-      },
+      // GSC ownership verified via DNS TXT (Domain property covers all subdomains/protocols) — no HTML tag needed
     ],
     components: {
       // Unified Header on /docs via DocsHeader (inline content; no nested <header>).

--- a/website/src/layouts/Landing.astro
+++ b/website/src/layouts/Landing.astro
@@ -66,8 +66,7 @@ const {
     </script>
     <title>{title}</title>
     <LandingMeta title={title} description={description} lang={lang} slug={slug} />
-    <!-- Google Search Console verification — replace TODO with content from GSC -->
-    <meta name="google-site-verification" content="TODO_PASTE_GSC_VERIFICATION_CODE_HERE" />
+    {/* GSC ownership verified via DNS TXT (Domain property covers all subdomains/protocols) — no HTML tag needed */}
     <SiteJsonLd lang={lang} includeSoftware={includeSoftware} />
   </head>
   <body class="bg-forge-bg text-forge-fg font-body antialiased">
@@ -75,8 +74,6 @@ const {
       Skip to content
     </a>
     <slot />
-    <!-- Cloudflare Web Analytics — paste beacon token after enabling in CF dashboard.
-         Get it from: https://dash.cloudflare.com/?to=/:account/analytics/web -->
-    <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "TODO_PASTE_CLOUDFLARE_BEACON_TOKEN"}'></script>
+    {/* Cloudflare Web Analytics injected automatically via 'Deploy with automatic setup' at the CF edge (domain on CF), no manual beacon script needed */}
   </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up cleanup after PR #336. Removes two TODO placeholders that are not needed:

- **GSC verification meta tag** — domain forgeplan.dev verified via DNS TXT (Domain property in Google Search Console), covers all subdomains/protocols. HTML tag verification is duplicate.
- **Cloudflare Web Analytics beacon script** — domain hosted on Cloudflare; beacon injected automatically via 'Deploy with automatic setup' at the CF edge. Manual script tag is duplicate.

Both removed from Landing.astro + Starlight head[] config. Inline comments explain the out-of-band mechanism for future reference.

## Test plan

- [ ] Build passes (already verified locally: 417 pages, 12s)
- [ ] No regression in OG/canonical/hreflang (LandingMeta + SeoMeta untouched)
- [ ] After merge to main: GSC accepts sitemap submission, CF Analytics shows data within 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)