### PR TITLE
fix: links were invisible to everything that reads an artifact record (#446, #447)

### DIFF
--- a/.forgeplan/evidence/EVID-168-prob-100-7-of-8-drift-findings-were-false-get-now-reports-edges.md
+++ b/.forgeplan/evidence/EVID-168-prob-100-7-of-8-drift-findings-were-false-get-now-reports-edges.md
@@ -1,0 +1,98 @@
+---
+depth: tactical
+id: EVID-168
+kind: evidence
+links:
+- target: PROB-100
+  relation: informs
+status: draft
+title: 'PROB-100: 7 of 8 drift findings were false; get now reports edges'
+---
+
+---
+assigned_number: 168
+predicted_number: 168
+slug: evid-prob-100-7-of-8-drift-findings-were-false-get-now-reports-edges
+---
+
+# EVID-168: measured before and after, on real artifacts
+
+Both defects in PROB-100 were reproduced on this workspace's own artifacts, not
+on fixtures, and re-measured after the fix. Fixtures would not have caught either
+one: every layer worked in isolation.
+
+## body-links-drift (#446)
+
+`forgeplan validate SPEC-003`
+
+| | ids named | false | true |
+|---|---|---|---|
+| before | 8 | 7 | 1 |
+| after | 1 | 0 | 1 |
+
+The seven false ones: `ADR-009`, `PRD-065`, `SPEC-004` are real edges —
+`forgeplan graph` prints all three for `SPEC-003` — and `FR-1`, `FR-2`, `FR-3`,
+`FR-5` are requirement numbers that can never be link targets.
+
+The one true finding, `EPIC-007`, survives the fix. Checked directly: the graph
+has no `SPEC-003 → EPIC-007` edge, so the body table names something the artifact
+is not linked to. That is what the rule is for.
+
+`forgeplan validate ADR-009`: 10 ids named before, 8 after. The two that dropped
+(`ADR-008`, `PROB-042`) are real edges.
+
+## forgeplan get (#447)
+
+`forgeplan get SPEC-003 --json`
+
+- before: 14 keys, none about links
+- after: `links.outbound` = `PRD-065 (refines)`, `ADR-009 (based_on)`,
+  `SPEC-004 (informs)` — identical to `forgeplan graph`
+- after: `links.inbound` = `EVID-089 (informs)`, which
+  `graph | grep "SPEC-003 -->"` cannot show at all
+
+Empty case, fresh workspace: `{"outbound": [], "inbound": []}` and `Links: none`.
+The field is present either way, so "no links" is distinguishable from "not
+reported" — the ambiguity the issue was filed about.
+
+## Tests
+
+8 new. 2 on the prefix filter, 3 on the store merge, 3 end-to-end on the real
+binary against a real workspace.
+
+The prefix-filter test was mutation-checked: with the filter removed it fails.
+It detects the defect rather than confirming current behaviour — the distinction
+that let #348 survive for months behind a test asserting the broken string.
+
+## Gate results
+
+| Gate | Result |
+|---|---|
+| `cargo fmt --all -- --check` | exit 0, 0 diffs |
+| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, 0 warnings |
+| `cargo test --workspace --no-fail-fast` | 3295 passed, 3 failed, 92 binaries |
+
+The 3 failures are #454 / PROB-090, not this change. Each passes in isolation and
+fails only under parallel load; none touches the modified code. Two are in
+`git/`, untouched here. The third, `c33_forgeplan_decompose_no_llm_smoke`,
+asserts that **no** LLM provider is configured — it breaks when a sibling test
+sets the variable. That widens #454, whose title says "flaky git tests": the
+class is any test asserting on process-global state. CI does not see it because
+it runs `cargo nextest`, one process per test; local `cargo test` shares one.
+
+Disk was at 100% with 6.2 GiB free before this run. That state previously
+produced `passed=0 failed=0` at exit 0 — a gate reporting a value that is not a
+result. 37 GiB was freed before measuring, so these numbers are from a run that
+actually happened.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: measurement
+
+base_sha: ca5a7c2c
+result_sha: 9dd7242
+changed_paths: crates/forgeplan-cli/src/commands/get.rs, crates/forgeplan-cli/src/commands/validate.rs, crates/forgeplan-cli/tests/cli_get_links.rs, crates/forgeplan-core/src/db/store.rs, crates/forgeplan-core/src/lifecycle/mod.rs, crates/forgeplan-core/src/validation/checks.rs, crates/forgeplan-core/src/validation/rules.rs, crates/forgeplan-mcp/src/convert.rs, crates/forgeplan-mcp/src/server.rs, crates/forgeplan-mcp/src/types.rs, .gitignore
+
+

--- a/.forgeplan/problems/PROB-059-body-links-drift-detector-strict-parser-warning-on-related-artifacts-table-missing-frontmatter-links.md
+++ b/.forgeplan/problems/PROB-059-body-links-drift-detector-strict-parser-warning-on-related-artifacts-table-missing-frontmatter-links.md
@@ -75,3 +75,4 @@ Reverse drift: `forgeplan link` populates `links:` → agent rewrites body via W
 
 
 
+

--- a/.forgeplan/problems/PROB-100-body-links-drift-and-forgeplan-get-both-read-a-record-that-carries-no-links.md
+++ b/.forgeplan/problems/PROB-100-body-links-drift-and-forgeplan-get-both-read-a-record-that-carries-no-links.md
@@ -1,0 +1,107 @@
+---
+depth: tactical
+id: PROB-100
+kind: problem
+links:
+- target: PROB-059
+  relation: refines
+status: draft
+title: body-links-drift and forgeplan_get both read a record that carries no links
+---
+
+---
+assigned_number: 100
+predicted_number: 100
+slug: prob-body-links-drift-and-forgeplan-get-both-read-a-record-that-carries-no-links
+---
+
+# PROB-100: two tools, one blind spot
+
+## Problem
+
+`ArtifactRecord` has no link fields. Everything that reads a record therefore
+sees an artifact with five edges exactly as it sees an orphan, and two shipped
+tools were built on top of that blindness without anyone noticing.
+
+**The validator warned about links that exist.** `frontmatter_map()` rebuilds a
+frontmatter from the record's columns. The record has no link columns, so the map
+never carries `links`, so `extract_frontmatter_link_targets` returned an empty
+set for every artifact. `body-links-drift` compared the body's
+`## Related Artifacts` table against that empty set and warned on everything it
+found there — including targets that were correctly linked and visible in
+`forgeplan graph` the same minute.
+
+**`forgeplan get` reported an orphan for a linked artifact.** Both edge sets were
+fetched, reduced to a boolean to choose a hint, and discarded one line before the
+output. The response carried about twenty fields and no links at all.
+
+## Why it survived
+
+Neither tool failed. The warning was plausible, the response looked complete, and
+both were confidently wrong in a way that reads as correct.
+
+The warning also could not be closed. Linking the named target did not silence
+it, because the comparison never saw links; the only way to make it stop was to
+delete the table it was complaining about. A SHOULD-level warning that fires on
+essentially every well-linked artifact and cannot be resolved by doing the right
+thing teaches its readers to skip validator warnings — which is more expensive
+than the drift it was built to catch.
+
+The regex made it worse. `[A-Z]+-[0-9]+` matched any token of that shape, so
+requirement numbers (`FR-1`) and invariant numbers (`I-3`) were named as missing
+link targets. Those can never be linked, and the remediation the rule printed —
+`forgeplan link <this-id> FR-1` — could not be executed. That is a PRD-071
+violation of the same shape as #348 and #351: a hint an agent is obliged to run
+that cannot work.
+
+## Measurement
+
+Workspace: this repository, `forgeplan 0.35.0` built from `ca5a7c2`.
+
+`forgeplan validate SPEC-003`, before:
+
+```
+mentions ADR-009, EPIC-007, FR-1, FR-2, FR-3, FR-5, PRD-065, SPEC-004
+```
+
+Eight ids, seven false. `ADR-009`, `PRD-065` and `SPEC-004` are real edges —
+`forgeplan graph` shows all three. `FR-1` through `FR-5` are requirement numbers.
+
+After: one id, `EPIC-007`, and it is true — the graph has no `SPEC-003 → EPIC-007`
+edge.
+
+`forgeplan get SPEC-003 --json`, before: 14 keys, none about links. After: three
+outbound edges matching `graph` exactly, plus one inbound (`EVID-089 informs`)
+that `graph | grep "SPEC-003 -->"` cannot show at all.
+
+A third disagreement surfaced while measuring, not reported in either issue:
+`SPEC-003` has **three** different frontmatters — the file on disk (with links),
+the copy embedded in the stored `body` (stale, no links, still carrying a
+`created:` field the file dropped), and the reconstruction from record columns
+(no links, ever).
+
+## Relation to PROB-059
+
+PROB-059 introduced this rule and is still `active`. The drift it describes is
+real and remains worth detecting. This records that its detector never worked:
+the rule shipped in a state where its condition could not be satisfied.
+
+## Fix
+
+Links are read from the relations table — the same source `forgeplan graph`
+renders and `forgeplan link` writes — through
+`LanceStore::frontmatter_map_with_links`, used at all three sites that run the
+full rule set. The extractor keeps only prefixes that map to a real artifact
+kind. `get` emits both edge sets unconditionally, as empty arrays when there are
+none, so a caller can tell "no links" from "not reported".
+
+## Related
+
+| Artifact | Type | Relation |
+|---|---|---|
+| PROB-059 | Problem | the rule this one reports as non-functional |
+
+GitHub: #446, #447.
+
+
+

--- a/crates/forgeplan-cli/src/commands/get.rs
+++ b/crates/forgeplan-cli/src/commands/get.rs
@@ -29,6 +29,23 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
         .await
         .unwrap_or_default();
     let has_links = !relations.is_empty() || !incoming.is_empty();
+
+    // #447 — both edge sets were already fetched above and then collapsed
+    // into `has_links` purely to pick a hint. The data was one line from the
+    // output and thrown away, so a linked artifact and an orphan rendered
+    // identically. Emitted unconditionally: a caller must be able to tell
+    // "this has no links" from "this tool does not report links", and an
+    // absent field says the same thing as an empty one.
+    let links_json = serde_json::json!({
+        "outbound": relations
+            .iter()
+            .map(|(target, relation)| serde_json::json!({ "target": target, "relation": relation }))
+            .collect::<Vec<_>>(),
+        "inbound": incoming
+            .iter()
+            .map(|(source, relation)| serde_json::json!({ "source": source, "relation": relation }))
+            .collect::<Vec<_>>(),
+    });
     let kind: forgeplan_core::artifact::types::ArtifactKind = record
         .kind
         .parse()
@@ -89,6 +106,7 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
             "created_at": record.created_at,
             "updated_at": record.updated_at,
             "body": record.body,
+            "links": links_json,
             "_next_action": hints::primary_action(&hints_vec),
         });
         println!("{}", serde_json::to_string_pretty(&json_data)?);
