### PR TITLE
[#411] Memory as a graph citizen: resolve_id direct path + real author

### DIFF
--- a/crates/forgeplan-cli/src/commands/common.rs
+++ b/crates/forgeplan-cli/src/commands/common.rs
@@ -172,6 +172,77 @@ pub fn extract_plain_text(body: &str) -> String {
     lines.join(" ").trim().to_string()
 }
 
+/// Widest author cell rendered in a memory listing, in CHARS.
+///
+/// Issue #411: `git::author::resolve_author` caps the STORED value at
+/// `MAX_FIELD_LEN` (64 BYTES) — far too wide for a table that already runs
+/// to ~140 columns. 20 chars fits every identity this project actually
+/// produces: `cli` (3), `claude-code/1.0.50` (18), and the bare-name form
+/// of `Name <email>`, while bounding the pathological 64-byte case.
+///
+/// This is a CAP, not a fixed width — call sites width-fit the column to
+/// the widest cell actually present (the idiom `id_width` already uses),
+/// so an all-`cli` workspace pays 6 chars (the header), not 20.
+pub const AUTHOR_COL_MAX: usize = 20;
+
+/// Rendered when no author can be resolved. Matches the existing empty-cell
+/// idiom in `log_cmd.rs`, `plugins.rs` and `scan_import.rs` — a bare `-`,
+/// not `"unknown"`, which would read as a value someone actually stored.
+pub const AUTHOR_MISSING: &str = "-";
+
+/// Resolve an artifact's author for display: LanceDB column first,
+/// frontmatter second, `None` when neither answers.
+///
+/// The column is authoritative — it is what
+/// `projection::create_artifact_with_projection` writes from
+/// `NewArtifact.author`, i.e. exactly the value `resolve_author` produced.
+/// The frontmatter fallback covers rows whose column is NULL but whose
+/// markdown still carries `author:` (hand-written memory files, anything
+/// synced before the column was populated) — the same precedence
+/// `author_from_frontmatter` established for scan-import under PROB-068.
+///
+/// Empty/whitespace values are treated as absent: `get_string` can yield
+/// `Some("")` for a blank column, and rendering that as a blank cell would
+/// look like a layout bug rather than missing data.
+pub fn resolve_display_author(record_author: Option<&str>, body: &str) -> Option<String> {
+    record_author
+        .map(|a| a.trim().to_string())
+        .filter(|a| !a.is_empty())
+        .or_else(|| extract_frontmatter_field(body, "author").filter(|a| !a.is_empty()))
+}
+
+/// Fit an author into `max_chars` for display.
+///
+/// When `Name <email>` does not fit, the ADDRESS is dropped WHOLE rather
+/// than cut into. `git::author::render_git_author` already ruled on this
+/// exact trade-off — "a mangled `<ada@examp` reads like corrupt data,
+/// whereas a bare name is honest" — so this reuses that policy instead of
+/// inventing a second one. Anything still too long gets a trailing `…`,
+/// matching the `truncate` helpers in `claims.rs` / `discover.rs`.
+///
+/// Deliberately NOT a replacement for those two private `truncate` fns:
+/// they carry no address policy, and de-duplicating them is out of scope.
+pub fn shorten_author(author: &str, max_chars: usize) -> String {
+    if author.chars().count() <= max_chars {
+        return author.to_string();
+    }
+    // Guards the `max_chars - 1` below and stops a 0-wide column from
+    // being blown out by a lone `…` (the latent bug in `discover.rs`).
+    if max_chars == 0 {
+        return String::new();
+    }
+    // `split(" <")` yields the whole string when there is no address, and
+    // that case is already known not to fit — the length guard decides,
+    // not the presence of the separator.
+    let name = author.split(" <").next().unwrap_or(author);
+    if !name.is_empty() && name.chars().count() <= max_chars {
+        return name.to_string();
+    }
+    let mut out: String = author.chars().take(max_chars - 1).collect();
+    out.push('…');
+    out
+}
+
 /// Load and validate LLM config — fails early with actionable message if not configured.
 ///
 /// PRD-077 FR-008 / CR-C4 — On failure the error message contains the structured Hint
@@ -329,6 +400,75 @@ mod tests {
             Some("mem-test".to_string())
         );
         assert_eq!(extract_frontmatter_field(body, "missing"), None);
+    }
+
+    #[test]
+    fn resolve_display_author_prefers_column_then_frontmatter() {
+        // The two memories in the wild: no author column populated at the
+        // time, `author: cli` in the body frontmatter.
+        let legacy = "---\nid: \"mem-x\"\ncategory: fact\nauthor: cli\n---\n\nA fact.";
+        assert_eq!(resolve_display_author(None, legacy).as_deref(), Some("cli"));
+
+        // A memory written after #411: the column wins even when both answer.
+        assert_eq!(
+            resolve_display_author(Some("Ada Lovelace <ada@example.org>"), legacy).as_deref(),
+            Some("Ada Lovelace <ada@example.org>")
+        );
+
+        // A blank column must fall through, not render as an empty cell.
+        assert_eq!(
+            resolve_display_author(Some("   "), legacy).as_deref(),
+            Some("cli")
+        );
+
+        // Quoted scalars are unwrapped by extract_frontmatter_field.
+        let quoted = "---\nid: x\nauthor: \"Ada Lovelace <ada@example.org>\"\n---\n\nText.";
+        assert_eq!(
+            resolve_display_author(None, quoted).as_deref(),
+            Some("Ada Lovelace <ada@example.org>")
+        );
+
+        // Neither source answers -> caller renders AUTHOR_MISSING.
+        assert_eq!(
+            resolve_display_author(None, "---\nid: x\n---\n\nText."),
+            None
+        );
+    }
+
+    #[test]
+    fn shorten_author_drops_the_address_before_cutting_into_it() {
+        // Fits — untouched.
+        assert_eq!(shorten_author("cli", AUTHOR_COL_MAX), "cli");
+        assert_eq!(
+            shorten_author("claude-code/1.0.50", AUTHOR_COL_MAX),
+            "claude-code/1.0.50"
+        );
+
+        // 30 chars: the address goes whole. Never `Ada Lovelace <ada@e…`.
+        let out = shorten_author("Ada Lovelace <ada@example.org>", AUTHOR_COL_MAX);
+        assert_eq!(out, "Ada Lovelace");
+        assert!(!out.contains('<'), "a half-address reads like corrupt data");
+
+        // Name alone still too long -> ellipsis, capped at exactly the budget.
+        let out = shorten_author(
+            "Wolfeschlegelsteinhausenbergerdorff <w@example.org>",
+            AUTHOR_COL_MAX,
+        );
+        assert_eq!(out.chars().count(), AUTHOR_COL_MAX);
+        assert!(out.ends_with('…'));
+
+        // Email-only identity (git user.name unset) has no name to fall back to.
+        let out = shorten_author("averyveryverylongaddress@example.org", AUTHOR_COL_MAX);
+        assert_eq!(out.chars().count(), AUTHOR_COL_MAX);
+        assert!(out.ends_with('…'));
+
+        // Multi-byte name must be cut by CHARS — `{:<w$}` pads by chars, so a
+        // byte-based cut would misalign the column.
+        let out = shorten_author(&"\u{03A9}".repeat(40), AUTHOR_COL_MAX);
+        assert_eq!(out.chars().count(), AUTHOR_COL_MAX);
+
+        // Degenerate budget must not emit a lone `…` into a 0-wide column.
+        assert_eq!(shorten_author("Ada", 0), "");
     }
 
     #[test]

