### PR TITLE
[PROB-073] create-roundtrip latency profile (broad — measure-first, accept+document)

### DIFF
--- a/.forgeplan/evidence/EVID-143-prob-073-broad-create-roundtrip-profile-13ms-p50-lancedb-commit-hot-spot.md
+++ b/.forgeplan/evidence/EVID-143-prob-073-broad-create-roundtrip-profile-13ms-p50-lancedb-commit-hot-spot.md
@@ -1,0 +1,60 @@
+---
+depth: tactical
+id: EVID-143
+kind: evidence
+links:
+- target: PROB-073
+  relation: informs
+status: draft
+title: 'PROB-073 broad: create-roundtrip profile — 13ms p50, LanceDB commit hot spot'
+---
+
+## Summary
+
+Measure-first profile of the `forgeplan_new` create-roundtrip — the path the user reports as slow ("медленно через MCP, file-first летает"). Decomposes the core create path to locate the hot spot BEFORE optimizing. Bench: `crates/forgeplan-core/tests/create_roundtrip_bench.rs`.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: benchmark
+
+CL3: direct component measurement of the exact shipped create path.
+
+## Measured (dev-profile, n=50/component)
+
+| Component | p50 | p95 | Note |
+|-----------|-----|-----|------|
+| store init | 22ms (one-time) | — | cached per-workspace since PRD-078 → NOT per-call |
+| **lance write (insert+commit)** | **7.1ms** | 10.5ms | **dominant** — manifest write / fsync per row |
+| projection (render + file I/O) | 6.2ms | — | markdown render + file write |
+| full create roundtrip | 13.3ms | 28.6ms | validate + projection + lance |
+
+## Findings
+
+1. **Hot spot = the per-write LanceDB commit (~7ms p50).** Each `add().execute()` does a manifest write + fsync. In an 11-agent pipeline issuing hundreds of `forgeplan_new`/`forgeplan_link` calls, this is what accumulates into "slow".
+2. **Projection (~6ms) is the second half** — markdown render + file write, near-equal to the lance cost.
+3. **Store-open is NOT the culprit** — 22ms but one-time, cached per-workspace by `workspace_store_cache` (PRD-078). Not paid per call.
+4. **Plan risk #1 is CLEARED**: the slowness is a localized per-write commit cost, NOT a "rewrite ~20% of the server" situation. v0.33 can address the symptom; no v0.34 engine rewrite forced.
+
+## Optimization candidates (surfaced, NOT applied)
+
+The fix is a decision with a real trade-off — recorded here, not chosen blind:
+
+- **(A) Batch / defer LanceDB commits** — accumulate N inserts, one commit. Biggest win on the dominant component, but changes durability semantics (a crash mid-batch loses the un-committed tail) and the per-workspace lock interaction. Best fit for pipeline bursts.
+- **(B) Async / background commit** — return after the in-memory insert, fsync off the hot path. Faster perceived latency; same durability caveat + needs failure surfacing.
+- **(C) Accept ~13ms** — the file-first workaround stays valid (ADR-003); document the per-call cost and the file-first+sync alternative for burst workloads. Zero risk, zero code.
+
+Projection (~6ms) is harder to cut without touching the file-first invariant (ADR-003), so the lance-commit path is the higher-ROI target.
+
+## Scope
+
+The detection slice of PROB-073 was closed separately (EVID-141, SC-2 via gating). This evidence covers the **broad** create-roundtrip cost — the real user complaint.
+
+## Provenance
+
+- Bench: `crates/forgeplan-core/tests/create_roundtrip_bench.rs`
+- Command: `cargo test -p forgeplan-core --features test-helpers --test create_roundtrip_bench -- --ignored --nocapture`
+- Branch: `chore/prob-073-roundtrip-profile` (off `origin/dev`)
+
+

--- a/.forgeplan/problems/PROB-073-mcp-per-call-latency-too-high-for-agentic-pipelines-filesystem-write-sync-workaround-faster-than-direct.md
+++ b/.forgeplan/problems/PROB-073-mcp-per-call-latency-too-high-for-agentic-pipelines-filesystem-write-sync-workaround-faster-than-direct.md
@@ -122,3 +122,4 @@ projection).
 
 
 
+