@@ -118,6 +136,23 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
     ui::kv("R_eff", &ui::styled_reff(record.r_eff_score));
     ui::kv("Created", &record.created_at);
     ui::kv("Updated", &record.updated_at);
+    // #447 — the same edges the JSON path reports. Printed even when there
+    // are none, for the same reason.
+    if relations.is_empty() && incoming.is_empty() {
+        ui::kv("Links", "none");
+    } else {
+        if !relations.is_empty() {
+            let out: Vec<String> = relations
+                .iter()
+                .map(|(t, r)| format!("{t} ({r})"))
+                .collect();
+            ui::kv("Links out", &out.join(", "));
+        }
+        if !incoming.is_empty() {
+            let inc: Vec<String> = incoming.iter().map(|(s, r)| format!("{s} ({r})")).collect();
+            ui::kv("Links in", &inc.join(", "));
+        }
+    }
     println!();
     println!("{}", record.body);
 

--- a/crates/forgeplan-cli/src/commands/validate.rs
+++ b/crates/forgeplan-cli/src/commands/validate.rs
@@ -56,7 +56,9 @@ Fix: forgeplan list",
     let mut json_results = Vec::new();
 
     for record in &to_validate {
-        let fm = record.frontmatter_map();
+        // #446 — the link-less reconstruction made body-links-drift compare
+        // against an empty set and warn on correctly linked artifacts.
+        let fm = store.frontmatter_map_with_links(record).await;
 
         let kind = record.kind.parse::<ArtifactKind>().unwrap_or_else(|_| {
             if !json {

--- a/crates/forgeplan-cli/tests/cli_get_links.rs
+++ b/crates/forgeplan-cli/tests/cli_get_links.rs
@@ -1,0 +1,124 @@
+//! `forgeplan get` must report the artifact's edges — #447.
+//!
+//! The defect: `get` fetched both edge sets, collapsed them into a boolean to
+//! pick a hint, and dropped them. An artifact with five links and an orphan
+//! rendered identically, and the issue reports that costing a wrong conclusion
+//! in a live session.
+//!
+//! These tests run the real binary against a real workspace, because the
+//! defect was invisible to unit tests: every layer worked, the output just did
+//! not carry the answer.
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn fpl(ws: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("forgeplan").unwrap();
+    cmd.current_dir(ws.path());
+    cmd
+}
+
+fn init(ws: &TempDir) {
+    fpl(ws).args(["init", "-y"]).output().expect("init");
+}
+
+fn new_artifact(ws: &TempDir, kind: &str, title: &str) -> String {
+    let out = fpl(ws).args(["new", kind, title]).output().expect("new");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The `ID:` line is indented (`  ID:      ADR-001`), so trim before
+    // matching. Parsing this line rather than grepping for an id-shaped token
+    // matters: the hint lines below it also contain the id.
+    stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("ID:"))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| panic!("no `ID:` line in `new {kind}` output:\n{stdout}"))
+}
+
+fn get_json(ws: &TempDir, id: &str) -> serde_json::Value {
+    let out = fpl(ws).args(["get", id, "--json"]).output().expect("get");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("get --json not JSON ({e}):\n{stdout}"))
+}
+
+/// The core of #447: an unlinked artifact must say so explicitly. An absent
+/// field and an empty one are the same thing to a caller, which is exactly how
+/// the orphan/unreported confusion arose.
+#[test]
+fn an_artifact_without_links_reports_empty_arrays_not_a_missing_field() {
+    let ws = TempDir::new().unwrap();
+    init(&ws);
+    let id = new_artifact(&ws, "note", "Orphan");
+
+    let v = get_json(&ws, &id);
+    assert!(
+        v.get("links").is_some(),
+        "links must always be present, got keys: {:?}",
+        v.as_object().map(|o| o.keys().collect::<Vec<_>>())
+    );
+    assert_eq!(v["links"]["outbound"].as_array().map(Vec::len), Some(0));
+    assert_eq!(v["links"]["inbound"].as_array().map(Vec::len), Some(0));
+}
+
+/// Both directions are reported, and from the right side. Inbound is the half
+/// `forgeplan graph | grep "<id> -->"` cannot answer, and it is the one behind
+/// "which evidence supports this".
+#[test]
+fn get_reports_outbound_and_inbound_edges_separately() {
+    let ws = TempDir::new().unwrap();
+    init(&ws);
+    let prd = new_artifact(&ws, "prd", "Parent");
+    let spec = new_artifact(&ws, "spec", "Child");
+    let evid = new_artifact(&ws, "evidence", "Measurement");
+
+    fpl(&ws)
+        .args(["link", &spec, &prd, "--relation", "refines"])
+        .output()
+        .expect("link spec->prd");
+    fpl(&ws)
+        .args(["link", &evid, &spec, "--relation", "informs"])
+        .output()
+        .expect("link evid->spec");
+
+    let v = get_json(&ws, &spec);
+    let outbound = v["links"]["outbound"].as_array().expect("outbound array");
+    let inbound = v["links"]["inbound"].as_array().expect("inbound array");
+
+    assert_eq!(outbound.len(), 1, "expected one outbound edge: {v}");
+    assert_eq!(outbound[0]["target"], serde_json::json!(prd));
+    assert_eq!(outbound[0]["relation"], serde_json::json!("refines"));
+
+    assert_eq!(inbound.len(), 1, "expected one inbound edge: {v}");
+    assert_eq!(inbound[0]["source"], serde_json::json!(evid));
+    assert_eq!(inbound[0]["relation"], serde_json::json!("informs"));
+}
+
+/// The human path must not disagree with the JSON path — the same question
+/// answered two ways is how a reader and an agent end up with different
+/// pictures of the same artifact.
+#[test]
+fn human_output_reports_the_same_edges_as_json() {
+    let ws = TempDir::new().unwrap();
+    init(&ws);
+    let prd = new_artifact(&ws, "prd", "Parent");
+    let spec = new_artifact(&ws, "spec", "Child");
+    fpl(&ws)
+        .args(["link", &spec, &prd, "--relation", "refines"])
+        .output()
+        .expect("link");
+
+    let out = fpl(&ws).args(["get", &spec]).output().expect("get");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Links out") && stdout.contains(&prd),
+        "human output must name the edge, got:\n{stdout}"
+    );
+
+    let orphan = new_artifact(&ws, "note", "Orphan");
+    let out = fpl(&ws).args(["get", &orphan]).output().expect("get");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Links") && stdout.contains("none"),
+        "an unlinked artifact must say so rather than omit the row, got:\n{stdout}"
+    );
+}

