### PR TITLE
fix(mcp): expand @filepath body in forgeplan_update + discover_finding (closes #350)

### DIFF
--- a/.forgeplan/evidence/EVID-142-prob-077-350-fix-mcp-filepath-expansion-in-forgeplan-update-discover-finding-4-e2e-pass.md
+++ b/.forgeplan/evidence/EVID-142-prob-077-350-fix-mcp-filepath-expansion-in-forgeplan-update-discover-finding-4-e2e-pass.md
@@ -1,0 +1,53 @@
+---
+depth: tactical
+id: EVID-142
+kind: evidence
+links:
+- target: PROB-077
+  relation: informs
+status: draft
+title: 'PROB-077/#350 fix: MCP @filepath expansion in forgeplan_update + discover_finding — 4 e2e PASS'
+---
+
+## Summary
+
+Fix evidence for **PROB-077 / GitHub #350** — MCP `@filepath` silent data loss. The MCP `forgeplan_update` and `forgeplan_discover_finding` tools now expand a `@/path` body into the file's content (CLI parity) instead of persisting the literal `@path` string.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: test
+
+CL3: direct e2e measurement of the exact shipped fix on the real MCP JSON-RPC surface (the same surface the bug was reported on).
+
+## Fix
+
+`expand_body_filepath()` helper added to `crates/forgeplan-mcp/src/server.rs`:
+- leading `@` → read the file (CLI parity: strips YAML frontmatter when present);
+- anything else → returned verbatim.
+
+Applied in both `body`-accepting handlers — `forgeplan_update` and `forgeplan_discover_finding`. The DoS body-length cap (`mcp_max_body_len`) now measures the **expanded** content, so a short `@path` cannot smuggle an oversized file past the limit. A read failure routes through `safe_invalid_params` (no `$HOME`/absolute-path leak) and surfaces as `invalid_params` — loud, never silent.
+
+## Tests
+
+4 e2e tests in `crates/forgeplan-mcp/tests/mcp_update_filepath_e2e.rs` (real JSON-RPC via McpFixture):
+
+| Test | Asserts |
+|------|---------|
+| `mcp_update_at_filepath_expands_into_body` | `@file` → body is file CONTENT, not the `@path` string (the #350 repro) |
+| `mcp_update_at_filepath_strips_frontmatter` | YAML frontmatter stripped from a `@file` body |
+| `mcp_update_at_nonexistent_file_errors_not_silent` | missing `@file` → `invalid_params` error, NOT a silent literal write |
+| `mcp_update_literal_body_without_at_is_verbatim` | plain body (incl. inline `a@b.com`) stored verbatim |
+
+`forgeplan_discover_finding` uses the same `expand_body_filepath` helper → covered transitively.
+
+Gate: forgeplan-mcp **259 passed / 0 failed**, clippy 0 (`--all-targets`), fmt 0.
+
+## Provenance
+
+- Branch: `fix/issue-350-mcp-update-filepath` (off `origin/dev`)
+- Fix commit: `0e3d8f6`
+- Files: `crates/forgeplan-mcp/src/server.rs` (helper + 2 handler call-sites), `crates/forgeplan-mcp/tests/mcp_update_filepath_e2e.rs` (new)
+
+

--- a/.forgeplan/problems/PROB-077-mcp-forgeplan-update-and-discover-finding-write-literal-filepath-as-body-silent-data-loss-gh-350.md
+++ b/.forgeplan/problems/PROB-077-mcp-forgeplan-update-and-discover-finding-write-literal-filepath-as-body-silent-data-loss-gh-350.md
@@ -1,0 +1,32 @@
+---
+depth: tactical
+id: PROB-077
+kind: problem
+status: deprecated
+title: 'MCP forgeplan_update and discover_finding write literal @filepath as body — silent data loss (GH #350)'
+---
+
+## Signal
+
+GitHub issue #350 (2026-05-27, reporter explosivebit), confirmed on two independent sessions (user's `gerts-hub` project + a marketplace sandbox repro). MCP `forgeplan_update` called with `body="@/path/to/file.md"` wrote the **literal string** `@/path/to/file.md` into the artifact body instead of the file's content — silently overwriting whatever was there. The call returned `Updated successfully`; the loss was invisible until a later `forgeplan_get`.
+
+## Root Cause
+
+The CLI (`forgeplan-cli/src/commands/update.rs`) expands a leading `@` into file content; the MCP `forgeplan_update` and `forgeplan_discover_finding` handlers did **not** — they persisted `p.body` verbatim. A CLI/MCP asymmetry: skills document the `--body @file` pattern, agents mirror it through MCP, and the MCP side wrote the path string.
+
+## Impact
+
+CRITICAL silent data loss. Any agent mirroring the documented CLI `@file` pattern through MCP destroys the target artifact's body. Worst failure mode — `Updated successfully` + invisible loss until someone re-reads the artifact.
+
+## Resolution
+
+Option (a) symmetry (the issue-preferred outcome): add an `expand_body_filepath()` helper to the MCP server — a leading `@` reads the file (CLI parity: strips YAML frontmatter), the DoS body-length cap applies to the **expanded** content, and a read error surfaces as `invalid_params` (loud, not silent) via the `$HOME`-sanitizing error path. Applied in both handlers (`forgeplan_update` + `forgeplan_discover_finding`). Fixed on branch `fix/issue-350-mcp-update-filepath`; evidence EVID-142.
+
+## Related
+
+- GitHub #350 (source signal)
+- Adjacent CLI/MCP asymmetry class: #353 (claim `--agent` `/` handling)
+
+
+
+

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -919,6 +919,46 @@ fn safe_invalid_params(msg: impl std::fmt::Display, data: Option<serde_json::Val
     McpError::invalid_params(sanitised, safe_data)
 }
 
+/// Issue #350 (CRITICAL silent data-loss): expand a `@/path/to/file.md` body
+/// into the file's content, matching the CLI `forgeplan update --body @file`
+/// semantics so MCP and CLI stay symmetric. Before this, an agent mirroring the
+/// CLI `@filepath` pattern through MCP wrote the **literal** `@path` string into
+/// the artifact body — silently overwriting the real content.
+///
+/// Parity with `forgeplan-cli/src/commands/update.rs`:
+/// - a leading `@` means "read the rest as a file path";
+/// - if the file begins with YAML frontmatter, strip it (we store body only);
+/// - anything without a leading `@` is returned verbatim.
+///
+/// Safety: the caller applies the configured `mcp_max_body_len` DoS cap to the
+/// **expanded** content (so a short `@path` can't smuggle a huge file past the
+/// limit), and the read error is routed through [`safe_invalid_params`] so an
+/// absolute path / `$HOME` never leaks into the MCP transcript.
+async fn expand_body_filepath(body: &str) -> Result<String, McpError> {
+    let Some(path) = body.strip_prefix('@') else {
+        return Ok(body.to_string());
+    };
+    let raw = tokio::fs::read_to_string(path).await.map_err(|e| {
+        safe_invalid_params(
+            format!(
+                "@filepath body: cannot read file '{path}': {e}. \
+                 Pass the body content directly, or verify the path exists and is readable."
+            ),
+            None,
+        )
+    })?;
+    // CLI parity: a file may carry YAML frontmatter; we persist body only.
+    let content = if raw.starts_with("---") {
+        match forgeplan_core::artifact::frontmatter::parse_frontmatter(&raw) {
+            Ok((_fm, b)) => b.to_string(),
+            Err(_) => raw,
+        }
+    } else {
+        raw
+    };
+    Ok(content)
+}
+
 /// Variant of [`safe_mcp_error`] for call sites that already hold an
 /// `anyhow::Error` (not just a Display value). Preserves the error chain
 /// so typed downcasts (e.g. [`MutationError::RetryExhausted`]) can inject
@@ -3726,7 +3766,14 @@ impl ForgeplanServer {
                 None,
             ));
         }
