### PR TITLE
fix(evid): renumber cleanup EVIDs off the vNext/provenance predicted-number clash

### DIFF
--- a/.forgeplan/adrs/ADR-013-ci-security-gate-policy-pr-trigger-vs-push-only-timing.md
+++ b/.forgeplan/adrs/ADR-013-ci-security-gate-policy-pr-trigger-vs-push-only-timing.md
@@ -121,3 +121,4 @@ A: No. Security posture is maintained by the weekly scan and the release-time ga
 
 
 
+

--- a/.forgeplan/evidence/EVID-152-id-collision-detector-prd-008-cleanup-scan-import-flags-two-md-with-one-id-prd-008-dup-stub-removed-resolver-consistent.md
+++ b/.forgeplan/evidence/EVID-152-id-collision-detector-prd-008-cleanup-scan-import-flags-two-md-with-one-id-prd-008-dup-stub-removed-resolver-consistent.md
@@ -1,6 +1,6 @@
 ---
 depth: tactical
-id: EVID-149
+id: EVID-152
 kind: evidence
 links:
 - target: PRD-008
@@ -41,5 +41,7 @@ evidence_type: test
 - Branch: `fix/id-collision-detector` (off `origin/dev`)
 - Files: `crates/forgeplan-core/src/scan/import.rs`, `crates/forgeplan-cli/src/commands/scan_import.rs`; removed `.forgeplan/prds/PRD-008-cli-ux-redesign.md`
 - **Renumber note (2026-08-06):** this evidence was itself a file-level id-collision — it and the earlier-committed EVID-143 (PROB-073 create-roundtrip profile) both carried `id: EVID-143`. Per the same one-id-one-file rule this evidence documents, it was re-minted as **EVID-149** (content unchanged) so PROB-073 keeps EVID-143. The companion reindex detector that catches this exact class at reindex time (not just scan-import) is issue #394.
+
+
 
 

--- a/.forgeplan/evidence/EVID-153-adr-013-ci-security-gate-implemented-audited-in-security-yml-honest-signal-pr-trigger-dropped-continue-on-error-removed.md
+++ b/.forgeplan/evidence/EVID-153-adr-013-ci-security-gate-implemented-audited-in-security-yml-honest-signal-pr-trigger-dropped-continue-on-error-removed.md
@@ -1,6 +1,6 @@
 ---
 depth: tactical
-id: EVID-150
+id: EVID-153
 kind: evidence
 links:
 - target: ADR-013


### PR DESCRIPTION
Follow-up to the batch merge. Merging #426 (vNext) + #423/#428 (provenance) alongside the cleanup PRs created **two duplicate-id collisions** on dev (EVID-149, EVID-150) — the older and newer branches independently minted the same predicted numbers. Caught by the #429 detector.

Resolved by git-first precedence: vNext keeps EVID-149, PRD-082 keeps EVID-150; the two cleanup packs re-minted as **EVID-152** (dedup) + **EVID-153** (ADR-013 audit; ADR-013 now informs EVID-153, R_eff 0.40). Git tracks both as renames. Fresh-index rebuild: **0 collisions**, four distinct artifacts.

Root cause: merged manually instead of via the assign-id `ready-to-merge` bot flow that serialises predicted→assigned numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)