### PR TITLE
fix(website/css): restore narrow guide widths (760 / 1080)

### DIFF
--- a/website/src/styles/blog-theme.css
+++ b/website/src/styles/blog-theme.css
@@ -1937,31 +1937,19 @@ article.guide-embedded {
   min-height: calc(100vh - 200px);
 }
 
-/* === PR-2A-followup: GUIDE article width = site/footer width === */
-/*
- * Lesson <main> originally has max-width 1080px (narrower than site).
- * Override to match site footer-inner (1280 max + 32 padding = content 1216),
- * which also matches /blog and /blog/welcome content areas.
+/* GUIDE article width — defer to each lesson's inline CSS.
+ *
+ * Lesson HTMLs in /public/guides-raw/*.html ship their own max-width on
+ * <main> (1080px is the common value) and a text max-width on <p> (760px).
+ * That combination gives a readable line-length for long-form guides.
+ *
+ * An earlier override forced .guide-embedded main to 1280px and .guide-embedded
+ * p to max-width:none "to match site footer width". That produced ~1216px
+ * lines on /guides/trust-calculus-overview and other guides — way past the
+ * 45-75 char readable range. The override has been removed: lesson inline
+ * CSS now wins the cascade as originally intended. Sections that need to
+ * be full-width (.scenario, .axes, .pipeline) define their own width.
  */
-/* !important required: scoped lesson CSS loads AFTER blog-theme.css via
-   <style is:global set:html>, so its '.guide-embedded main { max-width: 1080 }'
-   would otherwise win cascade. */
-.guide-embedded main {
-  max-width: 1280px !important;
-  margin: 0 auto !important;
-  padding: 32px 32px 64px !important;
-  box-sizing: border-box !important;
-}
-
-/* Lesson text blocks: lesson originally caps p at 760px, p.lead at 820px.
-   Override to use full container width так чтобы header content of the
-   lesson (eyebrow + h1 + lead) tянутся на всю ширину блока контейнера
-   (1216 = 1280 - 2*32 padding). Body paragraphs follow same rule for
-   visual rhythm with full-width sections (.scenario, .axes, .pipeline). */
-.guide-embedded p,
-.guide-embedded p.lead {
-  max-width: none !important;
-}
 
 /* === PR-2A-followup: tester-flagged contrast fixes (WCAG AA) === */
 /* Source: agents-core:tester sub-agent visual verification report */


### PR DESCRIPTION
## Summary

Hotfix: guides like \`/guides/trust-calculus-overview\` had body paragraphs stretched to ~1216 px (way past the 45-75 char readable range), making long-form lessons hard to read.

## Root cause

A PR-2A-followup block in \`blog-theme.css\` (lines ~1940-1964) forced \`.guide-embedded main\` to \`max-width: 1280px !important\` and \`.guide-embedded p\` to \`max-width: none !important\`, overriding the per-lesson inline CSS that every file under \`public/guides-raw/*.html\` ships (1080 px main, 760 px p, 820 px p.lead).

The override was added to "match site footer width" but produced unreadable line lengths in practice.

## Fix

Removed both \`!important\` blocks. Lesson inline CSS now wins as originally intended. Full-width sections inside guides (\`.scenario\`, \`.axes\`, \`.pipeline\`) define their own width so they are unaffected.

## Verification

Playwright on \`/ru/guides/trust-calculus-overview\` after the fix:

| Element | Before | After |
|---|---|---|
| \`<main>\` | 1280 px | **1080 px** ✅ |
| body \`<p>\` | 1216 px | **760 px** ✅ |
| lead \`<p>\` | 1216 px | **820 px** ✅ |

## Test plan

- [ ] After merge + deploy: visit \`https://forgeplan.dev/ru/guides/trust-calculus-overview\` - body paragraphs are ~760 px wide, comfortable to read
- [ ] Check 2-3 other lessons (adi-overview, evidence-and-decay, fpf-overview) for same effect
- [ ] No regression on \`/guides\` index or any \`.scenario\` / \`.axes\` full-width blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)