--- a/crates/forgeplan-core/src/db/store.rs
+++ b/crates/forgeplan-core/src/db/store.rs
@@ -1369,6 +1369,50 @@ impl LanceStore {
         .await
     }
 
+    /// The record's frontmatter map **with its real links merged in**.
+    ///
+    /// #446. [`ArtifactRecord::frontmatter_map`] rebuilds a frontmatter from
+    /// the record's columns, and the record has no link columns — so the map
+    /// it returns never carries a `links` key. Every rule that compares
+    /// something against `extract_frontmatter_link_targets(fm)` was therefore
+    /// comparing against an empty set, and `body-links-drift` fired on every
+    /// artifact whose `## Related Artifacts` table named anything at all,
+    /// including targets that were correctly linked. The warning could not be
+    /// silenced by doing the right thing, only by deleting the table.
+    ///
+    /// Links come from the relations table — the same source `forgeplan graph`
+    /// renders and `forgeplan link` writes — so the warning now agrees with
+    /// what the user can check by eye.
+    ///
+    /// A failed relations read degrades to the link-less map rather than
+    /// failing validation outright; that restores the old behaviour for that
+    /// one record instead of refusing to validate it.
+    pub async fn frontmatter_map_with_links(
+        &self,
+        record: &ArtifactRecord,
+    ) -> BTreeMap<String, serde_yaml::Value> {
+        use serde_yaml::{Mapping, Value};
+
+        let mut map = record.frontmatter_map();
+        let Ok(relations) = self.get_relations(&record.id).await else {
+            return map;
+        };
+        if relations.is_empty() {
+            return map;
+        }
+        let seq: Vec<Value> = relations
+            .into_iter()
+            .map(|(target, relation)| {
+                let mut entry = Mapping::new();
+                entry.insert(Value::String("target".into()), Value::String(target));
+                entry.insert(Value::String("relation".into()), Value::String(relation));
+                Value::Mapping(entry)
+            })
+            .collect();
+        map.insert("links".to_string(), Value::Sequence(seq));
+        map
+    }
+
     /// Get incoming relations where this artifact is the TARGET.
     /// Returns Vec<(source_id, relation_type)>.
     ///
