### PR TITLE
fix(cli): five v0.32.1 dogfood CLI bugs (claim/progress/playbook/order/activity)

### DIFF
--- a/crates/forgeplan-cli/src/commands/activity.rs
+++ b/crates/forgeplan-cli/src/commands/activity.rs
@@ -54,12 +54,21 @@ pub async fn run(
     let result = query(&ws, &filter).await?;
 
     // Build hints — actionable next step depending on whether results are present.
+    //
+    // Dogfood v0.32.1 fix: don't tell the caller to "try a wider window:
+    // --since-hours 720" when they're ALREADY at (or above) the 720h ceiling.
+    // After the clamp above, `since == 720` means the caller requested >= 720,
+    // so the widen-window hint would be self-referential. Emit a terminal
+    // `Done.` instead.
+    let at_max_window = since >= 720;
     let mut hint_list: Vec<Hint> = Vec::new();
     if result.entries.is_empty() {
-        hint_list.push(
-            Hint::info("Try a wider window")
-                .with_action("forgeplan activity --since-hours 720".to_string()),
-        );
+        if !at_max_window {
+            hint_list.push(
+                Hint::info("Try a wider window")
+                    .with_action("forgeplan activity --since-hours 720".to_string()),
+            );
+        }
     } else {
         hint_list.push(
             Hint::info("See aggregated stats")
@@ -83,10 +92,18 @@ pub async fn run(
 
     // Human-readable table — Forge tone, no emoji.
     if result.entries.is_empty() {
-        println!(
-            "No tool calls in the last {since} hour(s). Try a wider window: \
-             `--since-hours 720` for the last 30 days."
-        );
+        if at_max_window {
+            // Already at the 720h ceiling — no wider window to suggest.
+            println!(
+                "No tool calls in the last {since} hour(s) — that's the maximum \
+                 window (30 days)."
+            );
+        } else {
+            println!(
+                "No tool calls in the last {since} hour(s). Try a wider window: \
+                 `--since-hours 720` for the last 30 days."
+            );
+        }
         if !result.warnings.is_empty() {
             println!();
             println!("{}", style("Warnings:").yellow().bold());
@@ -94,7 +111,12 @@ pub async fn run(
                 println!("  - {w}");
             }
         }
-        print!("{}", hints::render_next_action_line(&hint_list));
+        if at_max_window {
+            println!();
+            println!("Done.");
+        } else {
+            print!("{}", hints::render_next_action_line(&hint_list));
+        }
         return Ok(());
     }
 

--- a/crates/forgeplan-cli/src/commands/activity_stats.rs
+++ b/crates/forgeplan-cli/src/commands/activity_stats.rs
@@ -32,12 +32,19 @@ pub async fn run(since_hours: u32, json: bool) -> anyhow::Result<()> {
     let total_errors: usize = stats.iter().map(|s| s.err_count).sum();
     let total_ms: u64 = stats.iter().map(|s| s.total_ms).sum();
 
+    // Dogfood v0.32.1 fix: suppress the "try a longer window: --since-hours
+    // 720" hint when the caller is ALREADY at (or above) the 720h ceiling.
+    // After the clamp above, `since == 720` means the caller requested >= 720,
+    // so the widen-window hint would be self-referential.
+    let at_max_window = since >= 720;
     let mut hint_list: Vec<Hint> = Vec::new();
     if stats.is_empty() {
-        hint_list.push(
-            Hint::info("Try a longer window")
-                .with_action("forgeplan activity-stats --since-hours 720".to_string()),
-        );
+        if !at_max_window {
+            hint_list.push(
+                Hint::info("Try a longer window")
+                    .with_action("forgeplan activity-stats --since-hours 720".to_string()),
+            );
+        }
     } else {
         hint_list.push(
             Hint::info("See raw entries")
@@ -60,11 +67,21 @@ pub async fn run(since_hours: u32, json: bool) -> anyhow::Result<()> {
     }
 
     if stats.is_empty() {
-        println!(
-            "No activity in the last {since} hour(s). Try a longer window: \
-             `--since-hours 720` for 30 days."
-        );
-        print!("{}", hints::render_next_action_line(&hint_list));
+        if at_max_window {
+            // Already at the 720h ceiling — no longer window to suggest.
+            println!(
+                "No activity in the last {since} hour(s) — that's the maximum \
+                 window (30 days)."
+            );
+            println!();
+            println!("Done.");
+        } else {
+            println!(
+                "No activity in the last {since} hour(s). Try a longer window: \
+                 `--since-hours 720` for 30 days."
+            );
+            print!("{}", hints::render_next_action_line(&hint_list));
+        }
         return Ok(());
     }
 

--- a/crates/forgeplan-cli/src/commands/claim.rs
+++ b/crates/forgeplan-cli/src/commands/claim.rs
@@ -14,11 +14,17 @@ use forgeplan_core::workspace;
 
 const MAX_TTL_MINUTES: u32 = 1440; // 24 h — matches claim::MAX_TTL.
 
-/// Default agent identity when caller omits `--agent`. Mirrors the MCP
-/// fallback: `cli/<crate version>` so each release has a stable signature
-/// while still being distinguishable from an MCP sub-agent.
+/// Default agent identity when caller omits `--agent`. Uses `cli-<crate
+/// version>` so each release has a stable signature while still being
+/// distinguishable from an MCP sub-agent.
+///
+/// **Must use `-` not `/`**: the CLI surface runs the *strict*
+/// [`claim::validate_agent_id`] which rejects `/` (it would let an operator
+/// enshrine the canonical MCP `name/version` path-shape as a CLI argument).
+/// A `cli/<version>` default therefore made bare `forgeplan claim <id>`
+/// (no `--agent`) always fail validation — the dogfood v0.32.1 HIGH bug.
 fn default_agent() -> String {
-    format!("cli/{}", env!("CARGO_PKG_VERSION"))
+    format!("cli-{}", env!("CARGO_PKG_VERSION"))
 }
 
 pub async fn run(
@@ -163,5 +169,35 @@ pub async fn run(
             std::process::exit(1);
         }
         Err(e) => anyhow::bail!("claim failed: {e}\nFix: forgeplan claims"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Dogfood v0.32.1 HIGH fix (#1): the implicit `--agent` default MUST pass
+    /// the *strict* CLI-side validator (`claim::validate_agent_id`, which
+    /// rejects `/`). The old `cli/<version>` default contained a `/`, so bare
+    /// `forgeplan claim <id>` always errored before this fix.
+    #[test]
+    fn default_agent_passes_strict_validator() {
+        let agent = default_agent();
+        assert!(
+            !agent.contains('/'),
+            "default agent must not contain '/': {agent}"
+        );
+        claim::validate_agent_id(&agent)
+            .unwrap_or_else(|e| panic!("default agent `{agent}` rejected by validator: {e:?}"));
+    }
+
+    #[test]
+    fn default_agent_has_cli_prefix_and_version() {
+        let agent = default_agent();
+        assert!(agent.starts_with("cli-"), "expected cli- prefix: {agent}");
+        assert!(
+            agent.len() > "cli-".len(),
+            "expected a version suffix: {agent}"
+        );
     }
 }

--- a/crates/forgeplan-cli/src/commands/order.rs
+++ b/crates/forgeplan-cli/src/commands/order.rs
@@ -20,6 +20,18 @@ pub async fn run(json: bool) -> anyhow::Result<()> {
     // For blocking logic: resolved = active + deprecated + superseded
     let resolved_ids = common::resolved_ids(&all_records);
 
+    // Dogfood v0.32.1 MED bug: the per-line label hardcoded "draft" for every
+    // non-active artifact, so a `deprecated`/`superseded`/`stale` artifact
+    // printed as `(draft, ready)`. Map each id to its REAL status so the
+    // label reflects the actual lifecycle state. Ids present in the relation
+    // graph but absent from the store (cross-PR forward refs) fall back to
+    // "unknown".
+    let status_by_id: std::collections::HashMap<&str, &str> = all_records
+        .iter()
+        .map(|r| (r.id.as_str(), r.status.as_str()))
+        .collect();
+    let real_status = |id: &str| -> &str { status_by_id.get(id).copied().unwrap_or("unknown") };
+
     let result = topological::kahn_sort(&all_relations, &resolved_ids);
 
     // PRD-071 contract: priority — fix cycles first, then activate ready
@@ -98,13 +110,19 @@ pub async fn run(json: bool) -> anyhow::Result<()> {
             "o"
         };
 
-        let status: String = if active_ids.contains(id) {
+        // Use the artifact's REAL lifecycle status (draft / active / deprecated
+        // / superseded / stale / unknown) instead of assuming "draft" for every
+        // non-active row. Active artifacts keep the bare "active" label; for
+        // everything else we pair the real status with the readiness signal
+        // (blocked-by vs ready).
+        let lifecycle = real_status(id);
+        let status: String = if lifecycle == "active" {
             "active".to_string()
         } else if let Some(blockers) = blocked_map.get(id.as_str()) {
             let names: Vec<&str> = blockers.iter().map(|s| s.as_str()).collect();
-            format!("draft, blocked by {}", names.join(", "))
+            format!("{}, blocked by {}", lifecycle, names.join(", "))
         } else {
-            "draft, ready".to_string()
+            format!("{}, ready", lifecycle)
         };
 
         println!("    {} {} ({})", marker, id, status);

--- a/crates/forgeplan-cli/src/commands/playbook.rs
+++ b/crates/forgeplan-cli/src/commands/playbook.rs
@@ -300,12 +300,28 @@ pub async fn run_show(target: &str, json: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// `forgeplan playbook validate <file> [--json]`
-pub async fn run_validate(file: &Path, json: bool) -> anyhow::Result<()> {
-    let yaml = match read_playbook_with_limits(file) {
+/// `forgeplan playbook validate <target> [--json]`
+///
+/// `target` may be a playbook name (matched against discovered playbooks) or
+/// a path to a `.yaml` file — same discovery contract as `show`/`run`.
+///
+/// Dogfood v0.32.1 LOW bug: this used to take a raw `PathBuf` and skip the
+/// `resolve_target` discovery step, so `playbook validate brownfield-code`
+/// (a name that `show`/`run` happily resolve) failed with "cannot read".
+/// A full path still works — `resolve_target` checks `path.exists()` first.
+pub async fn run_validate(target: &str, json: bool) -> anyhow::Result<()> {
+    let resolved = match resolve_target(target) {
+        Ok(path) => path,
+        Err(msg) => {
+            print_resolve_error(target, &msg, json);
+            std::process::exit(2);
+        }
+    };
+
+    let yaml = match read_playbook_with_limits(&resolved) {
         Ok(s) => s,
         Err(e) => {
-            print_playbook_read_error(file, &e, json);
+            print_playbook_read_error(&resolved, &e, json);
             std::process::exit(2);
         }
     };
@@ -318,7 +334,7 @@ pub async fn run_validate(file: &Path, json: bool) -> anyhow::Result<()> {
                     "name": pb.name,
                     "title": pb.title,
                     "steps_count": pb.steps.len(),
-                    "source_path": file.display().to_string(),
+                    "source_path": resolved.display().to_string(),
                     "_next_action": format!(
                         "forgeplan playbook run {} --yes --dry-run",
                         pb.name
@@ -333,7 +349,7 @@ pub async fn run_validate(file: &Path, json: bool) -> anyhow::Result<()> {
             Ok(())
         }
         Err(err) => {
-            emit_loader_error(file, &err, json);
+            emit_loader_error(&resolved, &err, json);
             std::process::exit(2);
         }
     }
@@ -1164,6 +1180,38 @@ mod tests {
         let path = std::path::PathBuf::from("/nonexistent/forgeplan/playbooks/xyz-test-9999");
         let v = collect_yaml_files(&path).expect("ok");
         assert!(v.is_empty());
+    }
+
+    /// Dogfood v0.32.1 LOW fix (#3): `playbook validate` now routes through
+    /// `resolve_target`, exactly like `show`/`run`. A full path to an
+    /// existing `.yaml` must still resolve as-is (the fallback branch that
+    /// preserves the old PathBuf behaviour).
+    #[test]
+    fn resolve_target_accepts_full_path_to_existing_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("my-playbook.yaml");
+        std::fs::write(
+            &file,
+            "schema_version: \"1.0\"\nname: x\ntitle: t\nsteps: []\n",
+        )
+        .unwrap();
+        let got = resolve_target(file.to_str().unwrap()).expect("full path resolves");
+        assert_eq!(got, file);
+    }
+
+    /// A bogus path that is neither a real file nor a discoverable name must
+    /// surface an error (callers map this to `print_resolve_error` + exit 2).
+    #[test]
+    fn resolve_target_errors_on_unknown_path() {
+        // Disable host plugin discovery so an installed pack can't satisfy
+        // this lookup and flake the assertion.
+        // SAFETY: test-only env mutation, single-threaded within this test.
+        unsafe {
+            std::env::set_var("FORGEPLAN_DISABLE_PLUGIN_DISCOVERY", "1");
+        }
+        let bogus = "/nonexistent/dir/xyz-no-such-playbook-9999.yaml";
+        let err = resolve_target(bogus).expect_err("unknown path errors");
+        assert!(err.contains("no playbook"), "got: {err}");
     }
 
     #[test]

--- a/crates/forgeplan-cli/src/commands/progress.rs
+++ b/crates/forgeplan-cli/src/commands/progress.rs
@@ -60,38 +60,84 @@ pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
         );
     }
 
+    // If a specific ID is requested, resolve it FIRST so BOTH the JSON and
+    // the text path scope output to that single artifact. Phase 2.5
+    // (PROB-060) — accept slug or display id form via resolver.
+    //
+    // Dogfood v0.32.1 MED bug: the all-artifacts JSON block used to run
+    // unconditionally *before* this filter, so `progress <id> --json` emitted
+    // every artifact and silently ignored `<id>`. We now branch the JSON
+    // payload on `id` presence: scoped-to-one when `Some`, all when `None`.
+    let single: Option<(usize, &forgeplan_core::db::store::ArtifactRecord)> =
+        if let Some(target_id) = id {
+            let canonical = store.resolve_id(target_id).await?.ok_or_else(|| {
+                anyhow::anyhow!("Artifact '{}' not found\nFix: forgeplan list", target_id)
+            })?;
+            let canonical_upper = canonical.to_uppercase();
+
+            // Find both progress and record in one pass
+            let found = records
+                .iter()
+                .enumerate()
+                .find(|(_, r)| r.id.to_uppercase() == canonical_upper);
+            let (idx, record) = found.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Artifact '{}' not found
+Fix: forgeplan list",
+                    target_id
+                )
+            })?;
+            Some((idx, record))
+        } else {
+            None
+        };
+
     if json {
-        let data: Vec<_> = all_progress.iter().filter(|p| p.count.total > 0).map(|p| {
-            serde_json::json!({"id": p.id, "title": p.title, "kind": p.kind, "completed": p.count.completed, "total": p.count.total, "percent": p.percent()})
-        }).collect();
+        // Scoped JSON when an id was given (PROB-060 resolver already ran);
+        // otherwise the all-artifacts-with-checkboxes payload.
+        let data: Vec<_> = match single {
+            Some((idx, _)) => {
+                let p = &all_progress[idx];
+                // Mirror the text path: an artifact with no checkboxes is a
+                // valid result, just an empty `progress[]` (not an error).
+                if p.count.total > 0 {
+                    vec![serde_json::json!({"id": p.id, "title": p.title, "kind": p.kind, "completed": p.count.completed, "total": p.count.total, "percent": p.percent()})]
+                } else {
+                    Vec::new()
+                }
+            }
+            None => all_progress
+                .iter()
+                .filter(|p| p.count.total > 0)
+                .map(|p| {
+                    serde_json::json!({"id": p.id, "title": p.title, "kind": p.kind, "completed": p.count.completed, "total": p.count.total, "percent": p.percent()})
+                })
+                .collect(),
+        };
+        // For the scoped case, the global lowest-percent hint is misleading
+        // (it may point at a *different* artifact than the one requested).
+        // Recompute a focused hint for the single artifact instead.
+        let next_action = match single {
+            Some((idx, _)) => {
+                let p = &all_progress[idx];
+                if p.count.total > 0 && p.count.completed == p.count.total {
+                    Some(format!("forgeplan activate {}", p.id))
+                } else {
+                    Some(format!("forgeplan get {}", p.id))
+                }
+            }
+            None => hints::primary_action(&hints_vec),
+        };
         let payload = serde_json::json!({
             "progress": data,
-            "_next_action": hints::primary_action(&hints_vec),
+            "_next_action": next_action,
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
     }
 
-    // If specific ID requested, show only that artifact.
-    // Phase 2.5 (PROB-060) — accept slug or display id form via resolver.
-    if let Some(target_id) = id {
-        let canonical = store.resolve_id(target_id).await?.ok_or_else(|| {
-            anyhow::anyhow!("Artifact '{}' not found\nFix: forgeplan list", target_id)
-        })?;
-        let canonical_upper = canonical.to_uppercase();
-
-        // Find both progress and record in one pass
-        let found = records
-            .iter()
-            .enumerate()
-            .find(|(_, r)| r.id.to_uppercase() == canonical_upper);
-        let (idx, record) = found.ok_or_else(|| {
-            anyhow::anyhow!(
-                "Artifact '{}' not found
-Fix: forgeplan list",
-                target_id
-            )
-        })?;
+    // Text path for a specific ID (resolved above).
+    if let Some((idx, record)) = single {
         let p = &all_progress[idx];
 
         println!();

--- a/crates/forgeplan-cli/src/main.rs
+++ b/crates/forgeplan-cli/src/main.rs
@@ -940,8 +940,8 @@ enum PlaybookAction {
     },
     /// Validate playbook YAML against SPEC-003 schema.
     Validate {
-        /// Path to playbook YAML file
-        file: std::path::PathBuf,
+        /// Playbook name (e.g. brownfield-code) or path to .yaml file
+        target: String,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -1497,8 +1497,8 @@ async fn main() -> anyhow::Result<()> {
             PlaybookAction::Show { target, json } => {
                 commands::playbook::run_show(&target, json).await
             }
-            PlaybookAction::Validate { file, json } => {
-                commands::playbook::run_validate(&file, json).await
+            PlaybookAction::Validate { target, json } => {
+                commands::playbook::run_validate(&target, json).await
             }
             PlaybookAction::Run {
                 target,


### PR DESCRIPTION
## Summary

Five CLI bugs surfaced by a live dogfood of the full v0.32.1 surface (82 CLI
commands + 73 MCP tools, run with the real binary). All five are fixed,
live-verified against the debug binary, and covered by tests. One additional
"exit-code" suspicion was empirically refuted (by-design) and left unchanged.

> Stacked on `fix/prob-mcp-stale-read` (#372) so the diff stays to the 7 changed
> files. Rebase onto `dev` after #372 merges.

## Fixes

| Sev | Bug | Fix |
|---|---|---|
| **HIGH** | `forgeplan claim <id>` without `--agent` always errored — the default agent-id `cli/<ver>` contains `/`, which the strict agent-id validator rejects | default → `cli-<ver>` (`claim.rs`) + 2 regression tests |
| MED | `progress <id> --json` ignored the id (the all-artifacts JSON block returned before the id filter) | resolve the id up front, branch the JSON payload (`progress.rs`) |
| LOW | `playbook validate <name>` didn't resolve playbook names (took a `PathBuf`, unlike `show`/`run`) | `file: PathBuf` → `target: String` + `resolve_target()` first (`main.rs`, `playbook.rs`) + 2 tests; a full path still works |
| MED | `order` labelled deprecated/superseded artifacts as `(draft, …)` (hardcoded "draft" for any non-active) | use each artifact's real status (`order.rs`) |
| MED | `activity` / `activity-stats` emitted a self-referential "try `--since-hours 720`" hint even when already at ≥720h (agents following hints loop) | suppress/replace the hint at the max window (`activity.rs`, `activity_stats.rs`) |

## Not a bug (verified by-design, no change)

`promote` / `calibrate-estimate` were reported as "print `Error:` but exit 0".
Empirically they exit **1** (raw `$?`) — they use `anyhow::bail!` and `main`
returns the dispatch result. The dogfood "exit 0" was a post-pipe `$?` artifact
(`forgeplan … | grep` returns grep's exit code). Left unchanged.

## Verification

- `cargo build -p forgeplan` — 0 errors; `cargo clippy -p forgeplan -- -D warnings` — 0; `cargo fmt --check` — 0 diffs.
- `cargo test -p forgeplan --lib` — 16 pass (incl. 4 new).
- Live-verified each fix with the real debug binary in a scratch workspace.

## Reversibility

Single self-contained commit, additive/localized, no schema or core changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
