### PR TITLE
release(website): trust-calculus deflist HTML fix + light-theme chip contrast

### DIFF
--- a/website/public/guides-raw/trust-calculus-overview.html
+++ b/website/public/guides-raw/trust-calculus-overview.html
@@ -345,7 +345,7 @@
     про нагрузку в 10 000 RPS, а у вас 50 RPS, то применимость ограничена.
   </p>
 
-  <div class="deflist">
+  <ul class="deflist">
     <li>
       <div class="def-num">CL3 · НАШ КОНТЕКСТ</div>
       <div class="def-title">Штраф: 0%</div>

--- a/website/src/styles/blog-theme.css
+++ b/website/src/styles/blog-theme.css
@@ -1972,6 +1972,32 @@ article.guide-embedded {
   color: var(--forge-fg) !important;
 }
 
+/* Light-theme contrast for hardcoded dark-only chip colors in guides.
+ * Lesson HTMLs hardcode pastel colors (#86efac green, #fca5a5 red,
+ * #fcd34d amber) on faint 12% backgrounds for .verdict / .hpill chips.
+ * Fine on dark bg, fails WCAG AA on the light cream theme.
+ * Selectors live here because embed-html.js prefixes every lesson
+ * selector with .guide-embedded, making `html.light` unreachable from
+ * inside a lesson. From this file the prefix is not applied. */
+html.light .guide-embedded .verdict.supports,
+html.light .guide-embedded .hpill.h3 {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+html.light .guide-embedded .verdict.refutes,
+html.light .guide-embedded .hpill.h1 {
+  background: rgba(239, 68, 68, 0.18);
+  color: #991b1b;
+}
+html.light .guide-embedded .verdict.weakens {
+  background: rgba(245, 158, 11, 0.18);
+  color: #92400e;
+}
+html.light .guide-embedded .hpill.h2 {
+  background: rgba(115, 115, 115, 0.18);
+  color: #404040;
+}
+
 /* ISSUE 3 - Ember text links + eyebrow on LIGHT background (2.85:1 → 4.6:1) */
 html.light .guide-embedded a,
 html.light .guide-embedded .eyebrow {


### PR DESCRIPTION
## Summary

Release PR \`dev -> main\` carrying the 2 hotfix commits merged into dev via PR #349.

### What ships

1. **HTML fix on /guides/trust-calculus-overview** - opening tag changed from \`<div class="deflist">\` to \`<ul class="deflist">\` so it matches the closing \`</ul>\`. Browsers were silently dropping the orphan \`</ul>\` and absorbing every element after the last \`<li>\` (formula paragraph, separator, "Простой пример" h2, case study, table, everything down to the closing block) into the 3-column \`.deflist\` CSS grid - that's what made the page look like it was breaking down columns from "Финальная формула" onward.

2. **Light-theme chip contrast in guides** - lesson HTMLs hardcoded pastel chip colors (#86efac green, #fca5a5 red, #fcd34d amber) that work on dark bg only. Same chips on the light cream bg read at ~1.6:1 contrast ratio (WCAG AA needs 4.5:1). Added \`html.light\` overrides in blog-theme.css with darker variants (forest green, dark red, burnt amber, dark gray) - now ~7.5:1.

### Commits

\`\`\`
b98c7f7 Merge pull request #349 from ForgePlan/fix/deflist-html-tag
63031b0 fix(website/css): light-theme contrast for .verdict and .hpill chips in guides
31577b4 fix(website/guides): close deflist with </ul> (was <div>) on trust-calculus
\`\`\`

## Test plan (after merge + deploy)

- [ ] \`git checkout main && git pull && cd website && npm run build && npx wrangler pages deploy dist --project-name=forgeplan --branch=main\`
- [ ] Visit \`https://forgeplan.dev/ru/guides/trust-calculus-overview\` - CL3/CL2/CL1/CL0 cards remain in a 3-column grid, the "Финальная формула" paragraph appears below in normal flow, the "Простой пример" h2 and everything below render as a normal vertical document
- [ ] Toggle to light theme on \`https://forgeplan.dev/ru/guides/trust-calculus\` - verdict labels (supports / refutes / weakens) and hypothesis labels (H1/H2/H3 · гипотеза) are clearly readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)