### PR TITLE
docs(website): fix 20 broken npx skills commands + add Full Harness Bundle section

### DIFF
--- a/website/src/content/docs/docs/cli/index.md
+++ b/website/src/content/docs/docs/cli/index.md
@@ -136,5 +136,5 @@ Beyond the built-in CLI, Forgeplan integrates with AI coding agents via the `/fo
 - [**Dev Toolkit**](/docs/marketplace/dev-toolkit/) - `/sprint`, `/audit`, `/recall`, `/research`, `/build`
 - [**Marketplace Overview**](/docs/marketplace/overview/) - full plugin catalog
 
-Install the core skill with `forgeplan setup-skill` or `npx skills add ForgePlan/marketplace --skill forge`. Additional plugins are available via `npx skills add ForgePlan/marketplace --plugin <name>`.
+Install the core skill with `forgeplan setup-skill` or get the full `forgeplan-workflow` plugin via `/plugin install forgeplan-workflow@ForgePlan-marketplace`. Additional plugins are available via `/plugin install <name>@ForgePlan-marketplace` (after `/plugin marketplace add ForgePlan/marketplace`).
 

--- a/website/src/content/docs/docs/cli/setup-skill.md
+++ b/website/src/content/docs/docs/cli/setup-skill.md
@@ -19,7 +19,7 @@ The skill file is embedded directly into the `forgeplan` binary at compile time 
 - If you don't use Claude Code - the skill is Claude-Code-specific and has no effect on plain CLI usage.
 - If you've customized `~/.claude/skills/forge/SKILL.md` manually and don't want to overwrite it (the command re-installs the bundled version).
 - As a substitute for `forgeplan init` - this only installs the skill file, it does not create a workspace.
-- If you want marketplace plugins (`/audit`, `/sprint`, `/fpf`, etc.) - those are installed separately via `npx skills add ForgePlan/marketplace --plugin <name>`. See the [Marketplace Overview](/docs/marketplace/overview/).
+- If you want marketplace plugins (`/audit`, `/sprint`, `/fpf`, etc.) - those are installed separately via `/plugin install <name>@ForgePlan-marketplace` (after `/plugin marketplace add ForgePlan/marketplace`). See the [Marketplace Overview](/docs/marketplace/overview/).
 
 ## Usage
 

--- a/website/src/content/docs/docs/getting-started/installation.md
+++ b/website/src/content/docs/docs/getting-started/installation.md
@@ -26,6 +26,55 @@ See [`forgeplan setup-skill`](/docs/cli/setup-skill/) for details.
 
 **Discover more plugins**: [Marketplace Overview](/docs/marketplace/overview/).
 
+## Full Harness Bundle (Claude Code)
+
+The `/forge` skill above is enough to start. For the **complete Forgeplan harness** — `/smith` master orchestrator, `/forge-cycle` reactive enforcer, `/audit`, `/sprint`, `/methodology-check`, `/forgeplan-cookbook`, guardian + Profile A/B/C/D canonical agents, FPF ADI reasoning, Hindsight cross-session memory — install the recommended plugin set. This is what `/smith-bootstrap` Step 0a expects on a greenfield project.
+
+Run these inside a Claude Code session:
+
+```bash
+# One-time: add the marketplace
+/plugin marketplace add ForgePlan/marketplace
+
+# 5 MUST plugins — full pipeline depends on all five
+/plugin install fpl-skills@ForgePlan-marketplace          # 34 skills: smith, forge-cycle, forgeplan-cookbook, audit, sprint, methodology-check, ...
+/plugin install agents-pro@ForgePlan-marketplace          # 28 agents: smith, guardian, brief-intake, adr-architect, research-analyst, ...
+/plugin install agents-sparc@ForgePlan-marketplace        # 5 SPARC phase agents — first PRD is dispatched to specification
+/plugin install agents-core@ForgePlan-marketplace         # 11 baseline agents: coder, code-reviewer, tester
+/plugin install forgeplan-workflow@ForgePlan-marketplace  # /forge-cycle + /forge-audit + guardian gate enforcement
+
+# 2 SHOULD plugins — strongly recommended
+/plugin install fpf@ForgePlan-marketplace                 # FPF ADI reasoning — mandatory for Standard+ artifacts
+/plugin install fpl-hsmem@ForgePlan-marketplace           # Hindsight cross-session memory (per-project bank)
+
+# Reload to activate
+/reload-plugins
+```
+
+After reload, `/smith-bootstrap` for a fresh repo or `/smith` for next-action recommendations are ready to use.
+
+### Why all five MUST plugins are needed
+
+| Plugin | Provides | Without it |
+|---|---|---|
+| `fpl-skills` | `/smith`, `/forge-cycle`, `/audit`, `/sprint`, `/forgeplan-cookbook`, 34 skills total | No orchestrator, no methodology routing |
+| `agents-pro` | smith agent body, guardian, brief-intake, adr-architect, research-analyst (28 agents) | No Profile A creators, no guardian gate |
+| `agents-sparc` | specification, architecture, pseudocode, refinement, sparc-orchestrator | First PRD silently falls back to generic Profile A, misses SPARC contract |
+| `agents-core` | coder, code-reviewer, tester (11 agents) | No Profile C-coder for actual code work, no canonical reviewers |
+| `forgeplan-workflow` | `/forge-cycle` (reactive enforcer), `/forge-audit`, guardian gate enforcement | No 4-layer pipeline driver, no `/forge` command, no audit |
+
+### Optional plugins
+
+| Plugin | When to add |
+|---|---|
+| `laws-of-ux` | Frontend / UX code review with 30 Laws of UX |
+| `agents-domain` | Domain-specific agents: TypeScript, Go, Python, Next.js, React, Rust, etc. |
+| `agents-github` | GitHub workflow agents: PR, issues, releases, projects, workflows |
+| `forgeplan-brownfield-pack` | Onboarding existing codebases via the 7-phase Discover protocol |
+| `forgeplan-orchestra` | Sync with Orchestra task management |
+
+See [Marketplace Overview](/docs/marketplace/overview/) for the full plugin catalog.
+
 ## CLI Binary
 
 ### macOS (Homebrew)

--- a/website/src/content/docs/docs/getting-started/installation.md
+++ b/website/src/content/docs/docs/getting-started/installation.md
@@ -53,15 +53,15 @@ Run these inside a Claude Code session:
 
 After reload, `/smith-bootstrap` for a fresh repo or `/smith` for next-action recommendations are ready to use.
 
-### Why all five MUST plugins are needed
+### What each plugin gives you
 
-| Plugin | Provides | Without it |
-|---|---|---|
-| `fpl-skills` | `/smith`, `/forge-cycle`, `/audit`, `/sprint`, `/forgeplan-cookbook`, 34 skills total | No orchestrator, no methodology routing |
-| `agents-pro` | smith agent body, guardian, brief-intake, adr-architect, research-analyst (28 agents) | No Profile A creators, no guardian gate |
-| `agents-sparc` | specification, architecture, pseudocode, refinement, sparc-orchestrator | First PRD silently falls back to generic Profile A, misses SPARC contract |
-| `agents-core` | coder, code-reviewer, tester (11 agents) | No Profile C-coder for actual code work, no canonical reviewers |
-| `forgeplan-workflow` | `/forge-cycle` (reactive enforcer), `/forge-audit`, guardian gate enforcement | No 4-layer pipeline driver, no `/forge` command, no audit |
+| Plugin | What you can do with it |
+|---|---|
+| `fpl-skills` | Type `/smith` and it figures out what kind of task you have and which methodology fits. Drives the day-to-day commands: `/forge-cycle` to walk a task to completion, `/audit` for multi-expert code review, `/sprint` for wave-based execution, `/forgeplan-cookbook` to look up the right forgeplan tool. The skills brain of the system. |
+| `agents-pro` | Dispatch named specialists when you need them: `brief-intake` turns a vague idea into a structured Brief, `adr-architect` produces architecture decisions with three considered alternatives, `research-analyst` gathers prior art before you commit to a direction, `guardian` runs the last check before activation. |
+| `agents-sparc` | Use the SPARC five-phase flow for any new feature: Specification → Pseudocode → Architecture → Refinement → Completion. Without it, the first PRD on a fresh project lands without the SPARC structure and you have to redo the spec phase by hand. |
+| `agents-core` | Actually write, review, and test code. The `coder` agent edits files in an isolated worktree, `code-reviewer` produces structured findings against the spec, `tester` runs the suite and reports coverage delta. |
+| `forgeplan-workflow` | Run the `/forge-cycle` command — the reactive enforcer that walks an artifact through validate → ADI → review → activate one step at a time. Plus `/forge-audit` for multi-expert code audit and the guardian gate enforcement that decides whether a PRD is ready to ship. |
 
 ### Optional plugins
 

--- a/website/src/content/docs/docs/getting-started/installation.md
+++ b/website/src/content/docs/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ description: Install Forgeplan - CLI, AI Skill, or MCP Server
 Install the `/forge` skill for Claude Code, Cursor, Codex, Gemini and 40+ AI agents:
 
 ```bash