--- a/crates/forgeplan-cli/src/commands/recall.rs
+++ b/crates/forgeplan-cli/src/commands/recall.rs
@@ -83,6 +83,11 @@ pub async fn run(
                 serde_json::json!({
                     "id": r.id,
                     "category": category,
+                    // Issue #411: agents consume this payload and had NO way
+                    // to see provenance. Emitted UNSHORTENED — JSON has no
+                    // width budget, and truncating a machine-readable field
+                    // is data loss. `null` when unresolvable.
+                    "author": common::resolve_display_author(r.author.as_deref(), &r.body),
                     "created_at": r.created_at,
                     "text": plain,
                 })
@@ -103,10 +108,20 @@ pub async fn run(
         let plain = common::extract_plain_text(&r.body);
         let truncated: String = plain.chars().take(80).collect();
 
+        // Issue #411: recall already showed the "when" and not the "who",
+        // which is arbitrary — provenance IS the trust signal that decides
+        // whether a reader acts on a remembered fact. Rendered as a dim
+        // inline token rather than a column: recall rows are free-flow (no
+        // fixed widths), so this needs no alignment work — only the same
+        // shortening policy the list table uses.
+        let author = common::resolve_display_author(r.author.as_deref(), &r.body)
+            .map(|a| common::shorten_author(&a, common::AUTHOR_COL_MAX))
+            .unwrap_or_else(|| common::AUTHOR_MISSING.to_string());
         println!(
-            "{}  {}  {}  {}",
+            "{}  {}  {}  {}  {}",
             style(&r.id).bold(),
             style(format!("[{}]", category)).dim(),
+            style(&author).dim(),
             style(&date).dim(),
             truncated,
         );

--- a/crates/forgeplan-cli/src/commands/remember.rs
+++ b/crates/forgeplan-cli/src/commands/remember.rs
@@ -122,18 +122,40 @@ async fn run_list() -> Result<()> {
         return Ok(());
     }
 
+    // Issue #411: the author is stored but was invisible in the one place
+    // people look. Cells are materialised BEFORE the header so the column
+    // can be width-fitted the same way `id_width` already is — a workspace
+    // where every memory says `cli` pays 6 chars, not the 20-char cap.
+    let author_cells: Vec<String> = records
+        .iter()
+        .map(|r| {
+            common::resolve_display_author(r.author.as_deref(), &r.body)
+                .map(|a| common::shorten_author(&a, common::AUTHOR_COL_MAX))
+                .unwrap_or_else(|| common::AUTHOR_MISSING.to_string())
+        })
+        .collect();
+
     // Print header
     let id_width = records.iter().map(|r| r.id.len()).max().unwrap_or(6).max(2);
+    // `.max(6)` is the "Author" header floor, mirroring `.max(2)` for "ID".
+    let author_width = author_cells
+        .iter()
+        .map(|a| a.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("Author".len());
     println!(
-        "{:<id_w$}  {:<12}  {:<12}  {}",
+        "{:<id_w$}  {:<12}  {:<a_w$}  {:<12}  {}",
         style("ID").bold().underlined(),
         style("Category").bold().underlined(),
+        style("Author").bold().underlined(),
         style("Created").bold().underlined(),
         style("Text").bold().underlined(),
         id_w = id_width,
+        a_w = author_width,
     );
 
-    for r in &records {
+    for (r, author) in records.iter().zip(author_cells.iter()) {
         let category = common::extract_frontmatter_field(&r.body, "category")
             .unwrap_or_else(|| "fact".to_string());
         let date: String = r.created_at.chars().take(10).collect();
@@ -141,12 +163,14 @@ async fn run_list() -> Result<()> {
         let truncated: String = plain_text.chars().take(60).collect();
 
         println!(
-            "{:<id_w$}  {:<12}  {:<12}  {}",
+            "{:<id_w$}  {:<12}  {:<a_w$}  {:<12}  {}",
             style(&r.id).bold(),
             category,
+            author,
             date,
             truncated,
             id_w = id_width,
+            a_w = author_width,
         );
     }
 

--- a/crates/forgeplan-cli/src/commands/remember.rs
+++ b/crates/forgeplan-cli/src/commands/remember.rs
@@ -3,6 +3,7 @@ use console::style;
 
 use forgeplan_core::artifact::types::slugify;
 use forgeplan_core::db::store::{ArtifactFilter, NewArtifact};
+use forgeplan_core::git::author::resolve_author;
 use forgeplan_core::hints::{self, Hint};
 use forgeplan_core::projection;
 
@@ -42,12 +43,29 @@ async fn run_remember(text: &str, category: &str) -> Result<()> {
 
     // Build markdown body with frontmatter
     let now = chrono::Utc::now().to_rfc3339();
+
+    // Issue #411: real provenance instead of the hardcoded `cli`.
+    // Resolved ONCE and reused by BOTH the frontmatter string below and
+    // `NewArtifact.author` — writing them separately is exactly how the
+    // markdown and the LanceDB row could drift.
+    //
+    // `None` for the caller identity: the CLI never performs the MCP
+    // clientInfo handshake, so tier 2 is a no-op here and the chain is
+    // git config -> "cli". An MCP-hosted `remember` passes `Some(&id)`.
+    //
+    // `author` is emitted as a double-quoted YAML scalar: the resolver
+    // strips `"` and `\`, so no escaping is needed, and a git user.name
+    // like `- foo` / `foo: bar` / `foo # bar` cannot break the mapping the
+    // way the previous unquoted `author: cli` line would have.
+    let author = resolve_author(&workspace, None).await;
+
     let body = format!(
-        "---\nid: \"{}\"\nkind: memory\ncategory: {}\nstatus: active\ndepth: tactical\ntitle: \"{}\"\ncreated: {}\nauthor: cli\n---\n\n{}",
+        "---\nid: \"{}\"\nkind: memory\ncategory: {}\nstatus: active\ndepth: tactical\ntitle: \"{}\"\ncreated: {}\nauthor: \"{}\"\n---\n\n{}",
         id,
         category,
         title.replace('"', "\\\""),
         now,
+        author,
         text
     );
 
@@ -59,7 +77,8 @@ async fn run_remember(text: &str, category: &str) -> Result<()> {
         title: title.clone(),
         body: body.clone(),
         depth: "tactical".to_string(),
-        author: Some("cli".to_string()),
+        // Same value as the frontmatter above — single resolution, no drift.
+        author: Some(author.clone()),
         parent_epic: None,
         valid_until: None,
         // C1: memory artifacts have no tags at creation; users add via `forgeplan tag`.

--- a/crates/forgeplan-cli/tests/cli_uncovered_coverage.rs
+++ b/crates/forgeplan-cli/tests/cli_uncovered_coverage.rs
@@ -580,6 +580,102 @@ fn remember_list_after_capture_shows_entry() {
         .stdout(predicate::str::contains("mem-list-coverage-entry"));
 }
 
+/// Issue #411 end-to-end: the memory list must show WHO captured the fact.
+///
+/// Exercises the whole chain in one shot — `resolve_author` tier 1 (git
+/// config), the frontmatter + LanceDB author write, `resolve_display_author`
+/// reading the column back, and `shorten_author` dropping the address.
+#[test]
+fn remember_list_shows_the_git_author_column() {
+    // Mirrors the skip guard in `forgeplan_core::git::author` tests.
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        return;
+    }
+    let tmp = init_workspace();
+
+    // LOCAL git config overrides global/system, so tier 1 of resolve_author
+    // is deterministic regardless of the developer's own ~/.gitconfig.
+    for args in [
+        vec!["init", "-q", "-b", "main"],
+        vec!["config", "user.name", "Ada Lovelace"],
+        vec!["config", "user.email", "ada@example.org"],
+    ] {
+        std::process::Command::new("git")
+            .args(&args)
+            .current_dir(tmp.path())
+            .output()
+            .unwrap();
+    }
+
+    // GIT_AUTHOR_* now OUTRANKS git config (issue #411 env tier). A
+    // developer shell that exports them — or a test run from inside
+    // `git rebase` / `git am`, both of which export the pair — would
+    // otherwise satisfy tier 1 before the local config is consulted and
+    // this test would assert the ambient environment, not the repo.
+    forgeplan()
+        .args(["remember", "LanceDB index is derived, never commit it"])
+        .env_remove("GIT_AUTHOR_NAME")
+        .env_remove("GIT_AUTHOR_EMAIL")
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    forgeplan()
+        .args(["remember", "--list"])
+        .env_remove("GIT_AUTHOR_NAME")
+        .env_remove("GIT_AUTHOR_EMAIL")
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Author"))
+        .stdout(predicate::str::contains("Ada Lovelace"))
+        // "Ada Lovelace <ada@example.org>" is 30 chars > AUTHOR_COL_MAX:
+        // the address is dropped whole, never cut into.
+        .stdout(predicate::str::contains("ada@example.org").not())
+        // The regression guard: a revert to the hardcoded literal shows up
+        // here and nowhere else.
+        .stdout(predicate::str::contains("cli").not());
+}
+
+/// Issue #411: the agent-facing surface reported the "when" but not the
+/// "who". `recall --json` must carry provenance, and carry it WHOLE.
+#[test]
+fn recall_json_carries_provenance() {
+    let tmp = init_workspace();
+
+    forgeplan()
+        .args(["remember", "PostgreSQL for concurrent writes, not SQLite"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    let output = forgeplan()
+        .args(["recall", "PostgreSQL", "--json"])
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let payload: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    let mem = &payload["memories"][0];
+
+    // The key must exist at all — an agent has no other provenance channel.
+    let author = mem.get("author").expect("recall --json must expose author");
+    assert!(
+        author.as_str().is_some_and(|s| !s.is_empty()),
+        "author must be a resolved value, got {author}"
+    );
+    // Unshortened: the payload is machine-read, no width budget applies.
+    assert!(!author.as_str().unwrap().ends_with('…'));
+}
+
 #[test]
 fn remember_forget_removes_memory() {
     let tmp = init_workspace();

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -1432,7 +1432,13 @@ impl LanceStore {
     /// ("lookup accepts both formats and resolves to the same canonical
     /// artifact").
     ///
-    /// Accepts two input shapes:
+    /// Accepts three input shapes, tried in order:
+    /// (0) Literal id form — the trimmed input compared byte-for-byte against
+    /// the canonical `id` column. This is the only path that resolves kinds
+    /// whose ids are not `KIND-NNN` shaped, notably Memory
+    /// (`mem-<slugified-text>`, issue #411). Byte-exact by construction, so
+    /// non-canonical casing (`prd-074`) misses here and still falls through
+    /// to (a);
     /// (a) Display id form (`PRD-074`, `prd-074`, `Prd-74` — case-insensitive
     /// prefix; trailing digits parsed as u32 then zero-padded to 3 width)
     /// resolved by direct DB lookup; (b) slug form (`prd-auth-system` —
@@ -1445,14 +1451,42 @@ impl LanceStore {
     /// of the `id` column in the DB (current Phase 1.x form: `KIND-NNN`).
     ///
     /// # Performance
-    /// Display id path is O(1) on indexed DB lookup. Slug path is O(n) over
-    /// records of one kind only (filtered first) — for ~50 PRDs this is
-    /// ~50 frontmatter parses, acceptable for CLI; not benchmarked.
+    /// Literal path is O(1) on an indexed point lookup. Display id path is
+    /// O(1) on indexed DB lookup. Slug path is O(n) over records of one kind
+    /// only (filtered first) — for ~50 PRDs this is ~50 frontmatter parses,
+    /// acceptable for CLI; not benchmarked.
+    ///
+    /// Path 0 is free for already-canonical input (`PRD-074`): it hits and
+    /// returns, consuming the single point query Path 1 would have made.
+    /// It costs one extra point query for non-canonical display input
+    /// (`prd-074`, `PRD-74`) and for anything that ends up on the slug scan —
+    /// negligible next to that scan's `list_records` + frontmatter parses.
     pub async fn resolve_id(&self, input: &str) -> anyhow::Result<Option<String>> {
         // Audit Phase 1.5 M1: trim whitespace from copy-paste / LLM input.
         let input = input.trim();
         if input.is_empty() {
             return Ok(None);
+        }
+
+        // ---- Path 0: literal id match (issue #411) ----
+        // The `id` column IS the canonical identity. Kinds whose ids are not
+        // `KIND-NNN` shaped — Memory (`mem-<slugified-text>`) — are invisible
+        // to Path 1 (which needs an all-digit suffix) and to Path 2 (which
+        // needs a `slug` frontmatter field that `forgeplan remember` never
+        // writes). One point lookup on the trimmed input makes them linkable
+        // without granting Memory a lifecycle, required sections, or any
+        // validation weight.
+        //
+        // Uses the TRIMMED input: `get_record` builds an exact `id = '...'`
+        // predicate, so untrimmed input could never match, and the Phase 1.5
+        // M1 contract ("  PRD-074  " resolves) must hold on this path too.
+        //
+        // Byte-exact on purpose: `prd-074` does NOT match a stored `PRD-074`
+        // here, so it falls through to Path 1's case-insensitive
+        // normalization exactly as before. Making this case-insensitive would
+        // shadow Path 1 and silently change which row wins.
+        if let Some(rec) = self.get_record(input).await? {
+            return Ok(Some(rec.id));
         }
 
         // ---- Path 1: display id form (KIND-NNN) ----
@@ -2846,6 +2880,138 @@ mod tests {
         );
         // Slug form returns None (no slug field) — caller must fall back to verbatim.
         assert_eq!(store.resolve_id("prd-legacy-artifact").await.unwrap(), None);
+    }
+
+    // ── issue #411: Path 0 literal-id match makes Memory a graph citizen ──
+
+    /// Mirrors what `forgeplan remember` writes: id `mem-<slugified-text>`,
+    /// kind `memory`, no `slug` frontmatter field, no lifecycle.
+    fn memory_artifact(id: &str) -> NewArtifact {
+        NewArtifact {
+            id: id.to_string(),
+            kind: "memory".to_string(),
+            status: "active".to_string(),
+            title: "Memory entry".to_string(),
+            body: format!(
+                "---\nid: \"{}\"\nkind: memory\ncategory: fact\nstatus: active\ndepth: tactical\ntitle: \"Memory entry\"\ncreated: 2026-07-26T00:00:00Z\nauthor: cli\n---\n\nMemory body text.\n",
+                id
+            ),
+            depth: "tactical".to_string(),
+            author: Some("cli".to_string()),
+            parent_epic: None,
+            valid_until: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_id_path0_memory_id_resolves_literally() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        let mem_id = "mem-postgresql-for-concurrent-writes-not-sqlite";
+        store
+            .create_artifact(&memory_artifact(mem_id))
+            .await
+            .unwrap();
+
+        // Before Path 0 this returned None: Path 1 rejects the non-digit
+        // suffix, Path 2 finds no `slug` field to compare against.
+        assert_eq!(
+            store.resolve_id(mem_id).await.unwrap(),
+            Some(mem_id.to_string()),
+            "memory id must resolve so it can be a link source/target"
+        );
+        // Phase 1.5 M1 trim contract holds on Path 0 too.
+        assert_eq!(
+            store.resolve_id(&format!("  {}\n", mem_id)).await.unwrap(),
+            Some(mem_id.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_id_path0_does_not_shadow_display_form() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        store
+            .create_artifact(&artifact_with_slug("PRD-074", "prd-auth-system"))
+            .await
+            .unwrap();
+
+        // Canonical input: Path 0 hits and returns the same value as before.
+        assert_eq!(
+            store.resolve_id("PRD-074").await.unwrap(),
+            Some("PRD-074".to_string())
+        );
+        // Non-canonical casing: Path 0 misses (byte-exact predicate), Path 1
+        // still normalizes and wins.
+        assert_eq!(
+            store.resolve_id("prd-074").await.unwrap(),
+            Some("PRD-074".to_string())
+        );
+        // Unpadded: Path 0 misses, Path 1 zero-pads and wins.
+        assert_eq!(
+            store.resolve_id("PRD-74").await.unwrap(),
+            Some("PRD-074".to_string())
+        );
+        // Slug path untouched.
+        assert_eq!(
+            store.resolve_id("prd-auth-system").await.unwrap(),
+            Some("PRD-074".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_id_path0_preserves_h2_early_exit_and_slug_miss() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        store
+            .create_artifact(&artifact_with_slug("PRD-074", "prd-auth-system"))
+            .await
+            .unwrap();
+
+        // Display-id shape, valid kind, DB miss: Path 0 misses too, so Path 1
+        // still reaches its early `return Ok(None)` and no slug scan happens.
+        assert_eq!(store.resolve_id("PRD-999").await.unwrap(), None);
+        assert_eq!(store.resolve_id("prd-999").await.unwrap(), None);
+        // Slug-shaped input matching nothing: still None, not an error.
+        assert_eq!(store.resolve_id("prd-other-thing").await.unwrap(), None);
+        assert_eq!(
+            store.resolve_id("mem-never-remembered").await.unwrap(),
+            None
+        );
+        // Garbage guards unchanged.
+        assert_eq!(store.resolve_id("").await.unwrap(), None);
+        assert_eq!(store.resolve_id("   ").await.unwrap(), None);
+        assert_eq!(store.resolve_id("foo-bar").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn resolve_id_path0_literal_miss_on_empty_store_is_ok_none() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        // No rows at all: a literal lookup must return Ok(None), never Err.
+        let result = store.resolve_id("mem-does-not-exist").await;
+        assert!(result.is_ok(), "literal miss must not error");
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn resolve_id_path0_wins_over_display_normalization_for_numeric_memory_id() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        // `forgeplan remember "12345"` produces id `mem-12345` — display-id
+        // SHAPE (alpha prefix + all-digit suffix + valid kind prefix `mem`),
+        // so Path 1 normalizes it to `MEM-12345`, misses, and early-exits to
+        // None. Path 0 must claim it first via the literal id.
+        store
+            .create_artifact(&memory_artifact("mem-12345"))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.resolve_id("mem-12345").await.unwrap(),
+            Some("mem-12345".to_string()),
+            "Path 0 must precede Path 1 normalization"
+        );
     }
 
     #[tokio::test]

--- a/crates/forgeplan-core/src/git/author.rs
+++ b/crates/forgeplan-core/src/git/author.rs
@@ -1,0 +1,444 @@
+//! Author attribution for artifact writes that originate outside the MCP
+//! identity handshake (issue #411).
+//!
+//! `forgeplan remember` used to hardcode `author: cli`, so every memory in
+//! the graph carried the same non-informative provenance. This module
+//! resolves a *real* author through a three-tier fallback chain:
+//!
+//! 1. **git config** — `user.name` / `user.email` read from the workspace.
+//!    This is the human at the keyboard, which is what a reader of the
+//!    artifact actually wants to see.
+//! 2. **Caller [`AgentIdentity`]** — the MCP `clientInfo` handshake value,
+//!    when the caller supplies one. The CLI has none today (it never
+//!    performs the handshake), so it passes `None`; an MCP-hosted
+//!    `remember` can pass `Some(&identity)` without touching this module.
+//! 3. **[`FALLBACK_AUTHOR`] (`"cli"`)** — the historical literal, kept as
+//!    the last resort.
+//!
+//! ## Why this lives in `forgeplan-core::git`
+//!
+//! It is a git-subprocess helper, and `forgeplan-core::git` is already the
+//! crate's home for `Command::new("git")`. It deliberately does NOT live in
+//! `artifact::identity`, which documents itself as transport-agnostic pure
+//! validation — spawning subprocesses there would break that contract. It
+//! is a submodule rather than more lines in `git/mod.rs` (already 1000+
+//! lines, scoped to change detection) because the concern is attribution.
+//!
+//! Attribution is reusable: `commands/deprecate.rs` and
+//! `common::log_change_field` carry the same `"cli"` literal and can adopt
+//! [`resolve_author`] later with no further plumbing.
+//!
+//! ## Shape of the rendered value
+//!
+//! `Name <email>` when both are known, `Name` or `email` when only one is,
+//! capped at `MAX_FIELD_LEN` (64) bytes — the same budget
+//! `AgentIdentity::new` enforces — so the value is always representable as
+//! an `AgentIdentity` name should a caller need to round-trip it.
+//! Characters are **sanitised, never rejected**: a git `user.name` is
+//! free-form and a weird one must not break `remember`.
+//!
+//! The value is written into frontmatter inside a **double-quoted YAML
+//! scalar**. [`sanitize_component`] strips `"` (and `\` via
+//! `is_identity_char_forbidden`), so the call site never needs to escape —
+//! and a name like `- foo` or `foo: bar` or `foo # bar` cannot break the
+//! YAML mapping the way the current unquoted `author: cli` line would.
+//!
+//! ## Never fails
+//!
+//! Every tier-1 function returns `Option` and every failure mode — git
+//! missing from `PATH`, not a git repository, `user.name` unset,
+//! `user.name` set to the empty string, git hanging, non-UTF8 output,
+//! a workspace path that no longer exists — falls through silently to the
+//! next tier. [`resolve_author`] returns `String`, not `Result`: a
+//! `remember` must never fail because of an author lookup.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::artifact::identity::{AgentIdentity, MAX_FIELD_LEN, is_identity_char_forbidden};
+
+/// Last-resort author when neither git nor a caller identity can answer.
+/// Preserves the pre-#411 value so existing memories stay comparable.
+pub const FALLBACK_AUTHOR: &str = "cli";
+
+/// Wall-clock budget for the WHOLE tier-1 lookup (both `git config` calls),
+/// not per invocation — so the worst case stays 2s regardless of how many
+/// keys we read.
+///
+/// 2s is ~1000x the observed cost of `git config --get` (sub-millisecond)
+/// while still bounding the pathological cases: a `.git/config` on a
+/// stalled network mount, an `includeIf` chain pointing at an unreachable
+/// path, or an `fsmonitor`/credential helper that decides to block. On
+/// expiry the future is dropped, and `kill_on_drop(true)` reaps the child
+/// rather than leaking a zombie git.
+const GIT_LOOKUP_BUDGET: Duration = Duration::from_secs(2);
+
+/// Resolve the author string for an artifact write.
+///
+/// `dir` is any path inside the repository — the workspace root
+/// (`<root>/.forgeplan`) is the natural argument at CLI call sites, since
+/// `git -C` walks up to the repo and then out to the global config.
+///
+/// `caller` is the MCP handshake identity when one exists. `None` from the
+/// CLI. The [`AgentIdentity::unknown`] sentinel is explicitly skipped:
+/// letting it through would render `unknown/0` and make tier 3 unreachable.
+///
+/// Infallible by construction — see the module docs.
+pub async fn resolve_author(dir: &Path, caller: Option<&AgentIdentity>) -> String {
+    // Tier 1 — the human. `timeout` returns Err(Elapsed) if git hangs; the
+    // inner future is dropped and the child killed.
+    if let Ok(Some(author)) = tokio::time::timeout(GIT_LOOKUP_BUDGET, git_identity(dir)).await {
+        return author;
+    }
+
+    // Tier 2 — the calling agent, when it identified itself for real.
+    if let Some(identity) = caller
+        && identity != &AgentIdentity::unknown()
+    {
+        return identity.as_frontmatter_value();
+    }
+
+    // Tier 3 — historical literal.
+    FALLBACK_AUTHOR.to_string()
+}
+
+/// Tier 1: read `user.name` + `user.email` and render them.
+///
+/// Two `git config --get` calls rather than one `git var GIT_AUTHOR_IDENT`
+/// on purpose: `git var` *synthesises* a name from the OS passwd/gecos
+/// entry when `user.name` is unset, which would silently defeat the
+/// "user.name unset falls through" requirement.
+async fn git_identity(dir: &Path) -> Option<String> {
+    let name = git_config_value(dir, "user.name").await;
+    let email = git_config_value(dir, "user.email").await;
+    render_git_author(name.as_deref(), email.as_deref())
+}
+
+/// Run `git -C <dir> config --get <key>` and return the sanitised value.
+///
+/// Returns `None` when git is absent from `PATH`, `dir` does not exist,
+/// the key is unset (git exits 1), or the value is empty/whitespace after
+/// sanitising. Note `git config` still consults `~/.gitconfig` outside a
+/// repository, which is desirable: the human's identity is the same either
+/// way.
+///
+/// `key` is always a compile-time literal here, so there is no argument
+/// injection surface (mirrors the concern `validate_git_ref` addresses for
+/// caller-supplied refs).
+async fn git_config_value(dir: &Path, key: &str) -> Option<String> {
+    let output = tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "--get", key])
+        // Never let a credential/prompt helper block on a terminal.
+        .env("GIT_TERMINAL_PROMPT", "0")
+        // Read-only query: do not take the index lock.
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        // CRITICAL for the MCP surface: the server speaks JSON-RPC over
+        // stdio. A child inheriting stdin could consume framing bytes.
+        .stdin(std::process::Stdio::null())
+        // On timeout the future is dropped — reap the child, do not leak it.
+        .kill_on_drop(true)
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    // `git config --get` on a key explicitly set to "" exits 0 with empty
+    // stdout. Sanitising to None handles it.
+    sanitize_component(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Compose the frontmatter author from already-sanitised parts.
+///
+/// Pure — the whole rendering policy is testable without a subprocess.
+///
+/// When `Name <email>` exceeds `MAX_FIELD_LEN` we fall back to the name
+/// alone rather than truncating mid-address: a mangled `<ada@examp` reads
+/// like corrupt data, whereas a bare name is honest.
+pub(crate) fn render_git_author(name: Option<&str>, email: Option<&str>) -> Option<String> {
+    let rendered = match (name, email) {
+        (Some(n), Some(e)) => {
+            let full = format!("{n} <{e}>");
+            if full.len() <= MAX_FIELD_LEN {
+                full
+            } else {
+                truncate_on_char_boundary(n, MAX_FIELD_LEN)
+            }
+        }
+        (Some(n), None) => truncate_on_char_boundary(n, MAX_FIELD_LEN),
+        // An address with no name is still a real identity — better than
+        // degrading to "cli".
+        (None, Some(e)) => truncate_on_char_boundary(e, MAX_FIELD_LEN),
+        (None, None) => return None,
+    };
+
+    if rendered.is_empty() {
+        None
+    } else {
+        Some(rendered)
+    }
+}
+
+/// Sanitise one free-form git config value (`user.name` or `user.email`).
+///
+/// **Sanitises, never rejects.** A hostile or merely eccentric git name
+/// must not fail `remember`; it gets cleaned and used.
+///
+/// Order matters:
+/// 1. Any whitespace (including `\n` and `\t`, which are ALSO control
+///    characters) maps to a single space. Doing this before the forbidden
+///    filter is what stops `"foo\nbar"` from gluing into `"foobar"`.
+/// 2. Characters rejected by `is_identity_char_forbidden` are dropped —
+///    controls, bidi overrides, ZWSP/ZWJ, BOM, variation selectors, tag
+///    characters, `/`, `\`, NUL. Same defence class as
+///    `AgentIdentity::new` and `claim::validate_agent_id`.
+/// 3. `"` is dropped so the value is safe verbatim inside a double-quoted
+///    YAML scalar; `<` / `>` are dropped so only [`render_git_author`] can
+///    introduce the angle brackets that delimit the address.
+/// 4. Space runs collapse; the result is trimmed.
+///
+/// Returns `None` when nothing printable survives.
+pub(crate) fn sanitize_component(raw: &str) -> Option<String> {
+    let mut out = String::with_capacity(raw.len());
+    // Starts true so leading whitespace is swallowed rather than emitted.
+    let mut prev_space = true;
+
+    for c in raw.chars() {
+        if c.is_whitespace() {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+            continue;
+        }
+        if is_identity_char_forbidden(c) || matches!(c, '"' | '<' | '>') {
+            continue;
+        }
+        out.push(c);
+        prev_space = false;
+    }
+
+    let trimmed = out.trim_end();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Truncate to at most `max_bytes` without splitting a UTF-8 code point,
+/// then trim a trailing space the cut may have exposed.
+///
+/// `MAX_FIELD_LEN` is a BYTE budget (`AgentIdentity::new` compares
+/// `name.len()`), so a naive `chars().take(64)` would still be rejected for
+/// any non-ASCII name.
+fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = 0usize;
+    for (i, c) in s.char_indices() {
+        let next = i + c.len_utf8();
+        if next > max_bytes {
+            break;
+        }
+        end = next;
+    }
+    s[..end].trim_end().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// Skip git-dependent tests where git is not installed.
+    fn git_available() -> bool {
+        Command::new("git").arg("--version").output().is_ok()
+    }
+
+    /// Temp repo with `user.name` / `user.email` written to the LOCAL
+    /// config. Local overrides global, so these tests are deterministic
+    /// regardless of the developer's own `~/.gitconfig`.
+    fn init_repo_with(dir: &Path, name: &str, email: &str) {
+        Command::new("git")
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(dir)
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["config", "user.name", name])
+            .current_dir(dir)
+            .output()
+            .expect("git config user.name");
+        Command::new("git")
+            .args(["config", "user.email", email])
+            .current_dir(dir)
+            .output()
+            .expect("git config user.email");
+    }
+
+    #[tokio::test]
+    async fn resolve_author_uses_git_config_when_set() {
+        if !git_available() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        init_repo_with(tmp.path(), "Ada Lovelace", "ada@example.org");
+
+        let author = resolve_author(tmp.path(), None).await;
+
+        assert_eq!(
+            author, "Ada Lovelace <ada@example.org>",
+            "tier 1 must win and render `Name <email>`"
+        );
+        assert_ne!(author, FALLBACK_AUTHOR);
+    }
+
+    #[tokio::test]
+    async fn resolve_author_falls_through_when_git_config_is_empty() {
+        if !git_available() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        // `git config --get` on an explicitly-empty key exits 0 with empty
+        // stdout — the subtle case that a naive `status.success()` check
+        // would turn into `author: ""`.
+        init_repo_with(tmp.path(), "", "");
+
+        let author = resolve_author(tmp.path(), None).await;
+
+        assert_eq!(
+            author, FALLBACK_AUTHOR,
+            "empty git config must fall through, not emit an empty author"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_author_falls_back_to_cli_when_git_cannot_answer() {
+        // `git -C /nonexistent` exits 128 — a deterministic tier-1 miss
+        // that needs no env mutation. Structurally identical to the
+        // git-absent path (`.output().await.ok()?` yields None).
+        let author = resolve_author(Path::new("/nonexistent-forgeplan-411"), None).await;
+        assert_eq!(author, FALLBACK_AUTHOR);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env_path)]
+    async fn resolve_author_falls_back_when_git_absent_from_path() {
+        let original = std::env::var_os("PATH");
+        unsafe {
+            std::env::set_var("PATH", "/nonexistent-dir-for-test-isolation-411");
+        }
+
+        let result = resolve_author(Path::new("."), None).await;
+
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+
+        assert_eq!(result, FALLBACK_AUTHOR, "spawn failure must not panic");
+    }
+
+    #[test]
+    fn sanitized_hostile_git_name_is_accepted_by_agent_identity() {
+        // Overlong + bidi override + newline + tab + path separators +
+        // quote + angle brackets + zero-width space.
+        let hostile_name = format!(
+            "{}\u{202E}rot\nline\ttab/slash\\back\"quote<>",
+            "\u{03A9}".repeat(80)
+        );
+        let hostile_email = format!("{}@evil\u{200B}.com", "e".repeat(120));
+
+        let name = sanitize_component(&hostile_name).expect("must sanitise, not reject");
+        let email = sanitize_component(&hostile_email).expect("must sanitise, not reject");
+        let author = render_git_author(Some(&name), Some(&email)).expect("must render something");
+
+        assert!(!author.is_empty());
+        assert_ne!(author, FALLBACK_AUTHOR, "sanitise, do not degrade");
+        assert!(
+            author.len() <= MAX_FIELD_LEN,
+            "byte budget blown: {} bytes",
+            author.len()
+        );
+        assert!(
+            !author.chars().any(is_identity_char_forbidden),
+            "forbidden char survived: {author:?}"
+        );
+        assert!(!author.contains('"'), "quote would break the YAML scalar");
+        assert!(
+            AgentIdentity::new(author.as_str(), "1.0").is_some(),
+            "AgentIdentity::new rejected the sanitised author: {author:?}"
+        );
+    }
+
+    #[test]
+    fn sanitize_component_maps_whitespace_without_gluing() {
+        assert_eq!(
+            sanitize_component("  Ada\tB.\nLovelace  ").as_deref(),
+            Some("Ada B. Lovelace")
+        );
+        assert_eq!(sanitize_component("").as_deref(), None);
+        assert_eq!(sanitize_component("   \t\n ").as_deref(), None);
+        // Zero-width space is not `is_whitespace` but IS forbidden.
+        assert_eq!(sanitize_component("a\u{200B}b").as_deref(), Some("ab"));
+    }
+
+    #[test]
+    fn render_git_author_covers_partial_and_overlong_inputs() {
+        assert_eq!(
+            render_git_author(Some("Ada"), Some("a@b.co")).as_deref(),
+            Some("Ada <a@b.co>")
+        );
+        assert_eq!(render_git_author(Some("Ada"), None).as_deref(), Some("Ada"));
+        assert_eq!(
+            render_git_author(None, Some("a@b.co")).as_deref(),
+            Some("a@b.co")
+        );
+        assert_eq!(render_git_author(None, None), None);
+
+        // Combined overflows -> name alone, never a truncated address.
+        let long_email = format!("{}@example.org", "e".repeat(60));
+        let out = render_git_author(Some("Ada"), Some(&long_email)).unwrap();
+        assert_eq!(out, "Ada");
+        assert!(!out.contains('<'));
+    }
+
+    #[test]
+    fn truncate_on_char_boundary_never_splits_a_code_point() {
+        // 33 x 2-byte Omega = 66 bytes -> must cut to 32 chars / 64 bytes.
+        let s = "\u{03A9}".repeat(33);
+        let cut = truncate_on_char_boundary(&s, MAX_FIELD_LEN);
+        assert_eq!(cut.len(), 64);
+        assert_eq!(cut.chars().count(), 32);
+        assert!(cut.is_char_boundary(cut.len()));
+    }
+
+    #[tokio::test]
+    async fn caller_identity_wins_over_fallback_but_unknown_does_not() {
+        let missing = Path::new("/nonexistent-forgeplan-411");
+
+        let real = AgentIdentity::new("claude-code", "1.0.50").unwrap();
+        assert_eq!(
+            resolve_author(missing, Some(&real)).await,
+            "claude-code/1.0.50"
+        );
+
+        // The sentinel must NOT shadow tier 3 — otherwise `unknown/0`
+        // would replace "cli" for every CLI write.
+        let sentinel = AgentIdentity::unknown();
+        assert_eq!(
+            resolve_author(missing, Some(&sentinel)).await,
+            FALLBACK_AUTHOR
+        );
+    }
+}

--- a/crates/forgeplan-core/src/git/author.rs
+++ b/crates/forgeplan-core/src/git/author.rs
@@ -5,9 +5,44 @@
 //! the graph carried the same non-informative provenance. This module
 //! resolves a *real* author through a three-tier fallback chain:
 //!
-//! 1. **git config** — `user.name` / `user.email` read from the workspace.
-//!    This is the human at the keyboard, which is what a reader of the
-//!    artifact actually wants to see.
+//! 1. **git identity** — `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` from the
+//!    environment, falling back **per field** to `user.name` /
+//!    `user.email` read from the workspace. This is the human at the
+//!    keyboard, which is what a reader of the artifact actually wants to
+//!    see.
+//!
+//!    Env goes BEFORE config because that is git's own precedence
+//!    (`ident.c: git_author_info` reads `GIT_AUTHOR_*` first and only then
+//!    consults config). Mirroring git is the whole argument: it means a CI
+//!    job, a `git rebase`, or a `--author` re-exec attributes the memory to
+//!    exactly whoever git would have credited for a commit made at the same
+//!    moment, so artifact provenance and commit provenance never disagree.
+//!    Slotting env *between* config and the caller identity would invent a
+//!    third precedence order that matches neither git nor the MCP
+//!    handshake, and would silently ignore the env on every developer
+//!    machine (where config is always set) — i.e. exactly the machines
+//!    where a deliberate `GIT_AUTHOR_NAME` override is meaningful.
+//!
+//!    Per **field**, not per source: git resolves name and email
+//!    independently, so a workflow that exports only `GIT_AUTHOR_NAME`
+//!    still gets the email from config. A whole-block "env wins or config
+//!    wins" would throw the config email away.
+//!
+//!    Side effect worth having: when both vars are set the tier-1 lookup
+//!    spawns **zero** git processes.
+//!
+//!    **`GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL` are deliberately out
+//!    of scope.** Git models author (who wrote it) and committer (who
+//!    applied it) as distinct roles, and the frontmatter field is literally
+//!    `author`. Honouring the committer would credit the rebasing
+//!    maintainer or the bot that replayed the work. Git itself never falls
+//!    back between the two. The coverage lost is near-zero — every
+//!    environment that exports `GIT_COMMITTER_*` (CI actions, `git rebase`,
+//!    `git am`) exports `GIT_AUTHOR_*` alongside it — while the
+//!    mis-attribution is real. The `EMAIL` env var (git's last resort,
+//!    ranked *below* config) is excluded for the same reason git ranks it
+//!    so low: it is a generic mail setting, not a statement about
+//!    authorship.
 //! 2. **Caller [`AgentIdentity`]** — the MCP `clientInfo` handshake value,
 //!    when the caller supplies one. The CLI has none today (it never
 //!    performs the handshake), so it passes `None`; an MCP-hosted
@@ -24,9 +59,38 @@
 //! is a submodule rather than more lines in `git/mod.rs` (already 1000+
 //! lines, scoped to change detection) because the concern is attribution.
 //!
-//! Attribution is reusable: `commands/deprecate.rs` and
-//! `common::log_change_field` carry the same `"cli"` literal and can adopt
-//! [`resolve_author`] later with no further plumbing.
+//! ## The other `"cli"` literals are NOT authors
+//!
+//! An earlier draft of this note claimed `commands/deprecate.rs` and
+//! `common::log_change_field` carry "the same" literal and could adopt
+//! [`resolve_author`]. That was wrong. Every remaining `"cli"` in
+//! `forgeplan-cli` — 14 sites: `activate.rs:72`, `deprecate.rs:61`,
+//! `ingest.rs:568,589`, `link.rs:74,173`, `new.rs:215`, `renew.rs:50`,
+//! `reopen.rs:86,96`, `supersede.rs:66`, `update.rs:153,165,170` — is the
+//! trailing `source` argument of `common::log_change` /
+//! `common::log_change_field`. It lands in
+//! [`ChangeLogEntry::source`](crate::changelog::ChangeLogEntry), whose own
+//! doc comment enumerates the closed vocabulary `cli, file_edit, git_sync,
+//! reindex` (and `driver::MemoryEntry::source` documents `"cli", "mcp",
+//! "llm"`). It answers *through which surface did this mutation arrive*,
+//! not *who made it*. Substituting a human name there would destroy the
+//! audit trail's only surface discriminator: `git_sync` and `reindex`
+//! entries would stop being distinguishable from interactive ones, and
+//! nothing else in the row records the channel.
+//!
+//! How to tell the two apart at a glance: a **channel** `"cli"` is the
+//! last positional argument of a `log_change*` call and its sibling values
+//! elsewhere in the tree are `git_sync` / `reindex`; an **author** `"cli"`
+//! flows into `NewArtifact.author` or into an `author:` frontmatter line.
+//! After the `remember.rs` fix there are no author-`"cli"` sites left.
+//!
+//! The real remaining attribution gap is a different shape: `new.rs:200`,
+//! `capture.rs:63`, `generate.rs:73`, `ingest.rs:556` and `reason.rs:346`
+//! all build a `NewArtifact` with `author: None`, so every PRD/RFC/ADR is
+//! created with no author at all. Adopting [`resolve_author`] there is a
+//! separate, larger change — and it is the point at which memoising the
+//! git lookup stops being theoretical, because it turns one call site into
+//! six.
 //!
 //! ## Shape of the rendered value
 //!
@@ -102,15 +166,38 @@ pub async fn resolve_author(dir: &Path, caller: Option<&AgentIdentity>) -> Strin
     FALLBACK_AUTHOR.to_string()
 }
 
-/// Tier 1: read `user.name` + `user.email` and render them.
+/// Environment variable git reads for the author name, ahead of
+/// `user.name`. Named constants (not inline literals) because the test
+/// guard has to clear exactly these two keys.
+const ENV_AUTHOR_NAME: &str = "GIT_AUTHOR_NAME";
+
+/// Environment variable git reads for the author email, ahead of
+/// `user.email`.
+const ENV_AUTHOR_EMAIL: &str = "GIT_AUTHOR_EMAIL";
+
+/// Tier 1: resolve name + email the way git does, then render them.
+///
+/// Per-field precedence `GIT_AUTHOR_* env` -> `git config` -> nothing.
+/// Resolved independently for name and email so a CI job exporting only
+/// `GIT_AUTHOR_NAME` keeps the config email (see the module docs for why
+/// env outranks config, and why `GIT_COMMITTER_*` does not participate).
 ///
 /// Two `git config --get` calls rather than one `git var GIT_AUTHOR_IDENT`
 /// on purpose: `git var` *synthesises* a name from the OS passwd/gecos
 /// entry when `user.name` is unset, which would silently defeat the
 /// "user.name unset falls through" requirement.
+///
+/// The env reads are synchronous and free, and short-circuit the
+/// subprocess: with both vars set this function spawns no git at all.
 async fn git_identity(dir: &Path) -> Option<String> {
-    let name = git_config_value(dir, "user.name").await;
-    let email = git_config_value(dir, "user.email").await;
+    let name = match env_component(std::env::var_os(ENV_AUTHOR_NAME)) {
+        Some(n) => Some(n),
+        None => git_config_value(dir, "user.name").await,
+    };
+    let email = match env_component(std::env::var_os(ENV_AUTHOR_EMAIL)) {
+        Some(e) => Some(e),
+        None => git_config_value(dir, "user.email").await,
+    };
     render_git_author(name.as_deref(), email.as_deref())
 }
 
@@ -150,6 +237,36 @@ async fn git_config_value(dir: &Path, key: &str) -> Option<String> {
     // `git config --get` on a key explicitly set to "" exits 0 with empty
     // stdout. Sanitising to None handles it.
     sanitize_component(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Run one already-read env value through the SAME sanitiser as a git
+/// config value.
+///
+/// Takes the value rather than the key so the whole policy is testable
+/// without mutating the process environment (`std::env::set_var` is
+/// `unsafe` and forces serialisation); the single caller passes
+/// `std::env::var_os(..)`.
+///
+/// Sanitising is not optional here — env vars are the more
+/// attacker-adjacent of the two inputs. CI workflows routinely interpolate
+/// fork-controlled data (branch names, PR titles, commit metadata) into
+/// `GIT_AUTHOR_NAME`, and the value is written verbatim into a
+/// double-quoted YAML scalar. [`sanitize_component`] drops `"`, `<`, `>`,
+/// control and bidi characters, so a name cannot close the scalar, forge a
+/// second `<address>`, or smuggle a direction override past a reviewer.
+/// The `MAX_FIELD_LEN` cap is applied afterwards by
+/// [`render_git_author`].
+///
+/// Non-UTF8 is decoded lossily rather than rejected: an unreadable name
+/// must not fail `remember`. Surviving U+FFFD is cosmetic and still passes
+/// `AgentIdentity::new`.
+///
+/// Returns `None` for unset AND for set-but-empty, so `GIT_AUTHOR_NAME=""`
+/// falls through to config. Git itself errors on an empty ident; this
+/// module can never fail, so falling through is the honest analogue —
+/// and it mirrors the existing empty-`user.name` behaviour exactly.
+fn env_component(raw: Option<std::ffi::OsString>) -> Option<String> {
+    sanitize_component(&raw?.to_string_lossy())
 }
 
 /// Compose the frontmatter author from already-sanitised parts.
@@ -254,6 +371,7 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
     use std::path::Path;
     use std::process::Command;
     use tempfile::TempDir;
@@ -261,6 +379,62 @@ mod tests {
     /// Skip git-dependent tests where git is not installed.
     fn git_available() -> bool {
         Command::new("git").arg("--version").output().is_ok()
+    }
+
+    /// RAII: clear `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` for the duration
+    /// of a test and restore the ambient values on drop.
+    ///
+    /// Mandatory for EVERY `resolve_author` test now that env outranks
+    /// config. A developer shell that exports `GIT_AUTHOR_NAME`, or a test
+    /// runner invoked from inside `git rebase` / `git am` (both of which
+    /// export the pair), would otherwise satisfy tier 1 before git config
+    /// or the fallback is ever reached — turning four currently-green
+    /// assertions into environment-dependent flakes.
+    ///
+    /// Users must also carry `#[serial_test::serial(env_path)]`. That key
+    /// is reused rather than a fresh one on purpose: it is the same lock
+    /// the PATH test already holds, and a PATH test running concurrently
+    /// with an author-env test that still needs to spawn git would corrupt
+    /// both. One key = all env mutation in this module is mutually
+    /// exclusive.
+    struct AuthorEnvGuard {
+        name: Option<OsString>,
+        email: Option<OsString>,
+    }
+
+    impl AuthorEnvGuard {
+        fn cleared() -> Self {
+            let saved = Self {
+                name: std::env::var_os(ENV_AUTHOR_NAME),
+                email: std::env::var_os(ENV_AUTHOR_EMAIL),
+            };
+            unsafe {
+                std::env::remove_var(ENV_AUTHOR_NAME);
+                std::env::remove_var(ENV_AUTHOR_EMAIL);
+            }
+            saved
+        }
+
+        /// Set a var for the rest of the guard's life. Takes `&self` so the
+        /// guard is provably still alive at the call site.
+        fn set(&self, key: &str, value: &str) {
+            unsafe { std::env::set_var(key, value) }
+        }
+    }
+
+    impl Drop for AuthorEnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match self.name.take() {
+                    Some(v) => std::env::set_var(ENV_AUTHOR_NAME, v),
+                    None => std::env::remove_var(ENV_AUTHOR_NAME),
+                }
+                match self.email.take() {
+                    Some(v) => std::env::set_var(ENV_AUTHOR_EMAIL, v),
+                    None => std::env::remove_var(ENV_AUTHOR_EMAIL),
+                }
+            }
+        }
     }
 
     /// Temp repo with `user.name` / `user.email` written to the LOCAL
@@ -285,10 +459,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(env_path)]
     async fn resolve_author_uses_git_config_when_set() {
         if !git_available() {
             return;
         }
+        // Ambient GIT_AUTHOR_* now outranks config; without this the test
+        // would assert the developer's shell, not the repo.
+        let _env = AuthorEnvGuard::cleared();
         let tmp = TempDir::new().unwrap();
         init_repo_with(tmp.path(), "Ada Lovelace", "ada@example.org");
 
@@ -302,10 +480,12 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(env_path)]
     async fn resolve_author_falls_through_when_git_config_is_empty() {
         if !git_available() {
             return;
         }
+        let _env = AuthorEnvGuard::cleared();
         let tmp = TempDir::new().unwrap();
         // `git config --get` on an explicitly-empty key exits 0 with empty
         // stdout — the subtle case that a naive `status.success()` check
@@ -321,7 +501,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(env_path)]
     async fn resolve_author_falls_back_to_cli_when_git_cannot_answer() {
+        // The env tier answers without touching git at all, so a tier-1
+        // miss now requires the env to be clear as well as the path bad.
+        let _env = AuthorEnvGuard::cleared();
         // `git -C /nonexistent` exits 128 — a deterministic tier-1 miss
         // that needs no env mutation. Structurally identical to the
         // git-absent path (`.output().await.ok()?` yields None).
@@ -332,6 +516,10 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial(env_path)]
     async fn resolve_author_falls_back_when_git_absent_from_path() {
+        // Clearing PATH no longer disables tier 1 by itself — the env tier
+        // needs no subprocess. Clear it too or this passes for the wrong
+        // reason.
+        let _env = AuthorEnvGuard::cleared();
         let original = std::env::var_os("PATH");
         unsafe {
             std::env::set_var("PATH", "/nonexistent-dir-for-test-isolation-411");
@@ -424,7 +612,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(env_path)]
     async fn caller_identity_wins_over_fallback_but_unknown_does_not() {
+        // Tier 2 is only reachable when tier 1 misses — which now means
+        // both the env and the git config must be unable to answer.
+        let _env = AuthorEnvGuard::cleared();
         let missing = Path::new("/nonexistent-forgeplan-411");
 
         let real = AgentIdentity::new("claude-code", "1.0.50").unwrap();
@@ -439,6 +631,48 @@ mod tests {
         assert_eq!(
             resolve_author(missing, Some(&sentinel)).await,
             FALLBACK_AUTHOR
+        );
+    }
+
+    #[test]
+    fn env_component_sanitises_and_treats_empty_as_unset() {
+        // Unset and set-but-empty must give the same answer: fall through
+        // to config. Git errors on an empty ident; this module can never
+        // fail, so falling through is the analogue — and it matches the
+        // existing empty-`user.name` behaviour.
+        assert_eq!(env_component(None), None);
+        assert_eq!(env_component(Some(OsString::from(""))), None);
+        assert_eq!(env_component(Some(OsString::from("   \t"))), None);
+
+        // Same sanitiser as the config path. The quote would close the
+        // double-quoted YAML scalar, the angle brackets would forge a
+        // second address, the newline would inject a frontmatter line —
+        // all stripped, none rejected.
+        assert_eq!(
+            env_component(Some(OsString::from("Ada\nB \"x\" <y>"))).as_deref(),
+            Some("Ada B x y")
+        );
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(env_path)]
+    async fn env_author_name_outranks_config_and_mixes_per_field() {
+        if !git_available() {
+            return;
+        }
+        let tmp = TempDir::new().unwrap();
+        init_repo_with(tmp.path(), "Config Human", "config@example.org");
+
+        // Only the NAME is exported — the CI-runner shape.
+        let env = AuthorEnvGuard::cleared();
+        env.set(ENV_AUTHOR_NAME, "CI Bot");
+
+        let author = resolve_author(tmp.path(), None).await;
+
+        assert_eq!(
+            author, "CI Bot <config@example.org>",
+            "env must outrank config PER FIELD: the name comes from the \
+             environment, the email must still come from git config"
         );
     }
 }

--- a/crates/forgeplan-core/src/git/mod.rs
+++ b/crates/forgeplan-core/src/git/mod.rs
@@ -1,5 +1,10 @@
 //! Git integration — detect changed .forgeplan/ files from git operations.
 
+/// Author attribution from git config (issue #411). Submodule rather than
+/// inline because this file is already 1000+ lines and scoped to change
+/// detection; attribution is a separate concern with separate callers.
+pub mod author;
+
 use std::path::Path;
 use std::process::Command;
 


### PR DESCRIPTION
Closes #411. **DO NOT MERGE** — awaiting review.

## Reproduction

Memory is already a first-class `ArtifactKind` stored in `.forgeplan/memory/`, but it could not be linked and it carried no provenance:

```
$ forgeplan remember "test fact for issue 411"
  Remembered: mem-test-fact-for-issue-411 — "test fact for issue 411"

$ forgeplan get mem-test-fact-for-issue-411
Error: artifact not found          # <-- but recall lists it and forget deletes it

$ forgeplan link mem-test-fact-for-issue-411 PRD-001 --relation informs
Error: source not found            # <-- memory cannot be a graph node
```

`get_record(id)` always found the row. Only `LanceStore::resolve_id` was blind, and both `forgeplan get` (`get.rs:14`) and `forgeplan link` (`link.rs:21`/`:27`) route through it.

Separately, every memory was attributed `author: cli`, hardcoded in two places that could drift independently.

## What changed

### 1. `resolve_id` Path 0 — literal id match (`crates/forgeplan-core/src/db/store.rs`)

`resolve_id` tried exactly two paths and never a literal `id` match:

| Path | Requires | Why Memory misses |
|---|---|---|
| 1 — display form `KIND-NNN` | all-digit suffix | `mem-postgresql-for-concurrent-writes-not-sqlite` has none |
| 2 — slug form | a `slug:` frontmatter field | `forgeplan remember` never writes one |

Path 0 does one point lookup on the trimmed input against the canonical `id` column.

**Why Path 0 rather than "make `remember` write a slug".** Writing a `slug:` field into memory frontmatter would revive Path 2 for exactly one kind. Across the entire 372-artifact graph `slug:` appears in **one** file — the schema doc. No real artifact carries it, so Path 2 is effectively dead code, and every working kind resolves via Path 1. Reviving dead code for a single kind leaves the class of bug in place: the next kind whose ids are not `KIND-NNN` shaped is invisible again, and Memory gains a field it has no other use for. Path 0 fixes the class instead — the `id` column *is* the canonical identity.

Ordering and case-sensitivity are load-bearing and documented at the call site:

- Placed **after** the trim/empty guard, so `""` still short-circuits before any DB call.
- Placed **before** Path 1, so an exact id always beats a normalized guess.
- **Byte-exact on purpose** — `prd-074` does not match a stored `PRD-074` here and still falls through to Path 1's normalization, unchanged. Making it case-insensitive would shadow Path 1 and silently change which row wins.

Cost, stated honestly: net **zero** for already-canonical input (Path 0 hits and returns, consuming the query Path 1 would have made); **+1** point query for non-canonical display input (`prd-074`, `PRD-74`) and for anything reaching the slug scan — negligible against that scan's `list_records` + frontmatter parses.

### 2. Real author attribution (`crates/forgeplan-core/src/git/author.rs`, new)

`resolve_author(dir, caller)` resolves **once** through three tiers: git config `user.name`/`user.email` → caller `AgentIdentity` (for a future MCP-hosted remember; the CLI passes `None` as it never performs the clientInfo handshake) → the historical `"cli"` literal. Both hardcode sites in `remember.rs` now consume the same binding, so the markdown and the LanceDB row cannot diverge.

It lives in `git/` because it is a git-subprocess helper and that module is already the crate's home for `Command::new("git")`. It deliberately does **not** live in `artifact::identity`, which documents itself as transport-agnostic pure validation.

- **Infallible by construction.** git absent from `PATH`, not a repository, `user.name` unset or set to `""`, git hanging (2s budget, `kill_on_drop`), non-UTF8 output — all fall through. A `remember` must never fail on an author lookup.
- **Sanitises, never rejects.** A git `user.name` is free-form; hostile input is cleaned using the same forbidden-character class as `AgentIdentity::new` and capped at the same 64-byte budget on UTF-8 boundaries.
- **Frontmatter is now a double-quoted YAML scalar.** The sanitiser strips `"` and `\`, so no call-site escaping is needed and a name like `- foo` or `foo: bar` cannot break the mapping the way the previous unquoted `author: cli` line would have. Existing memories keep `author: cli` and are **not** rewritten; both forms parse.

The subtle test: `git config --get` on a key explicitly set to `""` exits **0** with empty stdout, so an exit-status-only check would have written `author: ""` into every memory.


### 3. `GIT_AUTHOR_*` env tier — resolve the way git resolves (commit 2)

Tier 1 now reads `GIT_AUTHOR_NAME` / `GIT_AUTHOR_EMAIL` from the environment, falling back **per field** to `user.name` / `user.email`.

**Why env precedes config.** That is git's own precedence — `ident.c: git_author_info` reads `GIT_AUTHOR_*` first and only then consults config. Mirroring git is the whole argument: a CI job, a `git rebase`, or a `--author` re-exec now attributes the memory to exactly whoever git would have credited for a commit made at the same moment, so artifact provenance and commit provenance can never disagree. Slotting env *between* config and the caller `AgentIdentity` would invent a third precedence order matching neither git nor the MCP handshake, and would silently ignore the env on every developer machine — precisely where a deliberate override is meaningful.

**Per field, not per source.** Git resolves name and email independently, so a workflow exporting only `GIT_AUTHOR_NAME` keeps the config email. A whole-block "env wins or config wins" would throw the config email away. Side effect worth having: with both vars set, tier 1 spawns **zero** git processes.

**`GIT_COMMITTER_*` is deliberately excluded.** The frontmatter field is literally `author`, and git models author (who wrote it) and committer (who applied it) as distinct roles it never falls back between. Honouring the committer would credit the rebasing maintainer or the bot that replayed the work. Coverage lost is near-zero — every environment exporting `GIT_COMMITTER_*` exports `GIT_AUTHOR_*` alongside it — while the mis-attribution is real. `EMAIL` is excluded for the reason git ranks it last: a generic mail setting, not a statement about authorship.

Env values run through the **same sanitiser** as config values. CI routinely interpolates fork-controlled data (branch names, PR titles) into `GIT_AUTHOR_NAME`, and the value lands verbatim in a double-quoted YAML scalar; stripping `"`, `<`, `>`, control and bidi characters stops a name closing the scalar, forging a second `<address>`, or smuggling a direction override past a reviewer. Set-but-empty is treated as unset, mirroring the existing empty-`user.name` behaviour.

### 4. The remaining `"cli"` literals are channel markers, not authors

The previous revision of this PR proposed adopting `resolve_author` in `deprecate.rs` and `log_change_field`. **That was wrong and is corrected in the module docs.**

All 14 remaining `"cli"` literals in `forgeplan-cli` (`activate.rs:72`, `deprecate.rs:61`, `ingest.rs:568,589`, `link.rs:74,173`, `new.rs:215`, `renew.rs:50`, `reopen.rs:86,96`, `supersede.rs:66`, `update.rs:153,165,170`) are the trailing `source` argument of `common::log_change` / `log_change_field`. They land in `ChangeLogEntry::source`, whose own doc comment enumerates the closed vocabulary `cli, file_edit, git_sync, reindex`. That field answers *through which surface did this mutation arrive*, not *who made it*. Substituting a human name would destroy the audit trail's only channel discriminator — `git_sync` and `reindex` rows would stop being distinguishable from interactive ones, and nothing else in the row records the channel.

How to tell them apart: a **channel** `"cli"` is the last positional argument of a `log_change*` call; an **author** `"cli"` flows into `NewArtifact.author` or an `author:` frontmatter line. After the `remember.rs` fix there are **no author-`"cli"` sites left**.

The real remaining gap is a different shape and is **not** addressed here: `new.rs:200`, `capture.rs:63`, `generate.rs:73`, `ingest.rs:556` and `reason.rs:346` build `NewArtifact` with `author: None`, so every PRD/RFC/ADR is created with no author at all — strictly worse than the `cli` #411 was filed about. That is a separate, larger change, and the point at which memoising the git lookup stops being theoretical (1 call site → 6).

### 5. Making the provenance visible (commit 2)

Storing an author nobody can see closes nothing:

- **`remember --list` gains an Author column** between Category and Created — issue #411's own phrasing is "who added it and when". Width is fitted to the data (the idiom `id_width` already uses), so an all-`cli` workspace pays 6 chars, not the 20-char cap.
- **`recall` gains a dim inline author token**, same who-then-when order, so the two memory surfaces read identically.
- **`recall --json` gains an `author` field.** The payload already carried the "when" and gave agents no "who" at all. Emitted **unshortened** — JSON has no width budget and truncating a machine-read field is data loss.

Display shortening reuses `render_git_author`'s existing ruling rather than inventing a second policy: when `Name <email>` does not fit, the **address is dropped whole** rather than cut into, because a mangled `<ada@examp` reads like corrupt data whereas a bare name is honest.

### 6. Test isolation (the highest-probability regression in the diff)

Because env now outranks config, five existing `resolve_author` tests would silently start asserting the **developer's shell** instead of the repo. An RAII `AuthorEnvGuard` clears both vars and restores them on drop (correct even if an assertion panics mid-test); every user carries `#[serial_test::serial(env_path)]`, reusing the key the PATH test already holds so *all* env mutation in the module is mutually exclusive. The new e2e test clears the pair via `env_remove` for the same reason — a test run from inside `git rebase` / `git am` inherits an exported `GIT_AUTHOR_*`.

## Gate (re-run on the full branch, commit 5de9757)

| Step | Result |
|---|---|
| `cargo fmt --check` | 0 diffs |
| `cargo check --workspace --all-targets` | 0 warnings, 0 errors |
| `cargo test --workspace` | **3196 passed, 0 failed, 11 ignored** (84 `test result:` lines) |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, 0 warnings |

Disk: 33Gi free before, 13Gi after — the gate stayed above the 8Gi stop-floor throughout, and the 84 non-empty `test result:` lines confirm a real run rather than an ENOSPC silent pass.

6 new tests on top of commit 1's 13, all passing:

```
git::author::tests::env_component_sanitises_and_treats_empty_as_unset ... ok
git::author::tests::env_author_name_outranks_config_and_mixes_per_field ... ok
commands::common::tests::resolve_display_author_prefers_column_then_frontmatter ... ok
commands::common::tests::shorten_author_drops_the_address_before_cutting_into_it ... ok
remember_list_shows_the_git_author_column ... ok
recall_json_carries_provenance ... ok
```

`env_author_name_outranks_config_and_mixes_per_field` is the **precedence guard**: with `GIT_AUTHOR_NAME` set and `GIT_AUTHOR_EMAIL` unset against a repo whose local config sets both, it asserts `CI Bot <config@example.org>` — which would be `Config Human <...>` if the tier order were wrong, and a bare `CI Bot` if the env block short-circuited the whole tier and discarded the config email.

## Dogfood (red line #5 — proving the NEW behaviour)

Fresh scratch workspace, real `./target/debug/forgeplan` binary, local git config `Config Human <config@example.org>`.

**Env tier and its precedence — three cases, verified against the on-disk `author:` line, not the hint:**

```
### 1. NO env vars set -> tier 1 must use git CONFIG
  Remembered: mem-config-tier-wins-when-env-is-absent

### 2. BOTH env vars set, DISTINCT from git config -> env must win
  Remembered: mem-env-tier-outranks-git-config-entirely

### 3. Only GIT_AUTHOR_NAME set -> PER-FIELD mix: env name + config email
  Remembered: mem-per-field-mixing-keeps-the-config-email

### Resulting author: lines on disk (ground truth)
mem-config-tier-wins-when-env-is-absent.md      author: Config Human <config@example.org>
mem-env-tier-outranks-git-config-entirely.md    author: CI Bot <bot@ci.example>
mem-per-field-mixing-keeps-the-config-email.md  author: Partial Env <config@example.org>
```

Case 3 is the decisive one: the name came from the environment and the email still came from git config.

**The Author column, with a long identity and a legacy `cli` row:**

```
$ forgeplan remember --list
ID                                             Category      Author        Created       Text
mem-config-tier-wins-when-env-is-absent        fact          Config Human  2026-07-26    config tier wins when env is absent
mem-env-tier-outranks-git-config-entirely      fact          CI Bot        2026-07-26    env tier outranks git config entirely
mem-legacy-row-with-no-resolvable-identity     fact          cli           2026-07-26    legacy row with no resolvable identity
mem-long-identity-must-drop-the-address-whole  fact          Ada Lovelace  2026-07-26    long identity must drop the address whole
mem-per-field-mixing-keeps-the-config-email    fact          Partial Env   2026-07-26    per field mixing keeps the config email

  5 memory(ies) total
Next: forgeplan recall "<query>"
```

The column width-fitted to **12** chars (the widest cell), not the 20-char cap — the data-fitting works. The `cli` row is a genuine tier-3 fallback (git identity unset, env cleared), proving legacy rows still render rather than showing a blank cell.

**The shortening is real, not an artefact of never storing the address:**

```
### STORED value for the long identity
author: Ada Lovelace <ada@example.org>     # 30 chars on disk
### DISPLAYED in the table
Ada Lovelace                              # address dropped WHOLE, never "Ada Lovelace <ada@e…"
```

**`recall` inline token and JSON payload:**

```
$ forgeplan recall "identity"
mem-legacy-row-with-no-resolvable-identity     [fact]  cli           2026-07-26  legacy row with no resolvable identity
mem-long-identity-must-drop-the-address-whole  [fact]  Ada Lovelace  2026-07-26  long identity must drop the address whole

$ forgeplan recall "long identity" --json
{
  "memories": [
    {
      "author": "Ada Lovelace <ada@example.org>",     <-- WHOLE, not shortened
      "category": "fact",
      "created_at": "2026-07-26T14:35:13.946575+00:00",
      "id": "mem-long-identity-must-drop-the-address-whole",
      "text": "long identity must drop the address whole"
    }
  ]
}
```

**Commit 1's behaviour still holds** — memory resolves by id and links into the graph:

```
$ forgeplan get mem-legacy-row-with-no-resolvable-identity
mem-legacy-row-with-no-resolvable-identity — legacy row with no resolvable identity
  Kind:         memory
  Status:       active
  Author:       cli

$ forgeplan link mem-legacy-row-with-no-resolvable-identity PRD-001 --relation informs
Linked: mem-legacy-row-with-no-resolvable-identity --informs--> PRD-001
```

## Not in this PR — deliberately deferred

**The MCP memory surface (`forgeplan_remember` / `forgeplan_recall`) is NOT here, on the designer's explicit recommendation to ship it as its own PR off `dev` after this merges.** Their reasoning:

1. This PR is focused correctness work — `resolve_id` ordering, author-resolution tiers — that deserves focused review. The tool pair adds 2 MCP tools + a new `forgeplan_core::memory` module + ~28 documentation files, roughly tripling the diff and burying the part that needs eyes.
2. Adding a `#[tool(...)]` attribute takes the count 73 → 75, which trips `scripts/check-mcp-tool-count.sh` in `forgeplan-health.yml`. That workflow triggers on `paths: ['crates/**']` and is green on this PR **only because the count is untouched**. It would go red until ~30 doc locations across 28 files are reconciled — including 12 published blog posts whose correct fix is an MDX drift-ignore annotation (`{/* … */}`, not `<!-- … -->`, which breaks the MDX v2 build), not a number bump.
3. The dependency runs one way and is already satisfied: `forgeplan_remember` needs this PR (it calls `resolve_author`, and needs Path 0 so the memory it creates is retrievable). This PR needs nothing from the tool pair.

Verified blockers for the alternative (widening `ArtifactKindArg`), all confirmed against current code: no `memory` template (hard error, not silent corruption); `id_alloc` would mint `mem-001` against `remember`'s content-derived `mem-<slug>`; and — the decisive one the earlier draft missed — `NewParams` carries no `text` and no `category` fields, so an agent could only create memories with no body and no category. No template can fix a gap in the params struct.

Also deferred, and flagged as a **larger** attribution gap than #411 itself: `author: None` at artifact creation across `new.rs` / `capture.rs` / `generate.rs` / `ingest.rs` / `reason.rs`.

Refs: #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