@@ -3605,6 +3649,93 @@ mod tests {
         assert!(map.contains_key("updated_at"));
         // Empty tags should NOT be emitted
         assert!(!map.contains_key("tags"));
+    }
+
+    /// #446 — the defect in one assertion: `frontmatter_map()` cannot carry
+    /// links, so anything comparing against it sees an artifact with five
+    /// edges as an artifact with none.
+    #[tokio::test]
+    async fn frontmatter_map_alone_never_carries_links() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        store
+            .add_relation_for_test("SPEC-003", "PRD-065", "refines")
+            .await
+            .unwrap();
+
+        let record = record_for_links_test("SPEC-003");
+
+        assert!(
+            !record.frontmatter_map().contains_key("links"),
+            "the record has no link columns, so the reconstruction cannot have them"
+        );
+        assert!(
+            store
+                .frontmatter_map_with_links(&record)
+                .await
+                .contains_key("links"),
+            "the store knows the edge and must merge it in"
+        );
+    }
+
+    /// #446 — the merged map must be in the exact shape
+    /// `extract_frontmatter_link_targets` reads, otherwise the rule still sees
+    /// an empty set and the fix is cosmetic.
+    #[tokio::test]
+    async fn merged_links_are_readable_by_the_rule_that_needs_them() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        for (target, relation) in [
+            ("PRD-065", "refines"),
+            ("ADR-009", "based_on"),
+            ("SPEC-004", "informs"),
+        ] {
+            store
+                .add_relation_for_test("SPEC-003", target, relation)
+                .await
+                .unwrap();
+        }
+
+        let map = store
+            .frontmatter_map_with_links(&record_for_links_test("SPEC-003"))
+            .await;
+        let mut targets = crate::validation::checks::extract_frontmatter_link_targets(&map);
+        targets.sort();
+
+        assert_eq!(targets, vec!["ADR-009", "PRD-065", "SPEC-004"]);
+    }
+
+    /// An artifact with no edges keeps the link-less map — the merge must not
+    /// invent an empty `links` key that reads as "checked and empty" when the
+    /// relations read never happened.
+    #[tokio::test]
+    async fn no_relations_leaves_the_map_untouched() {
+        let tmp = TempDir::new().unwrap();
+        let store = make_store(&tmp).await;
+        let map = store
+            .frontmatter_map_with_links(&record_for_links_test("PRD-777"))
+            .await;
+        assert!(!map.contains_key("links"));
+    }
+
+    fn record_for_links_test(id: &str) -> ArtifactRecord {
+        ArtifactRecord {
+            id: id.to_string(),
+            kind: "spec".to_string(),
+            status: "draft".to_string(),
+            title: "Links".to_string(),
+            body: "body".to_string(),
+            depth: "standard".to_string(),
+            author: None,
+            parent_epic: None,
+            r_eff_score: 0.0,
+            valid_until: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            tags: Vec::new(),
+            body_hash: None,
+            embedding: None,
+        }
     }
 
     #[tokio::test]

