### PR TITLE
chore(deps): bump openssl 0.10.79→0.10.80 (security alert #34)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -4689,9 +4689,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
chore(deps): bump openssl 0.10.79->0.10.80 (security alert #34)

Closes Dependabot alert #34 (MEDIUM): rust-openssl potential out-of-bounds
write in `CipherCtxRef::cipher_update_inplace`, patched in 0.10.80.
Transitive dependency, Cargo.lock-only bump:
  openssl     0.10.79 -> 0.10.80
  openssl-sys 0.9.115 -> 0.9.116

lru LOW (alert #3) is carried accepted-with-justification: our requirement
pins lru 0.12.x and the 0.16.3 fix needs a major bump with API changes,
out of scope for v0.33 (IterMut StackedBorrows; no exploit path in our
single-threaded LRU usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)