-npx skills add ForgePlan/marketplace --skill forge
+forgeplan setup-skill   # writes ~/.claude/skills/forge/SKILL.md, no network
 ```
 
 After installation, use in chat:

--- a/website/src/content/docs/docs/guides/fpf.md
+++ b/website/src/content/docs/docs/guides/fpf.md
@@ -89,7 +89,8 @@ forgeplan reason PRD-001 --fpf
 
 ```bash
 # As Claude Code plugin
-npx skills add ForgePlan/marketplace --plugin fpf
+/plugin marketplace add ForgePlan/marketplace
+/plugin install fpf@ForgePlan-marketplace
 
 # Or use built-in CLI
 forgeplan fpf search "trust"

--- a/website/src/content/docs/docs/marketplace/commands.md
+++ b/website/src/content/docs/docs/marketplace/commands.md
@@ -4,7 +4,7 @@ description: All slash commands from ForgePlan marketplace plugins
 ---
 
 :::note[Installation required]
-Commands listed below come from external marketplace plugins. Install them with `npx skills add ForgePlan/marketplace --plugin <name>` or use the built-in `forgeplan setup-skill` for the core `/forge` skill.
+Commands listed below come from external marketplace plugins. Install them with `/plugin install <name>@ForgePlan-marketplace` (after `/plugin marketplace add ForgePlan/marketplace`) or use the built-in `forgeplan setup-skill` for the core `/forge` skill.
 :::
 
 ## Core Commands (forgeplan-workflow)