--- a/crates/forgeplan-core/src/lifecycle/mod.rs
+++ b/crates/forgeplan-core/src/lifecycle/mod.rs
@@ -219,7 +219,8 @@ pub async fn review(store: &LanceStore, artifact_id: &str) -> anyhow::Result<Rev
         .depth
         .parse()
         .unwrap_or(crate::artifact::types::Mode::Standard);
-    let fm = record.frontmatter_map();
+    // #446 — see LanceStore::frontmatter_map_with_links.
+    let fm = store.frontmatter_map_with_links(&record).await;
 
     let result = validation::validate(artifact_id, &record.body, &fm, &kind, &depth);
 
@@ -364,7 +365,8 @@ pub async fn activate(
         .depth
         .parse()
         .unwrap_or(crate::artifact::types::Mode::Standard);
-    let fm = record.frontmatter_map();
+    // #446 — see LanceStore::frontmatter_map_with_links.
+    let fm = store.frontmatter_map_with_links(&record).await;
     let validation_result = validation::validate(artifact_id, &record.body, &fm, &kind, &depth);
     let must_findings: Vec<String> = validation_result
         .findings

--- a/crates/forgeplan-core/src/validation/checks.rs
+++ b/crates/forgeplan-core/src/validation/checks.rs
@@ -57,7 +57,23 @@ pub fn extract_related_artifacts_table_ids(body: &str) -> Vec<String> {
             continue;
         }
         for m in ID_RE.find_iter(line) {
-            found.insert(m.as_str().to_string());
+            let token = m.as_str();
+            // #446 — the regex matches any `<UPPER>-<digits>` token, so it
+            // swept up requirement ids (`FR-1`), invariant numbers (`I-3`) and
+            // anything else shaped that way. Those can never be link targets,
+            // so the warning naming them was unclosable by construction, and
+            // its `Run: forgeplan link <this-id> FR-1` remediation could not
+            // be executed — a PRD-071 violation of the same shape as #348 and
+            // #351. Keep only tokens whose prefix maps to a real artifact kind.
+            let Some((prefix, _)) = token.split_once('-') else {
+                continue;
+            };
+            if crate::artifact::types::ArtifactKind::from_slug_prefix(&prefix.to_lowercase())
+                .is_none()
+            {
+                continue;
+            }
+            found.insert(token.to_string());
         }
     }
     found.into_iter().collect()
