### PR TITLE
chore: close PROB-088 and PROB-089 after #455

### DIFF
--- a/.forgeplan/evidence/EVID-158-five-target-dist-build-with-semantic-search-4-of-5-fail-three-distinct-causes.md
+++ b/.forgeplan/evidence/EVID-158-five-target-dist-build-with-semantic-search-4-of-5-fail-three-distinct-causes.md
@@ -7,6 +7,10 @@ links:
   relation: informs
 - target: ADR-022
   relation: informs
+- target: PROB-088
+  relation: informs
+- target: PROB-089
+  relation: informs
 status: active
 title: 'Five-target dist build with semantic-search: 4 of 5 fail, three distinct causes'
 ---
@@ -122,6 +126,8 @@ C-runtime (`_dup`, `strncpy`, `modf`, `_timezone`, `fopen_s`, `_dupenv_s`). Preb
 - PRD-083 — задача «измерить → решить → задокументировать»; это FR-002/FR-004
 - ADR-022 — решение, принятое на основании этого измерения
 - PR #455, run 33647382377
+
+
 
 
 

--- a/.forgeplan/problems/PROB-088-release-binaries-ship-without-semantic-search-cargo-dist-builds-default-features-only.md
+++ b/.forgeplan/problems/PROB-088-release-binaries-ship-without-semantic-search-cargo-dist-builds-default-features-only.md
@@ -4,7 +4,7 @@ id: PROB-088
 kind: problem
 last_modified_at: 2026-09-02T14:42:16.076193+00:00
 last_modified_by: claude-code/2.1.220
-status: draft
+status: deprecated
 title: 'Release binaries ship without semantic-search: cargo-dist builds default features only'
 ---
 
@@ -172,5 +172,8 @@ Embedding 396 artifact(s) (title + body, chunk_size=2000)...
   когда этот дефект будет закрыт
 - PRD-071 — hint-контракт, который нарушает M2
 - `docs/operations/RELEASE-PROTOCOL` — место, где контракт дистрибуции обязан быть зафиксирован
+
+
+
 
 

--- a/.forgeplan/problems/PROB-089-embedding-model-cache-per-project-duplication-ungitignored-2-1-gb-three-wrong-documented-sizes.md
+++ b/.forgeplan/problems/PROB-089-embedding-model-cache-per-project-duplication-ungitignored-2-1-gb-three-wrong-documented-sizes.md
@@ -4,7 +4,7 @@ id: PROB-089
 kind: problem
 last_modified_at: 2026-09-02T14:47:26.113848+00:00
 last_modified_by: claude-code/2.1.220
-status: draft
+status: deprecated
 title: 'Embedding model cache: per-project duplication, ungitignored 2.1 GB, three wrong documented sizes'
 ---
 
@@ -110,4 +110,7 @@ slug: prob-embedding-model-cache-per-project-duplication-ungitignored-2-1-gb-thr
   когда тот закрыт
 - PRD-083 — задача на решение, покрывает оба, GitHub #452
 - `dist-workspace.toml` — включение фичи сделает D1/D2/D3 массовыми
+
+
+
 


### PR DESCRIPTION
Lifecycle bookkeeping after #455 merged (88e0ccb). Both problems move `draft → active → deprecated`, since a problem is closed only once its fix has actually landed.

| Artifact | Status |
|---|---|
| PROB-088 | deprecated (resolved) |
| PROB-089 | deprecated (resolved) |
| PRD-083 | active, R_eff 1.00 |
| ADR-022 | active |
| EVID-158 | active |

**PROB-088** closed *without* the obvious fix. The measurement in EVID-158 built all five targets and 1 of 5 passed, so `features = ["semantic-search"]` cannot ship — it would prevent the release rather than degrade it. What resolves the problem is the contract declared in ADR-022, plus docs that no longer claim the opposite and a `Fix:` hint a binary-install user can run.

**PROB-089** closed by the shared model cache, the gitignore fix in both this repo and the `forgeplan init` template, a single source of truth for the model size, and a first-run notice that states 2.1 GB before the download begins.

EVID-158 is additionally linked `informs` to both problems — the measurement speaks to them directly, not only to the PRD and ADR it was first attached to.

Deprecating the problems does not weaken PRD-083: it stays at R_eff 1.00, since the evidence is current and the problems are now history.

No code changes. Artifact frontmatter and link graph only.

Still open: #454 (flaky git tests) — recorded, not fixed.