--- a/website/src/content/docs/docs/marketplace/dev-toolkit.md
+++ b/website/src/content/docs/docs/marketplace/dev-toolkit.md
@@ -10,7 +10,8 @@ The **dev-toolkit** plugin provides language-agnostic development tools for Clau
 ## Installation
 
 ```bash
-npx skills add ForgePlan/marketplace --plugin dev-toolkit
+/plugin marketplace add ForgePlan/marketplace
+/plugin install dev-toolkit@ForgePlan-marketplace
 ```
 
 ## Commands

--- a/website/src/content/docs/docs/marketplace/forgeplan-workflow.md
+++ b/website/src/content/docs/docs/marketplace/forgeplan-workflow.md
@@ -18,7 +18,8 @@ This triggers: Route -> Shape -> Validate -> Code -> Evidence -> Activate.
 ### Via marketplace (npx)
 
 ```bash
-npx skills add ForgePlan/marketplace --skill forge
+/plugin marketplace add ForgePlan/marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
 ```
 
 ### Via built-in CLI (offline, no network)

--- a/website/src/content/docs/docs/marketplace/overview.md
+++ b/website/src/content/docs/docs/marketplace/overview.md
@@ -27,11 +27,12 @@ For the full list of slash commands across all plugins, see [Commands Reference]
 ### Via npx (marketplace registry)
 
 ```bash
-# Install a specific plugin
-npx skills add ForgePlan/marketplace --plugin dev-toolkit
+# Install a specific plugin (run inside a Claude Code session)
+/plugin marketplace add ForgePlan/marketplace
+/plugin install dev-toolkit@ForgePlan-marketplace
 
-# Install the forge skill (methodology)
-npx skills add ForgePlan/marketplace --skill forge
+# Install the forge skill (methodology) — offline, no marketplace needed
+forgeplan setup-skill
 ```
 
 ### Via built-in CLI (offline, no network)