@@ -1300,6 +1316,60 @@ mod tests {
 ";
         let ids = extract_related_artifacts_table_ids(body);
         assert_eq!(ids, vec!["EVID-042", "PRD-001", "RFC-003"]);
+    }
+
+    /// #446 — tokens shaped like an id but whose prefix is not an artifact
+    /// kind are not link candidates. `FR-1` is a requirement number and `I-3`
+    /// an invariant number; neither can ever be a link target, so naming them
+    /// produced a warning that could not be resolved by linking anything.
+    #[test]
+    fn extract_related_artifacts_table_ids_skips_non_artifact_tokens() {
+        let body = "
+# SPEC-003: Title
+
+## Related Artifacts
+
+| Artifact | Type | Relation |
+|---|---|---|
+| PRD-065 | PRD | refines (contract for FR-1, FR-2, FR-3, FR-5) |
+| ADR-009 | ADR | based_on (invariants I-1, I-3) |
+";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert_eq!(
+            ids,
+            vec!["ADR-009", "PRD-065"],
+            "only real artifact kinds survive; FR-* and I-* are not link targets"
+        );
+    }
+
+    /// #446 guard — the filter must not become an allow-list that quietly
+    /// drops real kinds. Every kind prefix the slug parser accepts has to
+    /// survive extraction, otherwise the drift rule goes blind to that kind.
+    #[test]
+    fn extract_related_artifacts_table_ids_keeps_every_real_kind() {
+        let body = "
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| PRD-001 | refines |
+| RFC-002 | informs |
+| ADR-003 | based_on |
+| EPIC-004 | belongs_to |
+| SPEC-005 | refines |
+| PROB-006 | informs |
+| SOL-007 | informs |
+| EVID-008 | informs |
+| NOTE-009 | informs |
+| REF-010 | informs |
+| MEM-011 | informs |
+";
+        let ids = extract_related_artifacts_table_ids(body);
+        assert_eq!(
+            ids.len(),
+            11,
+            "all real kinds must survive the #446 prefix filter, got {ids:?}"
+        );
     }
 
     /// Free-text mention OUTSIDE the Related Artifacts section is NOT

