### PR TITLE
fix(health): exclude terminal-status artifacts from the At-Risk gate (PROB-078)

### DIFF
--- a/crates/forgeplan-core/src/health/mod.rs
+++ b/crates/forgeplan-core/src/health/mod.rs
@@ -117,6 +117,7 @@ use crate::artifact::sanitize::sanitize_for_hint;
 use crate::artifact::types::DECISION_KINDS_EVIDENCE;
 use crate::artifact::types::{ArtifactKind, Mode};
 use crate::db::store::{ArtifactFilter, ArtifactRecord, LanceStore};
+use crate::lifecycle::transitions::is_terminal;
 use crate::scoring::evidence::parse_evidence_from_record;
 use crate::scoring::reff;
 use crate::status::derived::{DerivedStatus, derive_status};
@@ -1593,6 +1594,15 @@ fn find_at_risk(
     let mut at_risk = Vec::new();
 
     for record in records {
+        // A terminal artifact (deprecated/superseded) is closed: its R_eff is
+        // frozen and no longer actionable, so surfacing it as "At Risk — inspect
+        // the score" is pure noise. PROB-078 (a refuted problem, deprecated,
+        // whose only evidence is a [Refutes] pack scoring R_eff=0) was wrongly
+        // flagged at-risk with a `forgeplan score PROB-078` next-action that can
+        // never clear it. At-risk is a signal for LIVE artifacts only.
+        if is_terminal(&record.status) {
+            continue;
+        }
         let key = record.id.to_ascii_lowercase();
         let Some(linked) = evidence_index.get(&key) else {
             continue;
@@ -2590,6 +2600,52 @@ mod tests {
             "PRD-007 should be at risk: {ids:?}"
         );
         assert!(!ids.contains(&"PROB-007"));
+    }
+
+    // PROB-078 regression: a terminal-status (deprecated/superseded) artifact
+    // must NOT be surfaced as at-risk. Its R_eff is frozen — flagging a closed
+    // artifact "At Risk, inspect the score" is noise the operator cannot act on
+    // (the live bug: `forgeplan health` listed the deprecated, refuted PROB-078
+    // as At Risk with a `forgeplan score PROB-078` next-action that never clears).
+    #[test]
+    fn find_at_risk_skips_terminal_status() {
+        // The same CL0 (R_eff well below 0.3) evidence shape links to two
+        // problems: one active, one deprecated. Only the active one is a live
+        // at-risk signal.
+        let mut live = make_record("PROB-100", "problem");
+        live.status = "active".into();
+        let mut closed = make_record("PROB-101", "problem");
+        closed.status = "deprecated".into();
+
+        let mut ev_live = make_record("EVID-100", "evidence");
+        ev_live.body =
+            "verdict: supports\ncongruence_level: 0\nevidence_type: measurement\n".into();
+        let mut ev_closed = make_record("EVID-101", "evidence");
+        ev_closed.body =
+            "verdict: refutes\ncongruence_level: 0\nevidence_type: measurement\n".into();
+
+        let mut outgoing: RelationIndex = BTreeMap::new();
+        outgoing.insert(
+            "EVID-100".into(),
+            vec![("PROB-100".into(), "informs".into())],
+        );
+        outgoing.insert(
+            "EVID-101".into(),
+            vec![("PROB-101".into(), "informs".into())],
+        );
+
+        let evs = vec![ev_live, ev_closed];
+        let refs: Vec<&ArtifactRecord> = vec![&live, &closed];
+        let at_risk = find_at_risk(&refs, &evs, &outgoing);
+        let ids: Vec<&str> = at_risk.iter().map(|a| a.id.as_str()).collect();
+        assert!(
+            ids.contains(&"PROB-100"),
+            "an ACTIVE low-R_eff artifact must still be at-risk: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"PROB-101"),
+            "a DEPRECATED artifact must NOT be flagged at-risk (PROB-078): {ids:?}"
+        );
     }
 
     // PROB-051 L-M2: find_duplicate_pairs returns FULL list (no truncation).


### PR DESCRIPTION
## What & why

`forgeplan health` flagged **PROB-078 as "At Risk" (R_eff = 0.00 below 0.3)** — but PROB-078 is `deprecated` (a refuted problem, closed via git `589047f`, whose only evidence is a `[Refutes]` pack that correctly scores R_eff=0). A terminal (deprecated/superseded) artifact is closed: its R_eff is frozen and no longer actionable, so an "At Risk — inspect the score" line plus a `forgeplan score PROB-078` next-action that **can never clear** is pure noise.

Root cause: `find_at_risk` (`health/mod.rs`) scored every artifact with linked evidence below the threshold **without checking status**.

## Change

Skip terminal-status records in `find_at_risk`, using the canonical `lifecycle::transitions::is_terminal` (`deprecated | superseded`). At-risk is a signal for **live** artifacts only. One guard + one import; no behavior change for active/draft/stale.

## How it was found

A health-debt triage workflow (4 read-only investigators, one per debt class, each finding skeptic-verified) classified the repo's 140 anomalies + 5 reindex errors. This was the **one finding with zero methodology ambiguity**. The workflow's other candidates — the `mistyped_based_on` firings (EVID-089/090/091) and the 137 `weakest_link_unresolvable` — were correctly left as **judgment calls** (the based_on swap would have *corrupted the graph* — evidence→evidence `based_on` is legitimate lineage, and `reff.rs:344` scores `based_on`==`informs`==CL2, so the anomaly's "CL penalty cascades" message is false). Those are surfaced for human decision, not auto-fixed here.

## Testing

- Unit: `find_at_risk_skips_terminal_status` — an **active** low-R_eff artifact stays at-risk; a **deprecated** one does not.
- Existing `find_at_risk_with_evidence_index_produces_same_results` still green.
- Dogfood: `forgeplan health` on this repo — the "At Risk (1)" line is gone; PROB-078 no longer appears.
- `fmt` 0, `clippy --all-targets --features test-helpers -D warnings` 0.

Refs: PROB-078

🤖 Generated with [Claude Code](https://claude.com/claude-code)