-        if let Some(ref b) = p.body
+        // Issue #350: expand a `@/path` body into the file's content (CLI parity)
+        // BEFORE the length cap, so the cap measures the RESOLVED content — a short
+        // `@path` must not smuggle a huge file past the limit. `None` stays `None`.
+        let expanded_body: Option<String> = match p.body.as_deref() {
+            Some(b) => Some(expand_body_filepath(b).await?),
+            None => None,
+        };
+        if let Some(ref b) = expanded_body
             && b.len() > integrity_config.mcp_max_body_len
         {
             return Err(McpError::invalid_params(
@@ -3764,7 +3811,7 @@ impl ForgeplanServer {
             .map_err(safe_mcp_error)?;
         }
 
-        if let Some(ref body) = p.body {
+        if let Some(ref body) = expanded_body {
             projection::update_body_with_projection(&ctx, &p.id, body)
                 .await
                 .map_err(safe_mcp_error)?;
@@ -7548,8 +7595,11 @@ impl ForgeplanServer {
         }
         tags.push(format!("discover-session={}", session.id));
 
-        // Format body with source files metadata
-        let mut full_body = p.body.clone();
+        // Format body with source files metadata.
+        // Issue #350: expand a `@/path` finding body into the file's content
+        // (CLI parity) — without this, an agent passing `@file.md` would persist
+        // the literal `@path` string as the finding body (silent data loss).
+        let mut full_body = expand_body_filepath(&p.body).await?;
         if !p.source_files.is_empty() {
             full_body.push_str("\n\n## Source Files\n\n");
             for f in &p.source_files {

--- a/crates/forgeplan-mcp/tests/mcp_update_filepath_e2e.rs
+++ b/crates/forgeplan-mcp/tests/mcp_update_filepath_e2e.rs
@@ -1,0 +1,136 @@
+//! Issue #350 (CRITICAL silent data-loss) regression — `forgeplan_update` and
+//! `forgeplan_discover_finding` MCP tools must expand a `@/path/to/file.md`
+//! body into the file's content (CLI parity), NOT write the literal `@path`
+//! string into the artifact body.
+//!
+//! Pre-fix, an agent mirroring the documented CLI `--body @file` pattern through
+//! MCP got `Updated successfully` while the artifact body was silently
+//! overwritten with the literal string `@/path/...`. The failure was invisible
+//! until a later `forgeplan_get`. These tests pin the fix: the file content
+//! lands in the body; a missing file errors loudly (not silently); a plain body
+//! without a leading `@` is stored verbatim.
+
+mod common;
+use common::McpFixture;
+
+fn assert_err_contains(err: rmcp::service::ServiceError, needle: &str) {
+    let msg = format!("{err}");
+    assert!(
+        msg.contains(needle),
+        "expected error message to contain {needle:?}, got: {msg}"
+    );
+}
+
+/// THE #350 regression: `forgeplan_update` with `body=@file` stores the file's
+/// CONTENT, not the literal `@path` string.
+#[tokio::test]
+async fn mcp_update_at_filepath_expands_into_body() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("issue-350 sandbox").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("body.md");
+    let content = "# Real body content\n\nThis text came from a FILE, not the path string.";
+    std::fs::write(&file, content).unwrap();
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_update",
+            serde_json::json!({ "id": id, "body": format!("@{}", file.display()) }),
+        )
+        .await;
+    env.assert_ok();
+
+    // Read back — body MUST be the file content, never the literal "@path".
+    let get = fx
+        .call_tool_json("forgeplan_get", serde_json::json!({ "id": id }))
+        .await;
+    let body = get.assert_ok()["body"].as_str().unwrap_or("").to_string();
+    assert!(
+        body.contains("Real body content"),
+        "body must be the FILE content (issue #350), got: {body:?}"
+    );
+    assert!(
+        !body.trim_start().starts_with('@'),
+        "body must NOT be the literal @path string (issue #350 regression): {body:?}"
+    );
+}
+
+/// A `@file` whose content carries YAML frontmatter must have the frontmatter
+/// stripped (CLI parity — we persist body only).
+#[tokio::test]
+async fn mcp_update_at_filepath_strips_frontmatter() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("issue-350 frontmatter").await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("with_fm.md");
+    std::fs::write(
+        &file,
+        "---\nid: PRD-999\nkind: prd\n---\n\n## Problem\nBody after frontmatter.",
+    )
+    .unwrap();
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_update",
+            serde_json::json!({ "id": id, "body": format!("@{}", file.display()) }),
+        )
+        .await;
+    env.assert_ok();
+
+    let get = fx
+        .call_tool_json("forgeplan_get", serde_json::json!({ "id": id }))
+        .await;
+    let body = get.assert_ok()["body"].as_str().unwrap_or("").to_string();
+    assert!(
+        body.contains("Body after frontmatter"),
+        "expected body content, got: {body:?}"
+    );
+    assert!(
+        !body.contains("kind: prd"),
+        "frontmatter must be stripped from a @file body (issue #350), got: {body:?}"
+    );
+}
+
+/// A missing `@file` must error LOUDLY (invalid_params), never silently write
+/// the literal `@path` — the whole point of #350 is no silent data loss.
+#[tokio::test]
+async fn mcp_update_at_nonexistent_file_errors_not_silent() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("issue-350 negative").await;
+
+    let err = fx
+        .try_call_tool(
+            "forgeplan_update",
+            serde_json::json!({ "id": id, "body": "@/nonexistent/issue-350/missing.md" }),
+        )
+        .await
+        .expect_err("a missing @file must error, not silently write the @path string");
+    assert_err_contains(err, "cannot read file");
+}
+
+/// A plain body with no leading `@` is stored verbatim (no accidental file read,
+/// no `@` interpretation mid-string).
+#[tokio::test]
+async fn mcp_update_literal_body_without_at_is_verbatim() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("issue-350 literal").await;
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_update",
+            serde_json::json!({ "id": id, "body": "Plain body. Email a@b.com stays inline." }),
+        )
+        .await;
+    env.assert_ok();
+
+    let get = fx
+        .call_tool_json("forgeplan_get", serde_json::json!({ "id": id }))
+        .await;
+    let body = get.assert_ok()["body"].as_str().unwrap_or("").to_string();
+    assert!(
+        body.contains("Plain body. Email a@b.com stays inline."),
+        "a non-@ body must be stored verbatim, got: {body:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes **#350** (CRITICAL silent data loss). The MCP `forgeplan_update` and `forgeplan_discover_finding` tools wrote a literal `@/path/to/file.md` body string into the artifact — silently overwriting real content. The call returned `Updated successfully`; the loss was invisible until a later `forgeplan_get`. An agent mirroring the documented CLI `--body @file` pattern through MCP triggered it.

## Fix

Option **(a) symmetry** (the issue-preferred outcome): a new `expand_body_filepath()` helper gives the MCP body the same semantics as the CLI —

- leading `@` → read the file (CLI parity: strip YAML frontmatter when present);
- anything else → stored verbatim.

Applied in **both** `body`-accepting handlers: `forgeplan_update` (the reported one) **and** `forgeplan_discover_finding` (the same latent bug — found by sweeping all handlers that take a raw agent body). `forgeplan_new` takes no body (template-generated) → out of scope.

Safety:
- the DoS body-length cap (`mcp_max_body_len`) now measures the **expanded** content, so a short `@path` can't smuggle an oversized file past the limit;
- a read failure surfaces as `invalid_params` (loud, not silent) and routes through `safe_invalid_params` so no `$HOME`/absolute path leaks into the transcript.

## Tests

4 e2e via the real MCP JSON-RPC surface (`crates/forgeplan-mcp/tests/mcp_update_filepath_e2e.rs`):

| Test | Asserts |
|------|---------|
| `mcp_update_at_filepath_expands_into_body` | `@file` → body is file CONTENT, not the `@path` string (the #350 repro) |
| `mcp_update_at_filepath_strips_frontmatter` | YAML frontmatter stripped from a `@file` body |
| `mcp_update_at_nonexistent_file_errors_not_silent` | missing `@file` → `invalid_params`, NOT a silent literal write |
| `mcp_update_literal_body_without_at_is_verbatim` | plain body (incl. inline `a@b.com`) stored verbatim |

`forgeplan_discover_finding` reuses the same helper → covered transitively.

Gate: **forgeplan-mcp 259 passed / 0 failed**, clippy 0 (`--all-targets`), fmt 0.

## Artifacts

PROB-077 (resolved) + EVID-142 (`informs`, validate PASS, CL3) record the problem + fix in the forgeplan graph.

## Notes

- fix → dev: **merge commit** (not squash).
- Backward-compatible: `@`-expansion is new behaviour replacing the literal-write bug; a non-`@` body is stored verbatim as before. No rollback risk beyond the touched handlers (MCP only; CLI untouched).

Closes #350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