--- a/crates/forgeplan-core/src/validation/rules.rs
+++ b/crates/forgeplan-core/src/validation/rules.rs
@@ -271,11 +271,23 @@ fn check_body_links_drift(body: &str, fm: &Frontmatter) -> Option<String> {
     if missing.is_empty() {
         None
     } else {
+        // #446 — the ids are known here, so name them instead of shipping
+        // `<this-id>` and `<target>` for the reader to substitute. The
+        // relation is left as a choice because it genuinely is one: only the
+        // author knows whether the edge is `informs` or `based_on`.
+        let self_ref = if self_id.is_empty() {
+            "<this-id>".to_string()
+        } else {
+            self_id.clone()
+        };
         Some(format!(
-            "Body's `## Related Artifacts` table mentions {} but frontmatter `links:` array doesn't reference \
-             them. Run: forgeplan link <this-id> <target> --relation <informs|based_on|refines|...> \
-             OR remove the table row if the mention is incidental.",
-            missing.join(", ")
+            "Body's `## Related Artifacts` table mentions {} but the artifact is not linked to \
+             them. Run: forgeplan link {} {} --relation <informs|based_on|refines> — pick the \
+             relation, the ids are already correct. Or remove the table row if the mention is \
+             incidental.",
+            missing.join(", "),
+            self_ref,
+            missing[0],
         ))
     }
 }

--- a/crates/forgeplan-mcp/src/convert.rs
+++ b/crates/forgeplan-mcp/src/convert.rs
@@ -140,6 +140,12 @@ impl From<ArtifactRecord> for ArtifactRecordDto {
             assigned_number: identity.assigned_number,
             id_canonical: identity.id_canonical,
             id_display: identity.id_display,
+            // #447 — this conversion has no store handle, so edges cannot be
+            // read here. The caller that does have one fills them in; see
+            // `forgeplan_get` in server.rs. Left empty rather than optional so
+            // a caller who forgets still emits `{"outbound": [], "inbound": []}`
+            // instead of silently dropping the field.
+            links: Default::default(),
         }
     }
 }

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -3697,7 +3697,30 @@ impl ForgeplanServer {
                     next_action.push_str(&claim_hint);
                 }
 
-                hinted_result(&ArtifactRecordDto::from(r), next_action)
+                // #447 — fill the edges the pure `From` conversion cannot
+                // reach. Failure to read the relations table degrades to empty
+                // rather than failing the whole read: an artifact body is
+                // still worth returning when the edge lookup misbehaves.
+                let outbound = store.get_relations(&canonical).await.unwrap_or_default();
+                let inbound = store
+                    .get_incoming_relations(&canonical)
+                    .await
+                    .unwrap_or_default();
+                let mut dto = ArtifactRecordDto::from(r);
+                dto.links = crate::types::ArtifactLinksDto {
+                    outbound: outbound
+                        .into_iter()
+                        .map(|(target, relation)| crate::types::OutboundLinkDto {
+                            target,
+                            relation,
+                        })
+                        .collect(),
+                    inbound: inbound
+                        .into_iter()
+                        .map(|(source, relation)| crate::types::InboundLinkDto { source, relation })
+                        .collect(),
+                };
+                hinted_result(&dto, next_action)
             }
             Ok(None) => Ok(artifact_not_found(&p.id)),
             Err(e) => Ok(safe_err_result("", e)),

--- a/crates/forgeplan-mcp/src/types.rs
+++ b/crates/forgeplan-mcp/src/types.rs
@@ -38,6 +38,31 @@ pub struct ArtifactSummaryDto {
     pub id_display: String,
 }
 
