### PR TITLE
chore(release): v0.33.0 — version bump + CHANGELOG + status banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-06-04
+
+Sprint headline: **MCP worktree-aware routing (PRD-078) + read-after-write correctness investigation (PROB-078 refuted) + dogfood-driven CLI hardening.**
+
+### Added
+
+- **Worktree-aware MCP routing** (PRD-078 / ADR-015 / ADR-016) — `forgeplan_get`, `forgeplan_update`, and the other store-resolution MCP tools accept an optional absolute `workspace` parameter so an agent running in a linked git worktree reads/writes the correct `.forgeplan/`. Writes use a strict multi-worktree detection gate (structured `-32602` error when ambiguous); reads fall back softly. Closes PROB-072 (sub-agents writing to the wrong repo).
+- **Duplicate-id detector in `scan-import`** — surfaces colliding artifact ids (same `KIND-NNN` across multiple files) as a warning instead of silently importing one and dropping the other.
+
+### Fixed
+
+- **CRITICAL silent data loss (#350)** — `forgeplan_update` / `forgeplan_discover_finding` with `body=@/path/file.md` stored the literal `@path` string instead of the file's content; the loss was invisible until a later `forgeplan_get`. The MCP tools now expand `@file` to its content (CLI parity) and error loudly on a missing file.
+- **`claim` without `--agent` always failed** — the default agent-id `cli/<version>` contained a `/`, which the agent-id validator rejects. Default is now `cli-<version>`.
+- **`progress <id> --json` ignored the id** — the JSON path returned all artifacts; it now scopes to the requested id.
+- **`playbook validate <name>` did not resolve playbook names** — it required a full path (unlike `show`/`run`). Names now resolve via the same discovery.
+- **`order` mislabeled non-active artifacts** — deprecated/superseded artifacts printed as `(draft, …)`; they now show their real status.
+- **`activity` / `activity-stats` hint loop** — the "try a wider window" hint unconditionally suggested `--since-hours 720` even at the maximum window, looping hint-following agents; it is now suppressed at the max window.
+- **Stale-cache hardening (PROB-075)** — bounded retry budget + exponential backoff on transient LanceDB staleness, a refresh rate-limit/debounce, and a typed `lancedb::Error` downcast so artifact bodies echoing a "Not found:" marker no longer trigger spurious refreshes.
+
+### Security
+
+- **openssl 0.10.79 → 0.10.80** (Dependabot alert #34, MEDIUM) — potential out-of-bounds write in `CipherCtxRef::cipher_update_inplace`.
+- **Supply-chain hardening (PROB-070)** — all GitHub Actions `uses:` pinned to 40-char commit SHAs; CI-gate `continue-on-error` theatre removed.
+
+### Internal
+
+- **PROB-078 (MCP read-after-write staleness) investigated and REFUTED** — the reported "stale body after your own write in the same session" was an artifact of an unreliable hand-rolled stdio-printf repro client, not a product bug. Read-after-write is correct at every layer, proven by 7 new regression tests across three layers: store-level reopened-handle, in-process MCP (`McpFixture`, incl. a two-store probe), and the **real `forgeplan-mcp` binary over real stdio** via the rmcp child-process transport (incl. a byte-exact replica of the original repro). These tests are permanent read-after-write guards and replace a previously weak Journey-1 e2e assertion (content-match, not non-empty).
+- **Latency measured (PROB-073)** — multi-worktree detection ~12 ms p95; create-roundtrip hot spot is the LanceDB commit (~7 ms). Accepted as documented behavior for v0.33; no code change.
+- **Dependabot triage (RED LINE #10)** — openssl fixed (above); `lru` LOW (alert #3) carried accepted-with-justification (requirement pins 0.12.x; the 0.16.3 fix needs an out-of-scope major bump; no exploit path in our usage). Deferred to v0.34: lancedb 0.30 (storage core — untested major bump, highest regression risk), sha2 0.11, notify 8, arrow-schema 58. schemars 1.x remains a separate scoped sprint (#318).
+
 ## [0.32.1] - 2026-05-21
 
 **Hotfix release.** v0.32.0 shipped with a Cargo.toml regression that prevented Windows binary publication via cargo-dist. macOS / Linux binaries also did not publish because cargo-dist exits the entire workflow when any target fails. No semantic / behaviour changes — purely a build-time dependency placement fix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,19 +86,18 @@ semantic search via BGE-M3, typed links, lifecycle with validation gates.
 
 ## Current status
 
-- **v0.32.1** (2026-05-21) — hotfix: Windows binary build (tera/walkdir/globset
-  moved out of cfg(unix)). v0.32.0 shipped on 2026-05-21 with Epic #287
-  brownfield extraction surface (6 new ArtifactKinds: use_case/glossary/
-  invariant/scenario/hypothesis/domain_model, 7 new MCP tools, hypothesis
-  state machine, ADR-014 catalog evolution policy) + 3 pre-Epic methodology
-  issues (#286 forgeplan_unlink, #288 auto-activate evidence + stale_drafts
-  health surface, #289 forgeplan_anomalies + v1 catalog of 9 anomaly kinds)
-  + 6 dogfood findings (#290-#295) + post-merge hardening (PROB-074 MCP
-  stale lance handle: lazy refresh + retry budget + rate-limit + lancedb
-  downcast hint; docs drift #306 81→73 MCP tools; PROB-075 F-2/F-3/F-4
-  audit follow-ups). Dependabot: devalue HIGH addressed (5.6.4→5.8.1),
-  lru LOW accepted-with-justification.
-- **76 CLI commands**, **73 MCP tools**, **3084 tests**, **0 warnings** on both feature configs
+- **v0.33.0** (2026-06-04) — MCP worktree-aware routing (PRD-078: optional
+  `workspace` param on store-resolution tools — strict write-gate / soft read,
+  closes PROB-072) + CRITICAL #350 fix (`@file` body expansion, no silent data
+  loss) + **PROB-078 read-after-write REFUTED** as a stdio-printf harness
+  artifact (7 new regression tests: store + in-process MCP + real-binary
+  subprocess) + 5 dogfood CLI fixes (claim default-id, progress/playbook/order,
+  activity hint-loop) + PROB-075 stale-cache hardening + PROB-070 supply-chain
+  (SHA-pinned actions). Security: openssl 0.10.80 (alert #34). Dependabot:
+  lru LOW carried; lancedb 0.30 / sha2 / notify / arrow-schema deferred to v0.34.
+- **v0.32.1** (2026-05-21) — hotfix: Windows binary build; v0.32.0: Epic #287
+  brownfield extraction surface + PROB-074 stale-handle hardening.
+- **76 CLI commands**, **73 MCP tools**, **3095+ tests**, **0 warnings** on both feature configs
 - **EPIC-001/002/003 ✅**, **Epic #287 ✅** (brownfield). Phase 5 (Desktop Tauri) — backlog
 - FPF KB semantic search via BGE-M3 (feature-gated, graceful fallback)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forgeplan"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-core"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "forgeplan-mcp"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.32.1"
+version = "0.33.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ForgePlan/forgeplan"

--- a/crates/forgeplan-cli/Cargo.toml
+++ b/crates/forgeplan-cli/Cargo.toml
@@ -18,8 +18,8 @@ name = "forgeplan"
 path = "src/main.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
-forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.32.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.33.0" }
+forgeplan-mcp = { path = "../forgeplan-mcp", version = "0.33.0" }
 clap = { version = "4", features = ["derive"] }
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/forgeplan-mcp/Cargo.toml
+++ b/crates/forgeplan-mcp/Cargo.toml
@@ -18,7 +18,7 @@ name = "forgeplan_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.1" }
+forgeplan-core = { path = "../forgeplan-core", version = "0.33.0" }
 rmcp = { version = "1.7", features = ["server", "transport-io"] }
 schemars = "0.8"
 serde.workspace = true
@@ -33,7 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 semantic-search = ["forgeplan-core/semantic-search"]
 
 [dev-dependencies]
-forgeplan-core = { path = "../forgeplan-core", version = "0.32.1", features = ["test-helpers"] }
+forgeplan-core = { path = "../forgeplan-core", version = "0.33.0", features = ["test-helpers"] }
 tempfile = "3"
 serde_yaml.workspace = true
 # Phase 2.4: enable the rmcp `client` role for E2E integration tests so we


### PR DESCRIPTION
chore(release): v0.33.0 — version bump + CHANGELOG + status banner

Bump workspace 0.32.1 -> 0.33.0 (workspace.package + inter-crate path-dep
version pins + Cargo.lock). Add CHANGELOG [0.33.0]: PRD-078 worktree-aware
MCP routing, CRITICAL #350 @file fix, PROB-078 read-after-write REFUTED
+ 7 regression tests, 5 dogfood CLI fixes, PROB-075/PROB-070 hardening,
openssl 0.10.80 security bump, Dependabot triage. Refresh CLAUDE.md status
banner to v0.33.0.

Refs: PRD-078, PROB-078, PROB-070, PROB-075

🤖 Generated with [Claude Code](https://claude.com/claude-code)