### PR TITLE
[chore] GitHub Actions bump with truthful SHA-pin comments (supersedes #399)

### DIFF
--- a/.github/workflows/assign-id.yml
+++ b/.github/workflows/assign-id.yml
@@ -37,7 +37,7 @@ jobs:
       DRY_RUN_MODE: ${{ github.event.inputs.dry-run-only || false }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
       - name: Fetch base
         run: git fetch origin dev:refs/remotes/origin/dev --no-tags --depth=200
 
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6  # v1.16.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659  # v1.17.0
         with:
           toolchain: stable
           components: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || (github.base_ref == 'main' && !startsWith(github.head_ref, 'release/')))
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0  # Full history for git diff to work correctly
 
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check Rust enum vs bash validator drift
         run: |
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Run validator audit on workspace
         run: |
@@ -126,7 +126,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch @ 2026-03-27 (no tag; verify with git ls-remote)
@@ -194,7 +194,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch @ 2026-03-27 (no tag; verify with git ls-remote)
@@ -234,7 +234,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538  # v2.81.1
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094  # v2.85.1
         with:
           tool: cargo-nextest
 
@@ -258,7 +258,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch @ 2026-03-27 (no tag; verify with git ls-remote)

--- a/.github/workflows/forgeplan-health.yml
+++ b/.github/workflows/forgeplan-health.yml
@@ -12,7 +12,7 @@ jobs:
     name: Forgeplan Health Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable branch @ 2026-03-27 (no tag; verify with git ls-remote)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive
@@ -116,7 +116,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive
@@ -183,7 +183,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive
@@ -233,7 +233,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive
@@ -298,7 +298,7 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: true
           repository: "ForgePlan/homebrew-tap"
@@ -345,7 +345,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,8 +43,8 @@ jobs:
     # here; that suppresses the job exit and makes the security badge green
     # even when cargo-deny reports a real advisory failure.
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2.0.20
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25  # v2.1.1
         with:
           command: check advisories licenses bans sources
           log-level: warn


### PR DESCRIPTION
## Summary

Same four action bumps as #399 — but the version comments are correct.

| Action | New SHA | Version |
|---|---|---|
| `actions/checkout` | `3d3c42e5` | **v7.0.1** |
| `actions-rust-lang/setup-rust-toolchain` | `166cdcfd` | **v1.17.0** |
| `taiki-e/install-action` | `3d7d7cd5` | **v2.85.1** |
| `EmbarkStudios/cargo-deny-action` | `3c634983` | **v2.1.1** |

Each version was resolved by querying upstream tag refs for the SHA (annotated tags peeled), not copied from the Dependabot PR body.

## Why not just merge #399

Merging it would have re-introduced the exact defect #407 (`6be6dd32`) removed hours earlier.

Dependabot rewrites the SHA but carries the **previous comment forward unchanged**. So #399 proposed:

```
actions/checkout@3d3c42e5...  # v4.0.0     <- in 4 files
actions/checkout@3d3c42e5...  # v4.1.7     <- in ci.yml
```

One SHA, two different version claims, and neither is v7.0.1.

Worse: on `@dependabot rebase` it resolved the conflict **in its own favour**, reverting dev's corrected `# v6.0.2` back to `# v4.0.0`. Verified directly — `git show origin/dev:.github/workflows/ci.yml` has `# v6.0.2`; `gh pr diff 399` proposes `# v4.0.0`.

The comment is the only human-auditable signal of what a 40-character SHA pins — a reviewer cannot expand it mentally. A wrong comment is worse than no comment: it invites a confident false conclusion. That is precisely what the v0.33.0 SHA-pinning work (PROB-070) exists to prevent, so shipping the bump with the lie intact would pay the pinning cost while discarding its benefit.

## Untouched (already correct on dev)

`rust-cache` v2.9.1, `upload-artifact` v7.0.1, `download-artifact` v8.0.1, `github-script` v9.0.0, `setup-protoc` v3.0.0, `sccache-action` v0.0.10.

`dtolnay/rust-toolchain@29eef336` is a commit on the moving `stable` branch, so it carries no version tag by design — its comment stays `# stable`.

## Verification

- All 19 pin lines changed, matching #399's pin count exactly
- No stale SHAs remain: `grep -E "de0fac2e|46268bd0|e49978b7" .github/workflows/*.yml` returns nothing
- Diff is 6 YAML files, 19 insertions / 19 deletions — no source code

## Follow-up

Once this lands, **#399 should be closed as superseded**. Left open for now so the maintainer decides.

Worth considering separately: Dependabot will keep doing this on every actions bump. Either the comments get re-checked each time, or the `# vX.Y.Z` convention gets replaced by something Dependabot maintains correctly.

## Risk

🟢 **Low.** CI configuration only. If a bumped action misbehaves, revert is one commit. The version comments carry no runtime effect — only the SHAs do, and those are exactly the ones Dependabot proposed.