### PR TITLE
fix(ci): tool-count drift gate blind to hyphenated RU + docs-only PRs (#421)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,29 @@ jobs:
           chmod +x scripts/check-kind-list-drift.sh
           scripts/check-kind-list-drift.sh
 
+  check-mcp-tool-count-drift:
+    name: Check MCP tool count drift
+    runs-on: ubuntu-latest
+    # In ci.yml (all PRs, no path filter) rather than forgeplan-health.yml
+    # (paths .forgeplan/**, crates/**): #421 showed the drift it guards lives
+    # in website/docs/CLAUDE.md/README/TODO, so a docs-only PR never ran it.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Self-test the detector's own regex
+        # #421: the extraction pattern had never been asserted, and a
+        # whitespace-only separator made it walk past `NN MCP-инструмента`
+        # (the idiomatic hyphenated Russian form) while printing "No drift".
+        # The pattern is tested before it is trusted.
+        run: SELF_TEST=1 scripts/check-mcp-tool-count.sh
+
+      - name: Check docs/site tool counts against src
+        # Fails CI if README/CLAUDE/landing/docs disagree with the actual
+        # #[tool(...)] count in src. Lessons learned 2026-05-04: an external
+        # reviewer caught 18+ stale references before the internal sweep.
+        run: scripts/check-mcp-tool-count.sh
+
   # PROB-060 Phase 2.3 (T4) — workspace audit of frontmatter validator coverage.
   #
   # Self-test job: runs scripts/validator-audit-all.sh against the canonical

--- a/.github/workflows/forgeplan-health.yml
+++ b/.github/workflows/forgeplan-health.yml
@@ -52,19 +52,9 @@ jobs:
       - name: Validate artifacts
         run: ./target/debug/forgeplan validate --ci
 
-      - name: MCP tool count drift check — detector self-test
-        # #421: the detector's own pattern had never been asserted, and a
-        # whitespace-only separator made it walk past `NN MCP-инструмента`
-        # (the idiomatic hyphenated Russian form) while printing "No drift".
-        # A green gate that certifies the drift it exists to catch is worse
-        # than no gate, so the pattern is now tested before it is trusted.
-        run: SELF_TEST=1 ./scripts/check-mcp-tool-count.sh
-
-      - name: MCP tool count drift check
-        # Drift detector — fails CI if README/CLAUDE/landing/docs disagree
-        # with actual MCP tool count в src. Lessons learned 2026-05-04:
-        # external OpenAI agent caught 18+ stale references (28/37/45/47
-        # vs actual 63) that passive grep sweeps had been missing.
-        # PR 2.6 audit C-2: this step closes "preventive value theoretical"
-        # finding by wiring the script into the health gate.
-        run: ./scripts/check-mcp-tool-count.sh
+      # The MCP tool-count drift check moved to ci.yml (job
+      # check-mcp-tool-count-drift). #421: this workflow only triggers on
+      # paths .forgeplan/** and crates/**, but the drift it guards lives in
+      # website/**, docs/**, CLAUDE.md, README.md and TODO.md — a docs-only PR
+      # never ran the detector here, which is exactly how the stale '63' in a
+      # RU page survived. ci.yml runs on every PR with no path filter.

--- a/.github/workflows/forgeplan-health.yml
+++ b/.github/workflows/forgeplan-health.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Validate artifacts
         run: ./target/debug/forgeplan validate --ci
 
+      - name: MCP tool count drift check — detector self-test
+        # #421: the detector's own pattern had never been asserted, and a
+        # whitespace-only separator made it walk past `NN MCP-инструмента`
+        # (the idiomatic hyphenated Russian form) while printing "No drift".
+        # A green gate that certifies the drift it exists to catch is worse
+        # than no gate, so the pattern is now tested before it is trusted.
+        run: SELF_TEST=1 ./scripts/check-mcp-tool-count.sh
+
       - name: MCP tool count drift check
         # Drift detector — fails CI if README/CLAUDE/landing/docs disagree
         # with actual MCP tool count в src. Lessons learned 2026-05-04:

--- a/scripts/check-mcp-tool-count.sh
+++ b/scripts/check-mcp-tool-count.sh
@@ -76,7 +76,48 @@ SEARCH_PATHS=(
 # not any other number on the same line (avoid false-positive "1940 tests"
 # / "76 CLI commands"). Word boundary anchored с trailing non-letter
 # чтобы не matchать `tooltip`/`toolbox`/`toolkit` (audit C-3 finding).
-EXTRACT_RE='[0-9]+[[:space:]]*(MCP[[:space:]]*tool[s]?([^a-zA-Z]|$)|tool[s]?([^a-zA-Z]|$)|MCP[[:space:]]*инструмент|инструмент)'
+#
+# Separator between `MCP` and the noun is [[:space:]-]*, NOT whitespace-only:
+# Russian writes the compound hyphenated (`73 MCP-инструмента`), which is the
+# idiomatic form and therefore what the RU pages actually use. With a
+# whitespace-only class this script scanned website/src, walked straight past
+# `63 MCP-инструмента` in ru/docs/cli/serve.md, and printed "No drift" — a
+# green gate certifying the very drift it exists to catch. English `MCP-tools`
+# has the same exposure. See #421.
+EXTRACT_RE='[0-9]+[[:space:]]*(MCP[[:space:]-]*tool[s]?([^a-zA-Z]|$)|tool[s]?([^a-zA-Z]|$)|MCP[[:space:]-]*инструмент|инструмент)'
+
+# --self-test: exercise the extraction regex against both languages and both
+# separators. Runs offline, touches no repo file. The blind spot in #421
+# survived because nothing ever asserted the pattern itself.
+if [[ "${SELF_TEST:-0}" -eq 1 ]]; then
+    st_fail=0
+    st_expect() { # <should-match 0|1> <sample>
+        local want="$1" sample="$2" got
+        got=$(printf '%s' "$sample" | grep -coE "$EXTRACT_RE")
+        if [[ "$got" -ne "$want" ]]; then
+            echo "  SELF-TEST FAIL: expected match=$want got=$got for: $sample" >&2
+            st_fail=1
+        else
+            echo "  ok (match=$got): $sample"
+        fi
+    }
+    echo "Self-test: EXTRACT_RE"
+    st_expect 1 '73 MCP tools for agents'
+    st_expect 1 '73 MCP-tools for agents'
+    st_expect 1 '73 tools for agents'
+    st_expect 1 '73 MCP инструмента для агентов'
+    st_expect 1 '73 MCP-инструмента, сопоставленных с операциями'
+    st_expect 1 '73 инструмента для агентов'
+    # Must NOT match — the audit C-3 false positives.
+    st_expect 0 'a tooltip and a toolbox'
+    st_expect 0 '76 CLI commands'
+    if [[ "$st_fail" -ne 0 ]]; then
+        echo "Self-test FAILED" >&2
+        exit 1
+    fi
+    echo "Self-test OK"
+    exit 0
+fi
 
 DRIFT_FOUND=0
 DRIFT_OUTPUT=$(mktemp)

--- a/scripts/check-mcp-tool-count.sh
+++ b/scripts/check-mcp-tool-count.sh
@@ -89,7 +89,7 @@ EXTRACT_RE='[0-9]+[[:space:]]*(MCP[[:space:]-]*tool[s]?([^a-zA-Z]|$)|tool[s]?([^
 # --self-test: exercise the extraction regex against both languages and both
 # separators. Runs offline, touches no repo file. The blind spot in #421
 # survived because nothing ever asserted the pattern itself.
-if [[ "${SELF_TEST:-0}" -eq 1 ]]; then
+if [[ "${SELF_TEST:-0}" == "1" ]]; then
     st_fail=0
     st_expect() { # <should-match 0|1> <sample>
         local want="$1" sample="$2" got

--- a/website/src/content/docs/ru/docs/cli/serve.md
+++ b/website/src/content/docs/ru/docs/cli/serve.md
@@ -20,7 +20,7 @@ forgeplan serve
 
 ## Что он предоставляет
 
-63 MCP-инструмента, сопоставленных с основными операциями Forgeplan:
+73 MCP-инструмента, сопоставленных с основными операциями Forgeplan:
 
 - **Жизненный цикл артефактов** - `new`, `validate`, `review`, `activate`, `supersede`, `deprecate`, `stale`, `renew`, `reopen`
 - **Запросы + обнаружение** - `list`, `get`, `search`, `blocked`, `order`, `tree`, `discover`, `blindspots`, `gaps`


### PR DESCRIPTION
## What

Fixes the MCP tool-count drift detector, which reported green while a scanned page held a stale count.

Closes #421.

## Bug

The extraction regex separated `MCP` from the noun with `[[:space:]]*` (space only). Russian writes the compound hyphenated — `NN MCP-инструмента` — which is what the translated docs use. The detector scanned `website/src`, walked past `63 MCP-инструмента` in a RU page, and printed "No drift". A green gate certifying the drift it exists to catch.

The audit for this fix then found a **second, larger hole**: the detector ran only in `forgeplan-health.yml`, whose trigger is `paths: ['.forgeplan/**','crates/**']` — so a PR touching only `website/`/`docs/` never ran it. That is exactly how #421's stale `63` reached a RU page in the first place.

## Fix

- Separator → `[[:space:]-]*` on both the English and Russian branches (`MCP-tools` covered too).
- New `SELF_TEST=1` mode: 8 assertions over EN/RU × space/hyphen/bare and the audit's false-positive cases (`tooltip`, `76 CLI commands`). Nothing had ever asserted the pattern itself.
- Moved the gate (self-test + drift check) to `ci.yml` — runs on **every** PR, no path filter — next to `check-kind-list-drift`. Removed from `forgeplan-health.yml`.
- Fixed the stale `63 → 73` (EN page and its RU translation list identical categories; only the number drifted).
- Guard `-eq 1` → `== "1"` so `SELF_TEST=true` doesn't abort under `set -u`.

## Verification

Seeding a hyphenated RU count makes the detector flag it; removing the probe returns green with no traces. Self-test passes; both workflow YAMLs validate; no `${{ github.* }}` in the new job's `run:` steps. Re-audited: GO.

## Accept-not-fix (documented, not changed)

- RU alternatives lack a trailing word-boundary (latent; the "obvious" fix would break declension positives like `73 инструмента` — escape-hatch `mcp-count-drift: ignore` exists).
- Self-test reads `server.rs` before the regex block (zero functional effect in CI).

## Rollback

Revert the branch; the gate returns to `forgeplan-health.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