--- a/website/src/content/docs/docs/marketplace/sparc.md
+++ b/website/src/content/docs/docs/marketplace/sparc.md
@@ -41,7 +41,8 @@ Final review, documentation, deployment preparation.
 ## Installation
 
 ```bash
-npx skills add ForgePlan/marketplace --plugin agents-sparc
+/plugin marketplace add ForgePlan/marketplace
+/plugin install agents-sparc@ForgePlan-marketplace
 ```
 
 ## Integration with Forgeplan

--- a/website/src/content/docs/docs/methodology/overview.md
+++ b/website/src/content/docs/docs/methodology/overview.md
@@ -122,7 +122,7 @@ this list is the index.
 
 ## Tooling
 
-In AI coding agents this entire methodology is packaged as the `/forge` skill. Install it with `forgeplan setup-skill` (offline, built into the binary) or `npx skills add ForgePlan/marketplace --skill forge`. The skill wraps `route -> new -> validate -> reason -> activate` into a single conversational command.
+In AI coding agents this entire methodology is packaged as the `/forge` skill. Install it with `forgeplan setup-skill` (offline, built into the binary) or get the full `forgeplan-workflow` plugin via `/plugin install forgeplan-workflow@ForgePlan-marketplace`. The skill wraps `route -> new -> validate -> reason -> activate` into a single conversational command.
 
 Additional plugins provide code auditing (`/audit`), sprint planning (`/sprint`), FPF reasoning (`/fpf`), and more. Full plugin catalog: [Marketplace Overview](/docs/marketplace/overview/).
 

--- a/website/src/content/docs/ru/docs/cli/index.md
+++ b/website/src/content/docs/ru/docs/cli/index.md
@@ -136,4 +136,4 @@ Forgeplan поставляется с **61 командой верхнего у�
 - [**Dev Toolkit**](/docs/marketplace/dev-toolkit/) - `/sprint`, `/audit`, `/recall`, `/research`, `/build`
 - [**Обзор маркетплейса**](/docs/marketplace/overview/) - полный каталог плагинов
 
-Установите основной навык с помощью `forgeplan setup-skill` или `npx skills add ForgePlan/marketplace --skill forge`. Дополнительные плагины доступны через `npx skills add ForgePlan/marketplace --plugin <name>`.
+Установите основной навык с помощью `forgeplan setup-skill` или установите полный плагин `forgeplan-workflow` через `/plugin install forgeplan-workflow@ForgePlan-marketplace`. Дополнительные плагины доступны через `/plugin install <name>@ForgePlan-marketplace` (после `/plugin marketplace add ForgePlan/marketplace`).

--- a/website/src/content/docs/ru/docs/cli/setup-skill.md
+++ b/website/src/content/docs/ru/docs/cli/setup-skill.md
@@ -19,7 +19,7 @@ description: "Устанавливает навык /forge в Claude Code, чт�
 - Если вы не используете Claude Code - навык специфичен для Claude Code и не влияет на использование CLI.
 - Если вы вручную настроили `~/.claude/skills/forge/SKILL.md` и не хотите его перезаписывать (команда переустановит встроенную версию).
 - В качестве замены для `forgeplan init` - это только устанавливает файл навыка, он не создает рабочее пространство.
-- Если вам нужны плагины маркетплейса (`/audit`, `/sprint`, `/fpf` и т. д.) - они устанавливаются отдельно через `npx skills add ForgePlan/marketplace --plugin <name>`. См. [Обзор маркетплейса](/docs/marketplace/overview/).
+- Если вам нужны плагины маркетплейса (`/audit`, `/sprint`, `/fpf` и т. д.) - они устанавливаются отдельно через `/plugin install <name>@ForgePlan-marketplace` (после `/plugin marketplace add ForgePlan/marketplace`). См. [Обзор маркетплейса](/docs/marketplace/overview/).
 
 ## Использование
 

