### PR TITLE
chore(prob-105): deprecate as resolved, with the reason actually in the file

### DIFF
--- a/.forgeplan/problems/PROB-105-the-spec-validator-passes-empty-templates-and-blocks-real-behavioural-specs.md
+++ b/.forgeplan/problems/PROB-105-the-spec-validator-passes-empty-templates-and-blocks-real-behavioural-specs.md
@@ -5,9 +5,10 @@ kind: problem
 links:
 - target: PRD-086
   relation: informs
-status: active
+status: deprecated
 title: The SPEC validator passes empty templates and blocks real behavioural specs
 ---
+
 
 ---
 assigned_number: 105
@@ -108,6 +109,8 @@ Three changes, none of which teaches the kernel a methodology:
 
 GitHub: #450 (its premise is inverted — see above), #449 (separate).
 
+## Deprecation
 
-
+Reason: Fixed and merged: 551ddb9 (PR #472). check_stub now scales the placeholder signal, spec-contracts accepts a behavioural contract, and spec-requirement-has-scenario covers the half-authored case. Verified by EVID-171 (before/after measurements, 3320 tests, 4 mutation checks). Kept as history rather than deleted.
+Date: 2026-09-08
 


### PR DESCRIPTION
Artifact-only. PROB-105 described a defect that #472 fixed (merged as 551ddb9), so it is retired as history rather than deleted.

## Why this is a PR and not a one-liner

`forgeplan deprecate PROB-105 --reason "..."` ran cleanly: it echoed the reason back, `forgeplan get PROB-105` showed a `## Deprecation` section containing it, and the status transitioned. **The markdown file got the status and not the reason.** `.forgeplan/lance/` is gitignored, so the only durable copy would have been missing the answer to "why was this retired".

The section here was restored through `forgeplan update --body`, which does project correctly.

Filed while recovering:

- **#478** — `deprecate` and `reopen` write their reason section to LanceDB only. Reproducer on the shipped v0.36.0 binary; `renew` shares the code shape, unverified.
- **#479** — `reopen` mints the replacement artifact as `PROBLEM-001` instead of continuing the `PROB-` sequence.

## Note for reviewers

`CLAUDE.md` RED LINE #8 names `commands/deprecate.rs` as the canonical projection flow, and it is — the CLI wrapper re-reads the record and calls `render_projection`. The loss happens under it, which is why nothing about the command looks wrong.