### PR TITLE
fix: the trust layer stops reporting values it never computed (#325, #330, #392, #393)

### DIFF
--- a/.forgeplan/adrs/ADR-001-no-adapter-traits-ai-agent-is-the-orchestrator-not-forgeplan.md
+++ b/.forgeplan/adrs/ADR-001-no-adapter-traits-ai-agent-is-the-orchestrator-not-forgeplan.md
@@ -64,3 +64,4 @@ Accepted
 - crates/forgeplan-core/src/artifact/**
 
 
+

--- a/.forgeplan/adrs/ADR-002-r-eff-skips-non-active-dependencies-draft-deprecated-superseded.md
+++ b/.forgeplan/adrs/ADR-002-r-eff-skips-non-active-dependencies-draft-deprecated-superseded.md
@@ -35,3 +35,4 @@ R_eff recursive вычисляет weakest link по всему дереву з�
 - crates/forgeplan-core/src/scoring/reff.rs
 
 
+

--- a/.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md
+++ b/.forgeplan/adrs/ADR-003-markdown-files-as-source-of-truth-lancedb-as-index-layer.md
@@ -320,3 +320,4 @@ stays scoped to the typed-error migration:
 
 
 
+

--- a/.forgeplan/adrs/ADR-009-forgeplan-as-orchestrator-playbook-skill-agent-mapping-pack-marketplace-model.md
+++ b/.forgeplan/adrs/ADR-009-forgeplan-as-orchestrator-playbook-skill-agent-mapping-pack-marketplace-model.md
@@ -270,3 +270,4 @@ Forgeplan-core получает **3 новые core capabilities**:
 
 
 
+

--- a/.forgeplan/adrs/ADR-020-r-eff-excludes-terminal-status-evidence-from-the-weakest-link-min.md
+++ b/.forgeplan/adrs/ADR-020-r-eff-excludes-terminal-status-evidence-from-the-weakest-link-min.md
@@ -79,3 +79,4 @@ title: R_eff excludes terminal-status evidence from the weakest-link min
 - **Фильтровать и draft (буквальный acceptance #436)** — отвергнуто: ломает score-гейт Standard-flow (см. Decision §2).
 
 
+

--- a/.forgeplan/adrs/ADR-025-orchestration-sits-above-forgeplan-the-core-is-the-contract-layer.md
+++ b/.forgeplan/adrs/ADR-025-orchestration-sits-above-forgeplan-the-core-is-the-contract-layer.md
@@ -1,0 +1,89 @@
+---
+depth: standard
+id: ADR-025
+kind: adr
+links:
+- target: ADR-001
+  relation: based_on
+- target: ADR-009
+  relation: refines
+status: draft
+title: Orchestration sits above ForgePlan; the core is the contract layer
+---
+
+---
+assigned_number: 25
+predicted_number: 25
+slug: adr-orchestration-sits-above-forgeplan-the-core-is-the-contract-layer
+---
+
+# ADR-025: Orchestration sits above ForgePlan; the core is the contract layer
+
+## Context
+
+Two active ADRs contradict each other, and the contradiction predates vNext:
+
+- **ADR-001**: "AI agent is the orchestrator, not Forgeplan." Rejects adapter
+  traits; ForgePlan does not integrate into external systems, they read it.
+- **ADR-009 §Decision**: "Forgeplan-core становится оркестратором — знает когда
+  какой playbook запускать, кому делегировать каждый шаг."
+
+The vNext audit flagged this as the blocker no document can resolve (B2:
+"недостижим, пока человек не выберет сторону"). The owner has chosen:
+**orchestration of agents lives above ForgePlan**. Orchestrators (Claude Code,
+Kandev, Conductor, human operators) decide who runs and when. ForgePlan is the
+system of record they run against: artifacts, contracts, evidence, verdicts,
+lifecycle.
+
+The audit also found sixteen shipped CLI/MCP surfaces that sit on or across
+this boundary (PB-01/B4) and demanded a per-surface disposition instead of a
+blanket claim. This ADR is that disposition.
+
+## Decision
+
+ADR-001 is **reaffirmed**. ADR-009's orchestrator clause (§Decision, first
+sentence) is **superseded by this ADR**; the rest of ADR-009 — the 4-primitive
++ Pack marketplace model — stands unchanged.
+
+The boundary test for any surface: **does it manage the artifact graph, or
+does it manage a process?** Graph management stays in core. Process management
+belongs to the orchestrator above.
+
+### Disposition of the sixteen surfaces
+
+| Surface | Verdict | Reasoning |
+|---|---|---|
+| `dispatch` | **KEEP** | Read-only planner: computes conflict-free buckets from the graph. Spawning was already documented as the orchestrator's job. A projection, not a process. |
+| `order`, `blocked` | **KEEP** | Pure graph projections over dependency edges. |
+| `progress` | **KEEP** | Reads FR checkboxes out of artifact bodies. A projection. |
+| `graph`, `tree`, `stale`, `blindspots` | **KEEP** | Same class, never contested. |
+| `claim` / `release` / `claims` | **KEEP, reframed as locks** | These are write-mutexes on artifacts — integrity infrastructure for one workspace, not work assignment. "Who is assigned" belongs to trackers; "who may write this artifact right now without collision" is the graph's own safety and stays. Docs and hints must stop using assignment language. |
+| `session` | **KEEP, explicitly non-canonical** | Per-machine plumbing, already gitignored. |
+| `phase` / `phase-advance` | **ABSORB, no new investment** | Three parallel state ladders exist today: lifecycle status, DerivedStatus, phase. Phase state is already per-machine (`.forgeplan/state/` is gitignored — it does not even travel with the repo). Keep advisory as shipped, fix the #330 regression because shipped code must not lie, and fold phase into the lifecycle model in vNext (FPV-03) rather than growing it. |
+| `estimate` / `calibrate` | **MOVE TO EXTENSION** | Effort estimation is planning-tool territory. It reads the graph but does not manage it. Marketplace extension; deprecation window in core. |
+| `remember` / `recall` (memory kind) | **DEPRECATE** | The boundary doc says "not a general-purpose memory platform" and the shipped reality agrees: 2 memory artifacts exist, `new memory` fails with "No template found", and #411 shows they cannot join the graph. NOTE covers durable engineering micro-facts as first-class artifacts; conversational memory is Hindsight's job. Closing #411 by removal, not repair. |
+| playbook runtime (5 dispatchers, `playbook run`/`ingest`, ADR-011's `claude --print`) | **MOVE TO EXTENSION, supersede ADR-011** | Spawning agent processes is the definition of the orchestration this ADR places above the core. The playbook *format* (methodology → steps mapping) remains marketplace data; the *runtime* leaves the core binary. This is the largest consequence and gets its own migration RFC before any code moves. |
+
+## Consequences
+
+- The FPV-01 blocker (two active ADRs claiming opposite things) is resolved;
+  the vNext boundary doc's ownership table now matches an actual decision.
+- ADR-009 needs an amendment note pointing here; ADR-011 needs supersession
+  when the playbook-runtime RFC lands. Neither is edited retroactively —
+  supersede, do not delete.
+- #411 closes as deprecation. The two existing memory artifacts get migrated
+  to NOTE or exported before removal.
+- No code changes in this ADR. Each MOVE/DEPRECATE row requires its own RFC
+  with a deprecation window; KEEP rows require only documentation alignment
+  (assignment language out of claim/release hints).
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| ADR-001 | based_on |
+| ADR-009 | refines |
+
+
+
+

--- a/.forgeplan/adrs/ADR-025-orchestration-sits-above-forgeplan-the-core-is-the-contract-layer.md
+++ b/.forgeplan/adrs/ADR-025-orchestration-sits-above-forgeplan-the-core-is-the-contract-layer.md
@@ -7,7 +7,7 @@ links:
   relation: based_on
 - target: ADR-009
   relation: refines
-status: draft
+status: active
 title: Orchestration sits above ForgePlan; the core is the contract layer
 ---
 
@@ -83,6 +83,8 @@ belongs to the orchestrator above.
 |---|---|
 | ADR-001 | based_on |
 | ADR-009 | refines |
+
+
 
 
 

--- a/.forgeplan/adrs/ADR-026-storage-classes-for-machine-written-records.md
+++ b/.forgeplan/adrs/ADR-026-storage-classes-for-machine-written-records.md
@@ -1,0 +1,120 @@
+---
+depth: standard
+id: ADR-026
+kind: adr
+links:
+- target: ADR-003
+  relation: refines
+- target: ADR-025
+  relation: based_on
+status: draft
+title: Storage classes for machine-written records
+---
+
+---
+assigned_number: 26
+predicted_number: 26
+slug: adr-storage-classes-for-machine-written-records
+---
+
+# ADR-026: Storage classes for machine-written records
+
+## Context
+
+vNext introduces four object classes that no shipped decision houses:
+WorkContract, ExecutionReceipt, EvidenceBundle, VerificationVerdict, plus an
+authority/audit trail. The audit blocked FPV-03/04/05 on this (B3): ADR-003
+declares markdown files the single source of truth and RED LINE #11 forbids
+direct edits — but receipts and verdicts are written by machines, at volume,
+and a git-tracked tree of machine-written files makes both rules unenforceable
+as stated. ADR-018 already rejected a second authoritative non-markdown store.
+
+Two constraints frame every option:
+
+- **Local-first, git for sync** (Non-Goals). Anything that must survive a
+  clone or be trusted by another machine has to ride git.
+- **One owner per state** (FORGE-O). ForgePlan should not become the canonical
+  store for facts another system already owns — CI results are the CI
+  provider's; ForgePlan references them.
+
+## Decision
+
+One rule, three storage classes. The rule:
+
+> **Git-tracked if a human must review it or another machine must trust it.
+> Local if it is raw per-machine material. Referenced if another system owns
+> it. Machine-written tracked files are append-only, schema-validated,
+> digest-linked, and mutated only through CLI/MCP — RED LINE #11 extends to
+> them verbatim.**
+
+### Class A — canonical, git-tracked, append-only
+
+| Object | Home | Form |
+|---|---|---|
+| WorkContract | `.forgeplan/contracts/` | JSON, one file per contract version, digest in the record |
+| EvidenceBundle | `.forgeplan/evidence/` | the EVID artifact evolved: structured machine section + human prose, same id space |
+| VerificationVerdict | `.forgeplan/verdicts/` | JSON, digest-links to bundle and contract |
+
+Reviewable in the PR that carries them, survive cloning, referenced by digest
+so retargeting is detectable. Append-only means a new version is a new file
+and supersession is a link — no merge conflicts by construction, and "edit"
+is not an operation that exists.
+
+This amends ADR-003 rather than violating it: *versioned files under
+`.forgeplan/` are the source of truth; markdown for human-authored artifacts,
+schema-validated JSON for machine-issued records; LanceDB stays derived.*
+ADR-003's actual load-bearing idea was never "markdown" — it was "canonical
+truth is versioned plain files, indexes are disposable."
+
+### Class B — local raw material, gitignored
+
+| Object | Home |
+|---|---|
+| ExecutionReceipt | `.forgeplan/receipts/` |
+| audit/authority event stream | the existing journal (`forgeplan-core::journal`) |
+
+Receipts are what a host reports about a run: commands, exit codes, streams.
+High-volume, per-machine, valuable for minutes-to-days. They are the raw
+material verification consumes on the machine where the run happened. What
+deserves to outlive the machine gets promoted: the EvidenceBundle embeds the
+receipt extract it relies on plus the receipt digest, and the bundle is
+Class A. This mirrors the CI precedent — the CI provider owns the run, the
+graph keeps the reference and the extract.
+
+The same promotion rule covers audit: routine events stay in the local
+journal; trust-relevant transitions (activation, dismissal, force, gate
+override) are recorded in the artifact's own tracked state history, which is
+per-artifact and append-capped, so the durable trail rides git without a
+global conflict-prone log file.
+
+### Class C — referenced, never stored
+
+CI results, deployment state, tracker assignments. A digest or URL plus the
+observation timestamp, inside a Class A record. Copying another system's
+state into the graph creates a second owner and guarantees drift.
+
+## Consequences
+
+- FPV-03/04/05 unblock: every object in the protocol has a declared home
+  before a schema is written.
+- `.gitignore` gains `receipts/`; `contracts/` and `verdicts/` are tracked
+  from birth. `.forgeplan/state/` is already gitignored today, consistent
+  with phase state being advisory and per-machine (ADR-025).
+- RED LINE #11 needs one sentence added: machine-issued records under
+  `contracts/`, `evidence/`, `verdicts/` are written only by the binary;
+  hand-editing them is the same violation as hand-editing an artifact.
+- The pre-existing `journal` module becomes the audit stream's home instead
+  of a new subsystem.
+- Verification MUST re-derive git facts (delta, SHAs) from the repository at
+  verdict time rather than trusting receipt contents — the receipt says what
+  the host claims happened; the repo says what happened.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| ADR-003 | refines |
+| ADR-025 | based_on |
+
+
+

--- a/.forgeplan/adrs/ADR-026-storage-classes-for-machine-written-records.md
+++ b/.forgeplan/adrs/ADR-026-storage-classes-for-machine-written-records.md
@@ -7,7 +7,7 @@ links:
   relation: refines
 - target: ADR-025
   relation: based_on
-status: draft
+status: active
 title: Storage classes for machine-written records
 ---
 
@@ -115,6 +115,8 @@ state into the graph creates a second owner and guarantees drift.
 |---|---|
 | ADR-003 | refines |
 | ADR-025 | based_on |
+
+
 
 
 

--- a/.forgeplan/evidence/EVID-169-adr-025-and-adr-026-basis-vnext-audit-measurements-plus-owner-approval.md
+++ b/.forgeplan/evidence/EVID-169-adr-025-and-adr-026-basis-vnext-audit-measurements-plus-owner-approval.md
@@ -1,0 +1,66 @@
+---
+depth: tactical
+id: EVID-169
+kind: evidence
+links:
+- target: ADR-025
+  relation: informs
+- target: ADR-026
+  relation: informs
+status: active
+title: 'ADR-025 and ADR-026 basis: vNext audit measurements plus owner approval'
+---
+
+---
+assigned_number: 169
+created: 2026-09-05
+predicted_number: 169
+slug: evid-adr-025-and-adr-026-basis-vnext-audit-measurements-plus-owner-approval
+updated: 2026-09-05
+---
+
+# EVID-169: the basis for ADR-025 and ADR-026
+
+## What this pack certifies
+
+Both ADRs resolve blockers the vNext adversarial audit raised
+(`docs/vnext/engineering-contract-layer/_audit/`), and both went through the
+owner. This pack records the measured basis and the approval, so activation
+does not rest on the author's own say-so.
+
+## Measurements behind ADR-025
+
+- ADR-001 and ADR-009 both `status: active` while asserting opposite owners
+  for orchestration — read directly from frontmatter, audit finding B2.
+- The playbook runtime spawns agents from the core binary
+  (`agent_dispatcher.rs:69`, `claude --print`) against the declared boundary.
+- The memory kind: 2 artifacts exist in this workspace, `forgeplan new
+  memory` fails with "No template found for kind 'memory'", #411 shows
+  mem-* ids cannot resolve for linking. Verified by execution on 0.36.0.
+- `.forgeplan/state/` is gitignored — phase state never leaves the machine.
+
+## Measurements behind ADR-026
+
+- The audit blocked FPV-03/04/05 on storage (B3): zero mentions of a storage
+  home for the four new object classes across `docs/vnext/architecture/`.
+- ADR-018 already rejected a second authoritative non-markdown store; the
+  journal module already exists in `forgeplan-core` for the audit stream.
+- Precedent: CI results are referenced, never copied — the same rule
+  generalises to receipts.
+
+## Owner decision
+
+2026-09-05. Decision #1 (orchestration above ForgePlan) made by the owner
+directly. Proposals #2 (storage classes) and #3 (surface dispositions)
+reviewed with plain-language explanations and approved: "да все понятно и
+все ок - зафиксировать". This pack is that fixation.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: audit
+
+
+
+

--- a/.forgeplan/evidence/EVID-170-prd-086-five-trust-layer-defects-measured-before-and-after.md
+++ b/.forgeplan/evidence/EVID-170-prd-086-five-trust-layer-defects-measured-before-and-after.md
@@ -1,0 +1,122 @@
+---
+depth: tactical
+id: EVID-170
+kind: evidence
+links:
+- target: PRD-086
+  relation: informs
+- target: PROB-101
+  relation: informs
+status: draft
+title: 'PRD-086: five trust-layer defects measured before and after'
+---
+
+---
+assigned_number: 170
+created: 2026-09-05
+predicted_number: 170
+slug: evid-prd-086-five-trust-layer-defects-measured-before-and-after
+updated: 2026-09-05
+---
+
+# EVID: the trust layer, measured before and after
+
+Five defects in PRD-086, each with a reproduction on 0.36.0 and a re-measurement
+after the fix. Every fix carries a test that was mutation-checked — the fix was
+reverted and the test had to fail. Two of my own tests failed that check and were
+rewritten; both stories are in the test file, because a test that looks like
+proof and is not is the defect this PRD exists to remove.
+
+## Fail-closed (FR-008 / FR-009, PROB-101)
+
+| Body | Score of the informed artifact — before | after |
+|---|---|---|
+| pure prose, no fields | **1.00 "Adequate"** | **0.10** |
+| `verdict: unknown`, `congruence_level: 3` | 1.00 | 0.10 |
+| `verdict: supports`, no CL source | 1.00 | 0.10 |
+| `verdict: supports`, `congruence_level: 3` | 1.00 | 1.00 (unchanged) |
+
+Three documents already specified the "after" column: `CLAUDE.md` RED LINE #7,
+the `/forge` skill installed by `setup-skill`, and `EVIDENCE-PROTOCOL.md`. The
+binary did the opposite, and in the inflating direction.
+
+Blast radius here, counted rather than estimated: **3 of 167 packs** lack a CL
+source — EVID-033, EVID-034, EVID-035 — feeding PROB-014, PROB-016 and RFC-004
+respectively. Those three drop to 0.1 and take their targets with them. That is
+the correct reading: the scores were never earned.
+
+## Leaf evidence (#325, FR-001/FR-002)
+
+- canonical pack (`supports` / CL3 / measurement) scored **0.0** with the factor
+  `No evidence found (L0)`; now **1.00**
+- `weakens` / CL3 / measurement now **0.50** — computed, not stamped
+- a canonical pack attached to an unevidenced PRD scored **0.0** because its
+  outgoing `informs` was walked as a dependency; now **1.00**
+
+## The cascade (#392, narrowed)
+
+- PRD with one CL3 `supports` pack, `based_on` an active unevidenced NOTE:
+  **0.00 AT RISK** before, non-zero after
+- PRD with the same evidence, `based_on` an active unevidenced **PRD**:
+  **0.00 before and after** — deliberately unchanged, and covered by its own
+  test so a future "simplification" cannot quietly soften it
+
+## Phase monotonicity (#330)
+
+`advance_phase(done → validate)` succeeded silently. It now returns an error
+naming both phases, and `read_phase` confirms the state was left at `done`.
+Forward jumps, no-ops, and the explicit `advance_phase_unchecked` path all still
+work, each with a test.
+
+## Anomaly detector (#393)
+
+Three separate misreports, each fixed at its source: the literal `0.0` replaced
+by the stored score and renamed `r_eff_cached`; the blanket
+`cycle or depth cap` replaced by the reason that actually occurred; and the
+ancestor walk given the scorer's skip rules so the two stop disagreeing about
+which artifact is the weakest link.
+
+## What dogfooding caught that the tests did not
+
+Running `forgeplan score EVID-170` on the real graph printed:
+
+```
+  No evidence linked. R_eff = 0.0
+  • Leaf evidence scored on its own fields: Supports CL3 = 1.00
+```
+
+The engine computed 1.00 and the command announced 0.0 over it. `score.rs` had
+its own display branch keyed on "no linked evidence", written when that
+condition could only mean one thing. Neither the unit tests nor the integration
+tests read that line, so both stayed green — the same shape as the defects this
+PRD closes, committed by the printer instead of the scorer.
+
+Fixed, and verified across all four cases: canonical pack (1.00), fieldless pack
+(0.10 plus a remediation naming the missing fields), an artifact with linked
+evidence (breakdown unchanged), an artifact with none (unchanged).
+
+## Gates
+
+| Gate | Result |
+|---|---|
+| `cargo fmt --all -- --check` | exit 0 |
+| `cargo clippy --workspace --all-targets` | exit 0, 0 warnings |
+| `cargo test --workspace --no-fail-fast` | **3307 passed, 3 failed**, 94 binaries |
+
+A first attempt at the full run produced `тестовых бинарей: 0` with
+`ld: write() failed, errno=28` — the disk was at 152 MB. The harness reported
+that the run had not happened instead of printing a passing summary, which is
+the behaviour PROB-090's class of failure needs. Re-run after `cargo clean` gave the numbers above.
+
+The 3 failures are #454 / PROB-090, not this change: all three are in
+`git::tests`, none of the commits here touch `crates/forgeplan-core/src/git/`,
+and all 51 tests in that module pass when run single-threaded. The flake is
+parallel env mutation dropping `PATH`; CI does not see it because `cargo
+nextest` gives each test its own process.
+
+## Structured Fields
+
+verdict: supports
+congruence_level: 3
+evidence_type: measurement
+

--- a/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
+++ b/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
@@ -111,6 +111,20 @@ numbers that were never computed, and neither has a way to tell which.
 - **FR-006**: The detector's ancestor walk resolves a weakest link wherever
   `forgeplan_score` resolves one, by sharing the traversal rather than
   reimplementing it.
+- **FR-008**: An unparseable or unknown `verdict` fails closed. Today it falls
+  through to `Supports` (score 1.0) while `congruence_level` in the same
+  function fails closed to CL0 with a warning — one field punishes garbage and
+  its neighbour rewards it. Protocol v1 introduces a fourth value (`unknown`),
+  which the current parser would score 1.0.
+- **FR-009**: Absent structured fields fail closed. A pack carrying no
+  `verdict` / `congruence_level` at all currently scores its target 1.00;
+  `CLAUDE.md` RED LINE #7, the `/forge` skill shipped by `setup-skill`, and
+  `EVIDENCE-PROTOCOL.md` all state the opposite (CL0, 0.1). The absence is
+  recorded as a factor rather than applied silently. Breaking: packs without
+  fields drop from 1.0 to 0.1, and artifacts whose weakest link was such a
+  pack drop with them — 3 of 166 here, unknown elsewhere. Requires a
+  migration note and `forgeplan score --all`.
+
 - **FR-007**: `advance_phase` refuses a transition to an earlier phase, leaving
   state unchanged and reporting the refusal to its caller. Explicit
   `forgeplan phase-advance --to <earlier>` remains available for deliberate
@@ -124,9 +138,5 @@ numbers that were never computed, and neither has a way to tell which.
 | ADR-020 | based_on |
 
 GitHub: #325, #392, #393, #330.
-
-
-
-
 
 

--- a/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
+++ b/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
@@ -140,3 +140,4 @@ numbers that were never computed, and neither has a way to tell which.
 GitHub: #325, #392, #393, #330.
 
 
+

--- a/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
+++ b/.forgeplan/prds/PRD-086-the-trust-layer-reports-values-it-never-computed.md
@@ -1,0 +1,132 @@
+---
+depth: standard
+id: PRD-086
+kind: prd
+links:
+- target: ADR-002
+  relation: based_on
+- target: ADR-020
+  relation: based_on
+status: draft
+title: The trust layer reports values it never computed
+---
+
+---
+assigned_number: 86
+predicted_number: 86
+slug: prd-the-trust-layer-reports-values-it-never-computed
+---
+
+# PRD-086: The trust layer reports values it never computed
+
+## Problem
+
+R_eff is the number the whole product is for. Four defects make it, and the
+detector that reads it, report things that were never computed.
+
+None of them fail. Each returns a plausible value, which is why all four
+survived: a zero looks like an honest zero, and a warning about a missing link
+looks like a warning about a missing link.
+
+**An EvidencePack is asked for its evidence.** `r_eff_recursive` collects the
+packs linked to an artifact and takes the min. Run against an EvidencePack it
+finds nothing — a pack has no packs — and returns `self_score = 0.0` with the
+factor `No evidence found (L0)`. A canonical pack (`verdict: supports`,
+`congruence_level: 3`) scores zero.
+
+The intrinsic score already exists. `score_evidence` computes it from verdict,
+congruence level and expiry, and is applied to that same pack whenever it is
+scored *as evidence for something else*. Only the pack itself never gets it.
+
+Worse, the pack's outgoing `informs` edge to the artifact it supports is
+classified as a **dependency**, so trust flows from the decision down into the
+evidence. Backwards.
+
+**The cascade contradicts the routing table.** A Note is the artifact for
+trivial, reversible work: no ADI, no evidence, expires in 90 days. The
+dependency walk then treats an active Note with no evidence as zero trust and
+poisons every chain based on it. Forgeplan says a Note needs no evidence and
+then scores everything downstream of it as unevidenced.
+
+ADR-002 already resolved this shape for `draft` dependencies — skip, with a
+logged factor — and rejected "count draft as 0" for penalising planning ahead.
+The same reasoning applies to kinds that are ceremony-free by design.
+
+**The anomaly detector reports three things it did not check.** It prints
+`R_eff=0` for artifacts whose stored `r_eff` is nonzero but below threshold; it
+labels every give-up `cycle or depth cap` in graphs with zero cycles; and its
+ancestor walk gives up where `forgeplan_score` resolves the weakest link fine,
+emitting `weakest_link: null, chain_depth: 0` for artifacts the scorer answers.
+
+**`advance_phase` regresses.** It has no monotonicity guard. MCP
+`forgeplan_validate` calls it with `Phase::Validate` on PASS, so validating an
+already-shipped artifact walks its phase back from `done`, and
+`forgeplan_health` then reports a phase mismatch that the artifact did not have
+until it was validated.
+
+## Goals
+
+- An EvidencePack scores on its own merits, using the formula that already
+  exists, without inventing child evidence to satisfy the walk.
+- The weakest-link cascade is preserved exactly as it is for kinds that can owe
+  evidence, and skips the kinds the methodology exempts.
+- Every number and label the anomaly detector prints is one it computed.
+- A phase never moves backwards on its own.
+
+## Non-Goals
+
+- **Weakening the weakest-link formula.** `R_eff = min(...)` stays. The three
+  fixes proposed in #392 — local-only scoring, one-hop propagation, a floor at
+  `self_score` — are each an average in disguise and are declined. If a
+  foundation is unproven, the floor above it is not trustworthy, and a number
+  saying otherwise is the failure the formula prevents.
+- Changing CL penalties, decay, or the verdict scale.
+- Raising the detector's depth cap. The walk is unified with the scorer's; if a
+  cap is still hit afterwards it must be reported as a depth cap, not guessed
+  at.
+- Backfilling or migrating stored scores. `forgeplan score --all` recomputes.
+
+## Target Users
+
+Agents reading `r_eff` to decide whether an artifact can be relied on, and
+maintainers triaging `forgeplan anomalies`. Both currently receive confident
+numbers that were never computed, and neither has a way to tell which.
+
+## Functional Requirements
+
+- **FR-001**: An EvidencePack with no linked child evidence derives
+  `self_score` from `score_evidence` over its own parsed fields, not from the
+  empty-evidence path. A pack whose fields do not parse keeps `0.0` — absent
+  structured fields remain CL0, per the existing contract.
+- **FR-002**: An EvidencePack's outgoing `informs` / `based_on` edges to the
+  artifacts it supports are excluded from its own dependency walk. Evidence
+  does not depend on what it evidences.
+- **FR-003**: The dependency walk skips `note` and `memory` dependencies,
+  recording a factor naming the id and kind, in the same shape ADR-002 uses for
+  non-active dependencies.
+- **FR-004**: The anomaly detector reports the artifact's actual stored
+  `r_eff`, not `0`.
+- **FR-005**: The detector distinguishes a depth cap from a cycle and names
+  which occurred.
+- **FR-006**: The detector's ancestor walk resolves a weakest link wherever
+  `forgeplan_score` resolves one, by sharing the traversal rather than
+  reimplementing it.
+- **FR-007**: `advance_phase` refuses a transition to an earlier phase, leaving
+  state unchanged and reporting the refusal to its caller. Explicit
+  `forgeplan phase-advance --to <earlier>` remains available for deliberate
+  correction.
+
+## Related Artifacts
+
+| Artifact | Relation |
+|---|---|
+| ADR-002 | based_on |
+| ADR-020 | based_on |
+
+GitHub: #325, #392, #393, #330.
+
+
+
+
+
+

--- a/.forgeplan/problems/PROB-101-missing-evidence-fields-grant-maximum-trust-and-three-documents-promise-the-opposite.md
+++ b/.forgeplan/problems/PROB-101-missing-evidence-fields-grant-maximum-trust-and-three-documents-promise-the-opposite.md
@@ -111,3 +111,4 @@ maximum trust on absent input is the one case where it cannot.
 |---|---|
 | PRD-086 | informs |
 
+

--- a/.forgeplan/problems/PROB-101-missing-evidence-fields-grant-maximum-trust-and-three-documents-promise-the-opposite.md
+++ b/.forgeplan/problems/PROB-101-missing-evidence-fields-grant-maximum-trust-and-three-documents-promise-the-opposite.md
@@ -1,0 +1,113 @@
+---
+depth: tactical
+id: PROB-101
+kind: problem
+links:
+- target: PRD-086
+  relation: informs
+status: draft
+title: Missing evidence fields grant maximum trust, and three documents promise the opposite
+---
+
+---
+assigned_number: 101
+predicted_number: 101
+slug: prob-missing-evidence-fields-grant-maximum-trust-and-three-documents-promise
+---
+
+# PROB-101: the evidence gate fails open, and everything says it fails closed
+
+(touched to force a re-embed)
+
+## Signal
+
+An EvidencePack containing no structured fields at all — pure prose, no
+`verdict`, no `congruence_level`, no `evidence_type` — gives the artifact it
+informs a perfect score.
+
+Measured on 0.36.0, fresh workspace:
+
+```
+Evidence breakdown:
+  EVID-001 [Supports] CL3 = 1.0
+R_eff:        1.00 -- Adequate
+```
+
+Three documents promise the opposite, in the same words:
+
+- `CLAUDE.md` RED LINE #7 — "без этих structured fields parser тихо ставит CL0
+  (silent failure → R_eff = 0.1)"
+- the `/forge` skill, shipped to every user by `setup-skill` — "Without them,
+  the R_eff parser silently defaults to CL0 (penalty 0.9), making R_eff = 0.1"
+- `docs/methodology/EVIDENCE-PROTOCOL.md`, same claim
+
+The code does the reverse, deliberately:
+`crates/forgeplan-core/src/scoring/evidence.rs` — `(None, None) => 3`, with the
+comment *"Default CL=3 (same context) — evidence created locally is
+same-context by default."*
+
+## Why this is the dangerous direction
+
+Absent metadata resolves to **maximum** trust. Every other unknown in this
+codebase fails closed: unparseable `congruence_level` → CL0 with a warning; an
+unclosed HTML comment that swallows the fields → CL0 with a warning. Both were
+fixed as trust-inflation bugs (PROB-034 and its follow-ups). The plain-absence
+case was left as the one path where saying nothing is rewarded.
+
+It also inverts the incentive. An agent that writes the fields honestly:
+
+```
+verdict: supports
+congruence_level: 2     → score 0.9
+```
+
+An agent that writes nothing:
+
+```
+(no fields)             → score 1.0
+```
+
+Skipping the discipline scores **better** than following it. The red line that
+exists to prevent silent failure is enforced by nothing, and the documentation
+that would warn an author is wrong in the direction that hides the problem.
+
+## Scale
+
+This repository: **3 of 166** packs lack `congruence_level`. The discipline is
+followed here, which is exactly why the missing guard went unnoticed — the
+convention holds, so nothing ever tested what happens when it does not.
+
+That number says nothing about other workspaces. A workspace where an agent
+skipped the fields has inflated scores and no signal that it did.
+
+## Not the same as #325
+
+#325 is a pack scoring 0 for itself. This is a pack scoring 1.0 for someone
+else on no information. Opposite direction, same root: the scorer has no
+concept of "this pack did not tell me anything."
+
+## The decision this needs
+
+Changing `(None, None)` from CL3 to CL0 aligns behaviour with all three
+documents and makes RED LINE #7 real. It is a **breaking scoring change**:
+every pack without the fields drops from 1.0 to 0.1, and every artifact whose
+weakest link was such a pack drops with it. Three artifacts here; unknown
+elsewhere.
+
+The alternative — keep CL3 and correct the three documents — is cheaper and
+defensible on the code's own rationale (locally-authored evidence really is
+same-context). But it means the product's headline number treats "I measured
+this and it strongly supports the claim" and "I wrote some prose" as identical,
+and no gate anywhere distinguishes them.
+
+Recommendation: fail closed, with the absence reported as a factor rather than
+a silent default, and a `forgeplan score --all` note in the release. The whole
+point of R_eff is that a number can be traced to something. A default of
+maximum trust on absent input is the one case where it cannot.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-086 | informs |
+

--- a/.forgeplan/problems/PROB-102-ci-compiles-the-semantic-search-surface-and-never-runs-it.md
+++ b/.forgeplan/problems/PROB-102-ci-compiles-the-semantic-search-surface-and-never-runs-it.md
@@ -1,0 +1,94 @@
+---
+depth: tactical
+id: PROB-102
+kind: problem
+links:
+- target: PRD-086
+  relation: informs
+status: draft
+title: CI compiles the semantic-search surface and never runs it
+---
+
+---
+assigned_number: 102
+predicted_number: 102
+slug: prob-ci-compiles-the-semantic-search-surface-and-never-runs-it
+---
+
+# PROB-102: the embedding oracle has never run
+
+## Signal
+
+`crates/forgeplan-core/tests/embedding_reference.rs` describes itself as the
+correctness oracle for the embedding engine — *"catches the one failure mode an
+engine swap has that nothing else would."* It holds three tests pinning vectors
+against values captured from the pre-tract engine.
+
+It executes zero of them in CI:
+
+```
+$ cargo test -p forgeplan-core --test embedding_reference
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored
+```
+
+The file is gated on `feature = "semantic-search"`. CI's test step is:
+
+```yaml
+- name: cargo nextest run
+  run: cargo nextest run --workspace --all-targets
+```
+
+No `--features`. The two steps above it *do* pass the feature:
+
+```yaml
+- run: cargo check --workspace --all-targets --features semantic-search
+- run: cargo clippy --workspace --all-targets --features semantic-search
+```
+
+So the semantic-search surface is compiled and linted on every PR, and executed
+on none. `0 passed` is reported as success.
+
+## Why this matters more than the count
+
+v0.35.0 replaced the entire embedding engine — ONNX Runtime to tract. This
+oracle is the safety net that swap was performed over. It was written for
+exactly that release, and it did not run during it. The vector-equivalence
+claim in the v0.35.0 notes (max deviation 7.0e-07 across six reference cases)
+came from a manual local run, not from the gate.
+
+The same hole explains PROB-103 (`embed` loading the model when there is
+nothing to embed, 8.22s on a current workspace): no CI job ever executes
+`embed`, so its cost was invisible until a user noticed the message.
+
+This is the release's own theme applied to the harness: a check that exists,
+is documented, is well-intentioned, and never runs — while reporting a green
+result.
+
+## Scope
+
+Only `embedding_reference.rs` is a fully-gated test file. Inline `#[cfg]`
+blocks elsewhere hide additional cases, but a reliable count needs a proper
+audit rather than a grep — an earlier attempt here produced inflated numbers by
+matching from the first `cfg` line to end of file, and was discarded.
+
+## Fix direction
+
+Add a nextest invocation with the feature enabled. It cannot simply replace the
+current one: the default-feature run is what proves the shipped-without-feature
+build still works, and that path has its own refusal branches worth executing.
+Two runs, or one matrix, both configurations.
+
+Cost is real and should be stated rather than discovered: the feature pulls the
+model at runtime, so the job needs the model cache or the tests need to be
+marked as requiring it. That is the reason it was left out, and it is a
+solvable reason, not a justification for reporting `0 passed` as green.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-086 | informs |
+
+
+

--- a/.forgeplan/problems/PROB-103-embed-loads-a-multi-gigabyte-model-to-discover-it-has-nothing-to-do.md
+++ b/.forgeplan/problems/PROB-103-embed-loads-a-multi-gigabyte-model-to-discover-it-has-nothing-to-do.md
@@ -1,0 +1,96 @@
+---
+depth: tactical
+id: PROB-103
+kind: problem
+links:
+- target: PROB-102
+  relation: based_on
+- target: PRD-086
+  relation: informs
+status: draft
+title: embed loads a multi-gigabyte model to discover it has nothing to do
+---
+
+---
+assigned_number: 103
+predicted_number: 103
+slug: prob-embed-loads-a-multi-gigabyte-model-to-discover-it-has-nothing-to-do
+---
+
+# PROB-103: embed pays the model's price to learn there is no work
+
+## Signal
+
+Reported by a user watching the output, not by any test:
+
+```
+$ forgeplan embed
+  Loading embedding model...
+Done: 2 embedded, 425 already current, 0 failed.
+
+$ forgeplan embed
+  Loading embedding model...
+```
+
+The model loads on every invocation, including runs where nothing needs
+encoding.
+
+Measured on 0.36.0, this workspace, 427 artifacts, all current:
+
+| | |
+|---|---|
+| before | **8.22 s** to report `0 embedded, 427 already current` |
+| after | **0.25 s** (warm, three consecutive runs: 0.83 / 0.25 / 0.25) |
+
+The model was read off disk and never used.
+
+## Root cause
+
+Half of PROB-093. That fix made `embed` incremental — a record is skipped when
+it already has a vector and its content hash still matches — which removed the
+13m18s of redundant encoding. But the skip decision was made *inside* the loop,
+after `Embedder::new()` had already run. The expensive part stayed
+unconditional.
+
+So the fix removed the work and left the setup for the work.
+
+## Why nobody noticed
+
+No CI job executes `embed` — see PROB-102, where the whole semantic-search
+surface is compiled and linted but never run. The cost was invisible to every
+gate and visible only to a person watching a terminal.
+
+The output made it worse: `Loading embedding model...` prints before the
+outcome, so the run *looks* like it is doing something. Only the final line
+says otherwise, and by then the 8 seconds are spent.
+
+## Fix
+
+Compute the work list first; load the model only if it is non-empty. On an
+empty list, print the same `Done:` summary and return.
+
+Also corrects the progress line, which claimed the wrong total:
+
+```
+- Embedding 427 artifact(s) ...     ← every record, including the skipped ones
++ Embedding 1 of 427 artifact(s) ...
+```
+
+`Loading embedding model...` now appears only when a model is actually about to
+be loaded, which is what a reader assumed it meant.
+
+## Verified
+
+- no-op run: 0.25 s warm, and the loading line is absent
+- real work: model loads, one changed artifact re-encoded, `1 embedded,
+  426 already current, 0 failed`
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PROB-102 | based_on |
+| PRD-086 | informs |
+
+
+

--- a/.forgeplan/problems/PROB-104-a-leaf-pack-with-an-evidence-neighbour-reports-the-neighbour-s-score.md
+++ b/.forgeplan/problems/PROB-104-a-leaf-pack-with-an-evidence-neighbour-reports-the-neighbour-s-score.md
@@ -1,0 +1,106 @@
+---
+depth: tactical
+id: PROB-104
+kind: problem
+links:
+- target: PRD-086
+  relation: informs
+status: draft
+title: A leaf pack with an evidence neighbour reports the neighbour's score
+---
+
+---
+assigned_number: 104
+context: '{grouping tag}'
+created: 2026-09-06
+predicted_number: 104
+slug: prob-a-leaf-pack-with-an-evidence-neighbour-reports-the-neighbour-s-score
+---
+
+# PROB-104: a leaf pack with an evidence neighbour reports the neighbour's score
+
+## Signal
+
+PRD-086 FR-001 gave an EvidencePack an intrinsic score computed from its own
+structured fields. The guard is:
+
+```rust
+if is_evidence_kind && evidence_items.is_empty() && terminal_skips == 0 {
+```
+
+`evidence_items` is built from `linked_evidence_ids` — every outgoing target id
+plus every incoming source id, filtered to `kind == "evidence"`, with **no
+relation-type filter**. So the moment a pack has any evidence-kind neighbour in
+either direction, the early return is skipped, its own `verdict` and
+`congruence_level` are never parsed, and `self_score` comes from the
+neighbour's fields instead.
+
+Measured on 0.36.0 with the prebuilt binary in a scratch workspace:
+
+| Pack under test | isolated | after one link to a supports/CL3 pack |
+|---|---|---|
+| body is pure prose, no fields | 0.10 | **1.00** |
+| `verdict: refutes`, `congruence_level: 3` | 0.00 | **1.00** |
+
+`forgeplan score` on the second row prints
+`Evidence breakdown: EVID-001 [Supports] CL3 = 1.0` for a pack whose own body
+says `refutes`.
+
+## Why this is low and not critical
+
+An adversarial reviewer raised it as a critical trust-laundering vector. A
+second agent tasked with refuting it measured the claims and downgraded it,
+correctly:
+
+- **Fail-closed parsing is intact.** FR-008/FR-009 govern how a pack scores its
+  *target*, and that call site runs `parse_evidence_from_record` from the
+  consumer's side. A PRD informed by the prose pack reports 0.10 before and
+  after the laundering link; informed by the refuting pack, 0.00 both times.
+- **Nothing propagates.** Only the pack's own self-report changes.
+- **It gates nothing.** `forgeplan activate` on an EvidencePack is not R_eff-gated,
+  and succeeds at 0.0 and 1.0 alike.
+- **Zero impact on this graph.** All six EVID→EVID edges here
+  (EVID-087→086, 089→088, 090→088, 091→089, 097→096, 099→098) are supports/CL3
+  packs pointing at supports/CL3 packs, so the substituted value equals the true
+  one everywhere it currently fires.
+
+## Mostly pre-existing, partly ours
+
+The evidence-collection code is untouched by PRD-086, and "self_score is the min
+over linked evidence, never the artifact's own fields" is the original design for
+every kind. Pre-diff, a prose pack scored 0.0 isolated and 1.0 once linked — so
+"one link makes it report 1.00" predates this work; PRD-086 only introduced the
+0.10 baseline that makes the jump visible.
+
+The genuinely new residue is narrow: for a pack with a **negative** verdict plus
+an evidence neighbour, FR-002 removed the dependency edge whose recursion used
+to pull the result back down. That accidental correctness *was* the backwards
+trust flow FR-002 deliberately removed, so the loss is a side effect of an
+intended change, not a regression to undo.
+
+## Fix direction
+
+The guard should ask whether the pack has *supporting children*, not whether it
+has *any evidence-kind neighbour*. Two candidate shapes:
+
+1. Filter `linked_evidence_ids` by relation direction when the artifact is an
+   evidence kind — only incoming `informs` / `based_on` / `supports` count as
+   children; outgoing edges point at what the pack supports.
+2. Fall back to the intrinsic score whenever the pack's own fields parse and the
+   collected set contains no *incoming* evidence, rather than gating on
+   emptiness.
+
+Either touches evidence collection, which is shared by every artifact kind, so
+it needs its own change with its own tests — the reason it was not folded into
+PRD-086.
+
+Regression test to write first: a `refutes`/CL3 pack linked to a `supports`/CL3
+pack must not report 1.00.
+
+## Related
+
+| Artifact | Relation |
+|---|---|
+| PRD-086 | informs |
+
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,58 @@ This file is the **entry point**. For full details, read the files it points to.
 
 7. **Markdown files in `.forgeplan/` are the source of truth** (per ADR-003). The LanceDB index in `.forgeplan/lance/` is derived — rebuild via `forgeplan scan-import` if needed.
 
+## Parallel agents and the build directory
+
+`target/` in this repository runs 20-45 GB. The disk it lives on is routinely
+under 20 GB free. Several agents compiling at once is the single most reliable
+way to break a session here, and it has happened four times.
+
+**The failure does not look like a failure.** When the disk fills, cargo dies
+with `ld: write() failed, errno=28`, and the harness around it reports
+`passed=0 failed=0` at exit 0 — or an empty summary. A check that never ran and
+a check that passed are indistinguishable in every summary format we use. On
+one occasion this produced 26 phantom clippy warnings that did not exist. Twice
+the result was reported as green before anyone noticed.
+
+Rules for anyone dispatching sub-agents in this repo:
+
+- **Never let more than one agent compile at a time.** No parallel `cargo
+  build` / `test` / `check` / `clippy`. Feature unification means agents with
+  different flags will also thrash each other's artifacts even when the disk
+  holds.
+- **Prefer read-only review.** Reading source with Read/Grep answers most
+  review questions. When execution is genuinely needed, hand agents the
+  already-built `./target/debug/forgeplan` and let them work in `/tmp`
+  workspaces via `forgeplan init -y`. Say so in the prompt — agents reach for
+  `cargo test` by default.
+- **Check `df -h .` before any full run**, and again in the same command that
+  reports the result. Under ~10 GB free, clean first:
+  `cargo clean -p forgeplan -p forgeplan-core -p forgeplan-mcp` recovers
+  15-37 GB while keeping compiled dependencies. `find target -maxdepth 2 -type
+  d -name incremental -exec rm -r {} +` is the cheap version — note that the
+  safety hook blocks `rm -rf` but permits this form.
+- **Make the harness say when a run did not happen.** Count the test binaries,
+  not just the pass/fail line:
+
+  ```bash
+  n=$(grep -c '^test result:' "$log")
+  if [ "$n" -eq 0 ]; then echo "RUN DID NOT HAPPEN"; df -h . | tail -1; fi
+  ```
+
+  A summary that cannot distinguish "zero failures" from "zero tests" is worse
+  than no summary.
+
+Two related traps, same family:
+
+- **Never edit source while a background build runs.** The binary captures the
+  file mid-edit, so the tree and the artifact disagree. It presents as a real
+  defect visible only in E2E while unit tests pass — suspect the binary before
+  the code.
+- **Two agents in one worktree is a race.** Use `git worktree add` per agent
+  for anything that writes. A concurrent commit from a second session has
+  already cost a lost commit-message file and half an hour of misdiagnosis in
+  this repo.
+
 ## Repository structure (quick map)
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,36 @@ ForgePlan/
 - **Code identifiers & commit descriptions:** English
 - **Communication with the user:** Russian
 
+## How to explain things to the owner
+
+Set by the owner on 2026-09-05, after comparing two answers about the same
+decisions: one written in architecture-speak, one in plain language. The
+plain one worked; the other one — «хрен поймёшь, о чём речь».
+
+When presenting a decision, a trade-off, or a piece of analysis:
+
+- **Plain, but not banal.** Simple words carrying real content — never
+  simple words instead of content. The test: the reader should be able to
+  retell the decision to someone else after one read.
+- **Name the collision before the answer.** Most decisions exist because two
+  things conflict. Show the conflict first («два действующих ADR говорили
+  противоположное»), then the resolution. An answer without its tension
+  reads as arbitrary.
+- **One live example beats three definitions.** «Приходит задача — кто
+  решает, что сначала запустится аналитик, потом кодер?» explains an
+  orchestration boundary faster than any glossary.
+- **Minimal anglicisms.** Code identifiers, artifact kinds, and command
+  names stay as-is (`claim`, `EvidencePack`, `based_on`). Everything else
+  gets a Russian phrasing: «замок на запись», not «лок»; «происхождение»,
+  not «провенанс»; «поверхность команд» needs an explanation the first time
+  it appears.
+- **Consequences, not just verdicts.** «Deprecated» is a verdict; «хоронить,
+  не лечить — всё, что она обещала, уже делают NOTE и Hindsight» is a
+  decision someone can agree or argue with.
+- **Metaphors must carry weight.** «Нотная тетрадь и приёмная комиссия» is
+  good because both halves map to real subsystems. Decoration is worse than
+  nothing.
+
 ## Authorship (single author)
 
 Forgeplan is a single-author project. When generating ANY author-attributed content, use:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,94 @@ corresponding sprint evidence under `.forgeplan/evidence/`.
 
 ## [Unreleased]
 
+### Changed — BREAKING, re-score required
+
+- **Evidence that declares nothing no longer scores full marks** (PROB-101,
+  PRD-086 FR-008/FR-009). An EvidencePack with no `verdict` and no
+  `congruence_level` scored the artifact it informs **1.00**. `CLAUDE.md`
+  RED LINE #7, the `/forge` skill that `setup-skill` installs, and
+  `EVIDENCE-PROTOCOL.md` all state the opposite — CL0, score 0.1 — so the
+  binary and every document describing it disagreed, in the direction that
+  inflates trust.
+
+  The incentive was backwards too: writing `congruence_level: 2` honestly
+  scored 0.9, writing nothing scored 1.0. An unrecognised `verdict` fell
+  through to `Supports` for the same reason, while `congruence_level` in the
+  same function already failed closed with a warning.
+
+  Both now fail closed to CL0 and log why. **Run `forgeplan score --all`
+  after upgrading.** Packs missing either field drop from 1.0 to 0.1, and
+  artifacts whose weakest link was such a pack drop with them. In this
+  repository that is 3 of 167 packs (EVID-033/034/035, feeding PROB-014,
+  PROB-016 and RFC-004). Your workspace may differ, and the drop is the
+  correct reading — those scores were never earned.
+
+### Fixed
+
+- **A leaf EvidencePack scored zero** (#325). The scorer asked a pack for its
+  evidence, found none — a pack has no packs — and returned 0.0 with the
+  factor `No evidence found (L0)`. A canonical pack (`verdict: supports`,
+  `congruence_level: 3`) was worth nothing, and the only way to raise it was
+  to invent child evidence.
+
+  The intrinsic score already existed: `score_evidence_full` is applied to
+  that same pack whenever it scores for something else. It is now applied to
+  the pack itself. Packs that do carry child evidence keep the normal
+  weakest-link path.
+
+- **Trust flowed backwards along `informs`** (#325, FR-002). A pack's
+  outgoing edges point at what it *supports*; treating them as dependencies
+  made a measurement's reliability depend on the decision it justifies. They
+  are excluded from the pack's own dependency walk.
+
+- **An exempt Note poisoned everything built on it** (#392, narrowed). The
+  routing table calls a Note the artifact for trivial reversible work — no
+  ADI, no evidence. The cascade then read an active unevidenced Note as zero
+  trust, so forgeplan said a Note needs no evidence and scored everything
+  downstream of it as unevidenced. `note` and `memory` are now skipped in the
+  dependency walk with a logged factor, exactly as ADR-002 skips non-active
+  dependencies.
+
+  The weakest-link formula is unchanged for every kind that *can* owe
+  evidence. The three fixes proposed in #392 — local-only scoring, one-hop
+  propagation, a floor at `self_score` — were each an average in disguise and
+  were declined; see the issue for the reasoning.
+
+- **`advance_phase` walked phases backwards** (#330). It had no monotonicity
+  guard, and MCP `forgeplan_validate` calls it with `Phase::Validate` on every
+  PASS — so validating an already-shipped artifact reset its phase from `done`
+  and `forgeplan_health` then reported a mismatch the artifact did not have
+  until someone checked it. Backward transitions are refused with an
+  explanation; `forgeplan phase-advance --to <earlier>` still works, because a
+  human correcting a mistake is not automation misfiring.
+
+- **The anomaly detector reported three things it never checked** (#393). It
+  printed `R_eff=0` from a literal rather than the stored score (now
+  `r_eff_cached`, named so, because the reporter's confusion came from
+  comparing it against a fresh `score` run); it labelled every give-up
+  `cycle or depth cap` in graphs with zero cycles (now names which of depth
+  cap, revisit, or exhausted actually happened); and its ancestor walk
+  followed edges the scorer skips, so the two disagreed about the weakest
+  link. The walk now applies the scorer's skip rules.
+
+- **`embed` loaded the model to discover it had nothing to do** (PROB-103).
+  8.22s on a fully-current 427-artifact workspace, spent reading a model that
+  was never used — the missing half of the PROB-093 incremental fix, which
+  removed the encoding work but left the setup for it. 0.25s now, and
+  `Loading embedding model...` prints only when a model is actually loading.
+  The progress line also counted every record instead of the ones being
+  encoded (`Embedding 1 of 427`, not `Embedding 427`).
+
+### Internal
+
+- ADR-025 (orchestration sits above ForgePlan; per-surface dispositions) and
+  ADR-026 (storage classes for machine-written records) resolve two vNext
+  audit blockers that required a human decision. EVID-169 records the basis.
+- PROB-102: `embedding_reference.rs` — the correctness oracle for the
+  embedding engine — runs zero tests in CI, because `cargo nextest run` passes
+  no features while `check` and `clippy` do. Recorded, not yet fixed.
+
+
 ## [0.36.0] - 2026-09-04
 
 Sprint headline: **Things that reported success while verifying nothing.** Every defect here behaved correctly — search returned plausible results, hints were runnable, the release built green — which is exactly what hid them.

--- a/crates/forgeplan-cli/src/commands/context.rs
+++ b/crates/forgeplan-cli/src/commands/context.rs
@@ -175,7 +175,17 @@ pub async fn run(id: &str, json: bool) -> anyhow::Result<()> {
             Hint::warning(format!("Fix {} MUST error(s)", must_errors))
                 .with_action(format!("forgeplan validate {}", ref_form)),
         );
-    } else if !has_evidence {
+    // PRD-086 FR-001. `has_evidence` counts LINKED child packs, which a leaf
+    // EvidencePack has none of by definition — it is the evidence. Since leaf
+    // packs began scoring on their own structured fields, this branch fired
+    // under an `R_eff: 1.00` printed a few lines above it, and its `Next:` told
+    // the agent to create an EvidencePack for an EvidencePack. That is a
+    // PRD-071 contract line an agent is obliged to run, so the cost is phantom
+    // artifacts in the graph, not just a confusing sentence.
+    //
+    // Guarding on the score keeps the advice true without teaching this
+    // function which kinds self-score.
+    } else if !has_evidence && report.r_eff <= 0.0 {
         hint_list.push(
             Hint::warning("No evidence linked")
                 .with_action(format!(
@@ -344,7 +354,8 @@ fn build_suggestions(
         ));
     }
 
-    if !has_evidence {
+    // PRD-086 FR-001 — see the hint above; same condition, same reason.
+    if !has_evidence && r_eff <= 0.0 {
         suggestions.push(format!(
             "Add evidence — `forgeplan new evidence \"Evidence for {}\"` + `forgeplan link EVID-XXX {} --relation informs`",
             id, id

--- a/crates/forgeplan-cli/src/commands/embed.rs
+++ b/crates/forgeplan-cli/src/commands/embed.rs
@@ -15,16 +15,6 @@ pub async fn run() -> anyhow::Result<()> {
         .map(|e| e.chunk_size)
         .unwrap_or(2000);
 
-    // Tell the user about a multi-gigabyte download BEFORE it starts, not
-    // after they notice the process sitting there. Silent when the model is
-    // already cached.
-    if let Some(notice) = forgeplan_core::embed::first_run_notice() {
-        ui::info(&notice);
-    }
-
-    ui::info("Loading embedding model...");
-    let mut embedder = Embedder::new()?;
-
     let records = store.list_records(None).await?;
     if records.is_empty() {
         ui::info("No artifacts to embed.");
@@ -36,22 +26,20 @@ pub async fn run() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    println!(
-        "Embedding {} artifact(s) (title + body, chunk_size={})...\n",
-        records.len(),
-        chunk_size
-    );
-
-    let mut ok = 0usize;
-    let mut err = 0usize;
+    // PROB-093: only encode what actually moved. A record is current when it
+    // already carries a vector AND its content hash still matches. Before
+    // that fix, `embed` recomputed all 400+ records to index one new artifact
+    // — 13m18s on this workspace, which is why the step people were supposed
+    // to run manually did not get run.
+    //
+    // Deciding this BEFORE the model loads is the other half, and it was
+    // missing: the incremental skip removed the encoding work but left the
+    // load unconditional, so a fully-current workspace still paid 8.22s to
+    // report "0 embedded, 427 already current". The model was read off disk
+    // and never used. Work first, model only if there is work.
+    let mut work: Vec<(&forgeplan_core::db::store::ArtifactRecord, String)> = Vec::new();
     let mut skipped = 0usize;
-
     for record in &records {
-        // PROB-093: only encode what actually moved. A record is current when
-        // it already carries a vector AND its content hash still matches.
-        // Before this, `embed` recomputed all 400+ records to index one new
-        // artifact — 13m18s on this workspace, which is why the step people
-        // were supposed to run manually did not get run.
         let current_hash =
             forgeplan_core::db::store::compute_content_hash(&record.title, &record.body);
         if record.embedding.is_some() && record.body_hash.as_deref() == Some(current_hash.as_str())
@@ -59,13 +47,47 @@ pub async fn run() -> anyhow::Result<()> {
             skipped += 1;
             continue;
         }
+        work.push((record, current_hash));
+    }
 
+    if work.is_empty() {
+        println!("Done: 0 embedded, {skipped} already current, 0 failed.");
+        let hint_list = vec![
+            Hint::info("Run a semantic search")
+                .with_action("forgeplan search \"<query>\"".to_string()),
+        ];
+        print!("{}", hints::render_next_action_line(&hint_list));
+        return Ok(());
+    }
+
+    // Tell the user about a multi-gigabyte download BEFORE it starts, not
+    // after they notice the process sitting there. Silent when the model is
+    // already cached — and now silent as well when nothing needs encoding,
+    // which is the common case.
+    if let Some(notice) = forgeplan_core::embed::first_run_notice() {
+        ui::info(&notice);
+    }
+
+    ui::info("Loading embedding model...");
+    let mut embedder = Embedder::new()?;
+
+    println!(
+        "Embedding {} of {} artifact(s) (title + body, chunk_size={})...\n",
+        work.len(),
+        records.len(),
+        chunk_size
+    );
+
+    let mut ok = 0usize;
+    let mut err = 0usize;
+
+    for (record, current_hash) in &work {
         let text = record.embedding_text(chunk_size);
         match embedder.embed(&text) {
             Ok(vec) => {
                 store.update_embedding(&record.id, &vec).await?;
                 store
-                    .update_body_hash(&record.id, &current_hash)
+                    .update_body_hash(&record.id, current_hash)
                     .await
                     // The vector is written; a failed hash stamp only costs a
                     // redundant re-encode next run, so it must not fail the

--- a/crates/forgeplan-cli/src/commands/phase_advance.rs
+++ b/crates/forgeplan-cli/src/commands/phase_advance.rs
@@ -75,7 +75,16 @@ pub async fn run(id: &str, to: PhaseArg, reason: Option<&str>, json: bool) -> an
 
     let target: Phase = to.into();
     let state =
-        phase::store::advance_phase(&ws, &canonical, target, reason.map(|s| s.to_string())).await?;
+        // #330 — the explicit operator path may move a phase in either
+        // direction; the guard belongs on automation, not on a deliberate
+        // command someone typed.
+        phase::store::advance_phase_unchecked(
+            &ws,
+            &canonical,
+            target,
+            reason.map(|s| s.to_string()),
+        )
+        .await?;
 
     // PRD-071 contract: produce a single Next: action — the next suggested phase
     // advance. No suggestion when at terminal phase (Done.).

--- a/crates/forgeplan-cli/src/commands/score.rs
+++ b/crates/forgeplan-cli/src/commands/score.rs
@@ -308,7 +308,29 @@ pub async fn run(id: Option<&str>, json: bool) -> anyhow::Result<()> {
     // --- Styled display ---
     ui::header(&target.id, &target.title);
 
-    if evidence_items.is_empty() {
+    // PRD-086 FR-001. "No evidence linked" is now only half a story for an
+    // EvidencePack: it has no child evidence and it is not supposed to, because
+    // it IS the evidence. The engine already scores it on its own fields — this
+    // branch was announcing `R_eff = 0.0` over a report that said 1.00, which is
+    // the same defect class the PRD exists to close, committed by the printer
+    // rather than the scorer. Caught by dogfooding on the real graph; the unit
+    // and integration tests both passed because neither reads this line.
+    let is_evidence = target.kind.eq_ignore_ascii_case("evidence");
+    if evidence_items.is_empty() && is_evidence {
+        ui::info(&format!(
+            "Leaf evidence — scored on its own structured fields. R_eff = {:.2}",
+            report.r_eff
+        ));
+        if report.r_eff <= 0.1 {
+            println!();
+            ui::error_hint(
+                "Structured fields missing or undeclared",
+                &format!(
+                    "forgeplan get {target_ref} — add `verdict:` and `congruence_level:` under `## Structured Fields`"
+                ),
+            );
+        }
+    } else if evidence_items.is_empty() {
         ui::info("No evidence linked. R_eff = 0.0");
         println!();
         ui::error_hint(

--- a/crates/forgeplan-cli/tests/cli_embed_lazy_model.rs
+++ b/crates/forgeplan-cli/tests/cli_embed_lazy_model.rs
@@ -1,0 +1,81 @@
+//! `embed` must not load the model when there is nothing to encode — PROB-103.
+//!
+//! The defect was reported by a user reading the output, because no gate runs
+//! `embed` at all (PROB-102). These tests are the gate that was missing.
+//!
+//! They are gated on `semantic-search` for the same reason the command is, and
+//! CI's `cargo nextest run` currently passes no features — so they compile in
+//! CI and execute only locally until PROB-102 is closed. That is stated here
+//! rather than left for the next reader to discover from a green `0 passed`.
+
+#![cfg(feature = "semantic-search")]
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn fpl(ws: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("forgeplan").unwrap();
+    cmd.current_dir(ws.path());
+    cmd
+}
+
+fn init(ws: &TempDir) {
+    fpl(ws).args(["init", "-y"]).output().expect("init");
+}
+
+/// An empty workspace has nothing to encode, so the model must stay on disk.
+///
+/// Note what this does and does not prove. It passes with the PROB-103 fix
+/// reverted, because an empty workspace is caught by an older early return
+/// (`No artifacts to embed.`) that predates it — verified by mutation. It is a
+/// regression guard for that path, not evidence for this one. The test below
+/// is the one that fails without the fix.
+#[test]
+fn no_artifacts_means_no_model_load() {
+    let ws = TempDir::new().unwrap();
+    init(&ws);
+
+    let out = fpl(&ws).arg("embed").output().expect("embed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("Loading embedding model"),
+        "an empty workspace must not load the model, got:\n{stdout}"
+    );
+}
+
+/// The case the user actually hit: everything already embedded, and `embed`
+/// run again. Before the fix this cost 8.22s on a 427-artifact workspace and
+/// printed the loading banner every time.
+#[test]
+fn a_current_workspace_does_not_reload_the_model() {
+    let ws = TempDir::new().unwrap();
+    init(&ws);
+    fpl(&ws)
+        .args(["new", "note", "Something to index"])
+        .output()
+        .expect("new");
+
+    // First run does the work — the banner is expected here.
+    let first = fpl(&ws).arg("embed").output().expect("embed");
+    let first_out = String::from_utf8_lossy(&first.stdout);
+    assert!(
+        first_out.contains("Loading embedding model"),
+        "a workspace with unembedded artifacts must load the model, got:\n{first_out}"
+    );
+
+    // Second run has nothing left to do.
+    let second = fpl(&ws).arg("embed").output().expect("embed");
+    let second_out = String::from_utf8_lossy(&second.stdout);
+    assert!(
+        !second_out.contains("Loading embedding model"),
+        "nothing changed, so the model must not be loaded again, got:\n{second_out}"
+    );
+    assert!(
+        second_out.contains("0 embedded"),
+        "the summary must still report the outcome, got:\n{second_out}"
+    );
+    assert!(
+        second_out.contains("already current"),
+        "the skipped count must still be reported, got:\n{second_out}"
+    );
+}

--- a/crates/forgeplan-core/src/anomalies.rs
+++ b/crates/forgeplan-core/src/anomalies.rs
@@ -782,6 +782,15 @@ pub async fn detect_anomalies(
         // #393 bug 2: every give-up was reported as "cycle or depth cap", in a
         // graph with zero cycles — 133 anomalies sending maintainers to hunt
         // for something that was not there. Record which actually happened.
+        //
+        // `hit_revisit` deliberately does NOT claim a cycle. The push guard
+        // checks `visited`, not frontier membership, so one node can be queued
+        // twice on a perfectly acyclic graph: C has parents [D, E] and E also
+        // points at D. Calling that "the chain loops" would repeat the very
+        // mistake this hunk fixes, narrowed instead of removed. The wording
+        // below states what was observed — the same artifact reached more than
+        // once — and leaves the cause to the reader, who can run
+        // `forgeplan blocked` to see whether real cycles exist.
         let mut hit_depth_cap = false;
         let mut hit_revisit = false;
         while let Some((node, depth)) = frontier.pop() {
@@ -800,6 +809,18 @@ pub async fn detect_anomalies(
             // — but check parents to ensure it's not just transitively
             // inheriting from a deeper artifact.
             let node_r_eff = r_eff_by_id.get(node).copied().unwrap_or(0.0);
+            // PRD-086 FR-006, second half. Filtering only at pop time was not
+            // enough: the acceptance test below asks whether every parent has
+            // been visited, and a skipped parent never gets visited — it is
+            // dropped when popped. So a node that IS the weakest link but sits
+            // behind a note failed the test, was never named, and the walk
+            // reported "the cause is local" while `forgeplan score` resolved
+            // the same chain and named the artifact. Two walks disagreeing
+            // again, which is the defect FR-006 exists to close.
+            //
+            // Applying the skip at collection time makes a skipped parent
+            // invisible to both the acceptance test and the frontier, which is
+            // exactly what "the scorer does not walk through this edge" means.
             let parents: Vec<&str> = outgoing
                 .get(node)
                 .map(|edges| {
@@ -807,6 +828,7 @@ pub async fn detect_anomalies(
                         .iter()
                         .filter(|(_, rel)| matches!(*rel, "based_on" | "informs"))
                         .map(|(t, _)| *t)
+                        .filter(|t| !skip_as_dependency.contains(t))
                         .collect()
                 })
                 .unwrap_or_default();
@@ -854,7 +876,8 @@ pub async fn detect_anomalies(
                             "walk stopped at the depth cap ({WEAKEST_LINK_MAX_DEPTH} hops)"
                         ),
                         (false, true) => {
-                            "walk revisited an artifact it had already seen — the chain loops"
+                            "walk reached the same artifact by more than one path; \
+                             run `forgeplan blocked` to check for real cycles"
                                 .to_string()
                         }
                         (false, false) => {

--- a/crates/forgeplan-core/src/anomalies.rs
+++ b/crates/forgeplan-core/src/anomalies.rs
@@ -727,6 +727,20 @@ pub async fn detect_anomalies(
         .iter()
         .map(|r| (r.id.as_str(), r.r_eff_score))
         .collect();
+    // PRD-086 FR-006 (#393). The walk below used to follow every `based_on` /
+    // `informs` edge, while `r_eff_recursive` skips non-active dependencies
+    // (ADR-002) and, since PRD-086 FR-003, ceremony-free kinds. Two walks with
+    // different rules disagree about which ancestor is the weakest link — the
+    // reporter saw the scorer resolve `NOTE-003` while the detector gave up on
+    // the same artifact. Same rules, same answer.
+    let skip_as_dependency: HashSet<&str> = all_records
+        .iter()
+        .filter(|r| {
+            matches!(r.status.as_str(), "draft" | "deprecated" | "superseded")
+                || matches!(r.kind.as_str(), "note" | "memory")
+        })
+        .map(|r| r.id.as_str())
+        .collect();
     const WEAKEST_LINK_MAX_DEPTH: usize = 16;
     for r in &all_records {
         // weakest_link_unresolvable diagnoses DECISION artifacts whose evidence
@@ -765,11 +779,21 @@ pub async fn detect_anomalies(
             initial_parents.iter().map(|p| (*p, 1usize)).collect();
         let mut weakest_link: Option<&str> = None;
         let mut chain_depth: usize = 0;
+        // #393 bug 2: every give-up was reported as "cycle or depth cap", in a
+        // graph with zero cycles — 133 anomalies sending maintainers to hunt
+        // for something that was not there. Record which actually happened.
+        let mut hit_depth_cap = false;
+        let mut hit_revisit = false;
         while let Some((node, depth)) = frontier.pop() {
             if !visited.insert(node) {
+                hit_revisit = true;
                 continue;
             }
             if depth > WEAKEST_LINK_MAX_DEPTH {
+                hit_depth_cap = true;
+                continue;
+            }
+            if skip_as_dependency.contains(node) {
                 continue;
             }
             // If this node's r_eff is 0, it's a candidate weakest link
@@ -821,18 +845,42 @@ pub async fn detect_anomalies(
             observed_at: now_str.clone(),
             description: match (&weakest_link_owned, chain_depth) {
                 (Some(wl), d) => format!(
-                    "{}: active with R_eff=0; weakest link in chain = {wl} (depth {d})",
-                    r.id
+                    "{}: active with cached R_eff={:.2}; weakest link in chain = {wl} (depth {d})",
+                    r.id, r.r_eff_score
                 ),
-                (None, _) => format!(
-                    "{}: active with R_eff=0; ancestor walk could not identify source (cycle or depth cap)",
-                    r.id
-                ),
+                (None, _) => {
+                    let why = match (hit_depth_cap, hit_revisit) {
+                        (true, _) => format!(
+                            "walk stopped at the depth cap ({WEAKEST_LINK_MAX_DEPTH} hops)"
+                        ),
+                        (false, true) => {
+                            "walk revisited an artifact it had already seen — the chain loops"
+                                .to_string()
+                        }
+                        (false, false) => {
+                            "every ancestor is skipped or scores above zero — the cause is local"
+                                .to_string()
+                        }
+                    };
+                    format!(
+                        "{}: active with cached R_eff={:.2}; no weakest link named — {why}",
+                        r.id, r.r_eff_score
+                    )
+                }
             },
+            // #393 bug 1: this was the literal `0.0`. The filter above only
+            // admits artifacts whose cached score is zero, so the literal was
+            // accidentally true — and would have started lying the moment the
+            // filter changed. It is also named `r_eff_cached` now, because the
+            // reporter's confusion came from comparing it against a fresh
+            // `forgeplan_score` run: the detector reads the stored column, and
+            // a stale column is a different number, not a wrong one.
             evidence: serde_json::json!({
-                "r_eff": 0.0,
+                "r_eff_cached": r.r_eff_score,
                 "weakest_link": weakest_link_owned,
                 "chain_depth": chain_depth,
+                "walk_hit_depth_cap": hit_depth_cap,
+                "walk_hit_revisit": hit_revisit,
             }),
             suggested_resolution: Some(SuggestedResolution {
                 tier: Tier::Adi,

--- a/crates/forgeplan-core/src/hints.rs
+++ b/crates/forgeplan-core/src/hints.rs
@@ -135,7 +135,20 @@ pub fn score_hints(
 ) -> Vec<Hint> {
     let mut hints = Vec::new();
 
-    if !has_evidence {
+    // PRD-086 FR-001. This warning states a number, and after leaf EvidencePacks
+    // began scoring on their own structured fields it started stating a false
+    // one: `forgeplan score` on a canonical pack printed "R_eff = 1.00" and then
+    // this line underneath, claiming the score "will be 0.0".
+    //
+    // Same defect class as the display branch in `score.rs` — an assertion keyed
+    // on a condition ("nothing linked") that used to have exactly one cause and
+    // now has two. The display was fixed; this was missed because no test reads
+    // the hint text. Found by running the binary, not by the suite.
+    //
+    // Guarding on the score rather than on the artifact kind keeps the hint
+    // honest for every future case where a nonzero score arrives without linked
+    // children, without this function needing to know what kinds exist.
+    if !has_evidence && r_eff <= 0.0 {
         hints.push(
             Hint::warning("No evidence linked — R_eff will be 0.0")
                 .with_action(format!(
@@ -403,6 +416,35 @@ mod tests {
             action
         );
         assert!(!action.contains("<artifact>"));
+    }
+
+    #[test]
+    fn score_hints_does_not_promise_zero_for_a_self_scoring_leaf() {
+        // PRD-086 FR-001. A leaf EvidencePack has no linked children by
+        // definition and now scores on its own structured fields, so
+        // `has_evidence: false` no longer implies a zero. The warning states a
+        // specific number, and stating it here would contradict the score
+        // printed two lines above it in `forgeplan score`.
+        let hints = score_hints("EVID-001", 1.0, false, 0);
+        assert!(
+            !hints
+                .iter()
+                .any(|h| h.message.contains("R_eff will be 0.0")),
+            "a nonzero score must not carry a warning promising 0.0: {hints:?}"
+        );
+    }
+
+    #[test]
+    fn score_hints_still_warns_when_the_score_really_is_zero() {
+        // The guard must not silence the case the warning exists for: an
+        // ordinary artifact with nothing linked.
+        let hints = score_hints("PRD-001", 0.0, false, 0);
+        assert!(
+            hints
+                .iter()
+                .any(|h| h.message.contains("R_eff will be 0.0")),
+            "an unevidenced artifact at zero must still be warned: {hints:?}"
+        );
     }
 
     #[test]

--- a/crates/forgeplan-core/src/phase/mod.rs
+++ b/crates/forgeplan-core/src/phase/mod.rs
@@ -108,6 +108,26 @@ pub enum Phase {
 }
 
 impl Phase {
+    /// Position in the canonical ladder, for monotonicity checks (#330).
+    ///
+    /// `Unknown` sits below everything: an artifact whose phase was never
+    /// tracked may advance to any real phase. Every other pair compares by
+    /// ladder position, so "is this a step backwards" has one answer rather
+    /// than one per call site.
+    pub fn rank(self) -> u8 {
+        match self {
+            Phase::Unknown => 0,
+            Phase::Shape => 1,
+            Phase::Validate => 2,
+            Phase::Adi => 3,
+            Phase::Code => 4,
+            Phase::Test => 5,
+            Phase::Audit => 6,
+            Phase::Evidence => 7,
+            Phase::Done => 8,
+        }
+    }
+
     /// Canonical string name (snake_case, matches serde output).
     pub fn as_str(self) -> &'static str {
         match self {

--- a/crates/forgeplan-core/src/phase/store.rs
+++ b/crates/forgeplan-core/src/phase/store.rs
@@ -282,6 +282,31 @@ pub async fn advance_phase(
     to: Phase,
     reason: Option<String>,
 ) -> anyhow::Result<PhaseState> {
+    advance_phase_inner(workspace, artifact_id, to, reason, false).await
+}
+
+/// Move the phase anywhere, including backwards — for deliberate correction.
+///
+/// #330. The checked [`advance_phase`] refuses a step down the ladder, because
+/// its own name promises it will not take one. An operator running
+/// `forgeplan phase-advance --to shape` on an artifact that reached `done` is
+/// making a decision, not tripping over automation, and that path stays open.
+pub async fn advance_phase_unchecked(
+    workspace: &Path,
+    artifact_id: &str,
+    to: Phase,
+    reason: Option<String>,
+) -> anyhow::Result<PhaseState> {
+    advance_phase_inner(workspace, artifact_id, to, reason, true).await
+}
+
+async fn advance_phase_inner(
+    workspace: &Path,
+    artifact_id: &str,
+    to: Phase,
+    reason: Option<String>,
+    allow_regression: bool,
+) -> anyhow::Result<PhaseState> {
     validate_artifact_id(artifact_id)?;
 
     // Track whether state existed on disk — if no, we synthesized the
@@ -295,6 +320,27 @@ pub async fn advance_phase(
     };
 
     let from = state.current_phase;
+
+    // #330. There was no monotonicity guard at all, and MCP `forgeplan_validate`
+    // calls this with `Phase::Validate` on every PASS — so validating an
+    // artifact that had already reached `done` walked it back to `validate`,
+    // and `forgeplan_health` then reported a phase mismatch the artifact did
+    // not have until someone checked it. A function named `advance` that
+    // silently reverses is the same defect class as a gate that reports a
+    // result it never computed.
+    //
+    // Refusing leaves state untouched and tells the caller why; the auto-advance
+    // path in MCP treats phase tracking as advisory and logs the refusal without
+    // failing the tool call.
+    if !allow_regression && to.rank() < from.rank() {
+        anyhow::bail!(
+            "Phase for {artifact_id} is already `{}`; refusing to move back to `{}`\nFix: forgeplan phase-advance {artifact_id} --to {}",
+            from.as_str(),
+            to.as_str(),
+            to.as_str()
+        );
+    }
+
     // Skip recording a no-op transition (e.g. double-call of auto-advance).
     if from == to {
         if was_missing {
@@ -527,6 +573,73 @@ mod tests {
         assert_eq!(still, "sensitive");
     }
 
+    /// #330. MCP `forgeplan_validate` auto-advances to `Validate` on every
+    /// PASS. Run against an artifact that already reached `done`, that walked
+    /// the phase backwards and made `forgeplan_health` report a mismatch the
+    /// artifact did not have until someone validated it.
+    #[tokio::test]
+    async fn validation_of_a_finished_artifact_does_not_walk_the_phase_back() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-MONO", None).await.unwrap();
+        advance_phase_unchecked(&ws, "PRD-MONO", Phase::Done, None)
+            .await
+            .unwrap();
+
+        let err = advance_phase(&ws, "PRD-MONO", Phase::Validate, Some("auto".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to move back"),
+            "the refusal must say what it refused, got: {err}"
+        );
+
+        let after = read_phase(&ws, "PRD-MONO").await.unwrap().unwrap();
+        assert_eq!(
+            after.current_phase,
+            Phase::Done,
+            "a refused transition must leave state untouched"
+        );
+    }
+
+    /// Forward motion and re-stating the current phase both stay legal — the
+    /// guard must not turn into a tripwire on the normal path.
+    #[tokio::test]
+    async fn forward_and_no_op_transitions_are_unaffected() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-FWD", None).await.unwrap();
+
+        advance_phase(&ws, "PRD-FWD", Phase::Code, None)
+            .await
+            .expect("forward jump is allowed");
+        advance_phase(&ws, "PRD-FWD", Phase::Code, None)
+            .await
+            .expect("re-stating the current phase is a no-op, not a regression");
+
+        let s = read_phase(&ws, "PRD-FWD").await.unwrap().unwrap();
+        assert_eq!(s.current_phase, Phase::Code);
+    }
+
+    /// The deliberate operator path keeps both directions — that is the whole
+    /// reason the guard lives on `advance_phase` and not inside `write_phase`.
+    #[tokio::test]
+    async fn the_explicit_path_may_still_correct_a_phase_downward() {
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-FIX", None).await.unwrap();
+        advance_phase_unchecked(&ws, "PRD-FIX", Phase::Done, None)
+            .await
+            .unwrap();
+
+        advance_phase_unchecked(&ws, "PRD-FIX", Phase::Shape, Some("mis-marked".into()))
+            .await
+            .expect("an operator correcting a mistake is not a regression");
+
+        let s = read_phase(&ws, "PRD-FIX").await.unwrap().unwrap();
+        assert_eq!(s.current_phase, Phase::Shape);
+    }
+
     #[tokio::test]
     async fn history_is_capped_fifo() {
         // Audit Round 1 H1: runaway loop must not balloon history.
@@ -537,7 +650,12 @@ mod tests {
 
         for i in 0..(MAX_HISTORY_ENTRIES + 100) {
             let p = if i % 2 == 0 { Phase::Code } else { Phase::Test };
-            advance_phase(&ws, "PRD-CAP", p, None).await.unwrap();
+            // #330: this oscillates on purpose to exercise the FIFO cap, which
+            // is a different question from whether automation may reverse a
+            // phase. The unchecked entry point is the honest one here.
+            advance_phase_unchecked(&ws, "PRD-CAP", p, None)
+                .await
+                .unwrap();
         }
         let s = read_phase(&ws, "PRD-CAP").await.unwrap().unwrap();
         assert!(

--- a/crates/forgeplan-core/src/phase/store.rs
+++ b/crates/forgeplan-core/src/phase/store.rs
@@ -727,7 +727,13 @@ mod tests {
             let ws = ws.clone();
             let phase = if i % 2 == 0 { Phase::Code } else { Phase::Test };
             tasks.push(tokio::spawn(async move {
-                advance_phase(&ws, "PRD-CC", phase, Some(format!("concurrent-{i}"))).await
+                // #330: the question here is tmp-filename collision under
+                // concurrent writes, not whether a phase may move backwards.
+                // The oscillation between Code and Test is just a way to make
+                // every task write; with the monotonicity guard in place the
+                // losers of that race are refused, which would turn a
+                // write-safety test into an ordering test by accident.
+                advance_phase_unchecked(&ws, "PRD-CC", phase, Some(format!("concurrent-{i}"))).await
             }));
         }
         let results = join_all(tasks).await;
@@ -737,6 +743,34 @@ mod tests {
         // State exists and is one of the expected phases.
         let s = read_phase(&ws, "PRD-CC").await.unwrap().unwrap();
         assert!(matches!(s.current_phase, Phase::Code | Phase::Test));
+    }
+
+    /// #330, the half the rewrite above would otherwise have dropped: under
+    /// concurrency the CHECKED entry point must refuse cleanly rather than
+    /// corrupt state or panic. Sixteen tasks all advancing forward to the same
+    /// phase — every one is either a real transition or a no-op, none is a
+    /// regression, so all must succeed and the state must land exactly there.
+    #[tokio::test]
+    async fn concurrent_checked_advances_are_safe() {
+        use futures::future::join_all;
+        let tmp = TempDir::new().unwrap();
+        let ws = ws(&tmp);
+        initialize_phase(&ws, "PRD-CCC", None).await.unwrap();
+
+        let mut tasks = Vec::new();
+        for i in 0..16 {
+            let ws = ws.clone();
+            tasks.push(tokio::spawn(async move {
+                advance_phase(&ws, "PRD-CCC", Phase::Code, Some(format!("fwd-{i}"))).await
+            }));
+        }
+        for r in join_all(tasks).await {
+            r.expect("task panicked")
+                .expect("a forward transition must never be refused");
+        }
+
+        let s = read_phase(&ws, "PRD-CCC").await.unwrap().unwrap();
+        assert_eq!(s.current_phase, Phase::Code);
     }
 
     #[tokio::test]

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -2371,7 +2371,10 @@ mod tests {
             );
         }
 
-        assert!(out.contains("new prose"), "the new prose must be what lands");
+        assert!(
+            out.contains("new prose"),
+            "the new prose must be what lands"
+        );
         assert!(!out.contains("old prose"), "old prose must not resurrect");
     }
 

--- a/crates/forgeplan-core/src/projection/mod.rs
+++ b/crates/forgeplan-core/src/projection/mod.rs
@@ -951,33 +951,56 @@ pub async fn update_metadata_with_projection(
     Ok(())
 }
 
-/// ADR-012 / SPEC-005 identity fields.
+/// Re-attach body-frontmatter fields from `old_body` that `new_body` does not
+/// carry and that the projection does not regenerate.
 ///
-/// Under the PRD-073 two-block layout these live in the **body's** own
-/// frontmatter, which makes them collateral damage of any body replacement —
-/// see [`carry_identity_forward`].
-const IDENTITY_FM_KEYS: &[&str] = &["slug", "predicted_number", "assigned_number"];
-
-/// Re-attach the ADR-012 identity fields from `old_body` when `new_body` does
-/// not carry them.
-///
-/// The identity triple lives inside the body's frontmatter block (PRD-073
-/// layout: synthetic projection block on top, canonical body below). A body
-/// replacement is therefore an *identity deletion* unless the fields are
+/// The body has its own frontmatter block (PRD-073 layout: synthetic
+/// projection block on top, canonical body below). A body replacement is
+/// therefore a *field deletion* for everything in that block unless it is
 /// carried across — which is why a mature workspace ends up with no artifact
 /// carrying a slug at all: `forgeplan new` writes one, and the very next
 /// `update --body` that CLAUDE.md prescribes silently drops it.
 ///
-/// Callers supply prose. Re-attaching here keeps every call site from having to
-/// remember, and is a no-op when the caller *did* supply identity (round-trip of
-/// a full document) or when the artifact never had one (legacy, pre-Phase-1.5).
+/// ## Why the rule is `KNOWN_FM_KEYS`, not a hand-listed triple
+///
+/// This carried exactly `["slug", "predicted_number", "assigned_number"]` —
+/// the three fields whose loss someone noticed. The argument that justified
+/// carrying those three applies verbatim to every other field in the block,
+/// so the list was a fix for three instances of a class, and everything
+/// outside it kept being deleted in silence.
+///
+/// Measured on a real workspace: a no-op round-trip of RFC-022 (read the body
+/// back with `forgeplan get --json`, hand it straight to `update --body`
+/// unchanged) dropped eight lines. Five of them — `author`, `depth`, `id`,
+/// `status`, `title` — are in [`KNOWN_FM_KEYS`] and are legitimately
+/// regenerated into the projection block above, so their in-body copies are
+/// redundant. Three were pure loss: `created`, `updated`, `prd`.
+///
+/// So the rule is the one the neighbouring [`filter_preserved`] already
+/// applies to the projection block's own unknown keys (PRD-057 FR-009):
+/// **anything the record does not own survives**. Deriving it from
+/// `KNOWN_FM_KEYS` rather than from a second authored list means a field
+/// added to the record is automatically excluded, and a field added to the
+/// body is automatically preserved — neither needs anyone to remember this
+/// function exists. Carrying a `KNOWN_FM_KEYS` field would be worse than
+/// dropping it: `update_body_with_projection` parses `status` back out of the
+/// new body to sync LanceDB, so a stale in-body copy could resurrect a
+/// superseded status.
+///
+/// Consequence, stated rather than discovered later: a caller cannot delete a
+/// body-frontmatter field by omitting it. That is deliberate — silent data
+/// loss is the failure this function exists to prevent, and it is the more
+/// expensive of the two. Removing a field means writing the block without it
+/// AND having the record not own it; for the record-owned ones there are
+/// dedicated mutators (`update --status`, `--title`, `--depth`).
 fn carry_identity_forward(old_body: &str, new_body: &str) -> String {
     let Ok((old_fm, _)) = frontmatter::parse_frontmatter(old_body) else {
         return new_body.to_string();
     };
-    let carried: Vec<(&str, serde_yaml::Value)> = IDENTITY_FM_KEYS
+    let carried: Vec<(&str, serde_yaml::Value)> = old_fm
         .iter()
-        .filter_map(|k| old_fm.get(*k).map(|v| (*k, v.clone())))
+        .filter(|(k, _)| !KNOWN_FM_KEYS.contains(&k.as_str()))
+        .map(|(k, v)| (k.as_str(), v.clone()))
         .collect();
     if carried.is_empty() {
         return new_body.to_string();
@@ -1043,9 +1066,11 @@ pub async fn update_body_with_projection(
     };
     let links = store.get_relations(id).await.unwrap_or_default();
 
-    // PROB-060 / ADR-012: preserve the identity triple the replacement would
-    // otherwise delete. Must happen before `derived_status` is parsed and
-    // before either write, so file and index agree on one body.
+    // PROB-060 / ADR-012: preserve the body-frontmatter fields the replacement
+    // would otherwise delete — every field the record does not own, not just
+    // the identity triple this originally carried. Must happen before
+    // `derived_status` is parsed and before either write, so file and index
+    // agree on one body.
     let carried = carry_identity_forward(&record.body, body);
     let body: &str = &carried;
 
@@ -2288,6 +2313,66 @@ mod tests {
         // A body with no frontmatter at all must not panic or corrupt.
         let new = "## Problem\n\nplain\n";
         assert_eq!(carry_identity_forward("no frontmatter here\n", new), new);
+    }
+
+    /// The identity triple was three instances of a class, and the rest of the
+    /// class kept being deleted in silence.
+    ///
+    /// Measured on a real workspace before this was fixed: reading RFC-022's
+    /// body back and handing it to `update --body` UNCHANGED — a no-op — cost
+    /// eight frontmatter lines. Five (`author`, `depth`, `id`, `status`,
+    /// `title`) are in `KNOWN_FM_KEYS` and are regenerated into the projection
+    /// block above, so losing the in-body copy is correct. Three were pure
+    /// loss, and this pins them.
+    #[test]
+    fn carry_identity_forward_keeps_every_field_the_record_does_not_own() {
+        // The second block of a generated artifact, as `forgeplan new` writes
+        // it. `created`/`updated`/`prd` exist ONLY here — no projection field
+        // regenerates them.
+        let old = "---\nassigned_number: 22\nauthor: null\ncreated: 2026-09-03\n\
+                   depth: standard\nid: RFC-022\nprd: null\npredicted_number: 22\n\
+                   slug: rfc-production-program\nstatus: Draft\ntitle: 'Production program'\n\
+                   updated: 2026-09-03\n---\n\n## Summary\n\nold prose\n";
+
+        let out = carry_identity_forward(old, "## Summary\n\nnew prose\n");
+
+        // Population before the claim: the call produced frontmatter at all.
+        // Without this a `!out.contains(...)` pair below would hold for an
+        // empty string.
+        assert!(
+            out.starts_with("---\n"),
+            "expected a frontmatter block, got:\n{out}"
+        );
+
+        for expected in [
+            "created: 2026-09-03",
+            "updated: 2026-09-03",
+            "prd: null",
+            "slug: rfc-production-program",
+            "predicted_number: 22",
+            "assigned_number: 22",
+        ] {
+            assert!(
+                out.contains(expected),
+                "`{expected}` was dropped — it is not a record-owned field:\n{out}"
+            );
+        }
+
+        // The other direction, and it is the half that keeps this from being
+        // "carry everything": a record-owned field must NOT be carried. Its
+        // authoritative copy is regenerated into the projection block, and
+        // `update_body_with_projection` parses `status` back out of the new
+        // body to sync LanceDB — a stale in-body copy could resurrect a
+        // superseded status.
+        for owned in ["status:", "title:", "depth:", "id:", "author:"] {
+            assert!(
+                !out.contains(owned),
+                "`{owned}` is in KNOWN_FM_KEYS and must not be carried:\n{out}"
+            );
+        }
+
+        assert!(out.contains("new prose"), "the new prose must be what lands");
+        assert!(!out.contains("old prose"), "old prose must not resurrect");
     }
 
     // ── #419 BLOCKER: same-slug title change must not delete the file ────

--- a/crates/forgeplan-core/src/scoring/evidence.rs
+++ b/crates/forgeplan-core/src/scoring/evidence.rs
@@ -55,14 +55,34 @@ impl SourceTier {
 /// PRD-035 Sprint 13.3 security audit H2 (a malicious contributor cannot
 /// inflate `R_eff` by tagging weak evidence as `source_tier: t1`).
 pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
-    let verdict = extract_field(&record.body, "verdict")
-        .map(|s| match s.to_lowercase().as_str() {
-            "supports" => Verdict::Supports,
-            "weakens" => Verdict::Weakens,
-            "refutes" => Verdict::Refutes,
-            _ => Verdict::Supports,
-        })
-        .unwrap_or(Verdict::Supports);
+    // PRD-086 FR-008. Both branches used to resolve to `Supports`, which scores
+    // 1.0 — an unreadable verdict and an absent one were rewarded with maximum
+    // trust, while `congruence_level` twenty lines below fails closed to CL0
+    // with a warning for exactly the same input classes. One field punished
+    // garbage and its neighbour paid for it.
+    //
+    // Protocol v1 adds a fourth value (`verdict: unknown`) that the old parser
+    // would have scored 1.0 on arrival.
+    //
+    // Fail closed via CL0, which is exactly the outcome the docs already
+    // promise (`Supports` 1.0 minus the CL0 penalty 0.9 = 0.1). `Refutes` would
+    // be the wrong landing — it means "this evidence argues against the claim",
+    // a statement nobody made. Undeclared is not opposed; it is unsupported.
+    let verdict_raw = extract_field(&record.body, "verdict");
+    let verdict_declared = match verdict_raw.as_deref().map(str::to_lowercase).as_deref() {
+        Some("supports") => Some(Verdict::Supports),
+        Some("weakens") => Some(Verdict::Weakens),
+        Some("refutes") => Some(Verdict::Refutes),
+        Some(other) => {
+            eprintln!(
+                "warn: evidence {} has unrecognised verdict='{}' — treated as undeclared (score 0.1) to prevent silent trust inflation",
+                record.id, other
+            );
+            None
+        }
+        None => None,
+    };
+    let verdict = verdict_declared.clone().unwrap_or(Verdict::Supports);
 
     let tier_cl = extract_field(&record.body, "source_tier")
         .and_then(|s| SourceTier::parse(&s))
@@ -114,11 +134,41 @@ pub fn parse_evidence_from_record(record: &ArtifactRecord) -> EvidenceItem {
     // Precedence: take MIN of (tier_cl, explicit_cl). Explicit operator
     // downgrade can never be silently overridden by an automatic tier mapping.
     // Default CL=3 (same context) — evidence created locally is same-context by default.
-    let cl = match (tier_cl, explicit_cl) {
-        (Some(t), Some(e)) => t.min(e),
-        (Some(t), None) => t,
-        (None, Some(e)) => e,
-        (None, None) => 3,
+    // PRD-086 FR-009. `(None, None)` used to mean CL3 — maximum trust for a
+    // pack that declared nothing at all. Three documents state the opposite in
+    // the same words: CLAUDE.md RED LINE #7, the `/forge` skill that
+    // `setup-skill` ships to every user, and EVIDENCE-PROTOCOL.md all say
+    // absent fields mean CL0 and a score of 0.1. Measured before this change:
+    // a body of pure prose scored its target 1.00 "Adequate".
+    //
+    // The rationale for the old default was that locally-authored evidence is
+    // same-context by construction. True, and beside the point — congruence is
+    // not the only thing a missing field withholds. A pack that says nothing
+    // has made no claim to be congruent WITH.
+    //
+    // The incentive was also backwards: writing `congruence_level: 2` honestly
+    // scored 0.9, writing nothing scored 1.0. Skipping the discipline paid
+    // better than following it.
+    //
+    // Verdict participates in the same gate. A pack with `congruence_level: 3`
+    // and no verdict still made no claim about direction, and the old code
+    // defaulted that to `Supports`.
+    let claim_declared = verdict_declared.is_some() && (tier_cl.is_some() || explicit_cl.is_some());
+    let cl = if !claim_declared {
+        if verdict_raw.is_none() && explicit_cl_raw.is_none() && tier_cl.is_none() {
+            eprintln!(
+                "warn: evidence {} declares no structured fields — scored CL0 (0.1). Add `verdict:` and `congruence_level:` under `## Structured Fields`",
+                record.id
+            );
+        }
+        0
+    } else {
+        match (tier_cl, explicit_cl) {
+            (Some(t), Some(e)) => t.min(e),
+            (Some(t), None) => t,
+            (None, Some(e)) => e,
+            (None, None) => unreachable!("claim_declared guarantees one CL source"),
+        }
     };
 
     let valid_until = record.valid_until.as_deref().and_then(|s| {
@@ -474,21 +524,21 @@ congruence_level: 3
 
     #[test]
     fn evidence_body_with_source_tier_maps_to_cl() {
-        let body = "source_tier: t2\nevidence_type: test\n";
+        let body = "verdict: supports\nsource_tier: t2\nevidence_type: test\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 2);
     }
 
     #[test]
     fn evidence_body_source_tier_t1_maps_to_cl3() {
-        let body = "source_tier: tier1\n";
+        let body = "verdict: supports\nsource_tier: tier1\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 3);
     }
 
     #[test]
     fn evidence_body_source_tier_t3_maps_to_cl1() {
-        let body = "source_tier: 3\n";
+        let body = "verdict: supports\nsource_tier: 3\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 1);
     }
@@ -507,35 +557,69 @@ congruence_level: 3
     #[test]
     fn explicit_cl_does_not_inflate_above_source_tier() {
         // source_tier=t3 (CL1) + congruence_level=3 → min = 1
-        let body = "source_tier: t3\ncongruence_level: 3\n";
+        let body = "verdict: supports\nsource_tier: t3\ncongruence_level: 3\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 1);
     }
 
     #[test]
     fn source_tier_used_when_no_explicit_cl() {
-        let body = "source_tier: t2\n";
+        let body = "verdict: supports\nsource_tier: t2\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 2);
     }
 
     #[test]
     fn explicit_cl_used_when_no_source_tier() {
-        let body = "congruence_level: 2\n";
+        let body = "verdict: supports\ncongruence_level: 2\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 2);
     }
 
     #[test]
-    fn neither_field_defaults_to_cl3() {
+    fn no_congruence_source_fails_closed_to_cl0() {
+        // PRD-086 FR-009. This test previously asserted CL3 — it defended the
+        // defect. A pack stating a verdict and no congruence has not said how
+        // close its context is to the claim's, and CLAUDE.md RED LINE #7, the
+        // `/forge` skill and EVIDENCE-PROTOCOL.md all specify CL0 for that.
+        // Renamed rather than edited in place so the old name cannot be found
+        // and trusted.
         let body = "verdict: supports\n";
         let item = parse_evidence_from_record(&mk_record(body));
-        assert_eq!(item.congruence_level, 3);
+        assert_eq!(item.congruence_level, 0);
+    }
+
+    #[test]
+    fn a_body_with_no_structured_fields_scores_a_tenth_not_full_marks() {
+        // The measured symptom behind PROB-101: pure prose scored its target
+        // 1.00 "Adequate". The documented outcome is 0.1 — Supports (1.0)
+        // minus the CL0 penalty (0.9).
+        let item = parse_evidence_from_record(&mk_record("Just prose. Ran it. Fine.\n"));
+        assert_eq!(item.congruence_level, 0);
+        assert!(
+            (crate::scoring::reff::raw_evidence_score(&item) - 0.1).abs() < 1e-9,
+            "expected the documented 0.1, got {}",
+            crate::scoring::reff::raw_evidence_score(&item)
+        );
+    }
+
+    #[test]
+    fn an_unrecognised_verdict_does_not_score_as_support() {
+        // PRD-086 FR-008. `_ => Verdict::Supports` scored garbage at 1.0 while
+        // `congruence_level` in the same function failed closed for the same
+        // input class. Protocol v1's `verdict: unknown` would have arrived
+        // scoring full marks.
+        let item =
+            parse_evidence_from_record(&mk_record("verdict: unknown\ncongruence_level: 3\n"));
+        assert_eq!(
+            item.congruence_level, 0,
+            "an undeclared direction is not a CL3 claim"
+        );
     }
 
     #[test]
     fn evidence_body_invalid_source_tier_falls_back_to_cl() {
-        let body = "source_tier: bogus\ncongruence_level: 2\n";
+        let body = "verdict: supports\nsource_tier: bogus\ncongruence_level: 2\n";
         let item = parse_evidence_from_record(&mk_record(body));
         assert_eq!(item.congruence_level, 2);
     }

--- a/crates/forgeplan-core/src/scoring/reff.rs
+++ b/crates/forgeplan-core/src/scoring/reff.rs
@@ -324,6 +324,52 @@ pub async fn r_eff_recursive(
         evidence_items.push(parse_evidence_from_record(rec));
     }
 
+    // PRD-086 FR-001 (#325). An EvidencePack asked for its evidence finds none —
+    // a pack has no packs — and the empty-evidence branch below returns 0.0 with
+    // the factor "No evidence found (L0)". A canonical pack (`verdict: supports`,
+    // `congruence_level: 3`) scored zero, and the only way to lift it was to
+    // invent child evidence, which is graph pollution to satisfy a walk.
+    //
+    // The intrinsic score already exists. `score_evidence_full` is applied to
+    // this very pack whenever it is scored AS evidence for something else; it
+    // was simply never applied to the pack itself. Trust in a measurement comes
+    // from its verdict, congruence and freshness — not from someone having
+    // measured the measurement.
+    //
+    // Packs that carry child evidence keep the normal path: an EVID built on
+    // other EVIDs is a real chain and the weakest link still rules it.
+    let is_evidence_kind = store
+        .get_record(artifact_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.kind.eq_ignore_ascii_case("evidence"))
+        .unwrap_or(false);
+
+    if is_evidence_kind && evidence_items.is_empty() && terminal_skips == 0 {
+        let own = store.get_record(artifact_id).await.ok().flatten();
+        if let Some(rec) = own {
+            let item = parse_evidence_from_record(&rec);
+            let intrinsic = score_evidence_full(&item);
+            factors.push(format!(
+                "Leaf evidence scored on its own fields: {:?} CL{} = {:.2}",
+                item.verdict, item.congruence_level, intrinsic
+            ));
+            return Ok(AssuranceReport {
+                artifact_id: artifact_id.to_string(),
+                r_eff: intrinsic,
+                self_score: intrinsic,
+                weakest_link: None,
+                decay_penalty: if is_expired(item.valid_until) {
+                    0.9
+                } else {
+                    0.0
+                },
+                factors,
+            });
+        }
+    }
+
     let self_score = if evidence_items.is_empty() {
         if terminal_skips > 0 {
             // quint-code edge case (decision.go:826): all evidence displaced
@@ -358,10 +404,17 @@ pub async fn r_eff_recursive(
         .copied()
         .collect();
 
-    // Collect dependency IDs from outgoing relations.
+    // PRD-086 FR-002 (#325). An EvidencePack's outgoing `informs` / `based_on`
+    // edges point at the artifacts it SUPPORTS. Treating those as dependencies
+    // makes trust in the measurement flow down from the decision it justifies —
+    // backwards. A pack does not become less reliable because the PRD it
+    // informs is poorly evidenced elsewhere.
     let deps: Vec<(String, String)> = outgoing
         .iter()
         .filter(|(_, rel_type)| dep_relation_types.contains(rel_type.as_str()))
+        .filter(|(_, rel_type)| {
+            !(is_evidence_kind && matches!(rel_type.as_str(), "informs" | "based_on"))
+        })
         .cloned()
         .collect();
 
@@ -370,14 +423,33 @@ pub async fn r_eff_recursive(
 
     for (dep_id, rel_type) in &deps {
         // Skip non-active dependencies — draft/deprecated/superseded should not drag down R_eff
-        if let Ok(Some(dep_record)) = store.get_record(dep_id).await
-            && matches!(
+        if let Ok(Some(dep_record)) = store.get_record(dep_id).await {
+            if matches!(
                 dep_record.status.as_str(),
                 "draft" | "deprecated" | "superseded"
-            )
-        {
-            factors.push(format!("Skipped {dep_id} (status: {})", dep_record.status));
-            continue;
+            ) {
+                factors.push(format!("Skipped {dep_id} (status: {})", dep_record.status));
+                continue;
+            }
+
+            // PRD-086 FR-003 (#392, narrowed). The routing table calls a Note
+            // the artifact for trivial, reversible work: no ADI, no evidence,
+            // expires in 90 days. The cascade then read an active Note with no
+            // evidence as zero trust and poisoned every chain based on it — so
+            // forgeplan said a Note needs no evidence and scored everything
+            // downstream of it as unevidenced. Two of its own rules disagreeing.
+            //
+            // Same remedy ADR-002 chose for `draft`: skip, logged, rather than
+            // soften the min. The weakest-link rule is untouched for every kind
+            // that CAN owe evidence — a PRD or ADR with none is real debt and
+            // the cascade surfacing it is the product working.
+            if matches!(dep_record.kind.as_str(), "note" | "memory") {
+                factors.push(format!(
+                    "Skipped {dep_id} (kind: {} — exempt from evidence by routing depth)",
+                    dep_record.kind
+                ));
+                continue;
+            }
         }
 
         let dep_report = match Box::pin(r_eff_recursive(dep_id, store, visited)).await {

--- a/crates/forgeplan-core/tests/scoring_cascade_test.rs
+++ b/crates/forgeplan-core/tests/scoring_cascade_test.rs
@@ -99,6 +99,13 @@ async fn the_leaf_score_still_discriminates() {
 /// as a dependency made trust in a measurement flow down from the decision it
 /// justifies — so a well-formed pack attached to an unevidenced PRD scored
 /// zero, which is the tail wagging the dog.
+///
+/// NOTE ON WHAT THIS PROVES. For a LEAF pack the FR-001 early return fires
+/// first and the dependency walk is never built, so deleting the FR-002 filter
+/// leaves this test green — an adversarial review caught that. It is kept as a
+/// behavioural guard on the observable outcome, and
+/// `a_pack_with_children_is_not_dragged_down_by_what_it_informs` below is the
+/// one that actually reaches the filter.
 #[tokio::test]
 async fn a_pack_is_not_dragged_down_by_the_artifact_it_supports() {
     let tmp = TempDir::new().unwrap();
@@ -120,6 +127,75 @@ async fn a_pack_is_not_dragged_down_by_the_artifact_it_supports() {
     assert!(
         (s - 1.0).abs() < 1e-9,
         "the pack's own quality does not depend on what it informs; got {s}"
+    );
+}
+
+/// FR-002 where it is actually reachable: a pack that HAS child evidence, so
+/// the FR-001 early return does not fire and the dependency walk runs, pointing
+/// at a decision that is weak for a reason of its OWN.
+///
+/// Getting this test to reach the code took three attempts, and the two failures
+/// are worth recording because both looked correct:
+///
+/// 1. A leaf pack informing an unevidenced PRD — the FR-001 early return fires
+///    first and the dependency walk is never built.
+/// 2. A pack WITH children informing an unevidenced PRD — the PRD is not
+///    unevidenced at all, because the pack under test informs it. Evidence
+///    collection reads incoming edges, so linking the pack to the PRD is what
+///    evidences the PRD. The min had nothing to drag anything down with.
+///
+/// So the weak artifact has to be weak independently: PRD-201 is unevidenced,
+/// PRD-200 is `based_on` it and therefore zero despite its own evidence, and
+/// EVID-200 informs PRD-200. Without the filter, EVID-200 inherits that zero.
+#[tokio::test]
+async fn a_pack_with_children_is_not_dragged_down_by_what_it_informs() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+
+    // The independent source of weakness, two hops away from the pack.
+    store
+        .create_artifact_for_test(&artifact("PRD-201", "prd", "active", "no evidence at all"))
+        .await
+        .unwrap();
+    // The decision the pack supports — evidenced, but zeroed by its own parent.
+    store
+        .create_artifact_for_test(&artifact("PRD-200", "prd", "active", "built on PRD-201"))
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("PRD-200", "PRD-201", "based_on")
+        .await
+        .unwrap();
+
+    // The pack under test, plus a child so the FR-001 early return does not fire.
+    store
+        .create_artifact_for_test(&artifact("EVID-200", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("EVID-201", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("EVID-201", "EVID-200", "informs")
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("EVID-200", "PRD-200", "informs")
+        .await
+        .unwrap();
+
+    // Precondition: the decision really is zero, or this test proves nothing.
+    let prd = score(&store, "PRD-200").await;
+    assert_eq!(
+        prd, 0.0,
+        "setup is wrong — PRD-200 must be zeroed by PRD-201"
+    );
+
+    let s = score(&store, "EVID-200").await;
+    assert!(
+        s > 0.0,
+        "a measurement's reliability must not depend on the decision it justifies; got {s}"
     );
 }
 

--- a/crates/forgeplan-core/tests/scoring_cascade_test.rs
+++ b/crates/forgeplan-core/tests/scoring_cascade_test.rs
@@ -1,0 +1,197 @@
+//! What R_eff means when the graph is not a clean chain — PRD-086.
+//!
+//! Three questions the recursive scorer answers badly enough that people filed
+//! issues about all three:
+//!
+//! - can a leaf EvidencePack be trusted at all (#325)
+//! - does trust flow the wrong way along an `informs` edge (#325, FR-002)
+//! - does a Note the methodology exempts from evidence poison everything
+//!   built on it (#392, narrowed)
+//!
+//! These run against a real store with real relations, because every one of
+//! them is about how the walk behaves, not about arithmetic on a Vec.
+
+use forgeplan_core::db::store::{LanceStore, NewArtifact};
+use forgeplan_core::scoring::reff::r_eff_recursive;
+use std::collections::HashSet;
+use tempfile::TempDir;
+
+async fn make_store(tmp: &TempDir) -> LanceStore {
+    let ws = tmp.path().join(".forgeplan");
+    LanceStore::init(&ws).await.unwrap()
+}
+
+fn artifact(id: &str, kind: &str, status: &str, body: &str) -> NewArtifact {
+    NewArtifact {
+        id: id.into(),
+        kind: kind.into(),
+        status: status.into(),
+        title: format!("Test {id}"),
+        body: body.into(),
+        depth: "standard".into(),
+        author: None,
+        parent_epic: None,
+        valid_until: None,
+        tags: Vec::new(),
+    }
+}
+
+const CANONICAL: &str = "verdict: supports\ncongruence_level: 3\nevidence_type: measurement\n";
+
+async fn score(store: &LanceStore, id: &str) -> f64 {
+    let mut seen: HashSet<String> = HashSet::new();
+    r_eff_recursive(id, store, &mut seen).await.unwrap().r_eff
+}
+
+/// #325. A pack has no packs, so asking it for its evidence found none and
+/// returned 0.0 with "No evidence found (L0)". The intrinsic score already
+/// existed — it is applied to this same pack whenever it scores for someone
+/// else — and was simply never applied to the pack itself.
+#[tokio::test]
+async fn a_canonical_leaf_pack_is_worth_something_on_its_own() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+    store
+        .create_artifact_for_test(&artifact("EVID-001", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+
+    let s = score(&store, "EVID-001").await;
+    assert!(
+        (s - 1.0).abs() < 1e-9,
+        "supports + CL3 is the strongest a pack can state; got {s}"
+    );
+}
+
+/// The intrinsic score is a score, not a rubber stamp: a weakening pack at a
+/// distant congruence level must land low.
+#[tokio::test]
+async fn the_leaf_score_still_discriminates() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+    store
+        .create_artifact_for_test(&artifact(
+            "EVID-002",
+            "evidence",
+            "active",
+            "verdict: weakens\ncongruence_level: 3\nevidence_type: measurement\n",
+        ))
+        .await
+        .unwrap();
+
+    // `weakens` is 0.5, CL3 costs nothing, `measurement` costs nothing — so the
+    // computed value is exactly 0.5, and only the fix can produce it.
+    //
+    // The first draft of this test used `weakens` at CL1 with `audit` and
+    // asserted `s < 0.2`. That passes on the broken code too, where every leaf
+    // is 0.0 — and worse, the honest score for those inputs IS 0.0 after
+    // penalties, so tightening it to `s > 0.0` made the test wrong rather than
+    // stronger. Mutation testing found the first mistake; running the fixed
+    // tree found the second.
+    let s = score(&store, "EVID-002").await;
+    assert!(
+        (s - 0.5).abs() < 1e-9,
+        "a weakening pack states half a case, not none and not all; got {s}"
+    );
+}
+
+/// FR-002. An outgoing `informs` points at what the pack SUPPORTS. Treating it
+/// as a dependency made trust in a measurement flow down from the decision it
+/// justifies — so a well-formed pack attached to an unevidenced PRD scored
+/// zero, which is the tail wagging the dog.
+#[tokio::test]
+async fn a_pack_is_not_dragged_down_by_the_artifact_it_supports() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+    store
+        .create_artifact_for_test(&artifact("PRD-001", "prd", "active", "no evidence here"))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("EVID-003", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("EVID-003", "PRD-001", "informs")
+        .await
+        .unwrap();
+
+    let s = score(&store, "EVID-003").await;
+    assert!(
+        (s - 1.0).abs() < 1e-9,
+        "the pack's own quality does not depend on what it informs; got {s}"
+    );
+}
+
+/// #392, narrowed. The routing table calls a Note the artifact for trivial
+/// reversible work — no evidence required. The cascade then read an active
+/// unevidenced Note as zero trust and poisoned everything based on it, so
+/// forgeplan contradicted itself: no evidence needed here, everything
+/// downstream unevidenced.
+#[tokio::test]
+async fn an_exempt_note_does_not_poison_what_is_built_on_it() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+    store
+        .create_artifact_for_test(&artifact("NOTE-001", "note", "active", "a design choice"))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("PRD-002", "prd", "active", "well evidenced"))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("EVID-004", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("EVID-004", "PRD-002", "informs")
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("PRD-002", "NOTE-001", "based_on")
+        .await
+        .unwrap();
+
+    let s = score(&store, "PRD-002").await;
+    assert!(
+        s > 0.0,
+        "a Note the methodology exempts from evidence must not zero its dependants; got {s}"
+    );
+}
+
+/// The other half of the same decision, and the one that keeps the product
+/// honest: a kind that CAN owe evidence and has none is real debt, and the
+/// weakest-link cascade surfacing it is the whole point. The #392 proposals
+/// that would have softened this were declined.
+#[tokio::test]
+async fn an_unevidenced_prd_still_drags_its_dependants_down() {
+    let tmp = TempDir::new().unwrap();
+    let store = make_store(&tmp).await;
+    store
+        .create_artifact_for_test(&artifact("PRD-100", "prd", "active", "no evidence"))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("PRD-101", "prd", "active", "well evidenced"))
+        .await
+        .unwrap();
+    store
+        .create_artifact_for_test(&artifact("EVID-005", "evidence", "active", CANONICAL))
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("EVID-005", "PRD-101", "informs")
+        .await
+        .unwrap();
+    store
+        .add_relation_for_test("PRD-101", "PRD-100", "based_on")
+        .await
+        .unwrap();
+
+    let s = score(&store, "PRD-101").await;
+    assert_eq!(
+        s, 0.0,
+        "an unevidenced PRD in the chain is debt the score must keep showing"
+    );
+}

--- a/crates/forgeplan-mcp/src/server.rs
+++ b/crates/forgeplan-mcp/src/server.rs
@@ -8145,8 +8145,10 @@ impl ForgeplanServer {
     #[tool(
         description = "Manually advance (or set) the advisory **artifact lifecycle phase** marker \
                        for an artifact (shape/validate/adi/code/test/audit/evidence/done). \
-                       Appends a transition to the history. Does NOT validate phase ordering — \
-                       advisory layer allows out-of-order jumps (e.g. direct `done` override). \
+                       Appends a transition to the history. Forward and out-of-order jumps are \
+                       allowed, including a direct `done` override, and so is moving BACKWARDS — \
+                       this tool is the deliberate-correction path (PRD-086 FR-007). Automatic \
+                       advancement triggered by other tools refuses to move a phase backwards. \
                        Full phase enforcement lands in a later PRD under EPIC-005. Use when \
                        auto-advancement missed a transition or when reclassifying workflow state. \
                        NOTE: this targets the artifact lifecycle phase machine, NOT the \
@@ -8187,8 +8189,20 @@ impl ForgeplanServer {
         let safe_id = sanitize_for_hint(&p.id);
         let safe_reason = p.reason.as_deref().map(sanitize_for_hint);
 
-        match forgeplan_core::phase::store::advance_phase(&ws, &p.id, target, p.reason.clone())
-            .await
+        // PRD-086 FR-007. The monotonicity guard belongs on AUTOMATIC advancement
+        // — `maybe_advance_phase`, which fires on every `forgeplan_validate`
+        // PASS and used to walk a shipped artifact back from `done`. An explicit
+        // call to THIS tool is the same act as `forgeplan phase-advance` on the
+        // command line: someone deciding to correct a marker. The CLI was moved
+        // to the unchecked entry point and this handler must match it, or the
+        // two surfaces disagree about what the same operation means.
+        match forgeplan_core::phase::store::advance_phase_unchecked(
+            &ws,
+            &p.id,
+            target,
+            p.reason.clone(),
+        )
+        .await
         {
             Ok(state) => {
                 let current = state.current_phase.as_str();


### PR DESCRIPTION
The R_eff trust layer stops reporting values it never computed, plus two boundary
decisions that were blocking the vNext program.

## Note on authorship

Commit `8c51d94` (`update --body` kept three frontmatter fields and deleted the
rest) is **not mine** — a second session working in this worktree committed it
into the same line while I was working. It is on-topic and tested, so it rides
along rather than being surgically extracted, but it should be reviewed as
someone else's change. Everything else here is one body of work.

## The defects

Five, all one shape: a surface returning a plausible number it never derived.

**Evidence that declared nothing scored full marks.** A pack with no `verdict`
and no `congruence_level` gave the artifact it informs **1.00**. `CLAUDE.md`
RED LINE #7, the `/forge` skill installed by `setup-skill`, and
`EVIDENCE-PROTOCOL.md` all specify CL0 and 0.1 — the binary and every document
describing it disagreed, in the inflating direction. The incentive was backwards
too: writing `congruence_level: 2` honestly scored 0.9, writing nothing scored
1.0. An unrecognised verdict fell through to `Supports` for the same reason,
while `congruence_level` in the same function already failed closed. Both now
fail closed and log why.

**A leaf EvidencePack scored zero** (#325). The scorer asked a pack for its
evidence, found none — a pack has no packs — and returned 0.0. `score_evidence_full`
already computed the intrinsic score and was applied to that same pack whenever
it scored for something else; it is now applied to the pack itself.

**Trust flowed backwards along `informs`** (#325). A pack's outgoing edges point
at what it *supports*; walking them as dependencies made a measurement's
reliability contingent on the decision it justifies.

**An exempt Note poisoned everything built on it** (#392, narrowed). The routing
table calls a Note the artifact for trivial reversible work — no evidence — and
the cascade read an active unevidenced Note as zero trust. Two of the product's
own rules contradicting each other. `note` and `memory` are skipped with a
logged factor, exactly as ADR-002 skips non-active dependencies.

**`advance_phase` walked phases backwards** (#330). No monotonicity guard, and
MCP `forgeplan_validate` calls it on every PASS — so validating a shipped
artifact reset it from `done` and health reported a mismatch it did not have
until someone checked it.

**The anomaly detector reported three things it never checked** (#393): a literal
`0.0` instead of the stored score, `cycle or depth cap` on every give-up in a
graph with zero cycles, and an ancestor walk that followed edges the scorer skips.

## What is explicitly NOT changed

`R_eff = min(...)` is untouched. The three fixes proposed in #392 — local-only
scoring, one-hop propagation, a floor at `self_score` — are each an average in
disguise and were declined; a test pins that an unevidenced **PRD** still drags
its dependants to zero so a future simplification cannot soften it quietly.

## Adversarial review

Five dimensions, every finding handed to a separate agent told to refute it:
**10 confirmed, 9 refuted**. Three confirmed defects were introduced by the first
round of these very fixes, all of the same class:

- `hints.rs` printed "R_eff will be 0.0" under a computed 1.00
- `context.rs` did the same, and its `Next:` told an agent to create an
  EvidencePack for an EvidencePack — a PRD-071 contract line, so the cost was
  phantom artifacts rather than a confusing sentence
- `anomalies.rs` applied the note skip at pop time but collected parents without
  it, so a node that *was* the weakest link but sat behind a Note was never named
  while `forgeplan score` resolved the same chain — the exact disagreement FR-006
  exists to close
- `anomalies.rs` again: the revisit flag fires on ordinary re-convergence in an
  acyclic graph, and the message called it "the chain loops" — #393 bug 2
  repeated in narrower form
- MCP `forgeplan_phase_advance` still called the checked path while the CLI moved
  to the unchecked one, its description advertised out-of-order jumps, and its
  error branch answered a monotonicity refusal with "check the directory is
  writable"

**And the test for FR-002 never reached FR-002.** Deleting the filter left all
five cascade tests green. The replacement took three attempts; both failures are
recorded in the test because both looked correct. Mutation-checked: removing the
filter now fails exactly one test.

One confirmed finding is deliberately **not** fixed here: a leaf pack with an
evidence-kind neighbour reports the neighbour's score (`reff.rs:349`). The
verifier downgraded it critical → low — fail-closed parsing intact, nothing
propagates to consumers, it gates nothing, and all six EVID→EVID edges in this
repo are supports/CL3 pointing at supports/CL3. Fixing it means changing evidence
collection, which is not this PR's scope. Filed separately.

## BREAKING — re-score required

Packs missing either structured field drop from 1.0 to 0.1, and artifacts whose
weakest link was such a pack drop with them. **Run `forgeplan score --all` after
merging.** In this repository that is 3 of 167 packs (EVID-033/034/035 → PROB-014,
PROB-016, RFC-004); elsewhere unknown. The drop is the correct reading.

## Also here

- `embed` no longer loads a multi-gigabyte model to discover it has nothing to
  encode: **8.22s → 0.25s** on a fully-current 427-artifact workspace (PROB-103).
  The missing half of PROB-093, which removed the encoding work and left the
  setup for it.
- **ADR-025** — orchestration sits above ForgePlan; ADR-001 reaffirmed, ADR-009's
  orchestrator clause superseded, with the per-surface disposition the vNext audit
  demanded. **ADR-026** — storage classes for machine-written records. Both
  approved by the owner; EVID-169 records the basis.
- `AGENTS.md` gains the build-directory rule (parallel agent compilation fills the
  disk; `errno=28` surfaces as `passed=0 failed=0` at exit 0) and the
  explanation-style section the owner asked for.

## Gates

`cargo fmt` clean, `cargo clippy --workspace --all-targets` **0 warnings**,
**3312 passed / 1 failed** across 94 binaries. The failure is #454:
`c34_forgeplan_generate_no_llm_smoke` asserts that *no* LLM provider is configured
and breaks when a sibling test sets the variable; it passes in isolation and no
line of this diff touches that path.

Artifacts: PRD-086, PROB-101, PROB-102, PROB-103, EVID-170, ADR-025, ADR-026,
EVID-169.

Closes #325
Closes #330
Closes #392
Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
