### PR TITLE
fix(cli): reindex surfaces duplicate-id collisions instead of silent overwrite (#394)

### DIFF
--- a/crates/forgeplan-cli/src/commands/reindex.rs
+++ b/crates/forgeplan-cli/src/commands/reindex.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
 use forgeplan_core::projection;
 
 use crate::commands::common;
@@ -40,6 +43,15 @@ pub async fn run() -> anyhow::Result<()> {
     let mut skipped = 0usize;
     let mut errors = 0usize;
 
+    // #394: detect duplicate-id collisions. Two `.md` files that carry the
+    // same frontmatter `id` both resolve to a single LanceDB row; Phase 1
+    // processes them in `read_dir` order (which is not even stable) and the
+    // last one silently overwrites the first — last-writer-wins with no
+    // anomaly surfaced. The scan-import surface already flags this via
+    // `find_duplicate_ids`; reindex was the blind spot. Record every file per
+    // id here and report after the walk.
+    let mut id_to_paths: HashMap<String, Vec<PathBuf>> = HashMap::new();
+
     for dir_name in forgeplan_core::workspace::ARTIFACT_DIRS {
         let dir = ws.join(dir_name);
         if !dir.exists() {
@@ -79,6 +91,14 @@ pub async fn run() -> anyhow::Result<()> {
                     continue;
                 }
             };
+
+            // #394: remember every file that resolves to this id so a
+            // duplicate-id collision (two files, same id) is reported after
+            // the walk instead of silently overwriting during the upsert below.
+            id_to_paths
+                .entry(id.clone())
+                .or_default()
+                .push(path.clone());
 
             // Check if artifact exists in LanceDB
             match store.get_record(&id).await? {
@@ -215,6 +235,38 @@ pub async fn run() -> anyhow::Result<()> {
         }
     }
 
+    // #394: surface the duplicate-id collisions gathered during Phase 1.
+    // Non-fatal (same convention as the per-file errors above) so an
+    // onboarding `git clone && forgeplan reindex` still completes on a repo
+    // that already carries a collision — but it is now LOUD on stderr and
+    // counted in the summary, never silent. `id_to_paths` is consumed here.
+    let mut id_collisions: Vec<(String, Vec<PathBuf>)> = id_to_paths
+        .into_iter()
+        .filter(|(_, paths)| paths.len() > 1)
+        .collect();
+    id_collisions.sort_by(|a, b| a.0.cmp(&b.0));
+    for (_, paths) in id_collisions.iter_mut() {
+        paths.sort();
+    }
+    if !id_collisions.is_empty() {
+        eprintln!(
+            "\n⚠ {} duplicate-id collision(s): multiple files claim the same artifact id.",
+            id_collisions.len()
+        );
+        eprintln!("  Reindex is last-writer-wins — the shadowed file(s) never reach the index");
+        eprintln!("  (ADR-003: one id = one file). Resolve before trusting the index:");
+        for (cid, paths) in &id_collisions {
+            eprintln!("    {cid}");
+            for p in paths {
+                let rel = p.strip_prefix(&ws).unwrap_or(p);
+                eprintln!("      {}", rel.display());
+            }
+        }
+        eprintln!(
+            "  Resolution: keep one file per id (renumber or delete the duplicate), then rerun forgeplan reindex.\n"
+        );
+    }
+
     // Phase 2: Remove DB records whose .md file no longer exists (files-first cleanup)
     //
     // PRD-044 fix: previously `parse::<ArtifactKind>()` returning Err caused
@@ -331,14 +383,30 @@ pub async fn run() -> anyhow::Result<()> {
     }
 
     println!(
-        "\nReindex complete: {} synced, {} unchanged, {} removed, {} orphan relations, {} errors.",
-        synced, skipped, removed, orphan_relations, errors
+        "\nReindex complete: {} synced, {} unchanged, {} removed, {} orphan relations, {} errors, {} id-collisions.",
+        synced,
+        skipped,
+        removed,
+        orphan_relations,
+        errors,
+        id_collisions.len()
     );
 
     // PRD-071 hint contract: reindex is a maintenance op — point user to
     // health for next-action surfacing (or to scan-import for new docs).
     let mut next_hints: Vec<forgeplan_core::hints::Hint> = Vec::new();
-    if errors > 0 {
+    if !id_collisions.is_empty() {
+        // #394: a duplicate-id collision means the index no longer faithfully
+        // mirrors the markdown (one row shadows another) — surface it above a
+        // plain parse/sync error.
+        next_hints.push(
+            forgeplan_core::hints::Hint::warning(format!(
+                "{} duplicate-id collision(s) — one id maps to multiple files; index is last-writer-wins",
+                id_collisions.len()
+            ))
+            .with_action("forgeplan health"),
+        );
+    } else if errors > 0 {
         next_hints.push(
             forgeplan_core::hints::Hint::warning(format!(
                 "{} parse/sync errors during reindex",

--- a/crates/forgeplan-cli/tests/cli_reindex_id_collision.rs
+++ b/crates/forgeplan-cli/tests/cli_reindex_id_collision.rs
@@ -1,0 +1,153 @@
+//! #394 regression — reindex MUST surface duplicate-id collisions instead of
+//! silently overwriting (last-writer-wins). Two `.md` files carrying the same
+//! frontmatter `id` both resolve to one LanceDB row; before this fix the file
+//! processed second silently shadowed the first with no anomaly reported (and
+//! `read_dir` order is not even stable, so *which* one won was arbitrary).
+//! This drives the REAL binary against a real workspace with a hand-crafted
+//! collision — the exact shape of the PRD-012 / EVID-143 dogfood collisions.
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn forgeplan() -> Command {
+    Command::cargo_bin("forgeplan").unwrap()
+}
+
+fn init_workspace(tmp: &TempDir) {
+    forgeplan()
+        .args(["init", "-y"])
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+}
+
+fn new_artifact(tmp: &TempDir, kind: &str, title: &str) -> String {
+    let out = forgeplan()
+        .args(["new", kind, title, "--allow-duplicate"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "new {kind} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for line in stdout.lines() {
+        if let Some(id) = line.trim().strip_prefix("ID:") {
+            return id.trim().to_string();
+        }
+    }
+    panic!("no ID parsed from new {kind}: {stdout}");
+}
+
+fn find_md(dir: &std::path::Path, id: &str) -> std::path::PathBuf {
+    for entry in std::fs::read_dir(dir).unwrap().flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with(id) && name.ends_with(".md") {
+            return entry.path();
+        }
+    }
+    panic!("no .md file for {id} in {}", dir.display());
+}
+
+/// Main trace: two files, same `id`, different filenames → reindex must report
+/// the collision LOUDLY, name both files, count it in the summary, and still
+/// exit 0 (non-fatal, so a pre-existing collision does not brick an onboarding
+/// `git clone && forgeplan reindex`).
+#[test]
+fn reindex_reports_duplicate_id_collision() {
+    let tmp = TempDir::new().unwrap();
+    init_workspace(&tmp);
+
+    let prd = new_artifact(&tmp, "prd", "Onboarding init scan");
+    let prds_dir = tmp.path().join(".forgeplan").join("prds");
+
+    // Hand-craft the collision: copy the canonical file to a second filename
+    // (different slug) that keeps the SAME frontmatter `id`. Append a body line
+    // so the content genuinely differs — exercising the silent-overwrite path,
+    // not an identical-file no-op.
+    let original = find_md(&prds_dir, &prd);
+    let content = std::fs::read_to_string(&original).unwrap();
+    let dup = prds_dir.join(format!("{prd}-onboarding-shadow-copy.md"));
+    std::fs::write(
+        &dup,
+        format!("{content}\n\nShadow copy body — #394 collision.\n"),
+    )
+    .unwrap();
+
+    let out = forgeplan()
+        .args(["reindex"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    // Non-fatal: a collision must NOT brick reindex (onboarding safety).
+    assert!(
+        out.status.success(),
+        "reindex must stay non-fatal on a collision: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The collision must be LOUD, name the id, and list BOTH files.
+    assert!(
+        combined.contains("duplicate-id collision"),
+        "reindex must announce the collision; got:\n{combined}"
+    );
+    assert!(
+        combined.contains(&prd),
+        "collision report must name the colliding id {prd}; got:\n{combined}"
+    );
+    let orig_name = original.file_name().unwrap().to_string_lossy().to_string();
+    assert!(
+        combined.contains(&orig_name),
+        "collision report must list the original file {orig_name}; got:\n{combined}"
+    );
+    assert!(
+        combined.contains("onboarding-shadow-copy.md"),
+        "collision report must list the shadow file; got:\n{combined}"
+    );
+    // Summary must COUNT it — a block alone can be scrolled past; the count is
+    // the machine-readable signal an agent/CI greps.
+    assert!(
+        combined.contains("1 id-collisions"),
+        "summary must count id-collisions; got:\n{combined}"
+    );
+}
+
+/// Negative control: a clean workspace reindex reports zero collisions and
+/// prints no collision block. Guards against a false-positive that would fire
+/// on every ordinary single-file artifact.
+#[test]
+fn reindex_reports_zero_collisions_on_clean_workspace() {
+    let tmp = TempDir::new().unwrap();
+    init_workspace(&tmp);
+    new_artifact(&tmp, "prd", "Solo artifact");
+
+    let out = forgeplan()
+        .args(["reindex"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("0 id-collisions"),
+        "clean workspace must report 0 id-collisions; got:\n{combined}"
+    );
+    assert!(
+        !combined.contains("duplicate-id collision"),
+        "clean workspace must NOT print a collision block; got:\n{combined}"
+    );
+}


### PR DESCRIPTION
## What & why

`forgeplan reindex` silently overwrote when two `.md` files carried the same frontmatter `id`. Phase 1 processed them in `read_dir` order (which is **not stable**) and the second file's row overwrote the first — last-writer-wins, no anomaly surfaced. The `scan-import` surface already flagged this class via `find_duplicate_ids`; **reindex was the blind spot** (#394).

## Change

`crates/forgeplan-cli/src/commands/reindex.rs::run()`:

- Build an `id -> [paths]` map during the Phase-1 walk.
- After the walk, report every id claimed by >1 file **loudly on stderr** (names both files, ws-relative, + a resolution line), **count** collisions in the summary line, and raise a **warning hint** above plain parse/sync errors.
- **Deliberately non-fatal (exit 0)** — same convention as reindex's existing per-file errors. A fresh `git clone && forgeplan reindex` on a repo that *already* carries a collision still completes; the **silence** was the bug, not the completion. (Hard-failing onboarding would trade one breakage for another.)

Scope is **detect + report only**. The deeper "reindex syncs body but not title/status when the id's owning file changes" is a separate pre-existing limitation and intentionally out of scope here.

## Testing

- `crates/forgeplan-cli/tests/cli_reindex_id_collision.rs` — real-binary E2E:
  - two same-id files → reindex names both, prints `1 id-collisions`, **exits 0**;
  - clean workspace → `0 id-collisions`, no block (false-positive guard).
- `fmt` 0, `clippy -D warnings` 0, all 4 reindex E2E green (2 new + 2 existing resilience — no regression).

## Live-repo dogfood

Ran the built binary against this repo's real `.forgeplan/`:

```
⚠ 2 duplicate-id collision(s): multiple files claim the same artifact id.
  ...
Reindex complete: 11 synced, 369 unchanged, 0 removed, 7 orphan relations, 5 errors, 2 id-collisions.
```

It independently caught exactly the two collisions found by hand (PRD-012, EVID-143) — both cleaned up in a companion `chore` PR.

## Review

Adversarial audit (generator≠verifier, 2 lenses + skeptic verify): 3 refuted, 1 CONFIRMED NIT — the commit originally referenced `PROB-083`, which lives only on an unmerged branch and would dangle at merge. **Fixed** by amending to `Refs: #394`.

Closes #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