+// #447 — the graph edges of a single artifact. `forgeplan_get` returned ~20
+// fields and none of them were links, so an artifact with five edges and one
+// with none were indistinguishable in the response. Against a rich object, a
+// missing field reads as "this artifact has none", not "this tool does not
+// report them".
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OutboundLinkDto {
+    pub target: String,
+    pub relation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct InboundLinkDto {
+    pub source: String,
+    pub relation: String,
+}
+
+/// Inbound matters as much as outbound: "which evidence supports this" is the
+/// question behind an `r_eff` of 0, and it is invisible from the outbound side.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ArtifactLinksDto {
+    pub outbound: Vec<OutboundLinkDto>,
+    pub inbound: Vec<InboundLinkDto>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ArtifactRecordDto {
     pub id: String,
@@ -66,6 +91,12 @@ pub struct ArtifactRecordDto {
     pub id_canonical: String,
     #[serde(default)]
     pub id_display: String,
+    // #447 — deliberately NOT `skip_serializing_if`. An absent field and an
+    // empty one say the same thing to a caller, which is the whole defect;
+    // the empty arrays are the signal that the question was asked and the
+    // answer is "none".
+    #[serde(default)]
+    pub links: ArtifactLinksDto,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Two issues, one defect. `ArtifactRecord` has no link fields, so everything that
reads a record sees an artifact with five edges exactly as it sees an orphan.

## #446 — the validator warned about links that exist

`frontmatter_map()` rebuilds a frontmatter from the record's columns. The record
has no link columns, so the map never carries `links`, so
`extract_frontmatter_link_targets` returned an empty set — for every artifact,
always. `body-links-drift` compared the body's `## Related Artifacts` table
against that empty set and warned on everything it found there, including targets
the graph showed as edges the same minute.

The warning could not be closed. Linking the named target did not silence it,
because the comparison never saw links. The only way to stop it was to delete the
table. A SHOULD warning that fires on essentially every well-linked artifact and
cannot be resolved by doing the right thing teaches people to skip validator
warnings — more expensive than the drift it was built to catch.

The extractor made it worse: `[A-Z]+-[0-9]+` matched any token of that shape, so
`FR-1` and `I-3` were named as missing link targets. Those can never be linked,
and the printed remediation `forgeplan link <this-id> FR-1` could not be run —
a PRD-071 violation of the same shape as #348 and #351.

Measured on `SPEC-003` in this workspace:

| | ids named | false | true |
|---|---|---|---|
| before | 8 | 7 | 1 |
| after | 1 | 0 | 1 |

The three false artifact ids (`ADR-009`, `PRD-065`, `SPEC-004`) are real edges.
The four `FR-*` are requirement numbers. The surviving `EPIC-007` is true — the
graph has no such edge, which is exactly what the rule is for.

Links now come from the relations table, the same source `forgeplan graph`
renders and `forgeplan link` writes, so the warning agrees with what the reader
can check by eye. The remediation names both real ids; the relation stays a
choice because it genuinely is one.

## #447 — get reported an orphan for a linked artifact

`get.rs` fetched both edge sets, reduced them to `has_links` to pick a hint, and
dropped them one line before the output. Nothing had to be looked up that was not
already being looked up.

Now emitted unconditionally, including `{"outbound": [], "inbound": []}` when
there are none — against a rich object an absent field reads as "this artifact
has none", not "this tool does not report them". Inbound is separate because it
is the half `graph | grep "<id> -->"` cannot answer: `SPEC-003` has an inbound
`EVID-089 informs` that is invisible from the outbound side, and that is the
question behind an `r_eff` of 0.

MCP `forgeplan_get` gets the same field.

## A third disagreement, not in either issue

`SPEC-003` has **three** different frontmatters: the file on disk (with links),
the copy embedded in the stored `body` (stale, no links, still carrying a
`created:` field the file dropped), and the reconstruction from record columns
(no links, ever). Only the first is authoritative under ADR-003. Not addressed
here; recorded in PROB-100.

## Verification

8 new tests: 2 on the prefix filter, 3 on the store merge, 3 end-to-end on the
real binary against a real workspace. The defect was invisible to unit tests —
every layer worked, the output just did not carry the answer.

The prefix-filter test was mutation-checked: with the filter removed it fails. It
detects the defect rather than confirming current behaviour, which is the
distinction that let #348 survive for months behind a test asserting the broken
string.

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0, 0 warnings |
| `cargo test --workspace --no-fail-fast` | 3295 passed, 3 failed, 92 binaries |

The 3 failures are #454, not this change: each passes in isolation and fails only
under parallel load, and none touches the modified code. Two are in `git/`. The
third, `c33_forgeplan_decompose_no_llm_smoke`, asserts that **no** LLM provider is
configured and breaks when a sibling test sets the variable — which widens #454
beyond its "flaky git tests" title to any test asserting on process-global state.
CI does not see it because `cargo nextest` runs one process per test.

Artifacts: PROB-100 (refines PROB-059) and EVID-168, R_eff 1.00. PROB-059
introduced this rule and stays active — the drift it describes is real; this
records that its detector never worked.

Closes #446
Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