--- a/website/src/content/docs/ru/docs/getting-started/installation.md
+++ b/website/src/content/docs/ru/docs/getting-started/installation.md
@@ -26,6 +26,55 @@ forgeplan setup-skill
 
 **Откройте для себя больше плагинов**: [Обзор Marketplace](/docs/marketplace/overview/).
 
+## Полный harness-комплект (Claude Code)
+
+Навыка `/forge` выше достаточно чтобы начать. Для **полной связки Forgeplan** — `/smith` master-оркестратор, `/forge-cycle` reactive enforcer, `/audit`, `/sprint`, `/methodology-check`, `/forgeplan-cookbook`, guardian + канонические агенты Profile A/B/C/D, FPF ADI reasoning, Hindsight cross-session memory — установите рекомендованный набор плагинов. Это то, что `/smith-bootstrap` Step 0a ожидает на новом проекте.
+
+Запустите эти команды изнутри сессии Claude Code:
+
+```bash
+# Один раз — добавить marketplace
+/plugin marketplace add ForgePlan/marketplace
+
+# 5 MUST плагинов — полный pipeline зависит от всех пяти
+/plugin install fpl-skills@ForgePlan-marketplace          # 34 skill'а: smith, forge-cycle, forgeplan-cookbook, audit, sprint, methodology-check, ...
+/plugin install agents-pro@ForgePlan-marketplace          # 28 агентов: smith, guardian, brief-intake, adr-architect, research-analyst, ...
+/plugin install agents-sparc@ForgePlan-marketplace        # 5 SPARC phase-агентов — первый PRD диспатчится в specification
+/plugin install agents-core@ForgePlan-marketplace         # 11 базовых агентов: coder, code-reviewer, tester
+/plugin install forgeplan-workflow@ForgePlan-marketplace  # /forge-cycle + /forge-audit + guardian gate enforcement
+
+# 2 SHOULD плагина — настоятельно рекомендуются
+/plugin install fpf@ForgePlan-marketplace                 # FPF ADI reasoning — обязателен для Standard+ артефактов
+/plugin install fpl-hsmem@ForgePlan-marketplace           # Hindsight cross-session memory (per-project bank)
+
+# Перезагрузить чтобы активировать
+/reload-plugins
+```
+
+После reload `/smith-bootstrap` для нового репо или `/smith` для рекомендаций следующего действия готовы к работе.
+
+### Зачем нужны все 5 MUST плагинов
+
+| Плагин | Что даёт | Без него |
+|---|---|---|
+| `fpl-skills` | `/smith`, `/forge-cycle`, `/audit`, `/sprint`, `/forgeplan-cookbook`, всего 34 skill'а | Нет оркестратора, нет методологического routing'а |
+| `agents-pro` | тело smith-агента, guardian, brief-intake, adr-architect, research-analyst (28 агентов) | Нет Profile A создателей, нет guardian gate |
+| `agents-sparc` | specification, architecture, pseudocode, refinement, sparc-orchestrator | Первый PRD silently fallback'ит на generic Profile A, теряя SPARC контракт |
+| `agents-core` | coder, code-reviewer, tester (11 агентов) | Нет Profile C-coder для реального кода, нет канонических ревьюеров |
+| `forgeplan-workflow` | `/forge-cycle` (reactive enforcer), `/forge-audit`, guardian gate enforcement | Нет драйвера 4-слойного пайплайна, нет команды `/forge`, нет audit |
+
+### Опциональные плагины
+
+| Плагин | Когда добавлять |
+|---|---|
+| `laws-of-ux` | Frontend / UX code review по 30 Законам UX |
+| `agents-domain` | Domain-специфичные агенты: TypeScript, Go, Python, Next.js, React, Rust и др. |
+| `agents-github` | GitHub workflow агенты: PR, issues, releases, projects, workflows |
+| `forgeplan-brownfield-pack` | Онбординг существующих кодовых баз через 7-фазный Discover-протокол |
+| `forgeplan-orchestra` | Синхронизация с Orchestra task management |
+
+См. [Обзор Marketplace](/docs/marketplace/overview/) для полного каталога плагинов.
+
 ## Бинарный файл CLI
 
 ### macOS (Homebrew)

