### PR TITLE
fix(mcp,core): MCP update case-id (#383) + at-rest linter false positive (#384)

### DIFF
--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -465,12 +465,58 @@ pub fn find_tech_leakage(text: &str) -> Vec<(usize, String)> {
     let mut results = Vec::new();
     for (i, line) in stripped.lines().enumerate() {
         for (keyword, re) in TECH_KEYWORD_REGEXES.iter() {
-            if re.is_match(line) {
+            // Issue #384: the security idiom "encrypted at-rest" / "data-at-rest"
+            // must NOT be flagged as the REST protocol. `-` is a word boundary, so
+            // `\bREST\b` matches the `rest` inside `at-rest`. Narrowly special-case
+            // ONLY the `rest` keyword: walk its match positions and suppress any
+            // occurrence that is the "at-rest" idiom, while standalone "REST" /
+            // "REST API" still flags. All other keywords keep the cheap is_match path.
+            if keyword == "rest" {
+                let has_real_rest = re
+                    .find_iter(line)
+                    .any(|m| !is_at_rest_idiom(line, m.start()));
+                if has_real_rest {
+                    results.push((i + 1, keyword.clone()));
+                }
+            } else if re.is_match(line) {
                 results.push((i + 1, keyword.clone()));
             }
         }
     }
     results
+}
+
+/// Issue #384 helper — decide whether a `rest` match at byte offset `match_start`
+/// is part of the "at-rest" security idiom (e.g. "encrypted at-rest",
+/// "data-at-rest") rather than the REST protocol.
+///
+/// True only when the match is immediately preceded by a standalone word `at`
+/// plus a single separator (`-` or space): `at-rest` / `at rest`. The leading
+/// word boundary guard prevents false suppression of tokens that merely end in
+/// `at` (e.g. "format-rest" → preceded by "format-", not the word "at").
+fn is_at_rest_idiom(line: &str, match_start: usize) -> bool {
+    let before = &line[..match_start];
+    // Strip exactly one separator immediately before the match (`at-rest` / `at rest`).
+    let Some(stem) = before
+        .strip_suffix('-')
+        .or_else(|| before.strip_suffix(' '))
+    else {
+        return false;
+    };
+    // The remaining text must end with the word `at` (case-insensitive).
+    let Some(tail_start) = stem.len().checked_sub(2) else {
+        return false;
+    };
+    if !stem.is_char_boundary(tail_start) || !stem[tail_start..].eq_ignore_ascii_case("at") {
+        return false;
+    }
+    // Guard: the `at` must itself be word-initial — the char before it (if any)
+    // must be a non-alphanumeric word boundary. Without this, "format-rest"
+    // (stem "format" ends in "at") would be wrongly suppressed.
+    match stem[..tail_start].chars().next_back() {
+        None => true,
+        Some(c) => !c.is_alphanumeric() && c != '_',
+    }
 }
 
 /// PROB-038 helper — remove HTML comments, fenced code blocks, и inline
@@ -1170,6 +1216,69 @@ mod tests {
         assert!(
             names.contains(&"postgresql"),
             "postgresql в prose: {names:?}"
+        );
+    }
+
+    // Issue #384 — the "encrypted at-rest" security idiom must NOT be flagged as
+    // the REST protocol, while standalone "REST" / "REST API" still flags.
+
+    /// Issue #384 — "encrypted at-rest" must NOT flag `rest`. `-` is a word
+    /// boundary so `\bREST\b` used to match the `rest` inside `at-rest`.
+    #[test]
+    fn find_tech_leakage_skips_at_rest_idiom() {
+        let text = "NFR-001: All secrets are encrypted at-rest and in transit";
+        let leaks = find_tech_leakage(text);
+        assert!(
+            !leaks.iter().any(|(_, name)| name == "rest"),
+            "`at-rest` idiom must not flag REST; got: {leaks:?}"
+        );
+    }
+
+    /// Issue #384 — REGRESSION GUARD: a real REST protocol mention still flags.
+    /// The narrow at-rest suppression must not blind the matcher to "REST API".
+    #[test]
+    fn find_tech_leakage_still_flags_rest_protocol() {
+        let text = "FR-002: The service must expose a REST API for clients";
+        let leaks = find_tech_leakage(text);
+        assert!(
+            leaks.iter().any(|(_, name)| name == "rest"),
+            "standalone `REST API` must still flag REST; got: {leaks:?}"
+        );
+    }
+
+    /// Issue #384 — variants of the idiom: "data-at-rest" (dash before `at`) and
+    /// "at rest" (space separator) are both suppressed.
+    #[test]
+    fn find_tech_leakage_skips_at_rest_variants() {
+        for text in ["Encrypt data-at-rest", "Stored at rest in the vault"] {
+            let leaks = find_tech_leakage(text);
+            assert!(
+                !leaks.iter().any(|(_, name)| name == "rest"),
+                "`{text}` must not flag REST; got: {leaks:?}"
+            );
+        }
+    }
+
+    /// Issue #384 — the word-boundary guard: a token that merely ENDS in `at`
+    /// before `-rest` (e.g. "format-rest") is NOT the idiom and still flags REST.
+    #[test]
+    fn find_tech_leakage_at_rest_guard_does_not_overmatch() {
+        let text = "FR-003: convert the payload to format-rest before sending";
+        let leaks = find_tech_leakage(text);
+        assert!(
+            leaks.iter().any(|(_, name)| name == "rest"),
+            "`format-rest` is not the at-rest idiom and must still flag; got: {leaks:?}"
+        );
+    }
+
+    /// Issue #384 — suppression is case-insensitive on the idiom ("At-Rest").
+    #[test]
+    fn find_tech_leakage_skips_at_rest_mixed_case() {
+        let text = "Data is encrypted At-Rest per policy";
+        let leaks = find_tech_leakage(text);
+        assert!(
+            !leaks.iter().any(|(_, name)| name == "rest"),
+            "`At-Rest` (mixed case) must not flag REST; got: {leaks:?}"
         );
     }
 

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -3733,14 +3733,29 @@ impl ForgeplanServer {
             }
         };
 
+        // Issue #383: resolve slug / lowercase display-id input to the canonical
+        // DB id ONCE, mirroring the `forgeplan_get` handler. Without this every
+        // downstream id use hits the case-sensitive direct `id` column lookup and
+        // `forgeplan_update id=prd-001` fails with "not found" even though
+        // `forgeplan_get`/`validate`/`list` accept the same lowercase/slug form.
+        // `resolve_id(None)` falls back to the verbatim id so legacy artifacts
+        // (no slug field) still load via the original direct path.
+        let canonical = match store.resolve_id(&p.id).await {
+            Ok(Some(c)) => c,
+            Ok(None) => p.id.clone(),
+            Err(e) => return Ok(safe_err_result("", e)),
+        };
+
         // Verify exists. The helpers do their own sync_before_mutation; we
         // only need the existence check here (and presence info downstream).
         let pre_record = store
-            .get_record(&p.id)
+            .get_record(&canonical)
             .await
             .map_err(|e| safe_mcp_error_anyhow(&e))?;
         let _pre_record = match pre_record {
             Some(r) => r,
+            // Surface the user's original input in the not-found message (mirrors
+            // `forgeplan_get`) — most helpful when the id genuinely doesn't exist.
             None => return Ok(artifact_not_found(&p.id)),
         };
 
@@ -3803,7 +3818,7 @@ impl ForgeplanServer {
             let status_str = p.status.as_ref().map(|s| s.as_str());
             projection::update_metadata_with_projection(
                 &ctx,
-                &p.id,
+                &canonical,
                 status_str,
                 p.title.as_deref(),
             )
@@ -3812,14 +3827,14 @@ impl ForgeplanServer {
         }
 
         if let Some(ref body) = expanded_body {
-            projection::update_body_with_projection(&ctx, &p.id, body)
+            projection::update_body_with_projection(&ctx, &canonical, body)
                 .await
                 .map_err(safe_mcp_error)?;
         }
 
         // Re-fetch for the response payload.
         let updated = store
-            .get_record(&p.id)
+            .get_record(&canonical)
             .await
             .map_err(|e| safe_mcp_error_anyhow(&e))?
             .ok_or_else(|| McpError::internal_error("Artifact disappeared after update", None))?;
@@ -3842,8 +3857,10 @@ impl ForgeplanServer {
             other => format!("Updated ({other}). Inspect lifecycle: `forgeplan_review {safe_id}`."),
         };
         // PRD-078 Phase 3 (W3 FR-007 / NFR-004): inject workspace trace.
+        // Issue #383: echo the resolved canonical id (== updated.id) rather than
+        // the raw input, so the agent sees the authoritative artifact id.
         let base = serde_json::json!({
-            "id": p.id,
+            "id": canonical,
             "message": "Updated successfully",
             "status": updated.status,
             "title": updated.title,

--- a/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
+++ b/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
@@ -150,3 +150,74 @@ async fn mcp_update_accepts_benign_rename() {
         "rename response title must reflect the new value"
     );
 }
+
+// ── Issue #383: forgeplan_update id resolution (case-insensitive) ──────
+//
+// `forgeplan_get` / `validate` / `list` all accept a lowercase display id
+// (`prd-001`) or slug because they call `store.resolve_id` first. Pre-fix
+// `forgeplan_update` passed the raw `id` straight to the case-SENSITIVE
+// `get_record` direct-column lookup, so `forgeplan_update id=prd-001`
+// returned "Artifact 'prd-001' not found" while `PRD-001` worked. The fix
+// resolves the id once at the top of the handler (mirroring forgeplan_get).
+
+#[tokio::test]
+async fn mcp_update_accepts_lowercase_display_id() {
+    let fx = McpFixture::new().await;
+    let canonical_id = fx.seed_prd("Title for lowercase-id update").await;
+    // `forgeplan_new` returns the canonical display id (e.g. `PRD-001`).
+    // Reproduce the user's report by addressing the SAME artifact with the
+    // lowercased form an agent might paste from another tool's output.
+    let lower_id = canonical_id.to_lowercase();
+    assert_ne!(
+        lower_id, canonical_id,
+        "test precondition: seeded id must contain letters so lowercasing \
+         actually differs from the canonical form (got {canonical_id:?})"
+    );
+
+    let env = fx
+        .call_tool_json(
+            "forgeplan_update",
+            serde_json::json!({"id": lower_id, "title": "Updated via lowercase id"}),
+        )
+        .await;
+    // Pre-fix this asserted false: the handler returned an is_error body
+    // ("Artifact '<lower>' not found").
+    let resp = env.assert_ok();
+    assert_eq!(
+        resp["title"].as_str().unwrap(),
+        "Updated via lowercase id",
+        "lowercase-id update must mutate the same artifact"
+    );
+    // The echoed id is the resolved canonical form, not the raw lowercase input.
+    assert_eq!(
+        resp["id"].as_str().unwrap(),
+        canonical_id,
+        "response must echo the resolved canonical id"
+    );
+}
+
+#[tokio::test]
+async fn mcp_update_lowercase_id_persists_change() {
+    // Stronger guard: prove the lowercase-id update actually hit the right
+    // artifact by reading it back with forgeplan_get afterwards.
+    let fx = McpFixture::new().await;
+    let canonical_id = fx.seed_prd("Persistence check title").await;
+    let lower_id = canonical_id.to_lowercase();
+
+    fx.call_tool_json(
+        "forgeplan_update",
+        serde_json::json!({"id": lower_id, "title": "Persisted new title"}),
+    )
+    .await
+    .assert_ok();
+
+    let got = fx
+        .call_tool_json("forgeplan_get", serde_json::json!({"id": canonical_id}))
+        .await;
+    let resp = got.assert_ok();
+    assert_eq!(
+        resp["title"].as_str().unwrap(),
+        "Persisted new title",
+        "the title written via the lowercase id must be visible on the canonical artifact"
+    );
+}


### PR DESCRIPTION
Two verified user-feedback bugs (re-verified with the real binary), targeted for v0.33.

## #383 — MCP `forgeplan_update` case-sensitive on `id`
`forgeplan_get`/`validate`/`list` accept `prd-001`; `forgeplan_update id=prd-001` returned 'not found' (only `PRD-001` worked). The MCP `forgeplan_update` handler passed `p.id` straight to `get_record`/projection with no `resolve_id`. Now resolves to `canonical` first (mirrors `forgeplan_get` + CLI `update`), routing all id uses through it. CLI was already correct — MCP-handler-only gap. +2 MCP integration tests.

## #384 — `prd-no-impl-leakage` flags 'at-rest' as tech name 'rest'
The security idiom 'encrypted at-rest' tripped the REST-API tech-name check (word-boundary match, `-` is a boundary). `find_tech_leakage` now suppresses a `rest` match that is the at-rest idiom (`at-rest`/`data-at-rest`/`at rest`, case-insensitive) while standalone 'REST API' still flags. Scoped to the `rest` token only; +5 inline tests incl. an over-match guard (`format-rest` still flags).

## Gates
build 0 / fmt 0 / clippy -D warnings 0 / core 1997 pass / mcp update tests 11 pass + 97 adjacent. Live-verified #384 via CLI; #383 via MCP integration test (CLI can't exercise the MCP handler — it already resolves).

Closes #383, closes #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)