--- a/crates/forgeplan-core/tests/create_roundtrip_bench.rs
+++ b/crates/forgeplan-core/tests/create_roundtrip_bench.rs
@@ -1,0 +1,135 @@
+//! PROB-073 (broad) — `forgeplan_new` create-roundtrip latency breakdown.
+//!
+//! The user's complaint: creating an artifact through the MCP server feels slow,
+//! while writing the markdown file directly + syncing "flies". This bench
+//! decomposes the **core** create path into its components to find where the
+//! time goes BEFORE anyone optimizes (measure-first; plan risk #1 — the profile
+//! decides v0.33-symptom-fix vs v0.34-engine-rewrite).
+//!
+//! Components measured (per `forgeplan_new`):
+//!   * **store init** — `LanceStore::init` (one-time per workspace; cached by the
+//!     MCP server's `workspace_store_cache` since PRD-078, so NOT per-call —
+//!     reported once for context).
+//!   * **lance write** — `create_artifact_for_test` = the `add().execute()`
+//!     LanceDB insert + commit (manifest write / fsync).
+//!   * **full roundtrip** — `create_artifact_with_projection` = id/kind validate
+//!     + markdown render + file write + the lance write above.
+//!   * **projection delta** — (full − lance) ≈ the render + file-I/O cost.
+//!
+//! Embedding is NOT in this path (feature-gated `semantic-search`/fastembed,
+//! computed separately), so it is intentionally excluded.
+//!
+//! Why not `criterion`: same as `health_bench.rs` — `Instant`, `#[ignore]`,
+//! human-readable table, no new dep.
+//!
+//!   cargo test -p forgeplan-core --features test-helpers \
+//!     --test create_roundtrip_bench -- --ignored --nocapture
+
+#![cfg(feature = "test-helpers")]
+
+use std::time::{Duration, Instant};
+
+use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::projection::{MutationContext, create_artifact_with_projection};
+use tempfile::TempDir;
+
+fn art(i: usize) -> NewArtifact {
+    NewArtifact {
+        id: format!("PRD-BENCH-{i:05}"),
+        kind: "prd".to_string(),
+        status: "draft".to_string(),
+        title: format!("Roundtrip bench {i}"),
+        body: "## Problem\nBench body.\n\n## Goals\nReal goals.\n".to_string(),
+        depth: "standard".to_string(),
+        author: None,
+        parent_epic: None,
+        valid_until: None,
+        tags: Vec::new(),
+    }
+}
+
+fn pct(sorted: &[Duration], p: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((p / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "perf bench — run with --ignored --nocapture"]
+async fn bench_create_roundtrip_components() {
+    let dir = TempDir::new().unwrap();
+    let ws = dir.path().join(".forgeplan");
+    std::fs::create_dir_all(&ws).unwrap();
+
+    // ── store init (one-time per workspace; cached per-workspace in prod) ──
+    let t = Instant::now();
+    let store = LanceStore::init(&ws).await.expect("init store");
+    let store_init = t.elapsed();
+
+    // warm-up — prime LanceDB table handles + FS caches.
+    for i in 0..3 {
+        store
+            .create_artifact_for_test(&art(i))
+            .await
+            .expect("warmup");
+    }
+
+    let n = 50usize;
+
+    // ── lance write only (add + execute = insert + commit) ────────────────
+    let mut lance = Vec::with_capacity(n);
+    for i in 1000..1000 + n {
+        let t = Instant::now();
+        store
+            .create_artifact_for_test(&art(i))
+            .await
+            .expect("lance write");
+        lance.push(t.elapsed());
+    }
+
+    // ── full roundtrip (validate + render + file write + lance write) ─────
+    let ctx = MutationContext::new(&ws, &store);
+    let mut full = Vec::with_capacity(n);
+    for i in 2000..2000 + n {
+        let t = Instant::now();
+        create_artifact_with_projection(&ctx, &art(i))
+            .await
+            .expect("full roundtrip");
+        full.push(t.elapsed());
+    }
+
+    lance.sort_unstable();
+    full.sort_unstable();
+
+    let lance_p50 = pct(&lance, 50.0);
+    let lance_p95 = pct(&lance, 95.0);
+    let full_p50 = pct(&full, 50.0);
+    let full_p95 = pct(&full, 95.0);
+    let proj_p50 = full_p50.saturating_sub(lance_p50);
+
+    eprintln!();
+    eprintln!("[bench] === forgeplan_new create-roundtrip breakdown (n={n}) ===");
+    eprintln!("[bench] store init (one-time, cached in prod) : {store_init:>10.3?}");
+    eprintln!(
+        "[bench] lance write (insert+commit)   p50/p95 : {lance_p50:>10.3?} / {lance_p95:.3?}"
+    );
+    eprintln!("[bench] full roundtrip (render+io+db) p50/p95 : {full_p50:>10.3?} / {full_p95:.3?}");
+    eprintln!("[bench] projection delta (render+fileio) p50  : {proj_p50:>10.3?}");
+    eprintln!();
+    let dom = if proj_p50 > lance_p50 {
+        "PROJECTION (render + file I/O)"
+    } else {
+        "LANCE WRITE (insert + commit/fsync)"
+    };
+    eprintln!("[bench] dominant component @ p50: {dom}");
+    eprintln!();
+
+    // Sanity ceiling only (catch a hang/runaway, not jitter) — the profile
+    // itself is the deliverable, not a pass/fail gate.
+    assert!(
+        full_p95 < Duration::from_secs(5),
+        "full create roundtrip p95 ({full_p95:?}) exceeded 5s — suspect a hang, not jitter"
+    );
+}


### PR DESCRIPTION
## Summary

Measure-first profile of the `forgeplan_new` create-roundtrip — the path PROB-073 reports as slow. **No production code change** — adds a profiling bench + evidence. Decision: **(C) accept + document** for v0.33 (batch-commit optimization is a v0.34 track).

## Measured (dev-profile, n=50)

| Component | p50 | Note |
|---|---|---|
| store init | 22ms (one-time) | cached per-workspace since PRD-078 — NOT per-call |
| **lance write (insert+commit)** | **7.1ms** | dominant — manifest/fsync per row |
| projection (render+file I/O) | 6.2ms | |
| full create roundtrip | 13.3ms / 28.6ms p95 | |

**Hot spot = per-write LanceDB commit (~7ms).** Localized — **plan risk #1 cleared** (not a 20%-engine rewrite). Optimization candidates (batch/async commit) surfaced in EVID-143 as a durability trade-off, deferred to v0.34. The file-first workaround stays valid (ADR-003).

## Files
- `crates/forgeplan-core/tests/create_roundtrip_bench.rs` (new, `#[ignore]`, health_bench convention)
- EVID-143 (profile) — `informs` PROB-073

clippy 0, fmt 0. fix → dev: merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