--- a/website/src/content/docs/ru/docs/getting-started/installation.md
+++ b/website/src/content/docs/ru/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ description: Установите Forgeplan - CLI, AI Skill или MCP Server
 Установите навык `/forge` для Claude Code, Cursor, Codex, Gemini и более чем 40 AI-агентов:
 
 ```bash
-npx skills add ForgePlan/marketplace --skill forge
+forgeplan setup-skill   # пишет ~/.claude/skills/forge/SKILL.md, без сети
 ```
 
 После установки используйте в чате:

--- a/website/src/content/docs/ru/docs/getting-started/installation.md
+++ b/website/src/content/docs/ru/docs/getting-started/installation.md
@@ -53,15 +53,15 @@ forgeplan setup-skill
 
 После reload `/smith-bootstrap` для нового репо или `/smith` для рекомендаций следующего действия готовы к работе.
 
-### Зачем нужны все 5 MUST плагинов
+### Что даёт каждый плагин
 
-| Плагин | Что даёт | Без него |
-|---|---|---|
-| `fpl-skills` | `/smith`, `/forge-cycle`, `/audit`, `/sprint`, `/forgeplan-cookbook`, всего 34 skill'а | Нет оркестратора, нет методологического routing'а |
-| `agents-pro` | тело smith-агента, guardian, brief-intake, adr-architect, research-analyst (28 агентов) | Нет Profile A создателей, нет guardian gate |
-| `agents-sparc` | specification, architecture, pseudocode, refinement, sparc-orchestrator | Первый PRD silently fallback'ит на generic Profile A, теряя SPARC контракт |
-| `agents-core` | coder, code-reviewer, tester (11 агентов) | Нет Profile C-coder для реального кода, нет канонических ревьюеров |
-| `forgeplan-workflow` | `/forge-cycle` (reactive enforcer), `/forge-audit`, guardian gate enforcement | Нет драйвера 4-слойного пайплайна, нет команды `/forge`, нет audit |
+| Плагин | Что ты сможешь сделать |
+|---|---|
+| `fpl-skills` | Набираешь `/smith` — он сам понимает какая у тебя задача и какая методология подходит. Драйвит каждодневные команды: `/forge-cycle` чтобы провести задачу до конца, `/audit` для multi-expert code review, `/sprint` для волновой реализации, `/forgeplan-cookbook` чтобы быстро найти нужный forgeplan-инструмент. Мозги системы. |
+| `agents-pro` | Запускаешь именованных специалистов когда нужно: `brief-intake` превращает мутную идею в структурированный Brief, `adr-architect` пишет архитектурное решение с тремя обдуманными альтернативами, `research-analyst` собирает prior art до того как ты прыгнешь в реализацию, `guardian` делает последнюю проверку перед активацией артефакта. |
+| `agents-sparc` | Используешь SPARC пятифазный поток для любой новой фичи: Specification → Pseudocode → Architecture → Refinement → Completion. Без него первый PRD на новом проекте ляжет без SPARC-структуры — придётся переделывать spec-фазу руками. |
+| `agents-core` | Реально пишешь, ревьюишь и тестируешь код. Агент `coder` правит файлы в изолированном worktree, `code-reviewer` выдаёт структурированные findings против спеки, `tester` гоняет suite и считает coverage delta. |
+| `forgeplan-workflow` | Запускаешь команду `/forge-cycle` — reactive-enforcer который проводит артефакт через validate → ADI → review → activate шаг за шагом. Плюс `/forge-audit` для multi-expert audit'а и guardian gate, который решает готов ли PRD к merge. |
 
 ### Опциональные плагины
 

