### PR TITLE
[docs] Homebrew 6.0 tap-trust: document 'brew trust forgeplan/tap'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Structured artifacts (PRD, RFC, ADR, Epic, Spec), quality scoring, evidence, and
 ```bash
 # Homebrew (macOS, Linux)
 brew install ForgePlan/tap/forgeplan
+# Homebrew 6.0+: if install is refused with "untrusted tap",
+# run `brew trust ForgePlan/tap` once, then re-run the line above.
 
 # Install script
 curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh

--- a/README.ru.md
+++ b/README.ru.md
@@ -79,6 +79,8 @@
 ```bash
 # Homebrew (macOS, Linux)
 brew install ForgePlan/tap/forgeplan
+# Homebrew 6.0+: если установка отклонена с "untrusted tap",
+# один раз выполните `brew trust ForgePlan/tap` и повторите строку выше.
 
 # Install script
 curl -fsSL https://raw.githubusercontent.com/ForgePlan/forgeplan/main/install.sh | sh

--- a/docs/methodology/FORGEPLAN-GUIDE.md
+++ b/docs/methodology/FORGEPLAN-GUIDE.md
@@ -36,6 +36,7 @@ The skill will be installed into selected agents. After that, in your AI chat:
 ```bash
 # macOS (Homebrew)
 brew install forgeplan/tap/forgeplan
+# Homebrew 6.0+: if refused with "untrusted tap", run `brew trust forgeplan/tap` once, then re-run.
 
 # From source (Rust)
 cargo install forgeplan

--- a/docs/methodology/FORGEPLAN-GUIDE.ru.md
+++ b/docs/methodology/FORGEPLAN-GUIDE.ru.md
@@ -36,6 +36,7 @@ Skill установится в выбранные агенты. После эт
 ```bash
 # macOS (Homebrew)
 brew install forgeplan/tap/forgeplan
+# Homebrew 6.0+: если отклонено с "untrusted tap", выполните `brew trust forgeplan/tap` один раз и повторите.
 
 # Из исходников (Rust)
 cargo install forgeplan

--- a/website/src/components/Install.astro
+++ b/website/src/components/Install.astro
@@ -38,7 +38,7 @@
           </div>
         </div>
         <div>
-          <p class="text-xs text-forge-dim mb-1">Homebrew</p>
+          <p class="text-xs text-forge-dim mb-1">Homebrew <span class="text-[10px] text-forge-ember">(6.0+: run <code>brew trust ForgePlan/tap</code> first)</span></p>
           <div class="flex items-center justify-between bg-forge-surface px-4 py-3">
             <code class="font-mono text-xs">brew install ForgePlan/tap/forgeplan</code>
             <button class="text-forge-dim hover:text-forge-fg transition-colors" aria-label="Copy command">

--- a/website/src/components/InstallMenu.astro
+++ b/website/src/components/InstallMenu.astro
@@ -38,7 +38,7 @@
     </div>
 
     <div class="install-popup-row" data-cmd="brew install ForgePlan/tap/forgeplan">
-      <p class="install-popup-label">Homebrew</p>
+      <p class="install-popup-label">Homebrew <span style="opacity:.6;font-size:10px">(6.0+: brew trust ForgePlan/tap)</span></p>
       <div class="install-popup-cmd">
         <code>brew install ForgePlan/tap/forgeplan</code>
         <button type="button" class="install-popup-copy" data-copy-target aria-label="Copy command" title="Copy">

--- a/website/src/content/docs/docs/getting-started/installation.md
+++ b/website/src/content/docs/docs/getting-started/installation.md
@@ -83,6 +83,20 @@ See [Marketplace Overview](/docs/marketplace/overview/) for the full plugin cata
 brew install forgeplan/tap/forgeplan
 ```
 
+:::note[Homebrew 6.0+ requires trusting the tap]
+Homebrew 6.0 made third-party taps **untrusted by default**. If you see
+`Error: Refusing to load formula forgeplan/tap/forgeplan from untrusted tap`,
+trust the tap once, then re-run the install:
+
+```bash
+brew trust forgeplan/tap
+brew install forgeplan/tap/forgeplan
+```
+
+This is a one-time, per-machine confirmation that you trust the ForgePlan tap.
+On Homebrew < 6.0 the plain `brew install` above works without this step.
+:::
+
 ### From source (Rust)
 
 ```bash

--- a/website/src/content/docs/ru/docs/getting-started/installation.md
+++ b/website/src/content/docs/ru/docs/getting-started/installation.md
@@ -83,6 +83,20 @@ forgeplan setup-skill
 brew install forgeplan/tap/forgeplan
 ```
 
+:::note[Homebrew 6.0+ требует доверия к tap]
+В Homebrew 6.0 сторонние tap'ы стали **недоверенными по умолчанию**. Если видите
+`Error: Refusing to load formula forgeplan/tap/forgeplan from untrusted tap`,
+один раз отметьте tap доверенным и повторите установку:
+
+```bash
+brew trust forgeplan/tap
+brew install forgeplan/tap/forgeplan
+```
+
+Это разовое (на машину) подтверждение, что вы доверяете tap'у ForgePlan.
+На Homebrew < 6.0 обычный `brew install` выше работает без этого шага.
+:::
+
 ### Из исходного кода (Rust)
 
 ```bash


### PR DESCRIPTION
## Summary

Homebrew 6.0 made third-party taps untrusted by default. Users on brew >= 6.0 who follow our install docs currently hit:

```
Error: Refusing to load formula forgeplan/tap/forgeplan from untrusted tap
```

The fix is a one-time `brew trust forgeplan/tap` before `brew install ForgePlan/tap/forgeplan`. None of our install surfaces mentioned this. This PR documents it everywhere users install from:

- `README.md` / `README.ru.md` — quick-install block comment
- `docs/methodology/FORGEPLAN-GUIDE.md` / `.ru.md` — install section comment
- `website/src/components/Install.astro` / `InstallMenu.astro` — Homebrew label hint
- `website/src/content/docs/docs/getting-started/installation.md` (EN + RU) — full note callout with the exact error and remediation

**Why now:** this work sat uncommitted in a worktree (`forgeplan-install-docs`) since June; the content is unique (verified absent from `origin/main`) and is being rescued into a proper branch + PR.

## Test plan

- [x] Docs-only change: +36/-2 across 8 files, no Rust, no build config
- [x] Site build unaffected — no component logic changed in `Install.astro` / `InstallMenu.astro`, only a copy string in the Homebrew label (verify by reading the diff)
- [x] EN and RU variants updated in parallel for every surface
- [x] Exact error string matches what Homebrew 6.0 emits

## Notes

- Branch base `731c246` is an ancestor of `dev`, so the merge is clean.
- `docs/*` branches are exempt from the evidence hook.