### PR TITLE
fix: artifact identity survival + same-slug data-loss guard (#418, #419)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,9 @@ Instructions for Claude Code when working in this repository.
   semantic search промахнётся. Если случайно отредактирован — recover через
   `forgeplan_update id=<ID> body=<full new body>` (читаешь файл, формируешь
   полное новое body без YAML frontmatter, пушишь через MCP). Last-resort
-  fallback: `forgeplan scan-import` пересоберёт LanceDB из markdown.
+  fallback: `forgeplan reindex` пересоберёт LanceDB из markdown
+  (**не** `scan-import` — тот ищет и импортирует новые артефакты из
+  произвольного markdown, существующие не синхронизирует; см. #420).
   Direct Edit OK ТОЛЬКО для не-forgeplan markdown (READMEs, CLAUDE.md,
   KNOWN-ISSUES, src code, .changeset/*.md).
 
@@ -542,7 +544,9 @@ Each MUST find ≥3 issues. Zero findings → re-spawn (suspect superficial revi
 1. Re-Read file to capture current content
 2. Strip YAML frontmatter (forgeplan_update body excludes it)
 3. `mcp__forgeplan__forgeplan_update(id="<ID>", body=<full body>)`
-4. Last-resort fallback: `forgeplan scan-import` rebuilds LanceDB from markdown
+4. Last-resort fallback: `forgeplan reindex` rebuilds LanceDB from markdown
+   (**not** `scan-import` — that one discovers and imports *new* artifacts from
+   arbitrary markdown; it does not sync artifacts already in the graph, #420)
 
 Document the violation в commit message so reviewer recognizes the pattern was caught.
 
@@ -663,14 +667,18 @@ forgeplan claims              # кто что захватил
 ├── evidence/ problems/ solutions/
 ├── notes/ refresh/ memory/
 ├── config.yaml         ← tracked (env var refs only, no hardcoded secrets)
-├── lance/              ← ⚠️ gitignored (derived index — forgeplan scan-import)
+├── lance/              ← ⚠️ gitignored (derived index — forgeplan reindex)
 ├── .fastembed_cache/   ← ⚠️ gitignored
 └── session.yaml        ← ⚠️ gitignored (per-machine runtime state)
 ```
 
-**Fresh clone**: `git clone → forgeplan init -y → forgeplan scan-import → forgeplan list`.
+**Fresh clone**: `git clone → forgeplan init -y → forgeplan reindex → forgeplan list`.
 
-**Rules**: edit via `forgeplan` CLI; direct markdown edits require `forgeplan scan-import`; DO NOT commit `lance/` or `session.yaml`.
+**`reindex` vs `scan-import`** — не взаимозаменяемы:
+- `forgeplan reindex` — синхронизирует **существующие** артефакты `.forgeplan/**.md` в LanceDB. Это команда восстановления индекса.
+- `forgeplan scan-import` — **находит и импортирует новые** артефакты из произвольного markdown. Существующие не трогает, и в этом репозитории затягивает `templates/` и `docs/` как ложные артефакты (PROB-047).
+
+**Rules**: edit via `forgeplan` CLI; direct markdown edits require `forgeplan reindex`; DO NOT commit `lance/` or `session.yaml`.
 
 ---
 

--- a/crates/forgeplan-cli/src/commands/update.rs
+++ b/crates/forgeplan-cli/src/commands/update.rs
@@ -137,8 +137,18 @@ Fix: forgeplan list",
     // PRD-073 audit M1 fix: clean up OLD slug AFTER the new file is in place
     // (so there's no orphan window) and use exact-path removal so we don't
     // accidentally clobber a sibling artifact whose ID is a prefix of this one.
-    if title.is_some() {
-        let _ = projection::remove_projection_at(&ws, id, &original.kind, &original.title).await;
+    // The rename-aware helper additionally skips removal when the new title
+    // slugifies to the same filename (case/punctuation-only edit) — otherwise
+    // it deletes the file update just wrote (silent, reindex-unrecoverable).
+    if let Some(new_title) = title {
+        let _ = projection::remove_stale_projection_after_rename(
+            &ws,
+            id,
+            &original.kind,
+            &original.title,
+            new_title,
+        )
+        .await;
     }
 
     // Log changes

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -692,6 +692,41 @@ pub async fn remove_projection_at(
     }
 }
 
+/// Remove the OLD projection file after a title change — but only if the title
+/// actually renamed the file.
+///
+/// A title edit that slugifies to the *same* filename (a case-only or
+/// punctuation-only change, or the identical title re-submitted) must NOT delete
+/// anything: the mutation path writes the new file at `slug(new_title)` first,
+/// and when `slug(old) == slug(new)` that is the very file we would then remove.
+/// `slugify` lowercases and collapses every non-alphanumeric run to `-`, so
+/// `"Auth system"`, `"Auth system!"` and `"auth system"` all map to
+/// `auth-system` — without this guard, `forgeplan_update --title` on any of
+/// those against an existing `auth-system` artifact deletes the markdown source
+/// of truth. `forgeplan_get` keeps working (the LanceDB row survives), so the
+/// loss is silent until the next `reindex` prunes the now-orphaned row —
+/// unrecoverable (ADR-003: markdown is the source of truth).
+///
+/// Comparing resolved file paths rather than raw slugs also means a future
+/// change to the slug algorithm cannot reopen the hole.
+///
+/// # Errors
+/// Same as [`remove_projection_at`]: invalid id/kind, or a filesystem error
+/// during removal.
+pub async fn remove_stale_projection_after_rename(
+    workspace: &Path,
+    id: &str,
+    kind: &str,
+    old_title: &str,
+    new_title: &str,
+) -> anyhow::Result<bool> {
+    if projection_slug(old_title) == projection_slug(new_title) {
+        // Same filename — the "old" file IS the file we just wrote. No-op.
+        return Ok(false);
+    }
+    remove_projection_at(workspace, id, kind, old_title).await
+}
+
 // =============================================================================
 // PRD-073 file-first mutation helpers
 // -----------------------------------------------------------------------------
@@ -2252,6 +2287,60 @@ mod tests {
         // A body with no frontmatter at all must not panic or corrupt.
         let new = "## Problem\n\nplain\n";
         assert_eq!(carry_identity_forward("no frontmatter here\n", new), new);
+    }
+
+    // ── #419 BLOCKER: same-slug title change must not delete the file ────
+
+    #[tokio::test]
+    async fn rename_helper_removes_old_file_on_a_real_rename() {
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path();
+        let dir = ws.join("prds");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        // Both files exist (new already written by the mutation path).
+        tokio::fs::write(dir.join("PRD-001-old-title.md"), "x")
+            .await
+            .unwrap();
+        tokio::fs::write(dir.join("PRD-001-new-title.md"), "x")
+            .await
+            .unwrap();
+
+        let removed =
+            remove_stale_projection_after_rename(ws, "PRD-001", "prd", "Old title", "New title")
+                .await
+                .unwrap();
+        assert!(removed, "a genuine rename must remove the stale file");
+        assert!(!dir.join("PRD-001-old-title.md").exists());
+        assert!(
+            dir.join("PRD-001-new-title.md").exists(),
+            "the new file must survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_helper_is_a_noop_when_slug_is_unchanged() {
+        // The #419 BLOCKER: "Probe" -> "probe" (or "Probe!") slugifies to the
+        // same filename. The helper must NOT delete the just-written file.
+        let tmp = TempDir::new().unwrap();
+        let ws = tmp.path();
+        let dir = ws.join("prds");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let f = dir.join("PRD-001-probe.md");
+        tokio::fs::write(&f, "the only copy").await.unwrap();
+
+        for (old, new) in [("Probe", "probe"), ("Probe", "Probe!"), ("Probe", "Probe")] {
+            let removed = remove_stale_projection_after_rename(ws, "PRD-001", "prd", old, new)
+                .await
+                .unwrap();
+            assert!(
+                !removed,
+                "same-slug edit {old:?}->{new:?} must be a no-op, not a delete"
+            );
+            assert!(
+                f.exists(),
+                "the artifact file must survive a same-slug edit {old:?}->{new:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -915,6 +915,57 @@ pub async fn update_metadata_with_projection(
     Ok(())
 }
 
+/// ADR-012 / SPEC-005 identity fields.
+///
+/// Under the PRD-073 two-block layout these live in the **body's** own
+/// frontmatter, which makes them collateral damage of any body replacement —
+/// see [`carry_identity_forward`].
+const IDENTITY_FM_KEYS: &[&str] = &["slug", "predicted_number", "assigned_number"];
+
+/// Re-attach the ADR-012 identity fields from `old_body` when `new_body` does
+/// not carry them.
+///
+/// The identity triple lives inside the body's frontmatter block (PRD-073
+/// layout: synthetic projection block on top, canonical body below). A body
+/// replacement is therefore an *identity deletion* unless the fields are
+/// carried across — which is why a mature workspace ends up with no artifact
+/// carrying a slug at all: `forgeplan new` writes one, and the very next
+/// `update --body` that CLAUDE.md prescribes silently drops it.
+///
+/// Callers supply prose. Re-attaching here keeps every call site from having to
+/// remember, and is a no-op when the caller *did* supply identity (round-trip of
+/// a full document) or when the artifact never had one (legacy, pre-Phase-1.5).
+fn carry_identity_forward(old_body: &str, new_body: &str) -> String {
+    let Ok((old_fm, _)) = frontmatter::parse_frontmatter(old_body) else {
+        return new_body.to_string();
+    };
+    let carried: Vec<(&str, serde_yaml::Value)> = IDENTITY_FM_KEYS
+        .iter()
+        .filter_map(|k| old_fm.get(*k).map(|v| (*k, v.clone())))
+        .collect();
+    if carried.is_empty() {
+        return new_body.to_string();
+    }
+
+    // Start from whatever frontmatter the replacement itself declares so a
+    // caller round-tripping a full document keeps their own values.
+    let (mut fm, prose) = match frontmatter::parse_frontmatter(new_body) {
+        Ok((fm, prose)) => (fm, prose),
+        Err(_) => (Frontmatter::new(), new_body.to_string()),
+    };
+    let mut changed = false;
+    for (k, v) in carried {
+        if !fm.contains_key(k) {
+            fm.insert(k.to_string(), v);
+            changed = true;
+        }
+    }
+    if !changed {
+        return new_body.to_string();
+    }
+    frontmatter::render_frontmatter(&fm, &prose).unwrap_or_else(|_| new_body.to_string())
+}
+
 /// Replace artifact body with the supplied content. Unlike other mutation
 /// helpers, this does NOT call `sync_before_mutation` — the caller is
 /// explicitly overwriting whatever is on disk with a CLI/MCP-supplied body,
@@ -955,6 +1006,12 @@ pub async fn update_body_with_projection(
         }
     };
     let links = store.get_relations(id).await.unwrap_or_default();
+
+    // PROB-060 / ADR-012: preserve the identity triple the replacement would
+    // otherwise delete. Must happen before `derived_status` is parsed and
+    // before either write, so file and index agree on one body.
+    let carried = carry_identity_forward(&record.body, body);
+    let body: &str = &carried;
 
     // Audit-r7 F1 (CRITICAL): parse the new body's frontmatter and sync
     // the `status` column in LanceDB if it changed. Without this, callers
@@ -2148,6 +2205,54 @@ mod tests {
     }
 
     // ── PRD-057 Inc 2: agent identity + unknown-fm preservation ─────────
+
+    // ── #418: body replacement must not delete the ADR-012 identity ─────
+
+    const OLD_WITH_IDENTITY: &str = "---\nid: PRD-001\nslug: prd-auth-system\npredicted_number: 1\nassigned_number: 1\nstatus: Draft\n---\n\n## Problem\n\nold prose\n";
+
+    #[test]
+    fn carry_identity_forward_reattaches_triple_to_a_bare_body() {
+        // The exact shape CLAUDE.md prescribes right after `forgeplan new`:
+        // the caller sends prose only.
+        let out = carry_identity_forward(OLD_WITH_IDENTITY, "## Problem\n\nnew prose\n");
+        assert!(
+            out.contains("slug: prd-auth-system"),
+            "slug must survive:\n{out}"
+        );
+        assert!(out.contains("predicted_number: 1"));
+        assert!(out.contains("assigned_number: 1"));
+        assert!(
+            out.contains("new prose"),
+            "the new prose must be what lands"
+        );
+        assert!(!out.contains("old prose"), "old prose must not resurrect");
+        // Only identity is carried — not the old block's stale scaffolding.
+        assert!(!out.contains("status: Draft"));
+    }
+
+    #[test]
+    fn carry_identity_forward_is_noop_for_legacy_artifacts() {
+        // Pre-Phase-1.5 artifacts never had a slug; nothing to carry, and the
+        // body must come through byte-for-byte.
+        let old = "---\nid: PRD-001\nstatus: Draft\n---\n\nold\n";
+        let new = "## Problem\n\nplain\n";
+        assert_eq!(carry_identity_forward(old, new), new);
+    }
+
+    #[test]
+    fn carry_identity_forward_respects_caller_supplied_identity() {
+        // Round-tripping a full document: the caller's own values win.
+        let new =
+            "---\nslug: caller-chosen\npredicted_number: 9\nassigned_number: 9\n---\n\nprose\n";
+        assert_eq!(carry_identity_forward(OLD_WITH_IDENTITY, new), new);
+    }
+
+    #[test]
+    fn carry_identity_forward_survives_unparseable_old_body() {
+        // A body with no frontmatter at all must not panic or corrupt.
+        let new = "## Problem\n\nplain\n";
+        assert_eq!(carry_identity_forward("no frontmatter here\n", new), new);
+    }
 
     #[test]
     fn filter_preserved_drops_known_keys() {

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -707,8 +707,9 @@ pub async fn remove_projection_at(
 /// loss is silent until the next `reindex` prunes the now-orphaned row —
 /// unrecoverable (ADR-003: markdown is the source of truth).
 ///
-/// Comparing resolved file paths rather than raw slugs also means a future
-/// change to the slug algorithm cannot reopen the hole.
+/// The comparison uses `projection_slug` — the same function that builds the
+/// on-disk filename from the title — so slug-equality is exactly file-path
+/// equality here (both paths share this artifact's id, kind and directory).
 ///
 /// # Errors
 /// Same as [`remove_projection_at`]: invalid id/kind, or a filesystem error

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -3843,10 +3843,15 @@ impl ForgeplanServer {
         // Exact-path removal (not a prefix glob) so a sibling whose id is a
         // prefix of this one is never clobbered, and AFTER the new file is in
         // place so there is no orphan window — same ordering as the CLI.
-        if p.title.is_some() {
-            let _ =
-                projection::remove_projection_at(&ws, &canonical, &original.kind, &original.title)
-                    .await;
+        if let Some(ref new_title) = p.title {
+            let _ = projection::remove_stale_projection_after_rename(
+                &ws,
+                &canonical,
+                &original.kind,
+                &original.title,
+                new_title,
+            )
+            .await;
         }
 
         // Re-fetch for the response payload.

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -3752,7 +3752,10 @@ impl ForgeplanServer {
             .get_record(&canonical)
             .await
             .map_err(|e| safe_mcp_error_anyhow(&e))?;
-        let _pre_record = match pre_record {
+        // Retained (not `_`-discarded): a title change needs the ORIGINAL title
+        // to locate the old projection file for cleanup — see the rename block
+        // after the mutation helpers.
+        let original = match pre_record {
             Some(r) => r,
             // Surface the user's original input in the not-found message (mirrors
             // `forgeplan_get`) — most helpful when the id genuinely doesn't exist.
@@ -3830,6 +3833,20 @@ impl ForgeplanServer {
             projection::update_body_with_projection(&ctx, &canonical, body)
                 .await
                 .map_err(safe_mcp_error)?;
+        }
+
+        // A title change renames the projection file, so the OLD path must be
+        // removed or both survive carrying the same id — a duplicate-id
+        // collision produced by one sanctioned call. `update.rs` has cleaned
+        // this up since the PRD-073 audit; the MCP handler never got the same
+        // fix, so renames through MCP silently forked the artifact in two.
+        // Exact-path removal (not a prefix glob) so a sibling whose id is a
+        // prefix of this one is never clobbered, and AFTER the new file is in
+        // place so there is no orphan window — same ordering as the CLI.
+        if p.title.is_some() {
+            let _ =
+                projection::remove_projection_at(&ws, &canonical, &original.kind, &original.title)
+                    .await;
         }
 
         // Re-fetch for the response payload.

--- a/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
+++ b/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
@@ -275,3 +275,92 @@ async fn mcp_update_title_removes_the_old_projection_file() {
         "the surviving file must carry the new slug, got: {names:?}"
     );
 }
+
+/// #419 BLOCKER regression: a title edit that slugifies to the SAME filename
+/// (case-only / punctuation-only) must NOT delete the artifact's file. The
+/// original #419 fix removed the old file unconditionally; when old and new
+/// slug are identical, the "old" file IS the just-written one, so the mutation
+/// silently destroyed the markdown source of truth. The first fix's test only
+/// covered a different-slug rename, so the suite was green over a live BLOCKER.
+#[tokio::test]
+async fn mcp_update_same_slug_title_keeps_the_file() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("Probe").await;
+
+    let prds_dir = fx.workspace_path.join("prds");
+    let survivors = || {
+        std::fs::read_dir(&prds_dir)
+            .expect("prds dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().to_uppercase();
+                n.ends_with(".MD") && n.starts_with(&format!("{}-", id.to_uppercase()))
+            })
+            .count()
+    };
+    assert_eq!(survivors(), 1, "one file after create");
+
+    // Case-only edit: "Probe" -> "probe" slugifies to the same "probe".
+    fx.call_tool_json(
+        "forgeplan_update",
+        serde_json::json!({"id": id, "title": "probe"}),
+    )
+    .await
+    .assert_ok();
+
+    assert_eq!(
+        survivors(),
+        1,
+        "same-slug title edit must leave the file intact, not delete it (id {id})"
+    );
+    // And forgeplan_get must still resolve — a reindex would otherwise prune the
+    // orphaned row and lose the artifact permanently.
+    let got = fx
+        .call_tool_json("forgeplan_get", serde_json::json!({"id": id}))
+        .await;
+    got.assert_ok();
+}
+
+/// #418 E2E on the MCP surface (RED LINE #5: real E2E on the affected surface,
+/// not just a pure-fn unit test). new -> update body=<prose only> must keep the
+/// ADR-012 identity triple that `forgeplan_new` wrote into the body block. The
+/// pure-function carry_identity_forward tests use a hand-written body; this
+/// drives the actual tool path end to end.
+#[tokio::test]
+async fn mcp_update_body_preserves_identity_triple() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("Identity survival probe").await;
+
+    // A body of prose only — exactly what CLAUDE.md prescribes right after new.
+    fx.call_tool_json(
+        "forgeplan_update",
+        serde_json::json!({"id": id, "body": "## Problem\n\nprobe body\n\n## Goals\n\nprobe\n"}),
+    )
+    .await
+    .assert_ok();
+
+    let prds_dir = fx.workspace_path.join("prds");
+    let file = std::fs::read_dir(&prds_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| {
+            p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                n.to_uppercase()
+                    .starts_with(&format!("{}-", id.to_uppercase()))
+            })
+        })
+        .expect("artifact file on disk");
+    let text = std::fs::read_to_string(&file).unwrap();
+
+    for field in ["slug:", "predicted_number:", "assigned_number:"] {
+        assert!(
+            text.contains(field),
+            "identity field {field:?} must survive a body replacement (#418), file:\n{text}"
+        );
+    }
+    assert!(
+        text.contains("probe body"),
+        "the new prose must have landed"
+    );
+}

--- a/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
+++ b/crates/forgeplan-mcp/tests/mcp_new_update_title_validation.rs
@@ -221,3 +221,57 @@ async fn mcp_update_lowercase_id_persists_change() {
         "the title written via the lowercase id must be visible on the canonical artifact"
     );
 }
+
+// ── #419: a title change must not leave the old file behind ──────────
+
+/// Renaming through MCP used to write the new slug-derived filename and leave
+/// the old one on disk, producing two `.md` files carrying the same `id:` — a
+/// duplicate-id collision created by one sanctioned call.
+///
+/// The CLI has cleaned this up since the PRD-073 audit (`update.rs` calls
+/// `remove_projection_at` with the ORIGINAL title); the MCP handler never got
+/// the same fix. This pins the parity.
+#[tokio::test]
+async fn mcp_update_title_removes_the_old_projection_file() {
+    let fx = McpFixture::new().await;
+    let id = fx.seed_prd("Original probe title").await;
+
+    let prds_dir = fx.workspace_path.join("prds");
+    let count_files = || {
+        std::fs::read_dir(&prds_dir)
+            .expect("prds dir")
+            .filter_map(Result::ok)
+            .filter(|e| {
+                let n = e.file_name().to_string_lossy().to_uppercase();
+                n.ends_with(".MD") && n.starts_with(&format!("{}-", id.to_uppercase()))
+            })
+            .count()
+    };
+    assert_eq!(count_files(), 1, "one file after create");
+
+    fx.call_tool_json(
+        "forgeplan_update",
+        serde_json::json!({"id": id, "title": "Renamed probe title"}),
+    )
+    .await
+    .assert_ok();
+
+    assert_eq!(
+        count_files(),
+        1,
+        "a rename must leave exactly one file — the old slug path has to go, \
+         otherwise two files carry id {id} and the resolver picks by scan order"
+    );
+
+    // And the survivor must be the NEW name, not the stale one.
+    let names: Vec<String> = std::fs::read_dir(&prds_dir)
+        .expect("prds dir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .filter(|n| n.ends_with(".md"))
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("renamed-probe-title")),
+        "the surviving file must carry the new slug, got: {names:?}"
+    );
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,7 @@ forgeplan list -t adr            # list all ADRs
 forgeplan get ADR-003            # read one
 forgeplan validate PRD-024       # check quality
 forgeplan score PRD-024          # compute R_eff
-forgeplan scan-import            # rebuild LanceDB index from markdown
+forgeplan reindex                # rebuild LanceDB index from markdown
 ```
 
 **Fresh clone workflow:**
@@ -107,7 +107,7 @@ forgeplan scan-import            # rebuild LanceDB index from markdown
 ```bash
 git clone <repo> && cd forgeplan
 forgeplan init -y                # creates .forgeplan/lance/ locally (empty)
-forgeplan scan-import            # indexes tracked markdown into LanceDB
+forgeplan reindex                # syncs tracked markdown into LanceDB
 forgeplan list                   # verify — should see all artifacts
 ```
 
@@ -122,6 +122,6 @@ forgeplan list                   # verify — should see all artifacts
 ## Conventions
 
 - **All paths in documents are relative to repository root.**
-- **Artifact files in `.forgeplan/` are managed by the `forgeplan` CLI** — hand-editing works but may cause drift with the LanceDB index until `scan-import` runs.
+- **Artifact files in `.forgeplan/` are managed by the `forgeplan` CLI** — hand-editing works but may cause drift with the LanceDB index until `reindex` runs.
 - **Methodology docs here are authoritative** — if a tutorial and a schema disagree, the schema wins.
 - **Activated artifacts are immutable** — supersede via `forgeplan supersede`, do not rewrite history.

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -97,7 +97,7 @@ forgeplan list -t adr            # список всех ADR
 forgeplan get ADR-003            # прочитать один
 forgeplan validate PRD-024       # проверить качество
 forgeplan score PRD-024          # вычислить R_eff
-forgeplan scan-import            # пересобрать LanceDB-индекс из markdown
+forgeplan reindex                # пересобрать LanceDB-индекс из markdown
 ```
 
 **Процесс при свежем клонировании:**
@@ -105,7 +105,7 @@ forgeplan scan-import            # пересобрать LanceDB-индекс �
 ```bash
 git clone <repo> && cd forgeplan
 forgeplan init -y                # создаёт .forgeplan/lance/ локально (пустую)
-forgeplan scan-import            # индексирует отслеживаемые markdown в LanceDB
+forgeplan reindex                # синхронизирует отслеживаемые markdown в LanceDB
 forgeplan list                   # проверка — должны отображаться все артефакты
 ```
 
@@ -120,6 +120,6 @@ forgeplan list                   # проверка — должны отобр�
 ## Соглашения
 
 - **Все пути в документах указаны относительно корня репозитория.**
-- **Файлы артефактов в `.forgeplan/` управляются CLI `forgeplan`** — ручное редактирование работает, но может вызвать рассинхронизацию с индексом LanceDB до запуска `scan-import`.
+- **Файлы артефактов в `.forgeplan/` управляются CLI `forgeplan`** — ручное редактирование работает, но может вызвать рассинхронизацию с индексом LanceDB до запуска `reindex`.
 - **Документация методологии здесь является авторитетной** — если руководство и схема расходятся, приоритет у схемы.
 - **Активированные артефакты неизменяемы** — замена через `forgeplan supersede`, историю не переписывать.


### PR DESCRIPTION
## What

Fixes two artifact-integrity bugs found by dogfooding, plus a data-loss BLOCKER the fix's own adversarial audit then found in the first cut.

Closes #418, #419.

## Bugs

**#418 — identity triple never persisted.** `forgeplan new` wrote `slug`/`predicted_number`/`assigned_number` into a template-derived body block; `forgeplan update --body` (the very next documented step) replaced the body and destroyed them. Result: **0 of 383** artifacts carried a slug, so ADR-012 was inert. Fix: `carry_identity_forward` re-attaches the triple on a body replacement (no-op for legacy packs and for a caller round-tripping a full document).

**#419 — `update --title` forked the artifact / then deleted it.**
- Original bug: MCP `forgeplan_update --title` wrote the new file and left the old one → two files, one id (a #394-class collision).
- **BLOCKER found in the first fix by pre-PR audit:** removing the old file unconditionally deletes it when the new title slugifies to the *same* filename (case/punctuation-only edit, or the identical title). `slugify` collapses case and punctuation, so `"Probe"`, `"Probe!"`, `"probe"` all map to `probe`. Silent loss — `forgeplan_get` keeps working until `reindex` prunes the orphan row (ADR-003, unrecoverable). The same latent bug existed on the pre-existing CLI path (`update.rs`).

Fix: `remove_stale_projection_after_rename` no-ops when `projection_slug(old) == projection_slug(new)`; both surfaces (MCP + CLI) route through it.

## Verification

`cargo fmt --check` 0 · `clippy -D warnings` 0 · 84 test sets green. Tests: same-slug no-op (unit + MCP E2E, **teeth-proven** — fails on the unguarded code), genuine-rename still removes, and a #418 identity-survival E2E on the real tool path (RED LINE #5). Re-audited on temp repos: GO, no regression.

## Not done / notes

- The BLOCKER's CLI twin was pre-existing on `dev`; this PR fixes both, but note the CLI half is not introduced by #419.
- No schema/behaviour change beyond the guard; `Refs: PROB-083`.

## Rollback

Revert the branch. The new `pub fn` is additive; existing callers switched from `remove_projection_at` to the guarded helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