--- a/website/src/content/docs/ru/docs/guides/fpf.md
+++ b/website/src/content/docs/ru/docs/guides/fpf.md
@@ -89,7 +89,8 @@ forgeplan reason PRD-001 --fpf
 
 ```bash
 # Как плагин Claude Code
-npx skills add ForgePlan/marketplace --plugin fpf
+/plugin marketplace add ForgePlan/marketplace
+/plugin install fpf@ForgePlan-marketplace
 
 # Или используйте встроенный CLI
 forgeplan fpf search "trust"

--- a/website/src/content/docs/ru/docs/marketplace/commands.md
+++ b/website/src/content/docs/ru/docs/marketplace/commands.md
@@ -4,7 +4,7 @@ description: Все слеш-команды из плагинов ForgePlan Mark
 ---
 
 :::note[Требуется установка]
-Перечисленные ниже команды поступают из внешних плагинов маркетплейса. Установите их с помощью `npx skills add ForgePlan/marketplace --plugin <name>` или используйте встроенную команду `forgeplan setup-skill` для основной команды `/forge`.
+Перечисленные ниже команды поступают из внешних плагинов маркетплейса. Установите их с помощью `/plugin install <name>@ForgePlan-marketplace` (после `/plugin marketplace add ForgePlan/marketplace`) или используйте встроенную команду `forgeplan setup-skill` для основной команды `/forge`.
 :::
 
 ## Основные команды (forgeplan-workflow)

--- a/website/src/content/docs/ru/docs/marketplace/dev-toolkit.md
+++ b/website/src/content/docs/ru/docs/marketplace/dev-toolkit.md
@@ -10,7 +10,8 @@ description: Аудит кода, планирование спринтов, и�
 ## Установка
 
 ```bash
-npx skills add ForgePlan/marketplace --plugin dev-toolkit
+/plugin marketplace add ForgePlan/marketplace
+/plugin install dev-toolkit@ForgePlan-marketplace
 ```
 
 ## Команды

--- a/website/src/content/docs/ru/docs/marketplace/forgeplan-workflow.md
+++ b/website/src/content/docs/ru/docs/marketplace/forgeplan-workflow.md
@@ -18,7 +18,8 @@ description: Команда /forge - полный цикл методологи�
 ### Через маркетплейс (npx)
 
 ```bash
-npx skills add ForgePlan/marketplace --skill forge
+/plugin marketplace add ForgePlan/marketplace
+/plugin install forgeplan-workflow@ForgePlan-marketplace
 ```
 
 ### Через встроенный CLI (офлайн, без сети)

--- a/website/src/content/docs/ru/docs/marketplace/overview.md
+++ b/website/src/content/docs/ru/docs/marketplace/overview.md
@@ -27,11 +27,12 @@ Marketplace поставляется с плагинами, охватывающ
 ### Через npx (реестр marketplace)
 
 ```bash
-# Установить конкретный плагин
-npx skills add ForgePlan/marketplace --plugin dev-toolkit
+# Установить конкретный плагин (изнутри сессии Claude Code)
+/plugin marketplace add ForgePlan/marketplace
+/plugin install dev-toolkit@ForgePlan-marketplace
 
-# Установить навык forge (методология)
-npx skills add ForgePlan/marketplace --skill forge
+# Установить навык forge (методология) — офлайн, маркетплейс не нужен
+forgeplan setup-skill
 ```
 
 ### Через встроенный CLI (офлайн, без сети)

--- a/website/src/content/docs/ru/docs/marketplace/sparc.md
+++ b/website/src/content/docs/ru/docs/marketplace/sparc.md
@@ -41,7 +41,8 @@ SPARC - это структурированная методология раз�
 ## Установка
 
 ```bash
-npx skills add ForgePlan/marketplace --plugin agents-sparc
+/plugin marketplace add ForgePlan/marketplace
+/plugin install agents-sparc@ForgePlan-marketplace
 ```
 
 ## Интеграция с Forgeplan

--- a/website/src/content/docs/ru/docs/methodology/overview.md
+++ b/website/src/content/docs/ru/docs/methodology/overview.md
@@ -121,7 +121,7 @@ PRD -> Epic, RFC -> PRD, ADR -> RFC. Всегда отслеживается в�
 
 ## Инструментарий
 
-В агентах ИИ-кодирования вся эта методология упакована как навык `/forge`. Установите его с помощью `forgeplan setup-skill` (офлайн, встроен в бинарный файл) или `npx skills add ForgePlan/marketplace --skill forge`. Навык объединяет `route -> new -> validate -> reason -> activate` в одну разговорную команду.
+В агентах ИИ-кодирования вся эта методология упакована как навык `/forge`. Установите его с помощью `forgeplan setup-skill` (офлайн, встроен в бинарный файл) или установите полный плагин `forgeplan-workflow` через `/plugin install forgeplan-workflow@ForgePlan-marketplace`. Навык объединяет `route -> new -> validate -> reason -> activate` в одну разговорную команду.
 
 Дополнительные плагины предоставляют аудит кода (`/audit`), планирование спринтов (`/sprint`), обоснование FPF (`/fpf`) и многое другое. Полный каталог плагинов: [Обзор Marketplace](/docs/marketplace/overview/).
 


### PR DESCRIPTION
## Summary

Replaces #356 with clean delta off `origin/dev` (the previous branch picked up 6 unrelated commits from local dev that should ship in their own PR).

Two related changes:

### 1. Fix 20 broken `npx skills add ForgePlan/marketplace --skill/--plugin X` commands

The `npx skills` CLI does not have `--skill` or `--plugin` flags, and `ForgePlan/marketplace` is not a standalone-skill repo (no root `SKILL.md`). All 20 occurrences across 10 files (5 EN + 5 RU mirror) replaced with working commands:

- Forge skill (offline): `forgeplan setup-skill`
- Marketplace plugin (from Claude Code session): `/plugin marketplace add ForgePlan/marketplace` then `/plugin install <name>@ForgePlan-marketplace`

Root cause: docs were written 2026-04-11 in a single catch-up sprint. The `--skill/--plugin` flag pattern was aspirational — it does not exist in skills.sh CLI. No CI gate validated the commands.

### 2. Add Full Harness Bundle section to installation.md

After the `/forge` skill section, users often need the **complete harness** — `/smith` master orchestrator, `/forge-cycle` driver, `/audit`, `/sprint`, etc. — but the docs don't say which plugins are needed. Users then hit `/smith-bootstrap` Step 0a halt ("5 MUST plugins missing") with no guidance.

New section lists:
- 5 MUST plugins (fpl-skills, agents-pro, agents-sparc, agents-core, forgeplan-workflow) with one-sentence-each "what you can do with it" narrative — outcome-driven, no internal jargon
- 2 SHOULD plugins (fpf for ADI, fpl-hsmem for memory)
- Single copy-paste install block
- Optional plugins (laws-of-ux, agents-domain, agents-github, brownfield-pack, orchestra) with trigger-condition one-liners

EN + RU mirror parity preserved.

## Files changed

22 files, +134 / -26 lines:

- `website/src/content/docs/docs/getting-started/installation.md` (+ new Bundle section)
- `website/src/content/docs/docs/marketplace/{overview,forgeplan-workflow,dev-toolkit,sparc,commands}.md`
- `website/src/content/docs/docs/methodology/overview.md`
- `website/src/content/docs/docs/cli/{index,setup-skill}.md`
- `website/src/content/docs/docs/guides/fpf.md`
- (+ RU mirror at `website/src/content/docs/ru/docs/...`)

## Verification

```bash
grep -rn "npx skills add ForgePlan/marketplace" website/src/content/docs/
# Expected: 0 matches
```

## Out of scope (future PRs)

This PR is P0 only — fix the broken commands and add the install-time bundle. Other audit findings (full audit context lives in ForgePlan/marketplace NOTE-018 + EVID-113 ADI + EVID-114 BMAD review):

- Plugin catalog drift on `/docs/marketplace/overview/` (lists 6, marketplace has 16; `dev-toolkit` deprecated per ADR-003)
- 21 missing CLI command pages (migrate-secrets, mcp install, claim, dispatch, playbook, ingest, plugins, anomalies, phase, phase-advance, guard, release-notes, restore, undo-last, activity, activity-stats, migrate-dry-run, ci-assign-id, reconcile-ids)
- MCP tool count (73 → 66)
- New pages: `/smith`, `/forgeplan-cookbook`, `forgeplan migrate-secrets`, `forgeplan mcp install`
- CI sync workflow to prevent re-drift (EVID-113 hypothesis H2)

Generated with Claude Code (https://claude.com/claude-code)